### PR TITLE
suppress dialyzer wanrings in generated code for ~L sigil

### DIFF
--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -309,7 +309,7 @@ defmodule Phoenix.LiveView.Engine do
 
   ## Optimize possible expressions into live structs (rendered / comprehensions)
 
-  @extra_clauses (quote do
+  @extra_clauses (quote generated: true do
                     %{__struct__: Phoenix.LiveView.Rendered} = other -> other
                   end)
 


### PR DESCRIPTION
code, generated by `~L` sigil contains chunks of code like this: 

```elixir
      case(
        if(Phoenix.LiveView.Engine.fetch_assign!(assigns, :tick) == 200) do
          "selected"
        else
          ""
        end
      ) do
        %{__struct__: Phoenix.LiveView.Rendered} = other ->
          other

        {:safe, data} ->
          data

        bin when is_binary(bin) ->
          Plug.HTML.html_escape_to_iodata(bin)

        other ->
          Phoenix.HTML.Safe.to_iodata(other)
      end
```

and for Dialyzer it's obvious that first clause here will never match. This is valid warning, and this PR just suppress it, because currently it's too hard to infer case expression argument type in compile time.