### PR TITLE
Add "use Phoenix.LiveView" in examples

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -148,6 +148,8 @@ defmodule Phoenix.LiveView do
   First, a LiveView requires two callbacks: `mount/2` and `render/1`:
 
       defmodule AppWeb.ThermostatLive do
+        use Phoenix.LiveView
+
         def render(assigns) do
           ~L\"""
           Current temperature: <%= @temperature %>
@@ -175,6 +177,8 @@ defmodule Phoenix.LiveView do
   module in your application. For example:
 
       defmodule AppWeb.ThermostatLive do
+        use Phoenix.LiveView
+
         def render(assigns) do
           AppWeb.PageView.render("page.html", assigns)
         end


### PR DESCRIPTION
From all of the LiveView modules in `test/support` it looks like we're supposed to add `use Phoenix.LiveView` to our modules as well. This updates the examples accordingly.