### PR TITLE
Reload with jitter on expired session token

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -460,7 +460,7 @@ defmodule Phoenix.LiveView.Channel do
       {:ok, verified} ->
         verified_mount(verified, params, from, phx_socket)
 
-      {:error, :outdated} ->
+      {:error, reason} when reason in [:outdated, :expired] ->
         GenServer.reply(from, {:error, %{reason: "outdated"}})
         {:stop, :shutdown, :no_state}
 

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -7,6 +7,8 @@ defmodule Phoenix.LiveView.Static do
   # Token version. Should be changed whenever new data is stored.
   @token_vsn 2
 
+  def token_vsn, do: @token_vsn
+
   # Max session age in seconds. Equivalent to 2 weeks.
   @max_session_age 1_209_600
 


### PR DESCRIPTION
An expired session token is currently not accounted for in error handling and passes through to causes a error log entry. This update handles an expired session token in the same way as an outdated token, by reloading with jitter and not logging an error.