### PR TITLE
Warn on mixed session keys, test regression after session consolidation

### DIFF
--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -103,7 +103,14 @@ defmodule Phoenix.LiveView.Static do
         %{assigned_new: {conn.assigns, []}, connect_params: %{}, conn_session: conn_session}
       )
 
-    case call_mount_and_handle_params!(socket, router, view, mount_session, conn.params, request_url) do
+    case call_mount_and_handle_params!(
+           socket,
+           router,
+           view,
+           mount_session,
+           conn.params,
+           request_url
+         ) do
       {:ok, socket} ->
         data_attrs = [
           phx_view: config.name,

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -56,9 +56,15 @@ defmodule Phoenix.LiveView.Static do
 
   # TODO: Warn if opts :session has atom keys
   defp load_session(conn_or_socket_session, opts) do
-    user_session = Keyword.get(opts, :session, %{})
+    user_session = stringify_keys(Keyword.get(opts, :session, %{}))
     {user_session, Map.merge(conn_or_socket_session, user_session)}
   end
+
+  # Session key conversion is not recursive, mimicking Plug.Session
+  defp stringify_keys(map) when is_map(map), do: Map.new(map, &stringify_key/1)
+  defp stringify_key({key, value}), do: {stringify_key(key), value}
+  defp stringify_key(binary) when is_binary(binary), do: binary
+  defp stringify_key(atom) when is_atom(atom), do: Atom.to_string(atom)
 
   defp maybe_get_session(conn) do
     Plug.Conn.get_session(conn)

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -55,18 +55,16 @@ defmodule Phoenix.LiveView.Static do
   end
 
   defp load_session(conn_or_socket_session, opts) do
-    user_session = validate_session(Keyword.get(opts, :session, %{}))
+    user_session = Keyword.get(opts, :session, %{})
+    validate_session(user_session)
     {user_session, Map.merge(conn_or_socket_session, user_session)}
   end
 
   # Validate user-supplied session data uses string keys
-  defp validate_session(map) when is_map(map), do: Map.new(map, &validate_session_key/1)
-  defp validate_session_key({key, value}), do: {validate_session_key(key), value}
-  defp validate_session_key(binary) when is_binary(binary), do: binary
-
-  defp validate_session_key(other) do
-    IO.warn("Phoenix.LiveView sessions require string keys, got: #{inspect(other)}")
-    other
+  defp validate_session(session) when is_map(session) do
+    for {key, _value} when not is_binary(key) <- session do
+      IO.warn("Phoenix.LiveView sessions require string keys, got: #{inspect(key)}")
+    end
   end
 
   defp maybe_get_session(conn) do

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -54,7 +54,6 @@ defmodule Phoenix.LiveView.Static do
     end
   end
 
-  # TODO: Warn if opts :session has atom keys
   defp load_session(conn_or_socket_session, opts) do
     user_session = stringify_keys(Keyword.get(opts, :session, %{}))
     {user_session, Map.merge(conn_or_socket_session, user_session)}
@@ -64,7 +63,11 @@ defmodule Phoenix.LiveView.Static do
   defp stringify_keys(map) when is_map(map), do: Map.new(map, &stringify_key/1)
   defp stringify_key({key, value}), do: {stringify_key(key), value}
   defp stringify_key(binary) when is_binary(binary), do: binary
-  defp stringify_key(atom) when is_atom(atom), do: Atom.to_string(atom)
+
+  defp stringify_key(atom) when is_atom(atom) do
+    IO.warn("Phoenix.LiveView sessions require string keys, got: #{inspect(atom)}")
+    Atom.to_string(atom)
+  end
 
   defp maybe_get_session(conn) do
     Plug.Conn.get_session(conn)

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -55,18 +55,18 @@ defmodule Phoenix.LiveView.Static do
   end
 
   defp load_session(conn_or_socket_session, opts) do
-    user_session = stringify_keys(Keyword.get(opts, :session, %{}))
+    user_session = validate_session(Keyword.get(opts, :session, %{}))
     {user_session, Map.merge(conn_or_socket_session, user_session)}
   end
 
-  # Session key conversion is not recursive, mimicking Plug.Session
-  defp stringify_keys(map) when is_map(map), do: Map.new(map, &stringify_key/1)
-  defp stringify_key({key, value}), do: {stringify_key(key), value}
-  defp stringify_key(binary) when is_binary(binary), do: binary
+  # Validate user-supplied session data uses string keys
+  defp validate_session(map) when is_map(map), do: Map.new(map, &validate_session_key/1)
+  defp validate_session_key({key, value}), do: {validate_session_key(key), value}
+  defp validate_session_key(binary) when is_binary(binary), do: binary
 
-  defp stringify_key(atom) when is_atom(atom) do
-    IO.warn("Phoenix.LiveView sessions require string keys, got: #{inspect(atom)}")
-    Atom.to_string(atom)
+  defp validate_session_key(other) do
+    IO.warn("Phoenix.LiveView sessions require string keys, got: #{inspect(other)}")
+    other
   end
 
   defp maybe_get_session(conn) do

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -225,6 +225,7 @@ defmodule Phoenix.LiveViewTest do
     {mount_opts, lv_opts} = Keyword.split(opts, [:connect_params])
 
     put_in(conn.private[:phoenix_endpoint], endpoint || raise("no @endpoint set in test case"))
+    |> Plug.Test.init_test_session(%{})
     |> Phoenix.LiveView.Controller.live_render(live_view, lv_opts)
     |> __live__(mount_opts)
   end
@@ -232,6 +233,7 @@ defmodule Phoenix.LiveViewTest do
   @doc false
   def __live__(%Plug.Conn{state: state, status: status} = conn, opts) do
     path = rebuild_path(conn)
+
     case {state, status} do
       {:sent, 200} ->
         connect_from_static_token(conn, path, opts)

--- a/test/phoenix_live_view/controller_test.exs
+++ b/test/phoenix_live_view/controller_test.exs
@@ -20,10 +20,10 @@ defmodule Phoenix.LiveView.ControllerTest do
     assert html_response(conn, 200) =~ "session: %{\"custom\" => :session}"
   end
 
-  test "live renders from controller with session with atom keys", %{conn: conn} do
+  test "when session data has atom keys, warns on live render", %{conn: conn} do
     assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
              conn = get(conn, "/controller/live-render-4")
-             assert html_response(conn, 200) =~ "session: %{\"custom\" => :session}"
+             assert html_response(conn, 200) =~ "session: %{custom: :session}"
            end) =~ "Phoenix.LiveView sessions require string keys, got: :custom"
   end
 end

