### PR TITLE
Add Phoenix.LiveView.Store

### DIFF
--- a/lib/phoenix_live_view/store.ex
+++ b/lib/phoenix_live_view/store.ex
@@ -56,7 +56,7 @@ defmodule Phoenix.LiveView.Store do
 
   defmodule NoSuchKeyError do
     @moduledoc """
-    An error raised when an expected key is not in the LiveStore
+    An error raised when an expected key is not in the store
     """
     defexception [:message]
 
@@ -66,7 +66,7 @@ defmodule Phoenix.LiveView.Store do
   end
 
   @doc """
-  Create a new LiveStore.
+  Create a new store.
   """
   @spec new(atom) :: store
   def new(name) do

--- a/lib/phoenix_live_view/store.ex
+++ b/lib/phoenix_live_view/store.ex
@@ -70,7 +70,7 @@ defmodule Phoenix.LiveView.Store do
   """
   @spec new(atom) :: store
   def new(name) do
-    :ets.new(name, [:set, :public])
+    :ets.new(name, [:public])
   end
 
   @doc """

--- a/lib/phoenix_live_view/store.ex
+++ b/lib/phoenix_live_view/store.ex
@@ -1,0 +1,105 @@
+defmodule Phoenix.LiveView.Store do
+  @moduledoc """
+  A key-value store for sharing data across Phoenix.LiveView components
+
+  ## Example
+
+      iex> store = Phoenix.LiveView.Store.new(App.LiveView)
+      iex> Phoenix.LiveView.Store.set(store, key: "value")
+      iex> Phoenix.LiveView.Store.get(store, :key)
+      {:ok, "value"}
+
+      iex> store = Phoenix.LiveView.Store.new(App.LiveView)
+      iex> Phoenix.LiveView.Store.set(store, key: "value")
+      iex> Phoenix.LiveView.Store.get(store, :no_such_key)
+      {:error, :not_found}
+
+  ## Usage
+
+  In order to share data across Phoenix.LiveView components, create a store in
+  a component's `mount/2` callback and pass its identifier to child components.
+
+      defmodule App.LiveView do
+        use Phoenix.LiveView
+
+        alias Phoenix.LiveView.Store
+
+        def mount(%{user_id: user_id}, socket) do
+          store = Store.new(__MODULE__)
+          user = App.Users.lookup_user(user_id)
+          Store.set(store, user: user)
+          {:ok, assign(socket, :store, store)}
+        end
+
+        def render(assigns) do
+          ~L\"""
+            <%= live_render @socket, App.ChildView, session: %{store: @store} %>
+          \"""
+        end
+      end
+
+  Now, your child view can access data stored by its parent:
+
+      defmodule App.ChildView do
+        use Phoenix.LiveView
+
+        alias Phoenix.LiveView.Store
+
+        def mount(%{store: store}, socket) do
+          user = Store.get!(store, :user)
+          {:ok, assign(socket, :user, user)}
+        end
+      end
+  """
+
+  @type store :: :ets.tid()
+
+  defmodule NoSuchKeyError do
+    @moduledoc """
+    An error raised when an expected key is not in the LiveStore
+    """
+    defexception [:message]
+
+    @impl true
+    def exception(key),
+      do: %__MODULE__{message: ~s(Expected key "#{key}", but no such key was found)}
+  end
+
+  @doc """
+  Create a new LiveStore.
+  """
+  @spec new(atom) :: store
+  def new(name) do
+    :ets.new(name, [:set, :public])
+  end
+
+  @doc """
+  Set one or more key/value pairs in the `store`.
+  """
+  @spec set(store, Keyword.t()) :: true
+  def set(store, objects) do
+    :ets.insert(store, objects)
+  end
+
+  @doc """
+  Get a key from the store.
+  """
+  @spec get(store, atom) :: {:ok, any} | {:error, :not_found}
+  def get(store, key) do
+    case :ets.lookup(store, key) do
+      [{^key, value}] -> {:ok, value}
+      [] -> {:error, :not_found}
+    end
+  end
+
+  @doc """
+  Get a key from the store, but raise if it is not present.
+  """
+  @spec get!(store, atom) :: any | no_return
+  def get!(store, key) do
+    case get(store, key) do
+      {:ok, value} -> value
+      {:error, :not_found} -> raise NoSuchKeyError, key
+    end
+  end
+end

