### PR TITLE
Fix moduledoc for live components

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -1,5 +1,5 @@
 defmodule Phoenix.LiveComponent do
-  @moduledoc ~S"""
+  @moduledoc """
   Components are a mechanism to compartmentalize state, markup, and
   events in LiveView.
 
@@ -14,9 +14,9 @@ defmodule Phoenix.LiveComponent do
         use Phoenix.LiveComponent
 
         def render(assigns) do
-          ~L"\""
+          ~L\"""
           <div class="hero"><%= @content %></div>
-          "\""
+          \"""
         end
       end
 
@@ -69,9 +69,9 @@ defmodule Phoenix.LiveComponent do
         use Phoenix.LiveComponent
 
         def render(assigns) do
-          ~L"\""
+          ~L\"""
           <div id="<%= @id %>" class="hero"><%= @content %></div>
-          "\""
+          \"""
         end
       end
 
@@ -275,7 +275,7 @@ defmodule Phoenix.LiveComponent do
         use Phoenix.LiveComponent
 
         def render(assigns) do
-          ~L"\""
+          ~L\"""
           <div class="grid">
             <%= for entry <- @entries do %>
               <div class="column">
@@ -283,7 +283,7 @@ defmodule Phoenix.LiveComponent do
               </div>
             <% end %>
           </div>
-          "\""
+          \"""
         end
       end
 


### PR DESCRIPTION
Heho! 
While getting started with live components and doing some copy & pasting from the docs I stumbled over the `\`. So I made it more consistent to the docs of the `Phoenix.LiveView` and therefore removed the `~S`. When I checked how the `@moduledoc` is used in Elixir for example, I couldn't really figure out when the string sigil is used 🤷‍♂ Cheers!

[Current Docs](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveComponent.html#content)
<img width="395" alt="image" src="https://user-images.githubusercontent.com/9000002/69362071-18d93980-0c8e-11ea-9f2b-52f36fc9d278.png">

Updated Docs
<img width="370" alt="image" src="https://user-images.githubusercontent.com/9000002/69378321-73828d80-0cae-11ea-8669-d011bf67c4d0.png">
