### PR TITLE
DEBUG flag

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -53,7 +53,7 @@ const DYNAMICS = "d"
 const STATIC = "s"
 const COMPONENTS = "c"
 
-let DEBUG = process.env.NODE_ENV === 'development';
+let DEBUG = process.env.NODE_ENV !== 'production';
 let logError = (msg, obj) => console.error && console.error(msg, obj)
 
 export let debug = (view, kind, msg, obj) => {

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -53,10 +53,13 @@ const DYNAMICS = "d"
 const STATIC = "s"
 const COMPONENTS = "c"
 
+let DEBUG = process.env.NODE_ENV === 'development';
 let logError = (msg, obj) => console.error && console.error(msg, obj)
 
 export let debug = (view, kind, msg, obj) => {
-  console.log(`${view.id} ${kind}: ${msg} - `, obj)
+  if (DEBUG) {
+    console.log(`${view.id} ${kind}: ${msg} - `, obj)
+  }
 }
 
 // wraps value in closure or returns closure


### PR DESCRIPTION
`process.env.NODE_ENV` is "development" in a development webpack build.
`process.env.NODE_ENV` is "production" in a production webpack build.

```js
if (DEBUG) {
  // this block will be stripped from a production build by webpack
}
```

We could use this for all sorts of things like detecting duplicate `id`s and deprecating events ref #536 