### PR TITLE
Update LiveViewTest docs

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -18,6 +18,7 @@ defmodule Phoenix.LiveViewTest do
   support testing both disconnected and connected mounts separately, for example:
 
       use Phoenix.ConnTest
+      import Phoenix.LiveViewTest
       @endpoint MyEndpoint
 
       test "disconnected and connected mount", %{conn: conn} do


### PR DESCRIPTION
* Update LiveViewTest docs with `import Phoenix.LiveViewTest`
* Examples using `LiveViewTest.live/1` as `{:ok, view, html} = live(conn)` need import
* Also applies to other functions called without module in the docs