--- a/test/phoenix_live_view/controller_test.exs
+++ b/test/phoenix_live_view/controller_test.exs
@@ -19,4 +19,9 @@ defmodule Phoenix.LiveView.ControllerTest do
     conn = get(conn, "/controller/live-render-3")
     assert html_response(conn, 200) =~ "session: %{\"custom\" => :session}"
   end
+
+  test "live renders from controller with session with atom keys", %{conn: conn} do
+    conn = get(conn, "/controller/live-render-4")
+    assert html_response(conn, 200) =~ "session: %{\"custom\" => :session}"
+  end
 end

--- a/test/phoenix_live_view/controller_test.exs
+++ b/test/phoenix_live_view/controller_test.exs
@@ -21,7 +21,9 @@ defmodule Phoenix.LiveView.ControllerTest do
   end
 
   test "live renders from controller with session with atom keys", %{conn: conn} do
-    conn = get(conn, "/controller/live-render-4")
-    assert html_response(conn, 200) =~ "session: %{\"custom\" => :session}"
+    assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
+             conn = get(conn, "/controller/live-render-4")
+             assert html_response(conn, 200) =~ "session: %{\"custom\" => :session}"
+           end) =~ "Phoenix.LiveView sessions require string keys, got: :custom"
   end
 end

--- a/test/phoenix_live_view/integrations/live_view_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test.exs
@@ -68,6 +68,24 @@ defmodule Phoenix.LiveView.LiveViewTest do
                    ~r/it is not mounted nor accessed through the router live\/3 macro/,
                    fn -> live_isolated(conn, Phoenix.LiveViewTest.ParamCounterLive) end
     end
+
+    test "works without an initialized session" do
+      {:ok, view, _} =
+        live_isolated(Phoenix.ConnTest.build_conn(), Phoenix.LiveViewTest.DashboardLive,
+          session: %{"hello" => "world"}
+        )
+
+      assert render(view) =~ "session: %{&quot;hello&quot; =&gt; &quot;world&quot;}"
+    end
+
+    test "converts custom session keys" do
+      {:ok, view, _} =
+        live_isolated(Phoenix.ConnTest.build_conn(), Phoenix.LiveViewTest.DashboardLive,
+          session: %{hello: "world"}
+        )
+
+      assert render(view) =~ "session: %{&quot;hello&quot; =&gt; &quot;world&quot;}"
+    end
   end
 
   describe "rendering" do

--- a/test/phoenix_live_view/integrations/live_view_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test.exs
@@ -78,14 +78,14 @@ defmodule Phoenix.LiveView.LiveViewTest do
       assert render(view) =~ "session: %{&quot;hello&quot; =&gt; &quot;world&quot;}"
     end
 
-    test "converts custom session keys" do
+    test "warns when session contains atom keys" do
       assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
                {:ok, view, _} =
                  live_isolated(Phoenix.ConnTest.build_conn(), Phoenix.LiveViewTest.DashboardLive,
                    session: %{hello: "world"}
                  )
 
-               assert render(view) =~ "session: %{&quot;hello&quot; =&gt; &quot;world&quot;}"
+               assert render(view) =~ "session: %{hello: &quot;world&quot;}"
              end) =~ "Phoenix.LiveView sessions require string keys, got: :hello"
     end
   end

--- a/test/phoenix_live_view/integrations/live_view_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test.exs
@@ -79,12 +79,14 @@ defmodule Phoenix.LiveView.LiveViewTest do
     end
 
     test "converts custom session keys" do
