### PR TITLE
Remove case clauses and use catch-all

### DIFF
--- a/lib/phoenix_live_view/plug.ex
+++ b/lib/phoenix_live_view/plug.ex
@@ -57,9 +57,6 @@ defmodule Phoenix.LiveView.Plug do
   end
 
   defp live_link?(%Plug.Conn{} = conn) do
-    case Plug.Conn.get_req_header(conn, @link_header) do
-      ["live-link"] -> true
-      _ -> false
-    end
+    Plug.Conn.get_req_header(conn, @link_header) == ["live-link"]
   end
 end

--- a/lib/phoenix_live_view/plug.ex
+++ b/lib/phoenix_live_view/plug.ex
@@ -59,8 +59,7 @@ defmodule Phoenix.LiveView.Plug do
   defp live_link?(%Plug.Conn{} = conn) do
     case Plug.Conn.get_req_header(conn, @link_header) do
       ["live-link"] -> true
-      [_] -> false
-      [] -> false
+      _ -> false
     end
   end
 end


### PR DESCRIPTION
I believe the two clauses represented no extra information.
Thanks for reviewing.