### PR TITLE
fix typo in phoenix_live_view.ex docs

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -189,7 +189,7 @@ defmodule Phoenix.LiveView do
         use Phoenix.LiveView
 
         def render(assigns) do
-          Phoenix.View.render(AppWeb.PageView, "page.html", assigns)
+          Phoenix.View.render(AppWeb.PageView, "page.leex", assigns)
         end
       end
 


### PR DESCRIPTION
Should this be `.leex` as in suggestion above?