### PR TITLE
A couple of proposed changes to the live navigation feature

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -313,11 +313,11 @@ export class LiveSocket {
     })
   }
 
-  replaceRoot(href, linkRef = this.setPendingLink(href)){
+  replaceRoot(href, callback = null, linkRef = this.setPendingLink(href)){
     this.root.showLoader(LOADER_TIMEOUT)
     Browser.fetchPage(href, (status, html) => {
       if(status !== 200){ return Browser.redirect(href) }
-      
+
       let div = document.createElement("div")
       div.innerHTML = html
       this.joinView(div.firstChild, null, href, newRoot => {
@@ -325,7 +325,7 @@ export class LiveSocket {
           newRoot.destroy()
           return
         }
-        Browser.pushState("push", {}, href)
+        callback && callback()
         let rootEl = this.root.el
         let wasLoading = this.root.isLoading()
         this.destroyViewById(this.root.id)
@@ -427,7 +427,7 @@ export class LiveSocket {
 
   }
 
-  setPendingLink(href){ 
+  setPendingLink(href){
     this.linkRef++
     let ref = this.linkRef
     this.pendingLink = href
@@ -560,7 +560,7 @@ export let Browser = {
     req.onerror = () => callback(400)
     req.ontimeout = () => callback(504)
     req.onreadystatechange = () => {
-      if(req.readyState !== 4){ return } 
+      if(req.readyState !== 4){ return }
       if(req.getResponseHeader(LINK_HEADER) !== "live-link"){ return callback(400) }
       if(req.status !== 200){ return callback(req.status) }
       callback(200, req.responseText)
@@ -568,10 +568,9 @@ export let Browser = {
     req.send()
   },
 
-  pushState(kind, meta, to, callback){ 
+  pushState(kind, meta, to){
     if(this.canPushState()){
       if(to !== window.location.href){ history[kind + "State"](meta, "", to) }
-      callback && callback()
     } else {
       this.redirect(to)
     }
@@ -888,7 +887,7 @@ export class View {
     this.channel.on("diff", (diff) => this.update(diff))
     this.channel.on("redirect", ({to, flash}) => this.onRedirect({to, flash}))
     this.channel.on("live_redirect", ({to, kind}) => this.onLiveRedirect({to, kind}))
-    this.channel.on("external_live_redirect", ({to, kind}) => this.onExternalLiveRedirect(to))
+    this.channel.on("external_live_redirect", ({to, kind}) => this.onExternalLiveRedirect({to, kind}))
     this.channel.on("session", ({token}) => this.el.setAttribute(PHX_SESSION, token))
     this.channel.onError(reason => this.onError(reason))
     this.channel.onClose(() => this.onGracefulClose())
@@ -899,15 +898,12 @@ export class View {
     this.liveSocket.destroyViewById(this.id)
   }
 
-  onExternalLiveRedirect(href, linkRef){
-    if(linkRef){
-      this.liveSocket.replaceRoot(href, linkRef)
-    } else {
-      this.liveSocket.replaceRoot(href)
-    }
+  onExternalLiveRedirect({to, kind}){
+    this.liveSocket.replaceRoot(to, () => Browser.pushState(kind, {}, to))
   }
+
   onLiveRedirect({to, kind}){
-    this.liveSocket.root.pushInternalLink(to, () => Browser.pushState(kind, {}, to)) 
+    Browser.pushState(kind, {}, to)
   }
 
   onRedirect({to, flash}){ Browser.redirect(to, flash) }
@@ -931,10 +927,7 @@ export class View {
 
   onJoinError(resp){
     if(resp.redirect){ return this.onRedirect(resp.redirect) }
-    if(resp.external_live_redirect){
-      let {to} = resp.external_live_redirect
-      return this.onExternalLiveRedirect(to)
-    }
+    if(resp.external_live_redirect){ return this.onExternalLiveRedirect(resp.external_live_redirect) }
     this.displayError()
     this.log("error", () => ["unable to join", resp])
   }
@@ -959,8 +952,9 @@ export class View {
     return(
       this.channel.push(event, payload, PUSH_TIMEOUT).receive("ok", resp => {
         if(resp.diff){ this.update(resp.diff) }
+        if(resp.redirect){ this.onRedirect(resp.redirect) }
         if(resp.live_redirect){ this.onLiveRedirect(resp.live_redirect) }
-        if(resp.redirect && event !== "link"){ this.onRedirect(resp.redirect) }
+        if(resp.external_live_redirect){ this.onExternalLiveRedirect(resp.external_live_redirect) }
         onReply(resp)
       })
     )
@@ -1003,8 +997,8 @@ export class View {
     if(!this.isLoading()){ this.showLoader(LOADER_TIMEOUT) }
     let linkRef = this.liveSocket.setPendingLink(href)
     this.pushWithReply("link", {url: href}, resp => {
-      if(resp.redirect){
-        this.onExternalLiveRedirect(href, linkRef)
+      if(resp.link_redirect){
+        this.liveSocket.replaceRoot(to, callback, linkRef)
       } else if(this.liveSocket.commitPendingLink(linkRef)){
         this.href = href
         this.applyPendingUpdates()

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -69,7 +69,7 @@ defmodule Phoenix.LiveView.Channel do
         |> handle_result({:handle_params, 3, msg.ref}, new_state)
 
       :external ->
-        {:noreply, reply(state, msg.ref, :ok, %{redirect: true})}
+        {:noreply, reply(state, msg.ref, :ok, %{link_redirect: true})}
     end
   end
 
@@ -341,7 +341,7 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   defp push_external_live_redirect(state, %{to: _, kind: _} = opts, ref) do
-    reply(state, ref, :ok, %{redirect: opts})
+    reply(state, ref, :ok, %{external_live_redirect: opts})
   end
 
   defp maybe_changed(%Socket{} = socket) do


### PR DESCRIPTION
  1. `onLiveRedirect` should directly change the state since
     `handle_params/3` has already been called on the server

  2. Preserve "kind" (push/replace) on `onExternalLiveRedirect`

  3. Treat `external_live_redirect` as live redirects on replies