### PR TITLE
Fix module concat for layout

### DIFF
--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -73,7 +73,7 @@ defmodule Phoenix.LiveView.Router do
       module
       |> Atom.to_string()
       |> String.split(".")
-      |> Enum.take(2)
+      |> Enum.drop(-1)
       |> Kernel.++(["LayoutView"])
       |> Module.concat()
 

--- a/test/support/layout_view.ex
+++ b/test/support/layout_view.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LayoutView do
+defmodule Phoenix.LiveViewTest.LayoutView do
   use Phoenix.View, root: ""
 
   def render("app.html", assigns) do


### PR DESCRIPTION
If your module looks like `App.Web.Router`, than application doesn't work and there is no way to fix it. Better approach for concatenation would be not to assume how long the prefix is, but just swap the last module name with `LayoutView`.