### PR TITLE
Fix typo in phoenix_live_view docs

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -716,7 +716,7 @@ defmodule Phoenix.LiveView do
   in the container, LiveView will replace the existing element with the
   new content instead appending or prepending a new element.
 
-  *Limitations*: LiveView will not apprend or prepend duplicate content that
+  *Limitations*: LiveView will not append or prepend duplicate content that
   was just added. If your goal is to append exactly duplicate rows for things
   such as a placeholder inputs, apply a unique ID to the newly appeneded rows
   to mark the content as unique.


### PR DESCRIPTION
Does what it says on the tin: fixes a small typo :+1: