### PR TITLE
Use "live" value when merging attrs for inputs on "change" events

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -747,7 +747,7 @@ let DOM = {
     var attrs = source.attributes
     for (let i = 0, length = attrs.length; i < length; i++){
       let name = attrs[i].name
-      let value = source.getAttribute(name)
+      let value = source[name]
       target.setAttribute(name, value)
     }
   },


### PR DESCRIPTION
My initial belief is we want the "real time" value.  `getAttribute` simply shows the whatever is in `value="foo-bar"`.  So in essence a difference between properties (live) and attributes (read only).  Or in other words, the `value` attribute on an input doesn't "reflect" the property

- [x] explore fix
- [ ] write test

close #70 #220 