### PR TITLE
Fix crash when name of element ends on []

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -262,6 +262,7 @@ defmodule Phoenix.LiveView.Channel do
   defp decode(_, _router, value), do: value
 
   defp decode_merge_target(%{"_target" => target} = params) when is_list(target), do: params
+
   defp decode_merge_target(%{"_target" => target} = params) when is_binary(target) do
     keyspace = target |> Plug.Conn.Query.decode() |> gather_keys([])
     Map.put(params, "_target", Enum.reverse(keyspace))
@@ -275,6 +276,8 @@ defmodule Phoenix.LiveView.Channel do
       nil -> acc
     end
   end
+
+  defp gather_keys([], acc), do: acc
 
   defp gather_keys(nil, acc), do: acc
 


### PR DESCRIPTION
Since liveview was updated, I'm having trouble when listening to change events inside a form on elements like multiple_selects because their names (html attribute name specifically) ends with [] (like object[attribute][]). Phoenix multiple_select method creates html elements with names ending in []

I'm using elixir 1.9, phoenix 1.4.10, Erlang/OTP 22.

You can try to reproduce this error using the following template (it won't even reach handle_event("apply_changes") inside the liveview).
```html
<form action="#" phx-submit="submit_form"  phx-change="apply_changes">

<%= multiple_select :object, :attribute, @attribute_values, selected: @object[:attribute] %>

<%= submit "Apply changes" %>

</form>
```

### The rendered html element (select) will have:
```
name = 'object[attribute][]'
```

### The error is something like that
```
[error] GenServer #PID<0.857.0> terminating
** (FunctionClauseError) no function clause matching in Phoenix.LiveView.Channel.gather_keys/2
    (phoenix_live_view) lib/phoenix_live_view/channel.ex:272: Phoenix.LiveView.Channel.gather_keys([], ["attribute", "object"])
    (phoenix_live_view) lib/phoenix_live_view/channel.ex:266: Phoenix.LiveView.Channel.decode_merge_target/1
    (phoenix_live_view) lib/phoenix_live_view/channel.ex:78: Phoenix.LiveView.Channel.handle_info/2
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```

So basically I suggest adding a function inside module `Phoenix.LiveView.Channel` that will just return the acc, like when it receives nil:
```elixir
  #Existing function
  defp gather_keys(%{} = map, acc) do
    case Enum.at(map, 0) do
      {key, val} -> gather_keys(val, [key | acc])
      nil -> acc
    end
  end

  # That's the new function
  defp gather_keys([], acc), do: acc 
  
  #Existing function
  defp gather_keys(nil, acc), do: acc
```

FIY I was using this feature before updating, I was using version/commit id a71590a1c4bac3575cd6bd1267ade924286912d8

I rolled back again to recheck, and this feature really works on this previous version.

This shall solve issue #324