### PR TITLE
Fix optimisation for mixed variables and condition in comprehension

### DIFF
--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -649,6 +649,11 @@ defmodule Phoenix.LiveView.Engine do
     {other, tainted_vars, vars, assigns}
   end
 
+  defp analyze_list([head | tail], :restricted, vars, assigns, acc) do
+    {head, tainted_vars, vars, assigns} = analyze(head, :restricted, vars, assigns)
+    analyze_list(tail, tainted_vars || :restricted, vars, assigns, [head | acc])
+  end
+
   defp analyze_list([head | tail], tainted_vars, vars, assigns, acc) do
     {head, tainted_vars, vars, assigns} = analyze(head, tainted_vars, vars, assigns)
     analyze_list(tail, tainted_vars, vars, assigns, [head | acc])

--- a/test/phoenix_live_view/engine_test.exs
+++ b/test/phoenix_live_view/engine_test.exs
@@ -241,6 +241,19 @@ defmodule Phoenix.LiveView.EngineTest do
                changed(template, %{foo: ["1", "2", "3"]}, %{foo: true})
     end
 
+    test "does not render dynamic if it has a variable after a condition inside optimized comprehension" do
+      template =
+        "<%= for foo <- @foo do %><%= if foo == @selected, do: ~s(selected) %><%= foo %><% end %>"
+
+      assert [%{dynamics: [["", "1"], ["selected", "2"], ["", "3"]]}] =
+               changed(template, %{foo: ["1", "2", "3"], selected: "2"}, nil)
+
+      assert [nil] = changed(template, %{foo: ["1", "2", "3"], selected: "2"}, %{})
+
+      assert [%{dynamics: [["", "1"], ["selected", "2"], ["", "3"]]}] =
+               changed(template, %{foo: ["1", "2", "3"], selected: "2"}, %{foo: true})
+    end
+
     test "does not render dynamic for nested optimized comprehensions with variables" do
       template =
         "<%= for x <- @foo do %>X: <%= for y <- @bar do %>Y: <%= x %><%= y %><% end %><% end %>"


### PR DESCRIPTION
### Issue

I noticed inconsistent optimisation when rendering conditions and variables in a comprehension. 

With the condition at the end, it would only re-render dynamics if the `@ids` or `@selected` got updated:
```eex
<%= for id <- @ids do %>
   <%= id %>
   <%= if id == @selected, do: "selected" %>
<% end %>
```

Rendering variables after the condition would cause the dynamics to be re-rendered on every update of liveview:
```eex
<%= for id <- @ids do %>
   <%= if id == @selected, do: "selected" %>
   <%= id %>
<% end %>
```

### Fix

I suspect this is because the `analyze_list` doesn't handle `:restricted` mode well. If an earlier analyze returns `tainted_vars` as `false`. It would not run the other items in the list with `:restricted` anymore. 

I assumed this is not intentional, but if it is, let me know!

