### PR TITLE
use liveSocket.main.href instead of liveSocket.root.href

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -949,7 +949,7 @@ export class View {
     this.viewHooks = {}
     this.channel = this.liveSocket.channel(`lv:${this.id}`, () => {
       return {
-        url: this.href || this.liveSocket.root.href,
+        url: this.href || this.liveSocket.main.href,
         params: this.liveSocket.params(this.view),
         session: this.getSession(),
         static: this.getStatic()


### PR DESCRIPTION
In #437 the concept of "main" was added and I suspect is related.  
In my own app that contains a live layout that contains a live_render 
navbar, live_links stopped working (`href on undefined`).  I tracked 
it down to this line.  I'm not sure if this change is fully sufficient or if 
there should be a null check, first try root, then try main, etc.