### PR TITLE
Mark extra_clauses in to_safe as :generated

### DIFF
--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -705,7 +705,7 @@ defmodule Phoenix.LiveView.Engine do
     line = line_from_expr(ast)
 
     extra_clauses =
-      quote do
+      quote generated: true do
         %{__struct__: Phoenix.LiveView.Rendered} = other -> other
         %{__struct__: Phoenix.LiveView.Component} = other -> other
         %{__struct__: Phoenix.LiveView.Comprehension} = other -> other


### PR DESCRIPTION
When the extra_clauses in Engine.to_safe are not marked as `:generated`, dialyzer will complain that the compiled ast will never match some of the clauses. Something like:

```
The pattern can never match the type.

Pattern:
_ = %Phoenix.LiveView.Rendered{}

Type:
nil | <<_::56>>

________________________________________________________________________________
The pattern can never match the type.

Pattern:
_ = %Phoenix.LiveView.Component{}

Type:
nil | <<_::56>>

________________________________________________________________________________
The pattern can never match the type.

Pattern:
_ = %Phoenix.LiveView.Comprehension{}

Type:
nil | <<_::56>>
```