### PR TITLE
Morphdom 2.5.2 containing fix for wrong select option getting selected

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -12,7 +12,7 @@
     "test.watch": "jest --watch"
   },
   "dependencies": {
-    "morphdom": "2.5.0",
+    "morphdom": "2.5.2",
     "phoenix": "file:../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html"
   },


### PR DESCRIPTION
Since patching elements like Select && Option happen at the end of the morphing phase, there was an issue updating the html with new options that came from the server.  This fixed it.

(note can you push up an updated lockfile?  I don't know how to pin it without updating all the other deps)

https://github.com/patrick-steele-idem/morphdom/pull/117
https://github.com/patrick-steele-idem/morphdom/blob/master/CHANGELOG.md#252