### PR TITLE
Added mount options to mount's behaviour

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -868,7 +868,7 @@ defmodule Phoenix.LiveView do
   @type from :: {pid, reference}
 
   @callback mount(session :: map, socket :: Socket.t()) ::
-              {:ok, Socket.t()}
+              {:ok, Socket.t()} | {:ok, Socket.t(), keyword()}
 
   @callback render(assigns :: Socket.assigns()) :: Phoenix.LiveView.Rendered.t()
 


### PR DESCRIPTION
I had a warning from [ElixirLS](https://github.com/JakeBecker/elixir-ls) saying my `mount`'s return didn't match the expected return type of the callback (because I had an extra keyword list).
I found it odd since the documentation clearly mentions temporary_assigns as a thing. So I dug through the [source code](https://github.com/phoenixframework/phoenix_live_view/blob/master/lib/phoenix_live_view/view.ex#L470-L481) and figured `keyword()` is the closest to what's expected.

I think this was just forgotten when the temporary_assigns' API was changed, so here's a patch for it.

If I missed something, let me know!