### PR TITLE
Improves explanation of data-phx-error-for

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -521,6 +521,10 @@ defmodule Phoenix.LiveView do
 
   *Note*: For proper form error tag updates, the error tag must specify which
   input it belongs to. This is accomplished with the `data-phx-error-for` attribute.
+  Failing to add the `data-phx-error-for` attribute will result in displaying error
+  messages for form fields that the user has not changed yet (e.g. required
+  fields further down on the page.)
+  
   For example, your `AppWeb.ErrorHelpers` may use this function:
 
       def error_tag(form, field) do


### PR DESCRIPTION
I was missing this data attribute which lead to having to ask other folks on the #phoenix channel in Slack, because I am not sure that "For proper form error tag updates" was clear enough about what the result of having/not having the attribute would be. Hopefully this makes it a bit clearer for the next person.