### PR TITLE
Adding support for iOS web apps

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -407,7 +407,8 @@ export class LiveSocket {
   }
 
   bindTopLevelEvents(){
-    this.bindClicks()
+    const clickListener = ("ontouchstart" in window) ? "touchstart" : "click"
+    this.bindClicks(clickListener)
     this.bindNav()
     this.bindForms()
     this.bindTargetable({keyup: "keyup", keydown: "keydown"}, (e, type, view, target, phxEvent, phxTarget) => {
@@ -424,7 +425,6 @@ export class LiveSocket {
         view.pushEvent(type, targetEl, phxEvent)
       }
     })
-
   }
 
   setPendingLink(href){ 
@@ -468,8 +468,8 @@ export class LiveSocket {
     }
   }
 
-  bindClicks(){
-    window.addEventListener("click", e => {
+  bindClicks(listener){
+    window.addEventListener(listener, e => {
       let click = this.binding("click")
       let target = closestPhxBinding(e.target, click)
       let phxEvent = target && target.getAttribute(click)


### PR DESCRIPTION
I am using live_view for a side project that is supposed to run as a PWA. 
It works great on desktop, but not in iOS safari. 
The `<button phx-click="event-name">` works as expected, but all the `<span phx-click="event-name">` stopped working on iOS.

I searched around and figured out this solution, and now my project runs perfectly on both desktop and iOS.