### PR TITLE
Address scenario where :log_join is not provided by %Phoenix.Socket

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -178,6 +178,7 @@ defmodule Phoenix.LiveView.Channel do
 
   defp log_mount(%Phoenix.Socket{private: %{log_join: false}}, _), do: :noop
   defp log_mount(%Phoenix.Socket{private: %{log_join: level}}, func), do: Logger.log(level, func)
+  defp log_mount(%Phoenix.Socket{private: _}, _), do: :noop
 
   defp reply(state, ref, status, payload) do
     reply_ref = {state.transport_pid, state.serializer, state.topic, ref, state.join_ref}


### PR DESCRIPTION
During a recent upgrade of components, the following error was bring observed

```
[error] GenServer #PID<0.403.0> terminating
** (FunctionClauseError) no function clause matching in Phoenix.LiveView.Channel.log_mount/2
    (phoenix_live_view) lib/phoenix_live_view/channel.ex:179: Phoenix.LiveView.Channel.log_mount(%Phoenix.Socket{assigns: %{}, channel: Phoenix.LiveView.Channel, channel_pid: nil, endpoint: HangmanWeb.Endpoint, handler: Phoenix.LiveView.Socket, id: nil, join_ref: "118", joined: false, private: %{}, pubsub_server: Hangman.PubSub, ref: nil, serializer: Phoenix.Socket.V2.JSONSerializer, topic: "lv:phx-gvdrSfdsJvM=", transport: :websocket, transport_pid: #PID<0.388.0>}, #Function<0.76975216/0 in Phoenix.LiveView.Channel.join/1>)
    (phoenix_live_view) lib/phoenix_live_view/channel.ex:201: Phoenix.LiveView.Channel.join/1
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: {:join, Phoenix.LiveView.Channel}
State: {%{"session" => "SFMyNTY.g3QAAAACZAAEZGF0YW0AAACQZzNRQUFBQUVaQUFDYVdSdEFBQUFFSEJvZUMxbmRtUnlVMlprYzBwMlRUMWtBQXB3WVhKbGJuUmZjR2xrWkFBRGJtbHNaQUFIYzJWemMybHZiblFBQUFBQVpBQUVkbWxsZDJRQUlFVnNhWGhwY2k1RmJYQmxlR3h2WjI5WFpXSXVVR0ZuWlV4cGRtVldhV1YzZAAGc2lnbmVkbgYASa3q1GkB.KbYipUCr9C0AFzDFSDPrJYhg1bWvMzopJW6YtE8wqCA"}, {#PID<0.388.0>, #Reference<0.3363977473.1562378243.177672>}, %Phoenix.Socket{assigns: %{}, channel: Phoenix.LiveView.Channel, channel_pid: nil, endpoint: HangmanWeb.Endpoint, handler: Phoenix.LiveView.Socket, id: nil, join_ref: "118", joined: false, private: %{}, pubsub_server: Hangman.PubSub, ref: nil, serializer: Phoenix.Socket.V2.JSONSerializer, topic: "lv:phx-gvdrSfdsJvM=", transport: :websocket, transport_pid: #PID<0.388.0>}}
[error] an exception was raised:
    ** (FunctionClauseError) no function clause matching in Phoenix.LiveView.Channel.log_mount/2
        (phoenix_live_view) lib/phoenix_live_view/channel.ex:179: Phoenix.LiveView.Channel.log_mount(%Phoenix.Socket{assigns: %{}, channel: Phoenix.LiveView.Channel, channel_pid: nil, endpoint: HangmanWeb.Endpoint, handler: Phoenix.LiveView.Socket, id: nil, join_ref: "118", joined: false, private: %{}, pubsub_server: Hangman.PubSub, ref: nil, serializer: Phoenix.Socket.V2.JSONSerializer, topic: "lv:phx-gvdrSfdsJvM=", transport: :websocket, transport_pid: #PID<0.388.0>}, #Function<0.76975216/0 in Phoenix.LiveView.Channel.join/1>)
        (phoenix_live_view) lib/phoenix_live_view/channel.ex:201: Phoenix.LiveView.Channel.join/1
        (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
        (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
        (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```

When poking at the data, I observed that socket data is not align with the `log_mount`

```
defp log_mount(%Phoenix.Socket{private: %{log_join: false}}, _), do: :noop
defp log_mount(%Phoenix.Socket{private: %{log_join: level}}, func), do: Logger.log(level, func)
```

There was no log_join information.

This change addresses the symptom, I am not sure if there's a separate change that I need
to make to avoid adding a second `:noop` match.

```
defp log_mount(%Phoenix.Socket{private: _}, _), do: :noop
```