--- a/lib/phoenix_live_view/store.ex
+++ b/lib/phoenix_live_view/store.ex
@@ -148,11 +148,13 @@ defmodule Phoenix.LiveView.Store do
 
   # GenServer Callbacks
 
+  @impl true
   def init(name) do
     tid = :ets.new(name, [:public])
     {:ok, %State{tid: tid}}
   end
 
+  @impl true
   def handle_call({:set, objects}, _from, state) do
     :ets.insert(state.tid, objects)
     Enum.each(state.subscribers, &notify_subscriber(&1, objects))
@@ -206,6 +208,7 @@ defmodule Phoenix.LiveView.Store do
     {:reply, state, state}
   end
 
+  @impl true
   def handle_info({:DOWN, _ref, _, pid, _reason}, state) do
     state = update_in(state, [Access.key(:subscribers)], &Map.delete(&1, pid))
     {:noreply, state}

--- a/lib/phoenix_live_view/store.ex
+++ b/lib/phoenix_live_view/store.ex
@@ -33,7 +33,7 @@ defmodule Phoenix.LiveView.Store do
 
         def render(assigns) do
           ~L\"""
-            <%= live_render @socket, App.ChildView, session: %{store: @store} %>
+          <%= live_render @socket, App.ChildView, session: %{store: @store} %>
           \"""
         end
       end
@@ -74,7 +74,7 @@ defmodule Phoenix.LiveView.Store do
   end
 
   @doc """
-  Set one or more key/value pairs in the `store`.
+  Set one or more key/value pairs in the store.
   """
   @spec set(store, Keyword.t()) :: true
   def set(store, objects) do
@@ -93,7 +93,7 @@ defmodule Phoenix.LiveView.Store do
   end
 
   @doc """
-  Get a key from the store, but raise if it is not present.
+  Get a key from the store, but raise an error if it is not present.
   """
   @spec get!(store, atom) :: any | no_return
   def get!(store, key) do

--- a/lib/phoenix_live_view/store.ex
+++ b/lib/phoenix_live_view/store.ex
@@ -193,13 +193,14 @@ defmodule Phoenix.LiveView.Store do
   end
 
   def handle_call({:unsubscribe, key}, {from, _tag}, state) do
-    state = update_in(state, [Access.key(:subscribers)], fn subscribers ->
-      case subscribers[from] do
-        # TODO: Should we be de-monitoring processes here? Or is it okay to just wait for :DOWN?
-        [^key] -> Map.delete(subscribers, from)
-        keys -> Map.put(subscribers, key, List.delete(keys, key))
-      end
-    end)
+    state =
+      update_in(state, [Access.key(:subscribers)], fn subscribers ->
+        case subscribers[from] do
+          # TODO: Should we be de-monitoring processes here? Or is it okay to just wait for :DOWN?
+          [^key] -> Map.delete(subscribers, from)
+          keys -> Map.put(subscribers, key, List.delete(keys, key))
+        end
+      end)
 
     {:reply, :ok, state}
   end

--- a/lib/phoenix_live_view/store.ex
+++ b/lib/phoenix_live_view/store.ex
@@ -89,7 +89,7 @@ defmodule Phoenix.LiveView.Store do
   def get!(store, key) do
     case get(store, key) do
       {:ok, value} -> value
-      {:error, :not_found} -> raise KeyError, "key #{inspect key} not found in store"
+      {:error, :not_found} -> raise KeyError, "key #{inspect(key)} not found in store"
     end
   end
 
@@ -108,7 +108,7 @@ defmodule Phoenix.LiveView.Store do
   def update!(store, key, fun) do
     case GenServer.call(store, {:update!, key, fun}) do
       :ok -> :ok
-      {:error, :not_found} -> raise KeyError, "key #{inspect key} not found in store"
+      {:error, :not_found} -> raise KeyError, "key #{inspect(key)} not found in store"
     end
   end
 
@@ -216,13 +216,13 @@ defmodule Phoenix.LiveView.Store do
   end
 
   def handle_call(:unsubscribe, {from, _tag}, state) do
-    state = update_in(state, [Access.key(:subscribers)], &Map.delete(&1, from))
+    state = Map.update!(state, :subscribers, &Map.delete(&1, from))
     {:reply, :ok, state}
   end
 
   def handle_call({:unsubscribe, key}, {from, _tag}, state) do
     state =
-      update_in(state, [Access.key(:subscribers)], fn subscribers ->
+      Map.update!(state, :subscribers, fn subscribers ->
         case subscribers[from] do
           # TODO: Should we be de-monitoring processes here? Or is it okay to just wait for :DOWN?
           [^key] -> Map.delete(subscribers, from)
@@ -239,7 +239,7 @@ defmodule Phoenix.LiveView.Store do
 
   @impl true
   def handle_info({:DOWN, _ref, _, pid, _reason}, state) do
-    state = update_in(state, [Access.key(:subscribers)], &Map.delete(&1, pid))
+    state = Map.update!(state, :subscribers, &Map.delete(&1, pid))
     {:noreply, state}
   end
 

--- a/lib/phoenix_live_view/store.ex
+++ b/lib/phoenix_live_view/store.ex
@@ -52,17 +52,6 @@ defmodule Phoenix.LiveView.Store do
       end
   """
 
