### PR TITLE
Fix documentation typo

### DIFF
--- a/lib/phoenix_live_view/socket.ex
+++ b/lib/phoenix_live_view/socket.ex
@@ -62,7 +62,7 @@ defmodule Phoenix.LiveView.Socket do
         5) Then in your app.js:
 
             let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
-            let liveSocket = new LiveSocket("/live", {params: {_csrf_token: csrfToken}});
+            let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}});
         """)
 
         :error


### PR DESCRIPTION
Fix https://github.com/phoenixframework/phoenix_live_view/issues/515

Phoenix socket must be always provided in order to setup live view.