### PR TITLE
Fix typo on error for invalid links

### DIFF
--- a/lib/phoenix_live_view/view.ex
+++ b/lib/phoenix_live_view/view.ex
@@ -379,7 +379,7 @@ defmodule Phoenix.LiveView.View do
 
       :error ->
         raise ArgumentError,
-              "cannot live_redirect/link_link to #{inspect(uri)} because " <>
+              "cannot live_redirect/live_link to #{inspect(uri)} because " <>
                 "it isn't defined in #{inspect(router)}"
     end
   end


### PR DESCRIPTION
Got that error and thought that `link_link` was a little bit strange and supposed to be `live_link` :grimacing: