### PR TITLE
Make handle_info's typespec more accurate

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -515,7 +515,7 @@ defmodule Phoenix.LiveView do
               {:noreply, Socket.t()} | {:reply, term, Socket.t()} | {:stop, Socket.t()}
 
   @callback handle_info(msg :: term, Socket.t()) ::
-              {:noreply, Socket.t()} | {:reply, term, Socket.t()} | {:stop, Socket.t()}
+              {:noreply, Socket.t()} | {:stop, Socket.t()}
 
   @optional_callbacks terminate: 2, handle_event: 3, handle_call: 3, handle_info: 2
 


### PR DESCRIPTION
`Phoenix.LiveView.Channel` does not seem to handle `:reply` in the `handle_info/2` callback. This also matches the behaviour of GenServer which does not support `:reply` in `handle_info/2`.