### PR TITLE
Make socket endpoint examples consistent in docs

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -858,7 +858,7 @@ defmodule Phoenix.LiveView do
         }
       }
 
-      let liveSocket = new LiveSocket("/socket", Socket, {hooks: Hooks})
+      let liveSocket = new LiveSocket("/live", Socket, {hooks: Hooks})
       ...
   """
 


### PR DESCRIPTION
All other examples of this call use `/live` as the socket endpoint.

I had a head-scratching moment when trying out hooks and pasted this line in and was met with many error messages about not joining the correct channel. It took me a while to spot the error.

This change would prevent similar mistakes from being made. If on the other hand this is intentional, some explanation would be useful.