### PR TITLE
Fix JS to respect user implemented container classes

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -102,7 +102,7 @@ container:
   - `"phx-connected"` - applied when the view has connected to the server
   - `"phx-disconnected"` - applied when the view is not connected to the server
   - `"phx-error"` - applied when an error occurs on the server. Note, this
-    class will be applied in conjunction with `"phx-disconnected"` connection
+    class will be applied in conjunction with `"phx-disconnected"` if connection
     to the server is lost.
 
 When a form bound with `phx-submit` is submitted, the `phx-loading` class
@@ -682,9 +682,18 @@ export class View {
     this.loader.style.display = "none"
   }
 
+  setContainerClasses(...classes){
+    this.el.classList.remove(
+      PHX_CONNECTED_CLASS,
+      PHX_DISCONNECTED_CLASS,
+      PHX_ERROR_CLASS
+    )
+    this.el.classList.add(...classes)
+  }
+
   showLoader(){
     clearTimeout(this.loaderTimer)
-    this.el.classList = PHX_DISCONNECTED_CLASS
+    this.setContainerClasses(PHX_DISCONNECTED_CLASS)
     this.loader.style.display = "block"
     let middle = Math.floor(this.el.clientHeight / LOADER_ZOOM)
     this.loader.style.top = `-${middle}px`
@@ -698,7 +707,7 @@ export class View {
     this.log("join", () => ["", JSON.stringify(rendered)])
     this.rendered = rendered
     this.hideLoader()
-    this.el.classList = PHX_CONNECTED_CLASS
+    this.setContainerClasses(PHX_CONNECTED_CLASS)
     DOM.patch(this, this.el, this.id, Rendered.toString(this.rendered))
     this.joinNewChildren()
   }
@@ -771,7 +780,7 @@ export class View {
 
   displayError(){
     this.showLoader()
-    this.el.classList = `${PHX_DISCONNECTED_CLASS} ${PHX_ERROR_CLASS}`
+    this.setContainerClasses(PHX_DISCONNECTED_CLASS, PHX_ERROR_CLASS)
   }
 
   pushWithReply(event, payload, onReply = function(){ }){

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -5,6 +5,7 @@ function liveViewDOM() {
   div.setAttribute('data-phx-view', '');
   div.setAttribute('data-phx-session', 'abc123');
   div.setAttribute('id', 'container');
+  div.setAttribute('class', 'user-implemented-class');
   div.innerHTML = `
     <label for="plus">Plus</label>
     <input id="plus" value="1" />
@@ -87,6 +88,8 @@ describe('View', function() {
     let view = new View(el, liveSocket);
     view.showLoader();
     expect(el.classList.contains('phx-disconnected')).toBeTruthy();
+    expect(el.classList.contains('phx-connected')).toBeFalsy();
+    expect(el.classList.contains('user-implemented-class')).toBeTruthy();
     expect(loader.style.display).toEqual('block');
 
     view.hideLoader();
@@ -104,6 +107,8 @@ describe('View', function() {
     view.displayError();
     expect(el.classList.contains('phx-disconnected')).toBeTruthy();
     expect(el.classList.contains('phx-error')).toBeTruthy();
+    expect(el.classList.contains('phx-connected')).toBeFalsy();
+    expect(el.classList.contains('user-implemented-class')).toBeTruthy();
     expect(loader.style.display).toEqual('block');
   });
 


### PR DESCRIPTION
**Problem**

1) #170: Previously when users defined their own container element to use as the Phoenix Live container, any class attribute defined would be overridden by the JS client library on connection, disconnection and error.

2) #179: `element.classList` is a [read-only property](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList), and we write to it in multiple places causing issues for some browsers.

**Solution**

With this change, the client library only controls classes it "owns" and thus any existing defined classes are left untouched by the lifecycle process. On top of that, `classList` is never written to directly.

Solves #170 and (partially) #179.