### PR TITLE
Support scroll event

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -61,7 +61,7 @@ otherwise the input's value will be used. For example:
 
 The scroll events are supported via the `phx-scroll` binding.
 By default, the bound element will be the event listener, but an
-optional `phx-target` may be provided which may be `"document"`
+optional `phx-target` may be provided which may be `"window"`
 to track the entire page scroll.
 
 When pushed, the value sent to the server will be scrollTop
@@ -487,7 +487,7 @@ export class LiveSocket {
 
       // Process global scroll
       if(e.target == document) {
-        all(document, `[${bindScroll}][${bindTarget}=document]`, el => {
+        all(document, `[${bindScroll}][${bindTarget}=window]`, el => {
           let documentEl = e.target.documentElement
           let phxEvent = el.getAttribute(bindScroll)
           this.owner(el, view => view.pushScroll(documentEl, phxEvent))
@@ -500,7 +500,7 @@ export class LiveSocket {
       if(!target) { return }
 
       let phxTarget = target.getAttribute(bindTarget)
-      if(phxTarget == "document") { return }
+      if(phxTarget == "window") { return }
 
       let phxEvent = target.getAttribute(bindScroll)
       if(!phxEvent) { return }

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -482,31 +482,30 @@ export class LiveSocket {
 
   bindScroll(){
     window.addEventListener("scroll", e => {
-      let binding = this.binding("scroll")
       let bindTarget = this.binding("target")
-      let scroll = this.binding("scroll")
+      let bindScroll = this.binding("scroll")
 
+      // Process global scroll
       if(e.target == document) {
-        // Process global scroll
-        document.querySelectorAll(`[${binding}][${bindTarget}=document]`).forEach(el => {
+        all(document, `[${bindScroll}][${bindTarget}=document]`, el => {
           let documentEl = e.target.documentElement
-          let phxEvent = el.getAttribute(scroll)
-          this.owner(el, view => view.pushScroll(
-            e.target,
-            phxEvent,
-            documentEl.scrollTop,
-            documentEl.scrollLeft
-          ))
+          let phxEvent = el.getAttribute(bindScroll)
+          this.owner(el, view => view.pushScroll(documentEl, phxEvent))
         })
-      } else {
-        // Process bound element scroll
-        let target = closestPhxBinding(e.target, scroll)
-        let phxEvent = target && target.getAttribute(scroll)
-        if(!phxEvent){ return }
-        e.preventDefault()
-        let el = e.target
-        this.owner(e.target, view => view.pushScroll(e.target, phxEvent, el.scrollTop, el.scrollLeft))
+        return
       }
+
+      // Process bound element scroll
+      let target = closestPhxBinding(e.target, bindScroll)
+      if(!target) { return }
+
+      let phxTarget = target.getAttribute(bindTarget)
+      if(phxTarget == "document") { return }
+
+      let phxEvent = target.getAttribute(bindScroll)
+      if(!phxEvent) { return }
+
+      this.owner(e.target, view => view.pushScroll(e.target, phxEvent))
     }, true)
   }
 
@@ -881,13 +880,13 @@ export class View {
     }, onReply)
   }
 
-  pushScroll(scrollElement, phxEvent, scrollTop, scrollLeft){
+  pushScroll(scrollElement, phxEvent){
     this.pushWithReply("event", {
       type: "scroll",
       event: phxEvent,
       value: {
-        scrollTop: scrollTop,
-        scrollLeft: scrollLeft
+        scrollTop: scrollElement.scrollTop,
+        scrollLeft: scrollElement.scrollLeft
       }
     })
   }


### PR DESCRIPTION
Add `phx-scroll` binding for handle JavaScript scroll event. 
This is required to implement infinite scrolling or animations when scrolling.