### PR TITLE
Mention registration of `leex` template engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ config :my_app, MyAppWeb.Endpoint,
    ]
 ```
 
+In order to write LiveView templates in their own `.leex` template files, you'll need to register the LiveLiew template engine. This step is optional, but if you don't do it, you'll have to write all LiveView templates using the `~L` sigil.
+
+```elixir
+# config/config.exs
+config :phoenix,
+  template_engines: [leex: Phoenix.LiveView.Engine]
+```
+
 Next, add the LiveView flash plug to your browser pipeline, after `:fetch_flash`:
 
 ```elixir


### PR DESCRIPTION
I think although this is an optional step, and does make the "quick start" a little longer, it may be worth mentioning registration of `leex` template engine. If folks follow this readme, then dive straight into the examples, they may be confused as to why their `.leex` templates aren't being discovered.