### PR TITLE
Clarify location of polyfill imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ $ npm install --save --prefix assets mdn-polyfills url-search-params-polyfill fo
 ```
 
 ```javascript
+// assets/js/app.js
 import "mdn-polyfills/NodeList.prototype.forEach"
 import "mdn-polyfills/Element.prototype.closest"
 import "mdn-polyfills/Element.prototype.matches"
@@ -166,6 +167,6 @@ import "child-replace-with-polyfill"
 import "url-search-params-polyfill"
 import "formdata-polyfill"
 
-import {LiveSocket} from "phoenix_live_view"
+import LiveSocket from "phoenix_live_view"
 ...
 ```


### PR DESCRIPTION
Also format `import LiveSocket` statement consistently with earlier example.