### PR TITLE
Fix arg error for configured_signing_salt!

### DIFF
--- a/lib/phoenix_live_view/view.ex
+++ b/lib/phoenix_live_view/view.ex
@@ -228,7 +228,7 @@ defmodule Phoenix.LiveView.View do
 
       Add the following LiveView configuration to your config/config.exs:
 
-          config :my_app, MyApp.Endpoint,
+          config :my_app, MyAppWeb.Endpoint,
               ...,
               live_view: [signing_salt: "#{random_signing_salt()}"]
 


### PR DESCRIPTION
Fixes #97 

The correct config should be at `MyAppWeb.Endpoint`, not `MyApp.Endpoint`.