### PR TITLE
Include binary in unsigned_params typespec

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -341,7 +341,7 @@ defmodule Phoenix.LiveView do
   alias Phoenix.LiveView
   alias Phoenix.LiveView.Socket
 
-  @type unsigned_params :: map
+  @type unsigned_params :: map | binary
   @type from :: binary
 
   @callback mount(session :: map, Socket.t()) ::


### PR DESCRIPTION
Fixes https://github.com/phoenixframework/phoenix_live_view/issues/86 by adding `binary` to the `unsigned_params` typespec in `phoenix_live_view.ex`

As mentioned in the issue, there are other ways to fix this, and perhaps `params` in `handle_event` should indeed always be a map. In that case, this PR shouldn't be merged :-)