### PR TITLE
Added overrides for live link navigation

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -541,7 +541,7 @@ export class LiveSocket {
     window.addEventListener("click", e => {
       let target = closestPhxBinding(e.target, PHX_LIVE_LINK)
       let phxEvent = target && target.getAttribute(PHX_LIVE_LINK)
-      if(!phxEvent || e.metaKey || e.ctrlKey || e.which === 2){ return }
+      if(!phxEvent || e.metaKey || e.ctrlKey || e.button === 1){ return }
       let href = target.href
       e.preventDefault()
       this.main.pushInternalLink(href, () => {

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -541,7 +541,7 @@ export class LiveSocket {
     window.addEventListener("click", e => {
       let target = closestPhxBinding(e.target, PHX_LIVE_LINK)
       let phxEvent = target && target.getAttribute(PHX_LIVE_LINK)
-      if(!phxEvent){ return }
+      if(!phxEvent || e.metaKey || e.ctrlKey || e.which === 2){ return }
       let href = target.href
       e.preventDefault()
       this.main.pushInternalLink(href, () => {


### PR DESCRIPTION
This should allow a user to open links in a new tab by doing:

- Control key (to allow users to open in new tab on Windows/Linux/etc.)
- Meta key (to allow command-click for macOS, which is used in lieu of control-click)
- Middle mouse click as an alternative, which is also generally used to do the same

This is in reference to issue #528 and seems to add the desired functionality. I did some quick testing and it appears to work in my use case. Please let me know if there is anything I overlooked or if you see any improvements, I'll be glad to assist.

Thanks!