### PR TITLE
Docs: Add a note about key event values and usage

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -563,6 +563,11 @@ defmodule Phoenix.LiveView do
         "shiftKey" => false, "which" => 27
       }
 
+  To determine which key has been pressed you should use `key` value. The
+  available options can be found on
+  [MDN](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values)
+  or via the [Key Event Viewer](https://w3c.github.io/uievents/tools/key-event-viewer.html).
+
   By default, the bound element will be the event listener, but a
   window-level binding may be provided via `phx-window-keydown`,
   for example:


### PR DESCRIPTION
- Note that `charCode`, `keyCode`, `which` are all deprecated and should not be relied on see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Browser_compatibility
- Point users to list of valid key codes (so they aren't doing by trial and error like I've done in the past)
- Point users to more info around all key event info including modifier keys and browser support