-  defmodule NoSuchKeyError do
-    @moduledoc """
-    An error raised when an expected key is not in the store
-    """
-    defexception [:message]
-
-    @impl true
-    def exception(key),
-      do: %__MODULE__{message: ~s(Expected key "#{key}", but no such key was found)}
-  end
-
   defmodule State do
     defstruct tid: nil, subscribers: %{}
   end
@@ -100,7 +89,7 @@ defmodule Phoenix.LiveView.Store do
   def get!(store, key) do
     case get(store, key) do
       {:ok, value} -> value
-      {:error, :not_found} -> raise NoSuchKeyError, key
+      {:error, :not_found} -> raise KeyError, "key #{inspect key} not found in store"
     end
   end
 
@@ -119,7 +108,7 @@ defmodule Phoenix.LiveView.Store do
   def update!(store, key, fun) do
     case GenServer.call(store, {:update!, key, fun}) do
       :ok -> :ok
-      {:error, :not_found} -> raise NoSuchKeyError, key
+      {:error, :not_found} -> raise KeyError, "key #{inspect key} not found in store"
     end
   end
 

--- a/test/phoenix_live_view/store_test.exs
+++ b/test/phoenix_live_view/store_test.exs
@@ -40,7 +40,7 @@ defmodule Phoenix.LiveView.StoreTest do
     end
 
     test "raises a NoSuchKeyError when no value is found", %{store: store} do
-      assert_raise Store.NoSuchKeyError, fn ->
+      assert_raise KeyError, fn ->
         Store.get!(store, :foo)
       end
     end
@@ -67,7 +67,7 @@ defmodule Phoenix.LiveView.StoreTest do
     end
 
     test "raises if a value is not present", %{store: store} do
-      assert_raise Store.NoSuchKeyError, fn ->
+      assert_raise KeyError, fn ->
         Store.update!(store, :key, &(&1 + 1))
       end
     end

