### PR TITLE
Remove deprecated key event fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ IE11 support is available with the following polyfills:
 $ npm install --save --prefix assets mdn-polyfills url-search-params-polyfill formdata-polyfill child-replace-with-polyfill classlist-polyfill shim-keyboard-event-key
 ```
 
+Note: The `shim-keyboard-event-key` polyfill is also required for [MS Edge 12-18](https://caniuse.com/#feat=keyboardevent-key).
+
 ```javascript
 // assets/js/app.js
 import "mdn-polyfills/CustomEvent"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ All current Chrome, Safari, Firefox, and MS Edge are supported.
 IE11 support is available with the following polyfills:
 
 ```console
-$ npm install --save --prefix assets mdn-polyfills url-search-params-polyfill formdata-polyfill child-replace-with-polyfill classlist-polyfill
+$ npm install --save --prefix assets mdn-polyfills url-search-params-polyfill formdata-polyfill child-replace-with-polyfill classlist-polyfill shim-keyboard-event-key
 ```
 
 ```javascript
@@ -44,6 +44,7 @@ import "child-replace-with-polyfill"
 import "url-search-params-polyfill"
 import "formdata-polyfill"
 import "classlist-polyfill"
+import "shim-keyboard-event-key"
 
 import {Socket} from "phoenix"
 import LiveSocket from "phoenix_live_view"

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -483,18 +483,15 @@ export class LiveSocket {
       view.pushKey(target, targetCtx, type, phxEvent, {
         altGraphKey: e.altGraphKey,
         altKey: e.altKey,
-        charCode: e.charCode,
         code: e.code,
         ctrlKey: e.ctrlKey,
         key: e.key,
-        keyCode: e.keyCode,
         keyIdentifier: e.keyIdentifier,
         keyLocation: e.keyLocation,
         location: e.location,
         metaKey: e.metaKey,
         repeat: e.repeat,
-        shiftKey: e.shiftKey,
-        which: e.which
+        shiftKey: e.shiftKey
       })
     })
     this.bind({blur: "focusout", focus: "focusin"}, (e, type, view, targetEl, targetCtx, phxEvent, phxTarget) => {

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -563,10 +563,8 @@ defmodule Phoenix.LiveView do
   object's metadata. For example, pressing the Escape key looks like this:
 
       %{
-        "altKey" => false, "charCode" => 0, "code" => "Escape",
-        "ctrlKey" => false, "key" => "Escape", "keyCode" => 27,
-        "location" => 0, "metaKey" => false, "repeat" => false,
-        "shiftKey" => false, "which" => 27
+        "altKey" => false, "code" => "Escape", "ctrlKey" => false, "key" => "Escape",
+        "location" => 0, "metaKey" => false, "repeat" => false, "shiftKey" => false
       }
 
   By default, the bound element will be the event listener, but a

--- a/test/phoenix_live_view/integrations/live_view_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test.exs
@@ -177,14 +177,12 @@ defmodule Phoenix.LiveView.LiveViewTest do
                "The temp is: 21[&quot;another&quot;, &quot;field&quot;]"
     end
 
-    @key_i 73
-    @key_d 68
     test "render_key|up|down", %{conn: conn} do
       {:ok, view, _} = live(conn, "/thermo")
       assert render(view) =~ "The temp is: 1"
-      assert render_keyup(view, :key, @key_i) =~ "The temp is: 2"
-      assert render_keydown(view, :key, @key_d) =~ "The temp is: 1"
-      assert render_keyup(view, :key, @key_d) =~ "The temp is: 0"
+      assert render_keyup(view, :key, %{"key" => "i"}) =~ "The temp is: 2"
+      assert render_keydown(view, :key, %{"key" => "d"}) =~ "The temp is: 1"
+      assert render_keyup(view, :key, %{"key" => "d"}) =~ "The temp is: 0"
       assert render(view) =~ "The temp is: 0"
     end
 

--- a/test/support/live_views/general.ex
+++ b/test/support/live_views/general.ex
@@ -32,13 +32,11 @@ defmodule Phoenix.LiveViewTest.ThermostatLive do
        )}
   end
 
-  @key_i 73
-  @key_d 68
-  def handle_event("key", @key_i, socket) do
+  def handle_event("key", %{"key" => "i"}, socket) do
     {:noreply, update(socket, :val, &(&1 + 1))}
   end
 
-  def handle_event("key", @key_d, socket) do
+  def handle_event("key", %{"key" => "d"}, socket) do
     {:noreply, update(socket, :val, &(&1 - 1))}
   end
 


### PR DESCRIPTION
- Recommend and use `key` instead
- Update tests to use `key` instead of raw numeric codes

`charCode`, `keyCode`, and `which` are all deprecated, poorly supported cross-browser and should not be relied on.

See https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Browser_compatibility for more details on this.

For more background see #536. This is also related to #535.