### PR TITLE
Add documentation about focus and window key events

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -438,9 +438,11 @@ defmodule Phoenix.LiveView do
       <input name="email" phx-focus="myfocus" phx-blur="myblur"/>
 
   To detect when the page itself has received focus or blur,
-  `phx-window-focus` and `phx-window-blur` may be specified. Like other
-  bindings, `phx-value-*` can be provided on the bound element,
-  and those values will be sent as part of the payload. For example:
+  `phx-window-focus` and `phx-window-blur` may be specified. These window
+  level events may also be necessary if the element in consideration
+  (most often a `div` with no tabindex) cannot receive focus. Like other
+  bindings, `phx-value-*` can be provided on the bound element, and those
+  values will be sent as part of the payload. For example:
 
       <div class="container"
           phx-window-focus="page-active"


### PR DESCRIPTION
ref #546 

Very slight documentation improvement.  I think this is important because it is easy to miss this when the element in question does not receive focus by default.  Anchor tags, links, buttons, inputs, selects, textareas do.  However, often a `div` is used as the element with `phx-keydown` and if it doesn't have `tabindex="0"`, events like `keydown` will not fire on the element.