### PR TITLE
WIP - handle redirect + flash from initial lv mount

### DIFF
--- a/lib/phoenix_live_view/controller.ex
+++ b/lib/phoenix_live_view/controller.ex
@@ -45,7 +45,15 @@ defmodule Phoenix.LiveView.Controller do
         })
 
       {:stop, {:redirect, opts}} ->
-        Phoenix.Controller.redirect(conn, to: Map.fetch!(opts, :to))
+        if Map.get(conn.private, :phoenix_flash) do
+          (Map.get(opts, :flash) || %{})
+          |> Enum.reduce(conn, fn {k, v}, conn ->
+            Phoenix.Controller.put_flash(conn, k, v)
+          end)
+          |> Phoenix.Controller.redirect(to: Map.fetch!(opts, :to))
+        else
+          Phoenix.Controller.redirect(conn, to: Map.fetch!(opts, :to))
+        end
     end
   end
 

--- a/lib/phoenix_live_view/view.ex
+++ b/lib/phoenix_live_view/view.ex
@@ -335,6 +335,9 @@ defmodule Phoenix.LiveView.View do
         session_token = sign_root_session(socket, view, session)
         {:ok, new_socket, session_token}
 
+      {:stop, %Socket{stopped: {:redirect, opts}} = socket} when is_map(opts) ->
+        {:stop, {:redirect, Map.put(opts, :flash, Phoenix.LiveView.View.get_flash(socket))}}
+
       {:stop, socket} ->
         {:stop, socket.stopped}
 


### PR DESCRIPTION
A live view may need to redirect with a flash message during mount - for
instance, if it's a "live show" view and determines that the current
user does not have access to the resource to be displayed.

Previously, the flash message was discarded in that case. This commit
begins adding support for displaying the flash message after
redirecting.

It does not yet have tests, and does not yet handle the case where the
redirect happens after the client has connected.