-      {:ok, view, _} =
-        live_isolated(Phoenix.ConnTest.build_conn(), Phoenix.LiveViewTest.DashboardLive,
-          session: %{hello: "world"}
-        )
+      assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
+               {:ok, view, _} =
+                 live_isolated(Phoenix.ConnTest.build_conn(), Phoenix.LiveViewTest.DashboardLive,
+                   session: %{hello: "world"}
+                 )
 
-      assert render(view) =~ "session: %{&quot;hello&quot; =&gt; &quot;world&quot;}"
+               assert render(view) =~ "session: %{&quot;hello&quot; =&gt; &quot;world&quot;}"
+             end) =~ "Phoenix.LiveView sessions require string keys, got: :hello"
     end
   end
 

--- a/test/phoenix_live_view/integrations/update_test.exs
+++ b/test/phoenix_live_view/integrations/update_test.exs
@@ -108,7 +108,9 @@ defmodule Phoenix.LiveView.UpdateTest do
   end
 
   describe "regular updates" do
-    @tag session: %{time_zones: [%{id: "ny", name: "NY"}, %{id: "sf", name: "SF"}]}
+    @tag session: %{
+           time_zones: [%{"id" => "ny", "name" => "NY"}, %{"id" => "sf", "name" => "SF"}]
+         }
     test "existing ids are replaced when patched without respawning children", %{conn: conn} do
       {:ok, view, html} = live(conn, "/shuffle")
 

--- a/test/support/live_views.ex
+++ b/test/support/live_views.ex
@@ -89,7 +89,7 @@ defmodule Phoenix.LiveViewTest.ClockLive do
   end
 
   def mount(session, socket) do
-    {:ok, assign(socket, time: "12:00", name: session[:name] || "NY")}
+    {:ok, assign(socket, time: "12:00", name: session["name"] || "NY")}
   end
 
   def handle_info(:snooze, socket) do

--- a/test/support/live_views.ex
+++ b/test/support/live_views.ex
@@ -138,7 +138,7 @@ defmodule Phoenix.LiveViewTest.SameChildLive do
   def render(%{dup: true} = assigns) do
     ~L"""
     <%= for name <- @names do %>
-      <%= live_render(@socket, ClockLive, id: :dup, session: %{name: name}) %>
+      <%= live_render(@socket, ClockLive, id: :dup, session: %{"name" => name}) %>
     <% end %>
     """
   end
@@ -146,7 +146,7 @@ defmodule Phoenix.LiveViewTest.SameChildLive do
   def render(%{dup: false} = assigns) do
     ~L"""
     <%= for name <- @names do %>
-      <%= live_render(@socket, ClockLive, session: %{name: name, count: @count}, id: name) %>
+      <%= live_render(@socket, ClockLive, session: %{"name" => name, "count" => @count}, id: name) %>
     <% end %>
     """
   end
@@ -283,7 +283,7 @@ defmodule Phoenix.LiveViewTest.AppendLive do
     <div id="times" phx-update="<%= @update_type %>">
       <%= for %{id: id, name: name} <- @time_zones do %>
         <h1 id="title-<%= id %>"><%= name %></h1>
-        <%= live_render(@socket, Phoenix.LiveViewTest.ClockLive, id: "tz-#{id}", session: %{name: name}) %>
+        <%= live_render(@socket, Phoenix.LiveViewTest.ClockLive, id: "tz-#{id}", session: %{"name" => name}) %>
       <% end %>
     </div>
     """
@@ -305,8 +305,8 @@ defmodule Phoenix.LiveViewTest.ShuffleLive do
   def render(assigns) do
     ~L"""
     <%= for zone <- @time_zones do %>
-      <div id="score-<%= zone.id %>">
-        <%= live_render(@socket, Phoenix.LiveViewTest.ClockLive, id: "tz-#{zone.id}", session: %{name: zone.name}) %>
+      <div id="score-<%= zone["id"] %>">
+        <%= live_render(@socket, Phoenix.LiveViewTest.ClockLive, id: "tz-#{zone["id"]}", session: %{"name" => zone["name"]}) %>
       </div>
     <% end %>
     """

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -11,6 +11,10 @@ defmodule Phoenix.LiveViewTest.Controller do
   def incoming(conn, %{"type" => "live-render-3"}) do
     live_render(conn, Phoenix.LiveViewTest.DashboardLive, session: %{"custom" => :session})
   end
+
+  def incoming(conn, %{"type" => "live-render-4"}) do
+    live_render(conn, Phoenix.LiveViewTest.DashboardLive, session: %{custom: :session})
+  end
 end
 
 defmodule Phoenix.LiveViewTest.Router do


### PR DESCRIPTION
Now that LiveView shares its session options with Plug, and the session received in `mount/2` gets string keys from the session, a few regressions popped up that this PR attempts to fix.

**Changes:**
1. Ensure `Plug.Test.init_test_session/2` is called when using `LiveViewTest.live_isolated/3`.
1. ~Convert root-level atom keys to strings for custom session data (mimicking Plug.Session)~
1. Emit a warning when a non-binary session key is provided.
1. Add tests for live_isolated/3 and live_render/3

~I left in the TODO about warning on atom keys -- didn't want to bikeshed on the wording, but I'm assuming that even if we issue a warning, we'd still convert the keys.~

Supercedes #514