### PR TITLE
Typo in live_view_test.ex

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -132,7 +132,7 @@ defmodule Phoenix.LiveViewTest do
 
   ## Options
 
-    * `:connect_parmas` - the map of params available in connected mount
+    * `:connect_params` - the map of params available in connected mount
 
   ## Examples
 


### PR DESCRIPTION
The option key is supposed to be `:connect_params` https://github.com/phoenixframework/phoenix_live_view/blob/master/lib/phoenix_live_view/test/live_view_test.ex#L228