### PR TITLE
Force an upgrade of the 'same' version

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ Then install the new npm dependency.
 npm install --prefix assets
 ```
 
+If you had previously installed phoenix_live_view and want to get the
+latest javascript, then force an install.
+
+```bash
+(cd assets && npm install --force phoenix_live_view)
+```
+
 Enable connecting to a LiveView socket in your `app.js` file.
 
 ```javascript


### PR DESCRIPTION
I believe because the version isn't changing, you have to force an install to get the latest javascript.  Note that I could not get the `--prefix` to work so instead opted for (`cd assets && ... `)

The output should look similar to

```
$ (cd assets && npm install --force phoenix_live_view)
npm WARN using --force I sure hope you know what you are doing.
/Users/aforward/sin/projects/current/payday/dividends/assets
└── phoenix_live_view@0.1.0-dev 

npm WARN assets No description
```