### PR TITLE
Fix layout not getting same assigns as the view

### DIFF
--- a/lib/phoenix_live_view/controller.ex
+++ b/lib/phoenix_live_view/controller.ex
@@ -37,8 +37,8 @@ defmodule Phoenix.LiveView.Controller do
   """
   def live_render(%Plug.Conn{} = conn, view, opts) do
     case LiveView.View.static_render(conn, view, opts) do
-      {:ok, content} ->
-        conn
+      {:ok, {assigns, content}} ->
+        %{conn | assigns: assigns}
         |> Plug.Conn.assign(:live_view_module, view)
         |> Phoenix.Controller.put_view(__MODULE__)
         |> Phoenix.Controller.render("template.html", %{

--- a/lib/phoenix_live_view/view.ex
+++ b/lib/phoenix_live_view/view.ex
@@ -210,7 +210,7 @@ defmodule Phoenix.LiveView.View do
         <% end %>
         <div class="phx-loader"></div>
         """
-        {:ok, html}
+        {:ok, {socket.assigns, html}}
 
       {:stop, reason} -> {:stop, reason}
     end


### PR DESCRIPTION
Issue: #207. 

When we do the `static_mount`, hang on to the assigns so we can also pass them to the layout, not just the view.
