### PR TITLE
properly handle down messages

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -33,8 +33,7 @@ defmodule Phoenix.LiveView.Channel do
     {:stop, reason, state}
   end
 
-  def handle_info({:DOWN, _, :process, parent, reason}, state) do
-    ^parent = state.socket.parent_pid
+  def handle_info({:DOWN, _, :process, parent, reason}, %{socket: %{parent_pid: parent}} = state) do
     send(state.transport_pid, {:socket_close, self(), reason})
 
     {:stop, reason, state}


### PR DESCRIPTION
If the live process monitors another process, down message is not correctly forwarded, because the channel always assumes that the parent process has terminated. As a result, the channel process will crash if a down message from a non-parent is received.

This commit switches to pattern matching which resolves the crash, and also properly forwards down messages to callback handle_info.