--- a/test/phoenix_live_view/store_test.exs
+++ b/test/phoenix_live_view/store_test.exs
@@ -1,0 +1,48 @@
+defmodule Phoenix.LiveView.StoreTest do
+  use ExUnit.Case, async: true
+  doctest Phoenix.LiveView.Store
+
+  alias Phoenix.LiveView.Store
+
+  setup do
+    store = Store.new(__MODULE__)
+    {:ok, store: store}
+  end
+
+  describe ".set/2" do
+    test "sets a single key/value pair", %{store: store} do
+      true = Store.set(store, key: "value")
+      assert "value" == Store.get!(store, :key)
+    end
+
+    test "sets multiple key/value pairs", %{store: store} do
+      true = Store.set(store, foo: "bar", baz: "quux")
+      assert "bar" == Store.get!(store, :foo)
+      assert "quux" == Store.get!(store, :baz)
+    end
+  end
+
+  describe ".get/2" do
+    test "returns an :ok tuple when a value is found", %{store: store} do
+      true = Store.set(store, foo: "bar")
+      assert {:ok, "bar"} == Store.get(store, :foo)
+    end
+
+    test "returns an :error tuple when a value is found", %{store: store} do
+      assert {:error, :not_found} == Store.get(store, :foo)
+    end
+  end
+
+  describe ".get!/2" do
+    test "returns a value when a value is found", %{store: store} do
+      true = Store.set(store, foo: "bar")
+      assert "bar" == Store.get!(store, :foo)
+    end
+
+    test "raises a NoSuchKeyError when no value is found", %{store: store} do
+      assert_raise Store.NoSuchKeyError, fn ->
+        Store.get!(store, :foo)
+      end
+    end
+  end
+end

--- a/test/phoenix_live_view/store_test.exs
+++ b/test/phoenix_live_view/store_test.exs
@@ -11,12 +11,12 @@ defmodule Phoenix.LiveView.StoreTest do
 
   describe ".set/2" do
     test "sets a single key/value pair", %{store: store} do
-      true = Store.set(store, key: "value")
+      :ok = Store.set(store, key: "value")
       assert "value" == Store.get!(store, :key)
     end
 
     test "sets multiple key/value pairs", %{store: store} do
-      true = Store.set(store, foo: "bar", baz: "quux")
+      :ok = Store.set(store, foo: "bar", baz: "quux")
       assert "bar" == Store.get!(store, :foo)
       assert "quux" == Store.get!(store, :baz)
     end
@@ -24,7 +24,7 @@ defmodule Phoenix.LiveView.StoreTest do
 
   describe ".get/2" do
     test "returns an :ok tuple when a value is found", %{store: store} do
-      true = Store.set(store, foo: "bar")
+      :ok = Store.set(store, foo: "bar")
       assert {:ok, "bar"} == Store.get(store, :foo)
     end
 
@@ -35,13 +35,40 @@ defmodule Phoenix.LiveView.StoreTest do
 
   describe ".get!/2" do
     test "returns a value when a value is found", %{store: store} do
-      true = Store.set(store, foo: "bar")
+      :ok = Store.set(store, foo: "bar")
       assert "bar" == Store.get!(store, :foo)
     end
 
     test "raises a NoSuchKeyError when no value is found", %{store: store} do
       assert_raise Store.NoSuchKeyError, fn ->
         Store.get!(store, :foo)
+      end
+    end
+  end
+
+  describe ".update/4" do
+    test "updates an existing value", %{store: store} do
+      :ok = Store.set(store, key: 1)
+      :ok = Store.update(store, :key, 0, &(&1 + 1))
+      assert Store.get!(store, :key) == 2
+    end
+
+    test "sets an initial value if value is present", %{store: store} do
+      :ok = Store.update(store, :key, 0, &(&1 + 1))
+      assert Store.get!(store, :key) == 0
+    end
+  end
+
+  describe ".update!/3" do
+    test "updates an existing value", %{store: store} do
+      :ok = Store.set(store, key: 1)
+      :ok = Store.update!(store, :key, &(&1 + 1))
+      assert Store.get!(store, :key) == 2
+    end
+
+    test "raises if a value is not present", %{store: store} do
+      assert_raise Store.NoSuchKeyError, fn ->
+        Store.update!(store, :key, &(&1 + 1))
       end
     end
   end


### PR DESCRIPTION
This adds a `Phoenix.LiveView.Store` module that can be used to share data between parent and child components. It is implemented as a simple wrapper around an ETS table.

See the module documentation for `Phoenix.LiveView.Store` for some justification and usage examples, but **tl;dr** Given a parent and child module that both want a reference to the logged-in user, you would currently have to pass `user_id` in the session from the parent view to the child and perform a database lookup in the child view. With `Phoenix.LiveView.Store`, the lookup can be done once by the parent view, and child views can find the user struct in the store, which should be much faster than doing another database lookup.