### PR TITLE
clarify docs on @session_options attribute

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -88,6 +88,8 @@ Next, expose a new socket for LiveView updates in your app's endpoint module.
 defmodule MyAppWeb.Endpoint do
   use Phoenix.Endpoint
 
+  # ...
+
   socket "/live", Phoenix.LiveView.Socket,
     websocket: [connect_info: [session: @session_options]]
 
@@ -95,23 +97,20 @@ defmodule MyAppWeb.Endpoint do
 end
 ```
 
-Where `@session_options` are the options given to `plug Plug.Session` extracted to a module attribute.
-
-Here are the steps to update your existing endpoint module.
+Where `@session_options` are the options given to `plug Plug.Session` extracted to a module attribute. If you don't have a `@session_options` in your endpoint yet, here is how to extract it out:
 
 1. Find plug Plug.Session in your endpoint.ex
+
 ```elixir
-# lib/my_app_web/endpoint.ex
-...
-plug Plug.Session
-  store: :cookie,
-  key: "_my_app_key",
-  signing_salt: "somesigningsalt"
+  plug Plug.Session
+    store: :cookie,
+    key: "_my_app_key",
+    signing_salt: "somesigningsalt"
 ```
 
 2. Move the options to a module attribute at the top of your file:
+
 ```elixir
-# lib/my_app_web/endpoint.ex
   @session_options [
     store: :cookie,
     key: "_my_app_key",
@@ -120,8 +119,8 @@ plug Plug.Session
 ```
 
 3. Change the plug Plug.Session to use the attribute:
+
 ```elixir
-# lib/my_app_web/endpoint.ex
   plug Plug.Session, @session_options
 ```
 

--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -97,6 +97,34 @@ end
 
 Where `@session_options` are the options given to `plug Plug.Session` extracted to a module attribute.
 
+Here are the steps to update your existing endpoint module.
+
+1. Find plug Plug.Session in your endpoint.ex
+```elixir
+# lib/my_app_web/endpoint.ex
+...
+plug Plug.Session
+  store: :cookie,
+  key: "_my_app_key",
+  signing_salt: "somesigningsalt"
+```
+
+2. Move the options to a module attribute at the top of your file:
+```elixir
+# lib/my_app_web/endpoint.ex
+  @session_options [
+    store: :cookie,
+    key: "_my_app_key",
+    signing_salt: "somesigningsalt"
+  ]
+```
+
+3. Change the plug Plug.Session to use the attribute:
+```elixir
+# lib/my_app_web/endpoint.ex
+  plug Plug.Session, @session_options
+```
+
 Add LiveView NPM dependencies in your `assets/package.json`. For a regular project, do:
 
 ```json


### PR DESCRIPTION
The session_options in the installation docs could need a bit of clarification to make it explicit what a user needs to do to install. I have added 3 steps to make it crystal clear. 

Let me know what you think.