### PR TITLE
Update assert_remove/3 typo in documentation

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -91,7 +91,7 @@ defmodule Phoenix.LiveViewTest do
   ## Testing shutdowns and stopping views
 
   Like all processes, views can shutdown normally or abnormally, and this
-  can be tested with `assert_removed/3`. For example:
+  can be tested with `assert_remove/3`. For example:
 
       send(view.pid, :boom)
       assert_remove view, {:shutdown, %RuntimeError{}}


### PR DESCRIPTION
Should be `assert_remove` instead of `assert_removed`