### PR TITLE
Automatically load session and csrf token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## 0.5.0-dev
+
+LiveView now makes all connection session automatically available in LiveViews. However, to do so, you need to configure your endpoint accordingly, **otherwise LiveView will fail to connect**.
+
+The steps are:
+
+1) Find `plug Plug.Session, ...` in your endpoint.ex and move the options `...` to a module attribute:
+
+    @session_options [
+      ...
+    ]
+
+2) Change the `plug Plug.Session` to use said attribute:
+
+    plug Plug.Session, @session_options
+
+3) Also pass the `@session_options` to your LiveView socket:
+
+    socket "/live", Phoenix.LiveView.Socket,
+      websocket: [connect_info: [session: @session_options]]
+
+4) You should define the CSRF meta tag inside the in <head> in your layout:
+
+    <%= csrf_meta_tag() %>
+
+5) Then in your app.js:
+
+    let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
+    let liveSocket = new LiveSocket("/live", {params: {_csrf_token: csrfToken}});
+
+Also note that **the session from now on will have string keys**. LiveView will warn if atom keys will be used for the session in the future.
+
 ## 0.4.1 (2019-11-07)
 
 ### Bug Fixes

--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -90,11 +90,14 @@ Next, expose a new socket for LiveView updates in your app's endpoint module.
 defmodule MyAppWeb.Endpoint do
   use Phoenix.Endpoint
 
-  socket "/live", Phoenix.LiveView.Socket
+  socket "/live", Phoenix.LiveView.Socket,
+    websocket: [connect_info: [session: @session_options]]
 
   # ...
 end
 ```
+
+Where `@session_options` are the options given to `plug Plug.Session` extracted to a module attribute.
 
 Add LiveView NPM dependencies in your `assets/package.json`. For a regular project, do:
 
@@ -142,7 +145,8 @@ Enable connecting to a LiveView socket in your `app.js` file.
 import {Socket} from "phoenix"
 import LiveSocket from "phoenix_live_view"
 
-let liveSocket = new LiveSocket("/live", Socket)
+let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
+let liveSocket = new LiveSocket("/live", {params: {_csrf_token: csrfToken}});
 liveSocket.connect()
 ```
 

--- a/lib/phoenix_live_view/controller.ex
+++ b/lib/phoenix_live_view/controller.ex
@@ -24,8 +24,8 @@ defmodule Phoenix.LiveView.Controller do
 
         def show(conn, %{"id" => thermostat_id}) do
           live_render(conn, ThermostatLive, session: %{
-            thermostat_id: id,
-            current_user_id: get_session(conn, :user_id),
+            "thermostat_id" => id,
+            "current_user_id" => get_session(conn, :user_id)
           })
         end
       end

--- a/lib/phoenix_live_view/plug.ex
+++ b/lib/phoenix_live_view/plug.ex
@@ -14,7 +14,7 @@ defmodule Phoenix.LiveView.Plug do
 
   @impl Plug
   def call(%Conn{private: %{phoenix_live_view: opts}} = conn, view) do
-    # TODO: warn if :session is set
+    # TODO: Deprecate atom entries in :session
     session_keys = Keyword.get(opts, :session, [])
 
     render_opts =

--- a/lib/phoenix_live_view/plug.ex
+++ b/lib/phoenix_live_view/plug.ex
@@ -14,6 +14,7 @@ defmodule Phoenix.LiveView.Plug do
 
   @impl Plug
   def call(%Conn{private: %{phoenix_live_view: opts}} = conn, view) do
+    # TODO: warn if :session is set
     session_keys = Keyword.get(opts, :session, [])
 
     render_opts =

--- a/lib/phoenix_live_view/socket.ex
+++ b/lib/phoenix_live_view/socket.ex
@@ -50,7 +50,7 @@ defmodule Phoenix.LiveView.Socket do
 
             plug Plug.Session, @session_options
 
