### PR TITLE
Change TableComponent to GridComponent in docs example

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -142,7 +142,7 @@ defmodule Phoenix.LiveComponent do
   of assigns that will be merged into the user assigns. For example, the grid
   component above could be implemented as:
 
-      defmodule TableComponent do
+      defmodule GridComponent do
         use Phoenix.LiveComponent
 
         def render(assigns) do


### PR DESCRIPTION
This updates example in documentation - both previous and next entry refer to `GridComponent`