### PR TITLE
Merge socket assigns for static render

### DIFF
--- a/lib/phoenix_live_view/controller.ex
+++ b/lib/phoenix_live_view/controller.ex
@@ -33,12 +33,15 @@ defmodule Phoenix.LiveView.Controller do
   """
   def live_render(%Plug.Conn{} = conn, view, opts \\ []) do
     case LiveView.Static.render(conn, view, opts) do
-      {:ok, content} ->
+      {:ok, content, socket_assigns} ->
         conn
         |> Plug.Conn.assign(:live_view_module, view)
         |> Phoenix.Controller.put_view(LiveView.Static)
         |> LiveView.Plug.put_cache_headers()
-        |> Phoenix.Controller.render("template.html", %{content: content})
+        |> Phoenix.Controller.render(
+          "template.html",
+          Map.merge(socket_assigns, %{content: content})
+        )
 
       {:stop, %Socket{redirected: {:redirect, opts}} = socket} ->
         conn

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -125,7 +125,7 @@ defmodule Phoenix.LiveView.Static do
           | extended_attrs
         ]
 
-        {:ok, to_rendered_content_tag(socket, tag, view, attrs)}
+        {:ok, to_rendered_content_tag(socket, tag, view, attrs), socket.assigns}
 
       {:stop, socket} ->
         {:stop, socket}

--- a/test/phoenix_live_view/controller_test.exs
+++ b/test/phoenix_live_view/controller_test.exs
@@ -26,4 +26,9 @@ defmodule Phoenix.LiveView.ControllerTest do
              assert html_response(conn, 200) =~ "session: %{custom: :session}"
            end) =~ "Phoenix.LiveView sessions require string keys, got: :custom"
   end
+
+  test "live renders from controller with merged assigns", %{conn: conn} do
+    conn = get(conn, "/controller/live-render-5")
+    assert html_response(conn, 200) =~ "title: Dashboard"
+  end
 end

--- a/test/support/layout_view.ex
+++ b/test/support/layout_view.ex
@@ -13,3 +13,11 @@ defmodule Phoenix.LiveViewTest.AlternativeLayout do
     ["ALTERNATIVE", render(assigns.view_module, assigns.view_template, assigns)]
   end
 end
+
+defmodule Phoenix.LiveViewTest.AssignsLayoutView do
+  use Phoenix.View, root: ""
+
+  def render("app.html", assigns) do
+    ["title: #{assigns.title}", render(assigns.view_module, assigns.view_template, assigns)]
+  end
+end

--- a/test/support/live_views.ex
+++ b/test/support/live_views.ex
@@ -128,7 +128,7 @@ defmodule Phoenix.LiveViewTest.DashboardLive do
   end
 
   def mount(session, socket) do
-    {:ok, assign(socket, session: session)}
+    {:ok, assign(socket, %{session: session, title: "Dashboard"})}
   end
 end
 

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -15,6 +15,12 @@ defmodule Phoenix.LiveViewTest.Controller do
   def incoming(conn, %{"type" => "live-render-4"}) do
     live_render(conn, Phoenix.LiveViewTest.DashboardLive, session: %{custom: :session})
   end
+
+  def incoming(conn, %{"type" => "live-render-5"}) do
+    conn
+    |> put_layout({Phoenix.LiveViewTest.AssignsLayoutView, :app})
+    |> live_render(Phoenix.LiveViewTest.DashboardLive)
+  end
 end
 
 defmodule Phoenix.LiveViewTest.Router do


### PR DESCRIPTION
**Issue**

Although LiveView calculates socket assigns prior to the static layout being rendered, this data is not currently reflected. Data in the socket assigns can be useful for populating SEO fields; i.e. title, meta.

**Resolution**

Socket assigns are now returned as part of `LiveView.Static.render/3`. These are merged with content and passed into `Phoenix.Controller.render/3`.

> Note: This solves only for initial layout availability. The change does not intend to solve for dynamic updating.

@mcrumm 