### PR TITLE
Fix error when floki is not loaded

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -274,6 +274,15 @@ defmodule Phoenix.LiveViewTest do
       |> Phoenix.ConnTest.html_response(200)
       |> IO.iodata_to_binary()
 
+    unless Code.ensure_loaded?(Floki) do
+      raise """
+      Phoenix LiveView requires Floki as a test dependency.
+      Please add to your mix.exs:
+
+      {:floki, ">= 0.0.0", only: :test}
+      """
+    end
+
     case DOM.find_views(html) do
       [{id, session_token, nil} | _] -> do_connect(conn, path, html, session_token, id, opts)
       [] -> {:error, :nosession}
@@ -297,15 +306,6 @@ defmodule Phoenix.LiveViewTest do
         endpoint: Phoenix.Controller.endpoint_module(conn),
         child_statics: child_statics
       )
-
-    unless Code.ensure_loaded?(Floki) do
-      raise """
-      Phoenix LiveView requires Floki as a test dependency.
-      Please add to your mix.exs:
-
-          {:floki, ">= 0.0.0", only: :test}
-      """
-    end
 
     case ClientProxy.start_link(caller: {self(), ref}, html: html, view: view, timeout: timeout) do
       {:ok, proxy_pid} ->


### PR DESCRIPTION
Fix https://github.com/phoenixframework/phoenix_live_view/issues/482

I'm moving the check to run right before `DOM.find_views/1` is called then we can see the error regarding Floki not loaded.