### PR TITLE
fix pushEvent for components

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1286,7 +1286,7 @@ class ViewHook {
   }
 
   pushEvent(event, payload = {}){
-    this.__view.pushWithReply("event", {type: "hook", event: event, value: payload})
+    this.__view.pushEvent("hook", this.el, event, payload)
   }
   __trigger__(kind){
     let callback = this.__callbacks[kind]


### PR DESCRIPTION
At the moment hooks `this.pushEvent`calls are going to LiveView instead of a possible component. This PR should fix that.

Please let me know if i should do the PR including the built `priv/static/phoenix_live_view.js`.