### PR TITLE
fix virtual keyboard on mobile browser

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -906,7 +906,7 @@ export let DOM = {
 
   restoreFocus(focused, selectionStart, selectionEnd){
     if(!DOM.isTextualInput(focused)){ return }
-    if(focused.value === "" || focused.readOnly){ focused.blur()}
+    if(focused.readOnly){ focused.blur()}
     focused.focus()
     if(focused.setSelectionRange && focused.type === "text" || focused.type === "textarea"){
       focused.setSelectionRange(selectionStart, selectionEnd)


### PR DESCRIPTION
blur() and immediately focus() raise virtual keyboard close and
immediately open.
i tested on browsers bromite, chromium, fennec and had problems while
inputing the fist symbol in input field if event rate is frequently than
one per second.

could you please review @chrismccord 