### PR TITLE
Minor Documentation Fix

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -414,7 +414,7 @@ defmodule Phoenix.LiveView do
 
     * Any number of optional `phx-value-` prefixed attributes, such as:
 
-          <div phx-click="inc" phx-value-myvar1="val1" phx-value-mvar2="val2">
+          <div phx-click="inc" phx-value-myvar1="val1" phx-value-myvar2="val2">
 
       will send the following map of params to the server:
 


### PR DESCRIPTION
Corrects a mismatch in the variable name used across a pair of the examples in the LiveView module's documentation. See https://github.com/hstrowd/phoenix_live_view/blob/7e5c8a90a3df948bfe3b2c37e851a1ab084b0b85/lib/phoenix_live_view.ex#L421 for the other reference to this same variable.

I stumbled on this trying to figure out how variables of the format "my_var" and "my-var" would be translated into the keys for the map of attributes passed into the `handle_event` function on the server side. To be honest, I couldn't find any documentation clarifying this nor the underlying implementation that handles this behavior. However empirically I'm seeing an attribute defined as "phx_value_my_var" translated into "my-var" in the attributes map on the server side.

Specifically I'm setting up this component in the following manner:

```
<%= checkbox(:agreed, input_id, value: checked?, phx_click: "agreed_changed", phx_value_my_var: input_id, class: "custom-class") %>
```

It may be helpful to also clarify this behavior in this documentation or to link to it if it already exists. Thanks!
 