### PR TITLE
Implemented phx-click on tapping on iOS

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -493,10 +493,6 @@ export class LiveSocket {
       const el = e.target
 
       if (listener === "touchend") {
-        // not a tap
-        if (!el.classList.contains(TAP_START_CLASS)) return
-
-        // is a tap
         el.classList.remove(TAP_START_CLASS)
       }
 


### PR DESCRIPTION
Thanks @snewcomer for your feedback, I reimplemented it with

1. more accurate tapping behavior - a `touchend` that happens after a `touchstart` without any `touchmove` in between.
2. event on "touchend" instead of "touchstart", so the 300ms virtual wait won't be a problem.