-        3) And pass said options to your LiveView socket:
+        3) Also pass the `@session_options` to your LiveView socket:
 
             socket "/live", Phoenix.LiveView.Socket,
               websocket: [connect_info: [session: @session_options]]

--- a/lib/phoenix_live_view/socket.ex
+++ b/lib/phoenix_live_view/socket.ex
@@ -3,6 +3,7 @@ defmodule Phoenix.LiveView.Socket do
   The LiveView socket for Phoenix Endpoints.
   """
   use Phoenix.Socket
+  require Logger
 
   if Version.match?(System.version(), ">= 1.8.0") do
     @derive {Inspect, only: [:id, :endpoint, :view, :parent_pid, :root_id, :assigns, :changed]}
@@ -30,13 +31,47 @@ defmodule Phoenix.LiveView.Socket do
   Connects the Phoenix.Socket for a LiveView client.
   """
   @impl Phoenix.Socket
-  def connect(_params, %Phoenix.Socket{} = socket, _connect_info) do
-    {:ok, socket}
+  def connect(_params, %Phoenix.Socket{} = socket, connect_info) do
+    case connect_info do
+      %{session: session} when is_map(session) ->
+        {:ok, put_in(socket.private[:session], session)}
+
+      _ ->
+        Logger.error("""
+        LiveView was not configured to use session. Do so with:
+
+        1) Find `plug Plug.Session, ...` in your endpoint.ex and move the options `...` to a module attribute:
+
+            @session_options [
+              ...
+            ]
+
+        2) Change the `plug Plug.Session` to use said attribute:
+
+            plug Plug.Session, @session_options
+
+        3) And pass said options to your LiveView socket:
+
+            socket "/live", Phoenix.LiveView.Socket,
+              websocket: [connect_info: [session: @session_options]]
+
+        4) You should define the CSRF meta tag inside the in <head> in your layout:
+
+            <%= csrf_meta_tag() %>
+
+        5) Then in your app.js:
+
+            let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
+            let liveSocket = new LiveSocket("/live", {params: {_csrf_token: csrfToken}});
+        """)
+
+        :error
+    end
   end
 
   @doc """
   Identifies the Phoenix.Socket for a LiveView client.
   """
   @impl Phoenix.Socket
-  def id(_socket), do: nil
+  def id(socket), do: socket.private[:session]["live_socket_id"]
 end

--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -500,7 +500,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
               throw({:stop, {:redirect, child_view, to}, acc})
 
             {:error, reason} ->
-              raise "failed to mount view: #{inspect(reason)}"
+              raise "failed to mount view: #{Exception.format_exit(reason)}"
           end
       end
     end)

--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -43,6 +43,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
     root_html = Keyword.fetch!(opts, :html)
     root_view = Keyword.fetch!(opts, :view)
     timeout = Keyword.fetch!(opts, :timeout)
+    session = Keyword.fetch!(opts, :session)
 
     state = %{
       timeout: timeout,
@@ -54,7 +55,8 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
       pids: %{},
       replies: %{},
       root_view: root_view,
-      html: root_html
+      html: root_html,
+      session: session
     }
 
     case mount_view(state, root_view, timeout) do
@@ -110,7 +112,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
       serializer: __MODULE__,
       channel: view.module,
       endpoint: view.endpoint,
-      private: %{},
+      private: %{session: state.session},
       topic: view.topic,
       join_ref: state.join_ref
     }

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -292,7 +292,6 @@ defmodule Phoenix.LiveViewTest do
   defp do_connect(%Plug.Conn{} = conn, path, raw_html, session_token, id, opts) do
     child_statics = DOM.find_static_views(raw_html)
     timeout = opts[:timeout] || 5000
-    # normalize
     html = DOM.to_html(DOM.parse(raw_html))
 
     %ClientProxy{ref: ref} =
@@ -307,7 +306,15 @@ defmodule Phoenix.LiveViewTest do
         child_statics: child_statics
       )
 
