### PR TITLE
Match Plug.opts type for LiveView.Plug

### DIFF
--- a/lib/phoenix_live_view/plug.ex
+++ b/lib/phoenix_live_view/plug.ex
@@ -11,8 +11,9 @@ defmodule Phoenix.LiveView.Plug do
   @impl Plug
   def init(view) when is_atom(view), do: view
 
-  def init({view, opts}) when is_atom(view) and is_list(opts) do
-    {view, __live_opts__(opts)}
+  def init(opts) when is_list(opts) do
+    view = Keyword.fetch!(opts, :view)
+    %{view: view, opts: __live_opts__(opts)}
   end
 
   @impl Plug
@@ -20,7 +21,7 @@ defmodule Phoenix.LiveView.Plug do
     do_call(conn, view, opts)
   end
 
-  def call(%Plug.Conn{} = conn, {view, opts}) when is_atom(view) and is_list(opts) do
+  def call(%Plug.Conn{} = conn, %{view: view, opts: opts}) when is_atom(view) and is_list(opts) do
     do_call(conn, view, opts)
   end
 

--- a/test/phoenix_live_view/plug_test.exs
+++ b/test/phoenix_live_view/plug_test.exs
@@ -7,7 +7,7 @@ defmodule Phoenix.LiveView.PlugTest do
 
   defp call(conn, view, opts \\ []) do
     opts = Keyword.merge([router: __MODULE__, layout: false], opts)
-    LiveViewPlug.call(conn, LiveViewPlug.init({view, opts}))
+    LiveViewPlug.call(conn, LiveViewPlug.init([view: view] ++ opts))
   end
 
   setup config do


### PR DESCRIPTION
Stops dialyzer from warning about `unmatched_return` from the `live/3` macro:

```shell
lib/my_app_web/router.ex:13:unmatched_return
The expression produces a value of type:

atom() | {atom(), Keyword.t()}

but this value is unmatched.
```

// @chrismccord 
