### PR TITLE
allow multiple events on a single node

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -781,8 +781,7 @@ class View {
       if(currentEvent){ eventCallback(currentEvent) }
     }
 
-    if(phxEvent && !el.getAttribute(PHX_BOUND) && this.ownsElement(el)){
-      el.setAttribute(PHX_BOUND, true)
+    if(phxEvent && this.ownsElement(el)){
       callback(getEvent)
     }
   }

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -486,6 +486,7 @@ class View {
     this.gracefullyClosed = false
     this.el = el
     this.prevKey = null
+    this.prevKind = null
     this.bindingPrefix = liveSocket.getBindingPrefix()
     this.loader = this.el.nextElementSibling
     this.id = this.el.id
@@ -626,7 +627,7 @@ class View {
   }
 
   pushKey(keyElement, kind, event, phxEvent){
-    if(this.prevKey === event.key){ return }
+    if(this.prevKey === event.key && this.prevKind === kind){ return }
     this.prevKey = event.key
     this.pushWithReply("event", {
       type: `key${kind}`,


### PR DESCRIPTION
This is an attempt to fix #94. I don't have the context here, so please correct me if this is wrong. I'm assuming you were tracking this for a good reason, so we can discuss better ways to handle this.

The problem here is two-fold. First, the node is marked as being bound, so when the next event comes through, it doesn't get re-bound. Once that problem is solved, it then fails to pass the `prevKey` check, so I added a `prevKind` as well. 

Side note on line 629: I would think that if I created a handler on keydown that i could repeatedly press the up arrow and get each key press, but this line shuts that down. In the situation of the thermostat example, if I bound the up key to increase the temp, I wouldn't be able to press up more than once. Am I understanding that right? If so, that smells like a bug imo. 

Thanks for the library! Hope this is helpful. 