### PR TITLE
Small refactors

### DIFF
--- a/lib/phoenix_live_view/plug.ex
+++ b/lib/phoenix_live_view/plug.ex
@@ -42,8 +42,8 @@ defmodule Phoenix.LiveView.Plug do
     |> Plug.Conn.put_resp_header("cache-control", "max-age=0, no-cache, no-store, must-revalidate, post-check=0, pre-check=0")
   end
 
-  defp session(conn, session_opts) do
-    for key <- session_opts, into: %{} do
+  defp session(conn, session_keys) do
+    for key <- session_keys, into: %{} do
       {key, Conn.get_session(conn, key)}
     end
   end


### PR DESCRIPTION
The session_opts variable was renamed to session_keys in top of the file so I also renamed it in the private function.

The other one is just a refactor that I believe makes the code easier to read.
Edit: it also sets the` :container` key explicitly to `nil` in the keyword list. The calls in the `View` module check for `nil` so the code is correct this way too.

Thanks for reviewing.