### PR TITLE
Preserve opts in live_link/2

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -916,7 +916,11 @@ defmodule Phoenix.LiveView do
     replace = Keyword.get(opts, :replace, false)
     kind = if replace, do: "replace", else: "push"
 
-    Phoenix.HTML.Tag.content_tag(:a, [href: uri, data: [phx_live_link: kind]], do: block)
+    opts = opts
+    |> Keyword.update(:data, [phx_live_link: kind], &Keyword.merge(&1, [phx_live_link: kind]))
+    |> Keyword.put(:href, uri)
+
+    Phoenix.HTML.Tag.content_tag(:a, opts, do: block)
   end
   def live_link(text, opts) when is_list(opts) do
     live_link(opts, do: text)

--- a/test/phoenix_live_view/phoenix_live_view_test.exs
+++ b/test/phoenix_live_view/phoenix_live_view_test.exs
@@ -433,4 +433,24 @@ defmodule Phoenix.LiveView.LiveViewTest do
       assert msg =~ "attempted to live_redirect from a nested child socket"
     end
   end
+
+  describe "live_link" do
+    test "forwards dom attribute options" do
+      dom =
+        LiveView.live_link("next", to: "/", class: "btn btn-large", data: [page_number: 2])
+        |> Phoenix.HTML.safe_to_string()
+      assert dom =~ ~s|class="btn btn-large"|
+      assert dom =~ ~s|data-page-number="2"|
+    end
+
+    test "overwrites reserved options" do
+      dom =
+        LiveView.live_link("next", to: "page-1", href: "page-2", data: [phx_live_link: "other"])
+        |> Phoenix.HTML.safe_to_string()
+      assert dom =~ ~s|href="page-1"|
+      refute dom =~ ~s|href="page-2"|
+      assert dom =~ ~s|data-phx-live-link="push"|
+      refute dom =~ ~s|data-phx-live-link="other"|
+    end
+  end
 end


### PR DESCRIPTION
Hi Chris,

I want to be able to style `live_link/2`, this PR preserve the opts given to `live_link/2` and overrides the `data-phx-live-link` and `href` attributes if set.

Let me know what you think?

Signed-off-by: Benjamin Schultzer <benjamin@schultzer.com>