### PR TITLE
I forgot to `npm install`, I added an explicit note to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Add LiveView NPM dependencies in your `package.json`.
 }
 ```
 
-Make sure you install the new dependency.
+Then install the new npm dependency.
 
 ```bash
 npm install --prefix assets
@@ -129,34 +129,4 @@ You can also optionally import the style for the default CSS classes in your `ap
 
 ```css
 @import "../../deps/phoenix_live_view/assets/css/live_view.css";
-```
-
-## Troubleshooting
-
-### Can't resolve 'phoenix_live_view'
-
-When you start up phoenix, you might see that the phoenix_live_view is not loading.
-With an error similar to
-
-```
-ERROR in ./js/app.js
-Module not found: Error: Can't resolve 'phoenix_live_view' in '/src/myapp/assets/js'
- @ ./js/app.js 3:0-43 8:21-31
- @ multi ./js/app.js
-```
-
-Even if you correctly update your NPM dependencies (e.g. `"phoenix_live_view": "file:../deps/phoenix_live_view"`), you
-may have forgotten to pull in that new dependency with `npm install`
-
-To install the new NPM Live View library you can run the following from your assets directory.
-
-```
-$ (cd assets && npm install)
-```
-
-The output should look similar to
-
-```
-/src/myapp/assets
-└── phoenix_live_view@0.1.0-dev
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Phoenix LiveView enables rich, real-time user experiences with server-rendered H
 
 ## Learning
 
-As official guides are being developed, see our existing 
+As official guides are being developed, see our existing
 comprehensive docs and examples to get up to speed:
 
   * [Phoenix.LiveView docs for general usage](https://github.com/phoenixframework/phoenix_live_view/blob/master/lib/phoenix_live_view.ex)
@@ -94,6 +94,12 @@ Add LiveView NPM dependencies in your `package.json`.
     "phoenix_live_view": "file:../deps/phoenix_live_view"
   }
 }
+```
+
+Make sure you install the new dependency.
+
+```bash
+npm install --prefix assets
 ```
 
 Enable connecting to a LiveView socket in your `app.js` file.

--- a/README.md
+++ b/README.md
@@ -130,3 +130,33 @@ You can also optionally import the style for the default CSS classes in your `ap
 ```css
 @import "../../deps/phoenix_live_view/assets/css/live_view.css";
 ```
+
+## Troubleshooting
+
+### Can't resolve 'phoenix_live_view'
+
+When you start up phoenix, you might see that the phoenix_live_view is not loading.
+With an error similar to
+
+```
+ERROR in ./js/app.js
+Module not found: Error: Can't resolve 'phoenix_live_view' in '/src/myapp/assets/js'
+ @ ./js/app.js 3:0-43 8:21-31
+ @ multi ./js/app.js
+```
+
+Even if you correctly update your NPM dependencies (e.g. `"phoenix_live_view": "file:../deps/phoenix_live_view"`), you
+may have forgotten to pull in that new dependency with `npm install`
+
+To install the new NPM Live View library you can run the following from your assets directory.
+
+```
+$ (cd assets && npm install)
+```
+
+The output should look similar to
+
+```
+/src/myapp/assets
+└── phoenix_live_view@0.1.0-dev
+```


### PR DESCRIPTION

First, awesome.

Second, as I was going through the installation, I forgot to pull in the new NPM library.  I thoughts others might benefit from the friendly reminder so here's a PR to add some notes about it.

I added an explicit note in the action instructions, as well as a troubleshooting with the exact error you will see for the forgotten step.

If there is something I am missing to have the npm libs automatically managed, then please let me know as I usually forget to update my NPM libs locally.

