### PR TITLE
Register new location on external live redirect

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -555,8 +555,8 @@ export let Browser = {
     req.setRequestHeader("content-type", "text/html")
     req.setRequestHeader("cache-control", "max-age=0, no-cache, no-store, must-revalidate, post-check=0, pre-check=0")
     req.setRequestHeader(LINK_HEADER, "live-link")
-    req.onerror = () => callback(400, '400 Not Found')
-    req.ontimeout = () => callback(504, '504 Timeout')
+    req.onerror = () => callback(400)
+    req.ontimeout = () => callback(504)
     return new Promise((resolve, reject) => {
       req.onreadystatechange = () => {
         if(req.readyState !== 4){ return }
@@ -569,7 +569,7 @@ export let Browser = {
           reject({ status: req.staus, reason: req.statusText })
         }
 
-        callback(200, req.responseText)
+        callback(200)
         resolve(req)
       }
       req.send()


### PR DESCRIPTION
This is up for discussion!  Took a brief look into this and on an external live redirect, we should register a new `currentLocation`.  The issue is the back button (`onpopstate`) matches the `currentLocation` with the `newLocation` in the reproduction in the referenced issue, thus effectively is a noop.

Would love to also think/chat more about how we are `pushing` state. Something like below is also a consideration.  Right now we are passing in `{}` as the first arg to `pushState`.  Using `window.history.state` combined with internal state can solve the question "what should I do at when I click the back button" perhaps a bit easier than a `currentLocation` state.

```js
history.pushState({ uuid: uuid() }, "", "https://live_view.com/registration/new")
```

ref #380 