### PR TITLE
Add ex_doc so docs can be generated with mix

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,8 @@ defmodule Phoenix.LiveView.MixProject do
     [
       {:phoenix, "~> 1.4.2"},
       {:phoenix_html, "~> 2.13"},
-      {:jason, "~> 1.0", optional: true}
+      {:jason, "~> 1.0", optional: true},
+      {:ex_doc, "~> 0.19.3", runtime: false}
     ]
   end
 end


### PR DESCRIPTION
Run `mix docs` then `open docs/index.html` for local hex docs while the hex package isn't published.