### PR TITLE
Update example for Controller.live_render/3

### DIFF
--- a/lib/phoenix_live_view/controller.ex
+++ b/lib/phoenix_live_view/controller.ex
@@ -22,11 +22,12 @@ defmodule Phoenix.LiveView.Controller do
 
   ## Examples
 
-      alias Phoenix.LiveView
+      defmodule ThermostatController do
+        ...
+        import Phoenix.LiveView.Controller
 
-      def ThermostatController do
         def show(conn, %{"id" => thermostat_id}) do
-          LiveView.Controller.live_render(conn, ThermostatLive, session: %{
+          live_render(conn, ThermostatLive, session: %{
             thermostat_id: id,
             current_user_id: get_session(conn, :user_id),
           })


### PR DESCRIPTION
The existing example for `Phoenix.LiveView.Controller.live_render/3` didn't look like valid elixir code. This updates the example to look like the one in `Phoenix.LiveView`'s moduledoc:

https://github.com/phoenixframework/phoenix_live_view/blob/92e4fd9fe15dcf639c97e7daef80f3cf30505dc3/lib/phoenix_live_view.ex#L215-L225

If you have other changes you'd like to see in this example, I'd be happy to make additional updates.