### PR TITLE
Fixes binding error

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -355,7 +355,11 @@ export class LiveSocket {
       let bindTarget = this.binding("target")
       window.addEventListener(type, e => {
         if(e.target.getAttribute(binding) && !e.target.getAttribute(bindTarget)){
-          this.owner(e.target, view => view.pushKey(el, type, e, phxEvent))
+          this.owner(e.target, view => {
+            let el = e.target
+            let phxEvent = el.getAttribute(binding)
+            view.pushKey(el, type, e, phxEvent)
+          })
         } else {
           document.querySelectorAll(`[${binding}][${bindTarget}=window]`).forEach(el => {
             let phxEvent = el.getAttribute(binding)

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -359,10 +359,13 @@ export class LiveSocket {
           let phxEvent = el.getAttribute(binding)
           this.owner(el, view => view.pushKey(el, type, e, phxEvent))
         } else {
-          document.querySelectorAll(`[${binding}][${bindTarget}=window]`).forEach(el => {
-            let phxEvent = el.getAttribute(binding)
-            this.owner(el, view => view.pushKey(el, type, e, phxEvent))
-          })
+          let target = e.target.getAttribute(bindTarget)
+          if(target === 'document' || target === 'window') {
+            document.querySelectorAll(`[${binding}][${bindTarget}=${target}]`).forEach(el => {
+              let phxEvent = el.getAttribute(binding)
+              this.owner(el, view => view.pushKey(el, type, e, phxEvent))
+            })
+          }
         }
       }, true)
     }

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -355,11 +355,9 @@ export class LiveSocket {
       let bindTarget = this.binding("target")
       window.addEventListener(type, e => {
         if(e.target.getAttribute(binding) && !e.target.getAttribute(bindTarget)){
-          this.owner(e.target, view => {
-            let el = e.target
-            let phxEvent = el.getAttribute(binding)
-            view.pushKey(el, type, e, phxEvent)
-          })
+          let el = e.target
+          let phxEvent = el.getAttribute(binding)
+          this.owner(el, view => view.pushKey(el, type, e, phxEvent))
         } else {
           document.querySelectorAll(`[${binding}][${bindTarget}=window]`).forEach(el => {
             let phxEvent = el.getAttribute(binding)


### PR DESCRIPTION
There was an error with binding the key events if no target was specified. No element was given and thus no `phxEvent`.

Relatedly, we were not handling cases where a handler was given (e.g., `phx-keyup`) _and_ a `phx-target` that was the ID of another dom element. 

As written, we _do not handle_ the case where an element has a `phx-target` attribute and _no_ `phx-[handler]`; presumably that would be a situation in which it _should_ fail with a JS error. 

I believe this fixes #115 .