### PR TITLE
Add offsetX and offsetY to click event metadata

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -509,7 +509,6 @@ export class LiveSocket {
         screenY: e.screenY,
         offsetX: e.offsetX,
         offsetY: e.offsetY,
-
       }
 
       this.owner(target, view => {

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -507,6 +507,9 @@ export class LiveSocket {
         pageY: e.pageY,
         screenX: e.screenX,
         screenY: e.screenY,
+        offsetX: e.offsetX,
+        offsetY: e.offsetY,
+
       }
 
       this.owner(target, view => {


### PR DESCRIPTION
resolves #493 

It adds `offsetX` and `offsetY` to click event metadata in `phoenix_live_view.js`, which are the click coordinates relative to the clicked element.

**A use case**: when clicking on a big rectangular div where we want to render new elements.

![](https://user-images.githubusercontent.com/486085/69256455-c9293e00-0bb9-11ea-81d8-76e8f167b96e.gif)

