### PR TITLE
Corrects mentioned JS attribute to reflect code

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -46,7 +46,7 @@ default, the bound element will be the event listener, but an
 optional `phx-target` may be provided which may be `"document"`,
 `"window"`, or the DOM id of a target element.
 
-When pushed, the value sent to the server will be the event's keyCode.
+When pushed, the value sent to the server will be the event's `key`.
 
 ## Forms and input handling
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -307,7 +307,7 @@ defmodule Phoenix.LiveView do
 
   The onkeypress, onkeydown, and onkeyup events are supported via
   the `phx-keypress`, `phx-keydown`, and `phx-keyup` bindings. When
-  pushed, the value sent to the server will be the event's keyCode.
+  pushed, the value sent to the server will be the event's `key`.
   By default, the bound element will be the event listener, but an
   optional `phx-target` may be provided which may be `"document"`,
   `"window"`, or the DOM id of a target element, for example:


### PR DESCRIPTION
The docs refer to `keyCode`, but the actual Javascript grabs the `key` value off the event.