### PR TITLE
Add root-level package.json to allow proper npm deps install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "phoenix_live_view",
+  "version": "0.1.0",
+  "main": "./priv/static/phoenix_live_view.js",
+  "repository": {
+  },
+  "files": ["README.md", "LICENSE.md", "package.json", "priv/static/phoenix_live_view.js"]
+}


### PR DESCRIPTION
Given the way we are showing how to import the JS, it breaks without declaring a root package.json.

![image](https://user-images.githubusercontent.com/911605/54040290-a3bee600-418a-11e9-97b3-c237a2862b7a.png)
