### PR TITLE
Pass :indentation to EEx

### DIFF
--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -220,7 +220,13 @@ defmodule Phoenix.LiveView.Helpers do
       {:safe, ["Hello ", "world", "\\n"]}
 
   """
-  defmacro sigil_L({:<<>>, _, [expr]}, []) do
-    EEx.compile_string(expr, engine: Phoenix.LiveView.Engine, line: __CALLER__.line + 1)
+  defmacro sigil_L({:<<>>, meta, [expr]}, []) do
+    options = [
+      engine: Phoenix.LiveView.Engine,
+      line: __CALLER__.line + 1,
+      indentation: meta[:indentation] || 0
+    ]
+
+    EEx.compile_string(expr, options)
   end
 end


### PR DESCRIPTION
Recent improvements on Elixir master allow to better track columns and
thus produce better stacktraces. For e.g.:

    defmodule AppWeb.ThermostatLive do
      use Phoenix.LiveView

      def render(assigns) do
        ~L"""
        Current temperature: <%= @temperature %><% end %>
        """
      end
    end

previously we had:

    ** (EEx.SyntaxError) foo.ex:6: unexpected end of expression <% end %>

but with this change we can know where exactly (which line+column) the
error occurs:

    ** (EEx.SyntaxError) foo.ex:6:45: unexpected end of expression <% end %>