### PR TITLE
Support setting flash in disconnected handle_params

### DIFF
--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -83,13 +83,12 @@ defmodule Phoenix.LiveView.Static do
 
     case call_mount_and_handle_params!(socket, router, view, session, conn.params, request_url) do
       {:ok, socket} ->
-
         data_attrs = [
           phx_view: config.name,
           phx_session: sign_root_session(socket, router, view, session)
         ]
 
-        data_attrs = (if router, do: [phx_main: true], else: []) ++ data_attrs
+        data_attrs = if(router, do: [phx_main: true], else: []) ++ data_attrs
 
         attrs = [
           {:id, socket.id},
@@ -99,8 +98,8 @@ defmodule Phoenix.LiveView.Static do
 
         {:ok, to_rendered_content_tag(socket, tag, view, attrs)}
 
-      {:stop, reason} ->
-        {:stop, reason}
+      {:stop, socket} ->
+        {:stop, socket}
     end
   end
 
@@ -233,8 +232,8 @@ defmodule Phoenix.LiveView.Static do
       {:noreply, %Socket{redirected: nil} = new_socket} ->
         {:ok, new_socket}
 
-      {:noreply, %Socket{redirected: redirected}} ->
-        {:stop, redirected}
+      {:noreply, %Socket{} = new_socket} ->
+        {:stop, new_socket}
 
       {:stop, %Socket{redirected: nil}} ->
         Utils.raise_bad_stop_and_no_redirect!()
@@ -242,8 +241,8 @@ defmodule Phoenix.LiveView.Static do
       {:stop, %Socket{redirected: {:live, _}}} ->
         Utils.raise_bad_stop_and_live_redirect!()
 
-      {:stop, %Socket{redirected: redirected}} ->
-        {:stop, redirected}
+      {:stop, %Socket{} = new_socket} ->
+        {:stop, new_socket}
     end
   end
 

--- a/test/phoenix_live_view/integrations/params_test.exs
+++ b/test/phoenix_live_view/integrations/params_test.exs
@@ -49,6 +49,18 @@ defmodule Phoenix.LiveView.ParamsTest do
              |> redirected_to() == "/"
     end
 
+    test "hard redirect with flash message", %{conn: conn} do
+      conn =
+        put_serialized_session(conn, :on_handle_params, fn socket ->
+          {:stop, socket |> LiveView.put_flash(:info, "msg") |> LiveView.redirect(to: "/")}
+        end)
+        |> fetch_flash()
+        |> get("/counter/123?from=handle_params")
+
+      assert redirected_to(conn) == "/"
+      assert get_flash(conn, :info) == "msg"
+    end
+
     test "internal live redirects", %{conn: conn} do
       assert conn
              |> put_serialized_session(:on_handle_params, fn socket ->


### PR DESCRIPTION
I had a use case in a router-rendered LiveView where I wanted to immediately redirect with flash a user passing invalid params.  Using redirect in `handle_params/3` worked great but the flash message was not rendered.  When `handle_params` first runs in disconnected state on the static render any flash set on the socket wasn't persisted. 

It was simplest for me to return the whole `%Socket{}` and pattern match in `Phoenix.LiveView.Controller` to copy any flash into the `conn` but please feel free to modify the implementation or provide feedback if there is a cleaner way to do it.

Also I'm not sure if the third pattern in `Controller.live_render` is ever called outside of tests anymore so I didn't add flash handling there at this point.