### PR TITLE
Raise if non router-based LiveView tries to live redirect

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1055,7 +1055,13 @@ defmodule Phoenix.LiveView do
   """
   def live_redirect(%Socket{} = socket, opts) do
     kind = if opts[:replace], do: :replace, else: :push
-    LiveView.View.put_redirect(socket, :live, %{to: Keyword.fetch!(opts, :to), kind: kind})
+
+    case socket do
+      %{plug: Phoenix.LiveView.Plug} ->
+        LiveView.View.put_redirect(socket, :live, %{to: Keyword.fetch!(opts, :to), kind: kind})
+      %{} ->
+        raise ArgumentError, "cannot live_redirect because this LiveView isn't defined in the Router"
+    end
   end
 
   @doc """

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -454,7 +454,8 @@ defmodule Phoenix.LiveView.Channel do
         parent_pid: parent,
         id: id,
         connect_params: connect_params,
-        assigned_new: {parent_assigns, assigned_new}
+        assigned_new: {parent_assigns, assigned_new},
+        plug: fetch_plug(url, router)
       })
 
     case View.call_mount(view, session, lv_socket) do
@@ -478,6 +479,14 @@ defmodule Phoenix.LiveView.Channel do
       other ->
         View.raise_invalid_mount(other, view)
     end
+  end
+
+  defp fetch_plug(url, router) do
+    %URI{host: host, path: path} = URI.parse(url)
+
+    router
+    |> Phoenix.Router.route_info("GET", path, host)
+    |> Map.get(:plug)
   end
 
   defp reply_mount(result, from, original_uri, view) do

--- a/lib/phoenix_live_view/socket.ex
+++ b/lib/phoenix_live_view/socket.ex
@@ -16,7 +16,8 @@ defmodule Phoenix.LiveView.Socket do
             private: %{},
             mounted: false,
             redirected: nil,
-            connected?: false
+            connected?: false,
+            plug: nil
 
   channel "lv:*", Phoenix.LiveView.Channel
 

--- a/test/phoenix_live_view/phoenix_live_view_test.exs
+++ b/test/phoenix_live_view/phoenix_live_view_test.exs
@@ -461,6 +461,22 @@ defmodule Phoenix.LiveView.LiveViewTest do
       assert_remove(clock_view, {%ArgumentError{message: msg}, _stack})
       assert msg =~ "attempted to live_redirect from a nested child socket"
     end
+
+    test "live_redirect from a non-router live view raises", %{conn: conn} do
+      conn = get(conn, "clock_controller")
+      {:ok, clock_view, _html} = live(conn)
+
+      send(
+        clock_view.pid,
+        {:run,
+        fn socket ->
+          {:noreply, LiveView.live_redirect(socket, to: "/thermo")}
+        end}
+        )
+
+      assert_remove(clock_view, {%ArgumentError{message: msg}, _stack})
+      assert msg =~ "cannot live_redirect because this LiveView isn't defined in the Router"
+    end
   end
 
   describe "live_link" do

--- a/test/support/controllers.ex
+++ b/test/support/controllers.ex
@@ -1,0 +1,9 @@
+defmodule Phoenix.LiveViewTest.ClockController do
+  use Phoenix.Controller
+
+  alias Phoenix.LiveViewTest.ClockLive
+
+  def index(conn, _params) do
+    Phoenix.LiveView.Controller.live_render(conn, ClockLive, session: %{})
+  end
+end

--- a/test/support/live_views.ex
+++ b/test/support/live_views.ex
@@ -269,11 +269,14 @@ defmodule Phoenix.LiveViewTest.ParamCounterLive do
   end
 
   def mount(%{test_pid: pid} = session, socket) do
-    do_mount(session, assign(socket, :test_pid, pid))
+     do_mount(session, assign(socket, :test_pid, pid))
   end
 
   defp do_mount(%{test: %{external_disconnected_redirect: redir}}, socket) do
     %{to: to} = redir
+
+    socket = Map.put(socket, :plug, Phoenix.LiveView.Plug)
+
     {:ok, live_redirect(socket, to: to)}
   end
 

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -17,6 +17,9 @@ defmodule Phoenix.LiveViewTest.Router do
   scope "/", Phoenix.LiveViewTest do
     pipe_through [:browser]
 
+    # controller test
+    get "/clock_controller", ClockController, :index
+
     # router test
     live "/router/thermo_defaults/:id", DashboardLive
     live "/router/thermo_session/:id", DashboardLive, session: [:path_params, :user_id]


### PR DESCRIPTION
Solves #309

I solved this issue by passing `plug` data to the socket that `live_redirect/2` uses and checking if it was `Phoenix.LiveView.Plug`. If there's a better way to do that, feel free to do any comments or suggestions 😬