### PR TITLE
Add render_hook function to LiveViewTest

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -456,6 +456,19 @@ defmodule Phoenix.LiveViewTest do
     render_event(view, :focus, event, value)
   end
 
+  @doc """
+  Sends a hook event to the view and returns the rendered result.
+
+  ## Examples
+
+      {:ok, view, html} = live(conn, "/thermo")
+      assert html =~ "The temp is: 30℉"
+      assert render_hook(view, :refresh, %{deg: 32}) =~ "The temp is: 32℉"
+  """
+  def render_hook(view, event, value \\ %{}) do
+    render_event(view, :hook, event, value)
+  end
+
   defp render_event([%View{} = view | path], type, event, value) do
     case GenServer.call(
            proxy_pid(view),

--- a/test/phoenix_live_view/integrations/live_view_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test.exs
@@ -160,6 +160,11 @@ defmodule Phoenix.LiveView.LiveViewTest do
       assert render_focus(view, :active, "Hello!") =~ "Waking up – Hello!"
     end
 
+    test "render_hook", %{conn: conn} do
+      {:ok, view, _} = live(conn, "/thermo")
+      assert render_hook(view, :save, %{temp: 20}) =~ "The temp is: 20"
+    end
+
     test "module DOM container", %{conn: conn} do
       conn =
         conn


### PR DESCRIPTION
We don't have a public function in `LiveViewTest` to use with "hook events", the ones that can be triggered from JS code via [ViewHook.pushEvent](https://github.com/phoenixframework/phoenix_live_view/blob/master/assets/js/phoenix_live_view.js#L1316).

This PR adds a `render_hook` helper, which is very similar to other existing functions such as `render_submit`, `render_update`, etc.