### PR TITLE
Add query_params to sessions

### DIFF
--- a/lib/phoenix_live_view/plug.ex
+++ b/lib/phoenix_live_view/plug.ex
@@ -43,6 +43,7 @@ defmodule Phoenix.LiveView.Plug do
   defp session(conn, session_opts) do
     Enum.reduce(session_opts, %{}, fn
       :path_params, acc -> Map.put(acc, :path_params, conn.path_params)
+      :query_params, acc -> Map.put(acc, :query_params, conn.query_params)
       key, acc -> Map.put(acc, key, Conn.get_session(conn, key))
     end)
   end

--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -16,12 +16,12 @@ defmodule Phoenix.LiveView.Router do
 
     * `:session` - the optional list of keys to pull out of the Plug
       connection session and into the LiveView session.
-      The `:path_params` keys may also be provided to copy the
-      plug path params into the session. Defaults to `[:path_params]`.
-      For example, the following would copy the path params and
-      Plug session current user ID into the LiveView session:
+      The `:path_params` or `:query_params` keys may also be provided to copy
+      the plug path params into the session. Defaults to `[:path_params]`.
+      For example, the following would copy the path params, the query params
+      and Plug session current user ID into the LiveView session:
 
-          [:path_params, :user_id, :remember_me]
+          [:path_params, :query_params, :user_id, :remember_me]
 
     * `:layout` - the optional tuple for specifying a layout to render the
       LiveView. Defaults to `{LayoutView, :app}` where LayoutView is relative to

--- a/test/phoenix_live_view/plug_test.exs
+++ b/test/phoenix_live_view/plug_test.exs
@@ -13,6 +13,7 @@ defmodule Phoenix.LiveView.PlugTest do
       |> Plug.Conn.put_private(:phoenix_endpoint, Endpoint)
       |> Plug.Conn.put_private(:phoenix_live_view, [])
       |> Map.put(:path_params, %{"id" => "123"})
+      |> Map.put(:query_params, config[:plug_query_params] || %{})
 
     {:ok, conn: conn}
   end
@@ -31,6 +32,17 @@ defmodule Phoenix.LiveView.PlugTest do
       |> LiveViewPlug.call(DashboardLive)
 
     assert conn.resp_body =~ ~s(session: %{path_params: %{"id" => "123"}, user_id: "alex"})
+  end
+
+  @tag plug_query_params: %{"page" => "1"}
+  test "with query params", %{conn: conn} do
+    conn =
+      conn
+      |> Plug.Conn.put_private(:phoenix_live_view, session: [:path_params, :query_params])
+      |> LiveViewPlug.call(DashboardLive)
+
+    assert conn.resp_body =~
+             ~s(session: %{path_params: %{"id" => "123"}, query_params: %{"page" => "1"}})
   end
 
   test "with a container", %{conn: conn} do


### PR DESCRIPTION
Add the option of getting the `query_params` along with the `path_params`.