### PR TITLE
Remove deprecated `keypress` event

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -40,8 +40,8 @@ following priority:
 
 ### Key Events
 
-The onkeypress, onkeydown, and onkeyup events are supported via
-the `phx-keypress`, `phx-keydown`, and `phx-keyup` bindings. By
+The onkeydown, and onkeyup events are supported via
+the `phx-keydown`, and `phx-keyup` bindings. By
 default, the bound element will be the event listener, but an
 optional `phx-target` may be provided which may be `"document"`,
 `"window"`, or the DOM id of a target element.
@@ -671,7 +671,6 @@ class View {
     this.eachChild(`[${this.binding("click")}]`, el => this.bindClick(el))
     this.eachChild(`[${this.binding("keyup")}]`, el => this.bindKey(el, "up"))
     this.eachChild(`[${this.binding("keydown")}]`, el => this.bindKey(el, "down"))
-    this.eachChild(`[${this.binding("keypress")}]`, el => this.bindKey(el, "press"))
   }
 
   bindClick(el){
@@ -757,7 +756,6 @@ class View {
     this.bindChange(el)
     this.bindKey(el, "up")
     this.bindKey(el, "down")
-    this.bindKey(el, "press")
 
   }
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -305,8 +305,8 @@ defmodule Phoenix.LiveView do
 
   ### Key Events
 
-  The onkeypress, onkeydown, and onkeyup events are supported via
-  the `phx-keypress`, `phx-keydown`, and `phx-keyup` bindings. When
+  The onkeydown, and onkeyup events are supported via
+  the `phx-keydown`, and `phx-keyup` bindings. When
   pushed, the value sent to the server will be the event's `key`.
   By default, the bound element will be the event listener, but an
   optional `phx-target` may be provided which may be `"document"`,

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -56,9 +56,6 @@ defmodule Phoenix.LiveViewTest do
     * `render_change/3` - sends a form phx-change event and value and
       returns the rendered result of the `handle_event/3` callback.
 
-    * `render_keypress/3` - sends a form phx-keypress event and value and
-      returns the rendered result of the `handle_event/3` callback.
-
     * `render_keydown/3` - sends a form phx-keydown event and value and
       returns the rendered result of the `handle_event/3` callback.
 
@@ -76,10 +73,6 @@ defmodule Phoenix.LiveViewTest do
       assert render_submit(view, :save, %{deg: 30}) =~ "The temperature is: 30℉"
 
       assert render_change(view, :validate, %{deg: -30}) =~ "invalid temperature"
-
-      assert render_keypress(view, :key, :ArrowUp) =~ "The temperature is: 31℉"
-
-      assert render_keypress(view, :key, :ArrowDown) =~ "The temperature is: 30℉"
 
   ## Testing regular messages
 
@@ -262,19 +255,6 @@ defmodule Phoenix.LiveViewTest do
   def render_change(view, event, value \\ %{}) do
     encoded_form = Plug.Conn.Query.encode(value)
     render_event(view, :form, event, encoded_form)
-  end
-
-  @doc """
-  Sends a keypress event to the view and returns the rendered result.
-
-  ## Examples
-
-      {:ok, view, html} = mount(MyEndpoint, ThermostatView, session: %{deg: 30})
-      assert html =~ "The temp is: 30℉"
-      assert render_keypress(view, :inc, :ArrowUp) =~ "The temp is: 32℉"
-  """
-  def render_keypress(view, event, key_code) do
-    render_event(view, :keypress, event, key_code)
   end
 
   @doc """

--- a/test/phoenix_live_view/phoenix_live_view_test.exs
+++ b/test/phoenix_live_view/phoenix_live_view_test.exs
@@ -197,6 +197,7 @@ defmodule Phoenix.LiveView.LiveViewTest do
     test "render_key|up|down", %{view: view} do
       {:ok, view, _} = mount(view)
       assert render(view) =~ "The temp is: 1"
+      assert render_keydown(view, :key, @key_i) =~ "The temp is: 2"
       assert render_keydown(view, :key, @key_d) =~ "The temp is: 1"
       assert render_keyup(view, :key, @key_d) =~ "The temp is: 0"
       assert render(view) =~ "The temp is: 0"

--- a/test/phoenix_live_view/phoenix_live_view_test.exs
+++ b/test/phoenix_live_view/phoenix_live_view_test.exs
@@ -194,10 +194,9 @@ defmodule Phoenix.LiveView.LiveViewTest do
 
     @key_i 73
     @key_d 68
-    test "render_key|press|up|down", %{view: view} do
+    test "render_key|up|down", %{view: view} do
       {:ok, view, _} = mount(view)
       assert render(view) =~ "The temp is: 1"
-      assert render_keypress(view, :key, @key_i) =~ "The temp is: 2"
       assert render_keydown(view, :key, @key_d) =~ "The temp is: 1"
       assert render_keyup(view, :key, @key_d) =~ "The temp is: 0"
       assert render(view) =~ "The temp is: 0"


### PR DESCRIPTION
[The `keypress` event is deprecated](https://developer.mozilla.org/en-US/docs/Web/Events/keypress). 

While a not trivial change, I figured it was better to get ahead of it _before_ any official release happened.