### PR TITLE
Ensure LiveViewTest.live_isolated/3 sets proper session

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -223,8 +223,10 @@ defmodule Phoenix.LiveViewTest do
   @doc false
   def __isolated__(conn, endpoint, live_view, opts) do
     {mount_opts, lv_opts} = Keyword.split(opts, [:connect_params])
+    {initial_session, lv_opts} = Keyword.pop(lv_opts, :session, %{})
 
     put_in(conn.private[:phoenix_endpoint], endpoint || raise("no @endpoint set in test case"))
+    |> Plug.Test.init_test_session(initial_session)
     |> Phoenix.LiveView.Controller.live_render(live_view, lv_opts)
     |> __live__(mount_opts)
   end
@@ -232,6 +234,7 @@ defmodule Phoenix.LiveViewTest do
   @doc false
   def __live__(%Plug.Conn{state: state, status: status} = conn, opts) do
     path = rebuild_path(conn)
+
     case {state, status} do
       {:sent, 200} ->
         connect_from_static_token(conn, path, opts)

--- a/test/phoenix_live_view/integrations/live_view_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test.exs
@@ -68,6 +68,24 @@ defmodule Phoenix.LiveView.LiveViewTest do
                    ~r/it is not mounted nor accessed through the router live\/3 macro/,
                    fn -> live_isolated(conn, Phoenix.LiveViewTest.ParamCounterLive) end
     end
+
+    test "works without an initialized session" do
+      {:ok, view, _} =
+        live_isolated(Phoenix.ConnTest.build_conn(), Phoenix.LiveViewTest.DashboardLive,
+          session: %{"hello" => "world"}
+        )
+
+      assert render(view) =~ "session: %{&quot;hello&quot; =&gt; &quot;world&quot;}"
+    end
+
+    test "works with atom keys" do
+      {:ok, view, _} =
+        live_isolated(Phoenix.ConnTest.build_conn(), Phoenix.LiveViewTest.DashboardLive,
+          session: %{hello: "world"}
+        )
+
+      assert render(view) =~ "session: %{&quot;hello&quot; =&gt; &quot;world&quot;}"
+    end
   end
 
   describe "rendering" do


### PR DESCRIPTION
Fixes a slight regression in `live_isolated/3` when a session has yet to be initialized. This also ensures that session data in test gets sent through the Conn's session so the keys get converted.