### PR TITLE
Allow binary values in handle_event/3 typespec

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -832,7 +832,7 @@ defmodule Phoenix.LiveView do
   @callback handle_params(unsigned_params, uri :: String.t(), Socket.t()) ::
               {:noreply, Socket.t()} | {:stop, Socket.t()}
 
-  @callback handle_event(event :: binary, unsigned_params, Socket.t()) ::
+  @callback handle_event(event :: binary, unsigned_params | binary, Socket.t()) ::
               {:noreply, Socket.t()} | {:stop, Socket.t()}
 
   @callback handle_call(msg :: term, {pid, reference}, Socket.t()) ::


### PR DESCRIPTION
PR to loosen slightly the typespec for `handle_event/3`.

Currently, given a callback with a single phx-value:

```html
<input type="button" phx-click="btn_click" phx-value="hello" value="Click Me!" />
```

Dialyzer halts with:

```
The inferred type for the 2nd argument is not a
supertype of the expected type for the handle_event/3 callback
in the Phoenix.LiveView behaviour.

Success type:
binary()

Behaviour callback type:
map()
```

I'm assuming this does not also apply to handle_params, so I made the change to the callback, and not the type itself.