-    case ClientProxy.start_link(caller: {self(), ref}, html: html, view: view, timeout: timeout) do
+    opts = [
+      caller: {self(), ref},
+      html: html,
+      view: view,
+      timeout: timeout,
+      session: Plug.Conn.get_session(conn)
+    ]
+
+    case ClientProxy.start_link(opts) do
       {:ok, proxy_pid} ->
         receive do
           {^ref, {:mounted, view_pid, html}} ->

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -212,7 +212,7 @@ defmodule Phoenix.LiveViewTest do
   ## Examples
 
       {:ok, view, html} =
-        live_isolated(conn, AppWeb.ClockLive, session: %{tz: "EST"})
+        live_isolated(conn, AppWeb.ClockLive, session: %{"tz" => "EST"})
   """
   defmacro live_isolated(conn, live_view, opts \\ []) do
     quote bind_quoted: binding(), unquote: true do

--- a/test/phoenix_live_view/controller_test.exs
+++ b/test/phoenix_live_view/controller_test.exs
@@ -17,6 +17,6 @@ defmodule Phoenix.LiveView.ControllerTest do
 
   test "live renders from controller with session", %{conn: conn} do
     conn = get(conn, "/controller/live-render-3")
-    assert html_response(conn, 200) =~ "session: %{custom: :session}"
+    assert html_response(conn, 200) =~ "session: %{\"custom\" => :session}"
   end
 end

--- a/test/phoenix_live_view/integrations/components_test.exs
+++ b/test/phoenix_live_view/integrations/components_test.exs
@@ -8,7 +8,7 @@ defmodule Phoenix.LiveView.ComponentTest do
   @endpoint Endpoint
   @moduletag :capture_log
 
-  @moduletag session: %{names: ["chris", "jose"]}
+  @moduletag session: %{names: ["chris", "jose"], from: nil}
 
   setup config do
     {:ok,

--- a/test/phoenix_live_view/integrations/live_view_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test.exs
@@ -469,7 +469,11 @@ defmodule Phoenix.LiveView.LiveViewTest do
 
     test "raises on duplicate child LiveView id", %{conn: conn} do
       Process.flag(:trap_exit, true)
-      {:ok, view, _html} = live(conn, "/root")
+
+      {:ok, view, _html} =
+        conn
+        |> Plug.Conn.put_session(:user_id, 13)
+        |> live("/root")
 
       assert ExUnit.CaptureLog.capture_log(fn ->
                :ok = GenServer.call(view.pid, {:dynamic_child, :static})

--- a/test/phoenix_live_view/plug_test.exs
+++ b/test/phoenix_live_view/plug_test.exs
@@ -35,19 +35,9 @@ defmodule Phoenix.LiveView.PlugTest do
   test "with session opts", %{conn: conn} do
     conn =
       conn
-      |> Plug.Conn.put_private(:phoenix_live_view, session: [:user_id])
       |> LiveViewPlug.call(DashboardLive)
 
-    assert conn.resp_body =~ ~s(session: %{user_id: "alex"})
-  end
-
-  test "with static session opts", %{conn: conn} do
-    conn =
-      conn
-      |> Plug.Conn.put_private(:phoenix_live_view, session: [foo: :bar])
-      |> LiveViewPlug.call(DashboardLive)
-
-    assert conn.resp_body =~ ~s(session: %{foo: :bar})
+    assert conn.resp_body =~ ~s(session: %{"user_id" => "alex"})
   end
 
   test "with a module container", %{conn: conn} do

--- a/test/phoenix_live_view/router_test.exs
+++ b/test/phoenix_live_view/router_test.exs
@@ -20,7 +20,7 @@ defmodule Phoenix.LiveView.RouterTest do
   @tag plug_session: %{user_id: "chris"}
   test "routing with custom session", %{conn: conn} do
     conn = get(conn, "/router/thermo_session/123")
-    assert conn.resp_body =~ ~s(session: %{user_id: "chris"})
+    assert conn.resp_body =~ ~s(session: %{"user_id" => "chris"})
   end
 
   test "routing with module container", %{conn: conn} do

--- a/test/support/live_views.ex
+++ b/test/support/live_views.ex
@@ -123,12 +123,12 @@ defmodule Phoenix.LiveViewTest.DashboardLive do
 
   def render(assigns) do
     ~L"""
