### PR TITLE
Specify location of csrf_meta_tag in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,10 @@ The steps are:
         socket "/live", Phoenix.LiveView.Socket,
           websocket: [connect_info: [session: @session_options]]
 
-  4) You should define the CSRF meta tag inside the in <head> in your layout:
+  4) You should define the CSRF meta tag inside <head> in your layout, before `app.js` is included:
 
         <%= csrf_meta_tag() %>
+        <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
 
   5) Then in your app.js:
 

--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -136,10 +136,11 @@ latest javascript, then force an install.
 (cd assets && npm install --force phoenix_live_view)
 ```
 
-Ensure you have placed a CSRF meta tag inside the `<head>` tag in your layout (`lib/my_app_web/templates/layout/app.html.eex`) like so:
+Ensure you have placed a CSRF meta tag inside the `<head>` tag in your layout (`lib/my_app_web/templates/layout/app.html.eex`), before `app.js` is included like so:
 
 ```html
 <%= csrf_meta_tag() %>
+<script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
 ```
 
 Enable connecting to a LiveView socket in your `app.js` file.


### PR DESCRIPTION
Hello and thank you for LiveView!

While upgrading from 4 to 5 I found that the socket was no longer connecting, and traced it to the socket not being able to read the `csrf_content_tag`... because I had included it in the wrong order!

I hope this helps, let me know if it can be improved :smile: 

This may be related to issue #575 