### PR TITLE
Include documentation on importing the live_render in the controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ Then add the following imports to your web file in `lib/my_app_web.ex`:
 ```elixir
 # lib/my_app_web.ex
 
+def controller do
+  quote do
+    ...
+    import Phoenix.LiveView.Controller, only: [live_render: 3]
+  end
+end
+
 def view do
   quote do
     ...


### PR DESCRIPTION
Based on question posed here
https://github.com/phoenixframework/phoenix/pull/3376#discussion_r275772263

I am updating the documentation to suggest that the controller also get the `live_render` method directly available in the controller.