### PR TITLE
Block helpers diffing

### DIFF
--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -363,6 +363,17 @@ defmodule Phoenix.LiveView.Engine do
     end
   end
 
+  defp to_live_struct({name, meta, [_|_] = args} = expr, tainted_vars, vars, assigns) do
+    case List.last(args) do
+      do: do_block ->
+        do_block = maybe_block_to_rendered(do_block, tainted_vars, vars, assigns)
+        to_safe({name, meta, List.replace_at(args, -1, [do: do_block])}, true)
+
+      _ ->
+        to_safe(expr, true)
+    end
+  end
+
   defp to_live_struct(expr, _tainted_vars, _vars, _assigns) do
     to_safe(expr, true)
   end

--- a/test/phoenix_live_view/engine_test.exs
+++ b/test/phoenix_live_view/engine_test.exs
@@ -3,8 +3,8 @@ defmodule Phoenix.LiveView.EngineTest do
 
   alias Phoenix.LiveView.{Engine, Rendered}
 
-  def safe(do: {:safe, _} = safe), do: safe
-  def unsafe(do: {:safe, content}), do: content
+  def safe(do: do_block), do: do_block
+  def unsafe(do: %{static: [content]}), do: content
 
   describe "rendering" do
     test "escapes HTML" do


### PR DESCRIPTION
This PR attempts to fix the diffing of block helpers in LiveView render. Should also fix #307.

```elixir
defmodule DemoWeb.HelpersLive do
  use Phoenix.LiveView

  def hero([title: title], do: content) do
    assigns = %{}

    ~L"""
    <section class="phx-hero">
      <h2><%= title %></h2>
      <%= content %>
    </section>
    """
  end

  def render(assigns) do
    ~L"""
    <button phx-click="inc">Inc</button>
    <%= hero title: "Counter" do %>
      <div><%= @counter %></div>
      <div>Some static content...</div>
      <div>
        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
        incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
        nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
        Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
        eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
        in culpa qui officia deserunt mollit anim id est laborum.
      </div>
    <% end %>
    """
  end

  def mount(_session, socket) do
    {:ok, socket |> assign(:counter, 0)}
  end

  def handle_event("inc", _, socket) do
    {:noreply, update(socket, :counter, &(&1 + 1))}
  end
end
```

### Current behavior

Changing `:counter` sends all of the static content over the wire. Thus using html functions has a significant negative impact on performance compared to inlining.

### Behavior after PR

Changing `:counter` sends only counter value over the wire like it is without using the helper. Thus no performance impact when using html block helpers.

It should also affect `live_link`, `form_for`, `link` block helpers.

It is adding one more `to_live_struct` clause to match AST nodes that have `do` block as last argument. What do you think?