### PR TITLE
Allow live/3 layout to override plug layout

### DIFF
--- a/lib/phoenix_live_view/plug.ex
+++ b/lib/phoenix_live_view/plug.ex
@@ -40,7 +40,7 @@ defmodule Phoenix.LiveView.Plug do
   defp put_new_layout_from_router(conn, opts) do
     cond do
       live_link?(conn) -> Phoenix.Controller.put_layout(conn, false)
-      layout = opts[:layout] -> Phoenix.Controller.put_new_layout(conn, layout)
+      layout = opts[:layout] -> Phoenix.Controller.put_layout(conn, layout)
       true -> conn
     end
   end

--- a/test/phoenix_live_view/router_test.exs
+++ b/test/phoenix_live_view/router_test.exs
@@ -46,6 +46,17 @@ defmodule Phoenix.LiveView.RouterTest do
     assert conn.resp_body =~ "ALTERNATIVE"
   end
 
+  test "routing with custom layout overrides pipeline", %{conn: conn} do
+    conn = get(conn, "/alt/router/thermo/123")
+    assert conn.resp_body =~ "ALTERNATIVE"
+  end
+
+  test "routing with custom layout and live layout", %{conn: conn} do
+    conn = get(conn, "/alt/layout")
+    assert conn.resp_body =~ "ALTERNATIVE"
+    assert conn.resp_body =~ "LIVELAYOUTSTART"
+  end
+
   test "live_path helper", %{conn: conn} do
     assert Phoenix.LiveViewTest.Router.Helpers.live_path(conn, ThermostatLive) == "/thermo"
   end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -6,6 +6,10 @@ defmodule Phoenix.LiveViewTest.Router do
     plug :accepts, ["html"]
   end
 
+  pipeline :layout do
+    plug :put_layout, {Phoenix.LiveViewTest.LayoutView, :app}
+  end
+
   scope "/", Phoenix.LiveViewTest do
     pipe_through [:browser]
 
@@ -34,5 +38,14 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/shuffle", ShuffleLive
     live "/components", WithComponentLive
     live "/layout", LayoutLive
+  end
+
+  scope "/alt", Phoenix.LiveViewTest do
+    pipe_through [:browser, :layout]
+
+    live "/router/thermo/:id", DashboardLive,
+      layout: {Phoenix.LiveViewTest.AlternativeLayout, :layout}
+
+    live "/layout", LayoutLive, layout: {Phoenix.LiveViewTest.AlternativeLayout, :layout}
   end
 end


### PR DESCRIPTION
Currently, invoking the `live/3` macro with the `:layout` option will only put the desired layout if no layout is set. This PR ensures that specifying `:layout` in the router will always apply the layout to the LiveView, even if the layout was already set, for instance by a pipeline plug.