### PR TITLE
Improve argument names in callbacks

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -809,26 +809,26 @@ defmodule Phoenix.LiveView do
   alias Phoenix.LiveView.Socket
 
   @type unsigned_params :: map
-  @type from :: binary
+  @type from :: {pid, reference}
 
-  @callback mount(session :: map, Socket.t()) ::
+  @callback mount(session :: map, socket :: Socket.t()) ::
               {:ok, Socket.t()}
 
-  @callback render(Socket.assigns()) :: Phoenix.LiveView.Rendered.t()
+  @callback render(socket :: Socket.assigns()) :: Phoenix.LiveView.Rendered.t()
 
-  @callback terminate(reason, Socket.t()) :: term
+  @callback terminate(reason, socket :: Socket.t()) :: term
             when reason: :normal | :shutdown | {:shutdown, :left | :closed | term}
 
-  @callback handle_params(unsigned_params, uri :: String.t(), Socket.t()) ::
+  @callback handle_params(unsigned_params, uri :: String.t(), socket :: Socket.t()) ::
               {:noreply, Socket.t()} | {:stop, Socket.t()}
 
-  @callback handle_event(event :: binary, unsigned_params, Socket.t()) ::
+  @callback handle_event(event :: binary, unsigned_params, socket :: Socket.t()) ::
               {:noreply, Socket.t()} | {:stop, Socket.t()}
 
-  @callback handle_call(msg :: term, {pid, reference}, Socket.t()) ::
+  @callback handle_call(msg :: term, from, socket :: Socket.t()) ::
               {:noreply, Socket.t()} | {:reply, term, Socket.t()} | {:stop, Socket.t()}
 
-  @callback handle_info(msg :: term, Socket.t()) ::
+  @callback handle_info(msg :: term, socket :: Socket.t()) ::
               {:noreply, Socket.t()} | {:stop, Socket.t()}
 
   @optional_callbacks terminate: 2,

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -814,7 +814,7 @@ defmodule Phoenix.LiveView do
   @callback mount(session :: map, socket :: Socket.t()) ::
               {:ok, Socket.t()}
 
-  @callback render(socket :: Socket.assigns()) :: Phoenix.LiveView.Rendered.t()
+  @callback render(assigns :: Socket.assigns()) :: Phoenix.LiveView.Rendered.t()
 
   @callback terminate(reason, socket :: Socket.t()) :: term
             when reason: :normal | :shutdown | {:shutdown, :left | :closed | term}


### PR DESCRIPTION
Currently in LiveView's  callback documentation, the socket param is showing up as `arg_*` and the the `handle_call/3`'s `from` param is showing up as `{}`.
<img width="513" alt="Screen Shot 2019-09-14 at 5 13 55 PM" src="https://user-images.githubusercontent.com/120878/64914743-958eeb00-d714-11e9-8b0e-d13c92ad5f97.png">

This PR does 2 things:

1. Sets a name for the unnamed `socket` params 
2. Updates the type of the `LiveView.from` type from `binary` to `{pid, reference}` and references this `from` type from the `handle_call/3` callback.

<img width="456" alt="Screen Shot 2019-09-14 at 5 27 40 PM" src="https://user-images.githubusercontent.com/120878/64914765-0df5ac00-d715-11e9-9489-165e7ae3e50c.png">

If the `from` type was supposed to be a `binary`, I'd be happy to remove that change and fix name of `handle_call/3`'s second argument in another way.