-    session: <%= Phoenix.HTML.raw inspect(@router_session) %>
+    session: <%= Phoenix.HTML.raw inspect(@session) %>
     """
   end
 
   def mount(session, socket) do
-    {:ok, assign(socket, router_session: session)}
+    {:ok, assign(socket, session: session)}
   end
 end
 

--- a/test/support/live_views.ex
+++ b/test/support/live_views.ex
@@ -17,15 +17,15 @@ defmodule Phoenix.LiveViewTest.ThermostatLive do
   end
 
   def mount(session, socket) do
-    nest = Map.get(session, :nest, false)
-    users = session[:users] || []
+    nest = Map.get(session, "nest", false)
+    users = session["users"] || []
     val = if connected?(socket), do: 1, else: 0
 
     {:ok,
      assign(socket,
        val: val,
        nest: nest,
-       redir: session[:redir],
+       redir: session["redir"],
        users: users,
        greeting: nil
      )}
@@ -151,7 +151,7 @@ defmodule Phoenix.LiveViewTest.SameChildLive do
     """
   end
 
-  def mount(%{dup: dup}, socket) do
+  def mount(%{"dup" => dup}, socket) do
     {:ok, assign(socket, count: 0, dup: dup, names: ~w(Tokyo Madrid Toronto))}
   end
 
@@ -167,14 +167,14 @@ defmodule Phoenix.LiveViewTest.RootLive do
   def render(assigns) do
     ~L"""
     root name: <%= @current_user.name %>
-    <%= live_render(@socket, ChildLive, id: :static, session: %{child: :static, user_id: @current_user.id}) %>
+    <%= live_render(@socket, ChildLive, id: :static, session: %{"child" => :static}) %>
     <%= if @dynamic_child do %>
-      <%= live_render(@socket, ChildLive, id: @dynamic_child, session: %{child: :dynamic, user_id: @current_user.id}) %>
+      <%= live_render(@socket, ChildLive, id: @dynamic_child, session: %{"child" => :dynamic}) %>
     <% end %>
     """
   end
 
