### PR TITLE
Allow form_for with @socket

### DIFF
--- a/lib/phoenix_live_view/html.ex
+++ b/lib/phoenix_live_view/html.ex
@@ -1,0 +1,93 @@
+if Code.ensure_loaded?(Phoenix.HTML) do
+  defimpl Phoenix.HTML.FormData, for: Phoenix.LiveView.Socket do
+    def to_form(socket, opts) do
+      params = Keyword.get(opts, :params, %{})
+      name = Keyword.fetch!(opts, :name)|| raise "name expected when using a socket form"
+      opts = Keyword.drop(opts, [:params, :name])
+      {errors, opts} = Keyword.pop(opts, :errors, [])
+
+      %Phoenix.HTML.Form{
+        source: socket,
+        impl: __MODULE__,
+        id: name,
+        name: name,
+        params: params,
+        data: %{},
+        errors: errors,
+        options: opts
+      }
+    end
+
+    def to_form(socket, form, field, opts) when is_atom(field) or is_binary(field) do
+      {default, opts} = Keyword.pop(opts, :default, %{})
+      {prepend, opts} = Keyword.pop(opts, :prepend, [])
+      {append, opts} = Keyword.pop(opts, :append, [])
+      {name, opts} = Keyword.pop(opts, :as)
+      {id, opts} = Keyword.pop(opts, :id)
+
+      id = to_string(id || form.id <> "_#{field}")
+      name = to_string(name || form.name <> "[#{field}]")
+      params = Map.get(form.params, field_to_string(field))
+
+      cond do
+        # cardinality: one
+        is_map(default) ->
+          [
+            %Phoenix.HTML.Form{
+              source: socket,
+              impl: __MODULE__,
+              id: id,
+              name: name,
+              data: default,
+              params: params || %{},
+              options: opts
+            }
+          ]
+
+          # cardinality: many
+        is_list(default) ->
+          entries =
+          if params do
+            params
+            |> Enum.sort_by(&elem(&1, 0))
+            |> Enum.map(&{nil, elem(&1, 1)})
+          else
+            Enum.map(prepend ++ default ++ append, &{&1, %{}})
+          end
+
+          for {{data, params}, index} <- Enum.with_index(entries) do
+            index_string = Integer.to_string(index)
+
+            %Phoenix.HTML.Form{
+              source: socket,
+              impl: __MODULE__,
+              index: index,
+              id: id <> "_" <> index_string,
+              name: name <> "[" <> index_string <> "]",
+              data: data,
+              params: params,
+              options: opts
+            }
+          end
+      end
+    end
+
+    def input_value(_socket, %{data: data, params: params}, field)
+    when is_atom(field) or is_binary(field) do
+      case Map.fetch(params, field_to_string(field)) do
+        {:ok, value} ->
+          value
+
+        :error ->
+          Map.get(data, field)
+      end
+    end
+
+    def input_type(_socket, _form, _field), do: :text_input
+    def input_validations(_socket, _form, _field), do: []
+
+    # Normalize field name to string version
+    defp field_to_string(field) when is_atom(field), do: Atom.to_string(field)
+    defp field_to_string(field) when is_binary(field), do: field
+  end
+end

--- a/test/phoenix_live_view/html_test.exs
+++ b/test/phoenix_live_view/html_test.exs
@@ -1,0 +1,59 @@
+defmodule Phoenix.LiveView.HTMLTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.HTML
+  import Phoenix.HTML.Form
+
+  defp safe_form_for(socket, opts \\ [name: "user"], function) do
+    safe_to_string(form_for(socket, "#", opts, function))
+  end
+
+  defp new_socket() do
+    %Phoenix.LiveView.Socket{}
+  end
+
+  describe "form_for/4" do
+    test "with new socket" do
+      socket = new_socket()
+
+      form =
+      safe_form_for(socket, fn f ->
+        assert f.id == "user"
+        assert f.name == "user"
+        assert f.impl == Phoenix.HTML.FormData.Phoenix.LiveView.Socket
+        assert f.source == socket
+        assert f.params == %{}
+        assert f.hidden == []
+        "FROM FORM"
+      end)
+
+      assert form =~ ~s(<form accept-charset="UTF-8" action="#" method="post">)
+      assert form =~ "FROM FORM"
+    end
+
+    test "with inputs" do
+      socket = new_socket()
+      params = %{"name" => "CM"}
+      form =
+      safe_form_for(socket, [name: "user", params: params], fn f ->
+        [text_input(f, :name), text_input(f, :other)]
+      end)
+
+      assert form =~ ~s(<input id="user_name" name="user[name]" type="text" value="CM">)
+      assert form =~ ~s(<input id="user_other" name="user[other]" type="text">)
+    end
+
+
+    test "with errors" do
+      socket = new_socket()
+      errors = [name: {"should be at least %{count} character(s)", count: 3}]
+      form =
+      safe_form_for(socket, [name: "user", errors: errors], fn f ->
+        assert f.errors == errors
+        "FROM FORM"
+      end)
+
+      assert form =~ "FROM FORM"
+    end
+  end
+end


### PR DESCRIPTION
The phoenix_html package ships with a default implementation of the
Phoenix.HTML.FormData struct for Plug.Conn, which allows the following:

    form_for @conn, "/", fn f ->

Currently, the only way to use `form_for` with Live View is to use a
library which provides an implementation for the FormData protocol (such
as phoenix_ecto for ecto changesets)

This commit adds an implementation of the FormData protocol (if
phoenix_html is available) allowing for:

    form_for @socket, "/", [name: "user"], fn f ->

This works in the same way as the implementation for Plug.Conn with the
following exceptions:

 * A name must be provided as an option
 * The params can be passed via options, allowing for default values,
   since there is no equivalent of `conn.params` on a socket.