### PR TITLE
Update README.md IE polyfill support

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ All current Chrome, Safari, Firefox, and MS Edge are supported.
 IE11 support is available with the following polyfills:
 
 ```console
-$ npm install --save --prefix assets mdn-polyfills url-search-params-polyfill formdata-polyfill child-replace-with-polyfill
+$ npm install --save --prefix assets mdn-polyfills url-search-params-polyfill formdata-polyfill child-replace-with-polyfill classlist-polyfill
 ```
 
 ```javascript
@@ -165,6 +165,7 @@ import "mdn-polyfills/Element.prototype.matches"
 import "child-replace-with-polyfill"
 import "url-search-params-polyfill"
 import "formdata-polyfill"
+import "classlist-polyfill"
 
 import {LiveSocket} from "phoenix_live_view"
 ...


### PR DESCRIPTION
Closes #260 

We are using `classList` to [add and remove CSS classes](https://github.com/phoenixframework/phoenix_live_view/blob/1e12305ca065f99543fc66db6504cb8c8f30c9fc/assets/js/phoenix_live_view.js#L816-L823) but IE does not support multiple parameters for the add() & remove() methods. Adding the `classlist-polyfill` fixes this issue.

References:
https://caniuse.com/#search=classList