### PR TITLE
Fix URLSearchParams constructor call on Edge

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -176,7 +176,13 @@ let maybe = (el, key) => {
 }
 
 let serializeForm = (form) => {
-  return((new URLSearchParams(new FormData(form))).toString())
+  // Display the key/value pairs
+  let form_data = new FormData(form);
+  let url_search_params = new URLSearchParams();
+  for(let pair of form_data.entries()) {
+     url_search_params.set(pair[0], pair[1]);
+  }
+  return url_search_params.toString();
 }
 
 let recursiveMerge = (target, source) => {


### PR DESCRIPTION
Edge doesn't seem to like receiving a FormData object in the
constructor for the URLSearchParams class.

I haven't attempted to fix the IsPersonal error, or compatibility
with IE11.

Fixes #191.