### PR TITLE
Add live_view.css into package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "LICENSE.md",
     "package.json",
     "priv/static/phoenix_live_view.js",
-    "assets/js/phoenix_live_view.js"
+    "assets/js/phoenix_live_view.js",
+    "assets/css/live_view.css"
   ]
 }


### PR DESCRIPTION
**Background:**
In generic project `phoenix_live_view` is included into `package.json ` with recommended
package.json entry:
```
  ...
  "dependencies": {
    "phoenix_live_view": "file:./deps/phoenix_live_view"
  }
  ...
```
which installs node_module with whole contents of `./deps/phoenix_live_view`.

**The problem:**
Some of devs could prefer to build frontend independently from backend by adding npm package into package.json:
```
  ...
  "dependencies": {
    "phoenix_live_view": "0.3.1",
  }
  ...
```
In this case npm includes into install only configured files and does not include live_view.css.

**Solution**
In order to make npm package complete, live_view.css should be included into package files.
