### PR TITLE
Retrieve session from Plug when keys are defined as string on router

### DIFF
--- a/lib/phoenix_live_view/plug.ex
+++ b/lib/phoenix_live_view/plug.ex
@@ -50,6 +50,7 @@ defmodule Phoenix.LiveView.Plug do
     for key_or_pair <- session_keys, into: %{} do
       case key_or_pair do
         key when is_atom(key) -> {key, Conn.get_session(conn, key)}
+        key when is_binary(key) -> {key, Conn.get_session(conn, key)}
         {key, value} -> {key, value}
       end
     end


### PR DESCRIPTION
This commit https://github.com/phoenixframework/phoenix_live_view/commit/05c5db9cc844d9c698fa51fb59803d09488e6d11 added warnings when session values are defined as atoms to enforce the use of string keys, which will trigger warnings when a routable live view is defined as `live "/", DummyLiveView, session: ~w(current_user_id)a`. So I guess the fix is to define it as `live "/", DummyLiveView, session: ~w(current_user_id)`, but it will raise the following error:
```
** (CaseClauseError) no case clause matching: "current_user_id"
stacktrace:
  (phoenix_live_view) lib/phoenix_live_view/plug.ex:57: anonymous fn/3 in Phoenix.LiveView.Plug.session/2
```
This PR fixes that by getting the session from Plug when it's defined as string.