### PR TITLE
Implemented static assigns in the `live` router macro

### DIFF
--- a/lib/phoenix_live_view/plug.ex
+++ b/lib/phoenix_live_view/plug.ex
@@ -43,9 +43,12 @@ defmodule Phoenix.LiveView.Plug do
   end
 
   defp session(conn, session_keys) do
-    for key <- session_keys, into: %{} do
-      {key, Conn.get_session(conn, key)}
-    end
+    session_keys
+    |> Enum.map(fn
+      key when is_atom(key) -> {key, Conn.get_session(conn, key)}
+      {key, value} -> {key, value}
+    end)
+    |> Enum.into(%{})
   end
 
   defp put_new_layout_from_router(conn, opts) do

--- a/lib/phoenix_live_view/plug.ex
+++ b/lib/phoenix_live_view/plug.ex
@@ -43,12 +43,12 @@ defmodule Phoenix.LiveView.Plug do
   end
 
   defp session(conn, session_keys) do
-    session_keys
-    |> Enum.map(fn
-      key when is_atom(key) -> {key, Conn.get_session(conn, key)}
-      {key, value} -> {key, value}
-    end)
-    |> Enum.into(%{})
+    for key_or_pair <- session_keys, into: %{} do
+      case key_or_pair do
+        key when is_atom(key) -> {key, Conn.get_session(conn, key)}
+        {key, value} -> {key, value}
+      end
+    end
   end
 
   defp put_new_layout_from_router(conn, opts) do

--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -20,6 +20,12 @@ defmodule Phoenix.LiveView.Router do
       user ID and the `remember_me` value into the LiveView session:
 
           [:user_id, :remember_me]
+      
+      This also accepts key/value entries which are mapped directly into the
+      LiveView session.  This is useful for identifying which `live` macro was
+      matched.
+      
+          [action: :index]
 
     * `:layout` - the optional tuple for specifying a layout to render the
       LiveView. Defaults to `{LayoutView, :app}` where LayoutView is relative to

--- a/test/phoenix_live_view/plug_test.exs
+++ b/test/phoenix_live_view/plug_test.exs
@@ -41,6 +41,15 @@ defmodule Phoenix.LiveView.PlugTest do
     assert conn.resp_body =~ ~s(session: %{user_id: "alex"})
   end
 
+  test "with static session opts", %{conn: conn} do
+    conn =
+      conn
+      |> Plug.Conn.put_private(:phoenix_live_view, session: [foo: :bar])
+      |> LiveViewPlug.call(DashboardLive)
+
+    assert conn.resp_body =~ ~s(session: %{foo: :bar})
+  end
+
   test "with a module container", %{conn: conn} do
     conn = LiveViewPlug.call(conn, ThermostatLive)
 


### PR DESCRIPTION
If there are multiple routes pointing to the same live view, there is no way for the live view to know which route it came from.  I found this problematic when trying to build a REST inspired live view.

```elixir
scope "/groups" do
  live "/", MyApp.Live.GroupControllerLive
  live "/:id", MyApp.Live.GroupControllerLive
  live "/:id/edit", MyApp.Live.GroupControllerLive
end
```

The problem with this is that `handle_params` can't tell which route was matched, and therefore it can't call the appropriate "action".

This PR allows the `session` option to also accept static values which are injected directly into the live view session.  That allows me to do:

```elixir
scope "/groups" do
  live "/", MyApp.Live.GroupControllerLive, session: [action: :index]
  live "/:id", MyApp.Live.GroupControllerLive, session: [action: :show]
  live "/:id/edit", MyApp.Live.GroupControllerLive, session: [action: :edit]
end
```

... and then I can pattern match in `handle_params` and build my live view.

I was also wondering about extending this to pull keys from `conn.assigns` as well as `conn |> get_session` but I'm not certain if that's a good idea or not.