### PR TITLE
Use @down_key in example

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -328,7 +328,7 @@ defmodule Phoenix.LiveView do
         {:noreply, assign(socket, :temperature, new_temp)}
       end
 
-      def handle_event("update_temp", _key, socket) do
+      def handle_event("update_temp", @down_key, socket) do
         {:ok, new_temp} = Thermostat.dec_temperature(socket.assigns.id)
         {:noreply, assign(socket, :temperature, new_temp)}
       end


### PR DESCRIPTION
Currently the example will allow any key other than the `@up_key` to decrement the temperature. Because there is also a catch-all keypress handler defined, I think this is supposed to pattern match on the `@down_key`.

If it really should allow for any key, the catch-all definition should be removed since this one is currently a catch-all.