### PR TITLE
Fix error in live view plug when `x-requested-with` header is present.

### DIFF
--- a/lib/phoenix_live_view/plug.ex
+++ b/lib/phoenix_live_view/plug.ex
@@ -7,6 +7,7 @@ defmodule Phoenix.LiveView.Plug do
   @behaviour Plug
 
   @link_header "x-requested-with"
+  def link_header, do: @link_header
 
   @impl Plug
   def init(opts), do: opts
@@ -58,6 +59,7 @@ defmodule Phoenix.LiveView.Plug do
   defp live_link?(%Plug.Conn{} = conn) do
     case Plug.Conn.get_req_header(conn, @link_header) do
       ["live-link"] -> true
+      [_] -> false
       [] -> false
     end
   end

--- a/test/phoenix_live_view/plug_test.exs
+++ b/test/phoenix_live_view/plug_test.exs
@@ -23,6 +23,15 @@ defmodule Phoenix.LiveView.PlugTest do
     assert conn.resp_body =~ ~s(session: %{path_params: %{"id" => "123"}})
   end
 
+  test "with existing #{LiveViewPlug.link_header} header", %{conn: conn} do
+    conn =
+      conn
+      |> put_req_header(LiveViewPlug.link_header, "some.site.com")
+      |> LiveViewPlug.call(DashboardLive)
+
+    assert conn.resp_body =~ ~s(session: %{path_params: %{"id" => "123"}})
+  end
+
   @tag plug_session: %{user_id: "alex"}
   test "with session opts", %{conn: conn} do
     conn =


### PR DESCRIPTION
```
GET /
Sent 500 in 408µs
Converted error {:case_clause, ["com.facebook.katana"]} to 500 response
[error] #PID<0.15816.0> running WhatcardWeb.Endpoint (connection #PID<0.15815.0>, stream id 1) terminated
Server: some.site.com:80 (http)
Request: GET /?q=something
** (exit) an exception was raised:
    ** (CaseClauseError) no case clause matching: ["com.facebook.katana"]
        (phoenix_live_view) lib/phoenix_live_view/plug.ex:59: Phoenix.LiveView.Plug.live_link?/1
        (phoenix_live_view) lib/phoenix_live_view/plug.ex:22: Phoenix.LiveView.Plug.call/2
        (phoenix) lib/phoenix/router.ex:288: Phoenix.Router.__call__/2
        (whatcard) lib/whatcard_web/endpoint.ex:1: WhatcardWeb.Endpoint.plug_builder_call/2
        (whatcard) lib/whatcard_web/endpoint.ex:1: WhatcardWeb.Endpoint.call/2
        (phoenix) lib/phoenix/endpoint/cowboy2_handler.ex:40: Phoenix.Endpoint.Cowboy2Handler.init/2
        (cowboy) /home/tgxworld/personal/whatcard/deps/cowboy/src/cowboy_handler.erl:41: :cowboy_handler.execute/2
        (cowboy) /home/tgxworld/personal/whatcard/deps/cowboy/src/cowboy_stream_h.erl:296: :cowboy_stream_h.execute/3
```
If the `X-Requested-With` header has been set in a request, the `Phoenix.LiveView.Plug` will throw an error with the stacktrace above.
