### PR TITLE
Fix examples in LiveComponent documentation

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -201,7 +201,7 @@ defmodule Phoenix.LiveComponent do
   tracked. For example, if you render a component inside `form_for`, like
   this:
 
-      <%= form_for @changeset, fn f -> %>
+      <%= form_for @changeset, "#", fn f -> %>
         <%= live_component @socket, SomeComponent, f: f %>
       <% end %>
 
@@ -214,7 +214,7 @@ defmodule Phoenix.LiveComponent do
   In this particular case, this can be addressed by using the `form_for`
   variant without anonymous functions:
 
-      <%= f = form_for @changeset %>
+      <%= f = form_for @changeset, "#" %>
         <%= live_component @socket, SomeComponent, f: f %>
       </form>
 


### PR DESCRIPTION
The `action` argument is required for [`Phoenix.HTML.Form.form_for`](https://hexdocs.pm/phoenix_html/Phoenix.HTML.Form.html#form_for/2).

