### PR TITLE
Problem: can't refer to Phoenix.LiveView.Socket as Phoenix.LiveView.Socket.t

### DIFF
--- a/lib/phoenix_live_view/socket.ex
+++ b/lib/phoenix_live_view/socket.ex
@@ -18,6 +18,8 @@ defmodule Phoenix.LiveView.Socket do
             redirected: nil,
             connected?: false
 
+  @type t :: %__MODULE__{}
+
   channel "lv:*", Phoenix.LiveView.Channel
 
   @doc """


### PR DESCRIPTION
Solution: define the type, to be usable as `Phoenix.LiveView.Socket.t` instead of `%Phoenix.LiveView.Socket{}`