### PR TITLE
Allow single string keys in the router

### DIFF
--- a/lib/phoenix_live_view/plug.ex
+++ b/lib/phoenix_live_view/plug.ex
@@ -50,6 +50,7 @@ defmodule Phoenix.LiveView.Plug do
     for key_or_pair <- session_keys, into: %{} do
       case key_or_pair do
         key when is_atom(key) -> {key, Conn.get_session(conn, key)}
+        key when is_binary(key) -> {key, Conn.get_session(conn, key)}
         {key, value} -> {key, value}
       end
     end


### PR DESCRIPTION
Previously on 0.4.1 this allowed `key` to always be present in the liveview session:

```
# lib/app/router.ex
live MyView, session: [:key]
```

In `master` / `0.5.x` this will cause a warning because `:key` is an atom, changing it to a string causes a case match error.

This PR treat single strings as if they were atoms, and sets it in the session restoring the old behaviour with the new string key format. An alternative solution is to cast the key from the atom to a string in the line above, but I'm not sure if that would allow atom keys elsewhere...