### PR TITLE
Properly get URL from live socket

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1069,7 +1069,7 @@ export class View {
     this.viewHooks = {}
     this.channel = this.liveSocket.channel(`lv:${this.id}`, () => {
       return {
-        url: this.href || this.liveSocket.main.href,
+        url: this.href,
         params: this.liveSocket.params(this.view),
         session: this.getSession(),
         static: this.getStatic()


### PR DESCRIPTION
Fixes https://github.com/phoenixframework/phoenix_live_view/issues/575

We don't need to get the URL from any other place than `this.href`. Also, this optional after 07aa098e5526cd1000d6270d40ea98c27f415ed6 and 07aa098e5526cd1000d6270d40ea98c27f415ed6.