### PR TITLE
Update docs to send user_id in session from template

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -230,7 +230,7 @@ defmodule Phoenix.LiveView do
   You can also `live_render` from any template:
 
       <h1>Temperature Control</h1>
-      <%= Phoenix.LiveView.live_render(@conn, AppWeb.ThermostatLive, session: %{user: @user}) %>
+      <%= Phoenix.LiveView.live_render(@conn, AppWeb.ThermostatLive, session: %{user_id: @user.id}) %>
 
   Or you can `live_render` your view from any controller:
 


### PR DESCRIPTION
* Update docs to send user_id in session from template in `Phoenix.LiveView.live_render/3`
* Consistent with recommendation elsewhere to only send integers, strings, etc. in session