### PR TITLE
Update example with fully-qualified namespace

### DIFF
--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -41,7 +41,7 @@ defmodule Phoenix.LiveView.Router do
 
           live "/thermostat", ThermostatLive
           live "/clock", ClockLive, session: [:path_params, :user_id]
-          live "/dashbaord, DashboardLive, layout: {AlternativeView, "app.html"}
+          live "/dashboard, DashboardLive, layout: {MyApp.AlternativeView, "app.html"}
         end
       end
 


### PR DESCRIPTION
The example uses the module name for layout as if `scope` were to work like an alias. The layout module needs to be aliased elsewhere or the fully qualified module needs to be used.