### PR TITLE
Remove need to explicitly pass flash into sign_flash

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -347,13 +347,11 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   defp push_redirect(state, %{to: to}, nil = _ref) do
-    flash = View.get_flash(state.socket)
-    push(state, "redirect", %{to: to, flash: View.sign_flash(state.socket, flash)})
+    push(state, "redirect", %{to: to, flash: View.sign_flash(state.socket)})
   end
 
   defp push_redirect(state, %{to: to}, ref) do
-    flash = View.get_flash(state.socket)
-    reply(state, ref, :ok, %{redirect: %{to: to, flash: View.sign_flash(state.socket, flash)}})
+    reply(state, ref, :ok, %{redirect: %{to: to, flash: View.sign_flash(state.socket)}})
   end
 
   defp push_noop(state, nil = _ref), do: state
@@ -509,7 +507,7 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   defp put_flash(%{socket: socket}, opts) do
-    Map.put(opts, :flash, View.sign_flash(socket, View.get_flash(socket)))
+    Map.put(opts, :flash, View.sign_flash(socket))
   end
 
   defp parse_uri(url) do

--- a/lib/phoenix_live_view/view.ex
+++ b/lib/phoenix_live_view/view.ex
@@ -199,6 +199,10 @@ defmodule Phoenix.LiveView.View do
   @doc """
   Signs the socket's flash into a token if it has been set.
   """
+  def sign_flash(%Socket{} = socket) do
+    sign_flash(socket, get_flash(socket))
+  end
+
   def sign_flash(%Socket{}, nil), do: nil
 
   def sign_flash(%Socket{endpoint: endpoint}, %{} = flash) do


### PR DESCRIPTION
I believe this refactor is in line with the doc of the `sign_flash` function:
"Signs the socket's flash into a token if it has been set."

It removes the explicit `View.get_flash()` calls from the Channel module.

Thanks for reviewing.
(I hope this doesn't count as arbitrary refactor. If however it is one, then please close and I will take note.)