### PR TITLE
Add @behaviour to LiveComponent

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -342,9 +342,13 @@ defmodule Phoenix.LiveComponent do
   In this case, the solution is to not use `content_tag` and rely on LiveEEx
   to build the markup.
   """
+
+  alias Phoenix.LiveView.Socket
+
   defmacro __using__(_) do
     quote do
       import Phoenix.LiveView
+      @behaviour unquote(__MODULE__)
 
       @doc false
       def __live__, do: %{kind: :component, module: __MODULE__}
@@ -354,19 +358,20 @@ defmodule Phoenix.LiveComponent do
   @callback mount(socket :: Socket.t()) ::
               {:ok, Socket.t()} | {:ok, Socket.t(), keyword()}
 
-  @callback preload([Socket.assigns()]) :: [Socket.assigns()]
+  @callback preload(list_of_assigns :: [Socket.assigns()]) ::
+              list_of_assigns :: [Socket.assigns()]
 
-  @callback update(Socket.assigns(), socket :: Socket.t()) ::
+  @callback update(assigns :: Socket.assigns(), socket :: Socket.t()) ::
               {:ok, Socket.t()}
 
   @callback render(assigns :: Socket.assigns()) :: Phoenix.LiveView.Rendered.t()
 
   @callback handle_event(
               event :: binary,
-              Phoenix.LiveView.unsigned_params(),
+              unsigned_params :: Socket.unsigned_params(),
               socket :: Socket.t()
             ) ::
               {:noreply, Socket.t()}
 
-  @optional_callbacks mount: 1, update: 2, handle_event: 3
+  @optional_callbacks mount: 1, preload: 1, update: 2, handle_event: 3
 end


### PR DESCRIPTION
Phoenix.LiveComponent appeared to be missing its behaviour when calling `use Phoenix.LiveComponent`. I assume this was unintentional, so I have added it here. Additional related changes:

* Alias Phoenix.LiveView.Socket for callback specs
* Add preload/1 to optional_callbacks list
* Fix params spec in handle_event/3 callback

**Current Docs:**
![live_component_before](https://user-images.githubusercontent.com/168677/69367122-81072b80-0c4c-11ea-8fc7-58b95eb8a428.png)

**Updated Docs:**
![live_component_after](https://user-images.githubusercontent.com/168677/69367146-8f554780-0c4c-11ea-9621-75d290f6cc38.png)