-  def mount(%{user_id: user_id}, socket) do
+  def mount(%{"user_id" => user_id}, socket) do
     {:ok,
      socket
      |> assign(:dynamic_child, nil)
@@ -197,7 +197,8 @@ defmodule Phoenix.LiveViewTest.ChildLive do
     """
   end
 
-  def mount(%{user_id: user_id, child: id}, socket) do
+  # The "user_id" is carried from the session to the child live view too
+  def mount(%{"user_id" => user_id, "child" => id}, socket) do
     {:ok,
      socket
      |> assign(:id, id)
@@ -219,14 +220,14 @@ defmodule Phoenix.LiveViewTest.ParamCounterLive do
   end
 
   def mount(session, socket) do
-    on_handle_params = session[:on_handle_params]
+    on_handle_params = session["on_handle_params"]
 
     {:ok,
      assign(
        socket,
        val: 1,
        connect_params: get_connect_params(socket) || %{},
-       test_pid: session[:test_pid],
+       test_pid: session["test_pid"],
        on_handle_params: on_handle_params && :erlang.binary_to_term(on_handle_params)
      )}
   end
@@ -265,7 +266,7 @@ defmodule Phoenix.LiveViewTest.OptsLive do
 
   def render(assigns), do: ~L|<%= @description %>. <%= @canary %>|
 
-  def mount(%{opts: opts}, socket) do
+  def mount(%{"opts" => opts}, socket) do
     {:ok, assign(socket, description: "long description", canary: "canary"), opts}
   end
 
@@ -288,7 +289,7 @@ defmodule Phoenix.LiveViewTest.AppendLive do
     """
   end
 
-  def mount(%{time_zones: {update_type, time_zones}}, socket) do
+  def mount(%{"time_zones" => {update_type, time_zones}}, socket) do
     {:ok, assign(socket, update_type: update_type, time_zones: time_zones),
      temporary_assigns: [time_zones: []]}
   end
@@ -311,7 +312,7 @@ defmodule Phoenix.LiveViewTest.ShuffleLive do
     """
   end
 
-  def mount(%{time_zones: time_zones}, socket) do
+  def mount(%{"time_zones" => time_zones}, socket) do
     {:ok, assign(socket, time_zones: time_zones)}
   end
 
@@ -396,7 +397,7 @@ defmodule Phoenix.LiveViewTest.WithComponentLive do
     """
   end
 
-  def mount(%{names: names, from: from}, socket) do
+  def mount(%{"names" => names, "from" => from}, socket) do
     {:ok, assign(socket, names: names, from: from)}
   end
 

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -9,7 +9,7 @@ defmodule Phoenix.LiveViewTest.Controller do
   end
 
   def incoming(conn, %{"type" => "live-render-3"}) do
-    live_render(conn, Phoenix.LiveViewTest.DashboardLive, session: %{custom: :session})
+    live_render(conn, Phoenix.LiveViewTest.DashboardLive, session: %{"custom" => :session})
   end
 end
 
@@ -35,20 +35,16 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/router/thermo_layout/:id", DashboardLive,
       layout: {Phoenix.LiveViewTest.AlternativeLayout, :layout}
 
-    # live view test
-    live "/thermo", ThermostatLive, session: [:nest, :users, :redir]
-    live "/thermo/:id", ThermostatLive, session: [:nest, :users, :redir]
+    live "/thermo", ThermostatLive
+    live "/thermo/:id", ThermostatLive
+    live "/thermo-container", ThermostatLive, container: {:span, style: "thermo-flex<script>"}
 
-    live "/thermo-container", ThermostatLive,
-      session: [:nest],
-      container: {:span, style: "thermo-flex<script>"}
-
-    live "/same-child", SameChildLive, session: [:dup]
-    live "/root", RootLive, session: [:user_id]
-    live "/counter/:id", ParamCounterLive, session: [:test, :test_pid, :on_handle_params]
-    live "/opts", OptsLive, session: [:opts]
-    live "/time-zones", AppendLive, session: [:time_zones]
-    live "/shuffle", ShuffleLive, session: [:time_zones]
-    live "/components", WithComponentLive, session: [:names, :from]
+    live "/same-child", SameChildLive
+    live "/root", RootLive
+    live "/counter/:id", ParamCounterLive
+    live "/opts", OptsLive
+    live "/time-zones", AppendLive
+    live "/shuffle", ShuffleLive
+    live "/components", WithComponentLive
   end
 end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -29,7 +29,7 @@ defmodule Phoenix.LiveViewTest.Router do
 
     # router test
     live "/router/thermo_defaults/:id", DashboardLive
-    live "/router/thermo_session/:id", DashboardLive, session: [:user_id]
+    live "/router/thermo_session/:id", DashboardLive
     live "/router/thermo_container/:id", DashboardLive, container: {:span, style: "flex-grow"}
 
     live "/router/thermo_layout/:id", DashboardLive,


### PR DESCRIPTION
Pending:

  * [x] Docs
  * [x] Remove tests that use the router session
  * [x] Ensure for nested live view renders the sessions are mixed
  * [x] Discuss which changes to the installation step should make it to the latest Phoenix (csrf_meta_tag and/or @session_options)