### PR TITLE
Ensure mergeAttributes removes extraneous attrs

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -926,10 +926,16 @@ export let DOM = {
   },
 
   mergeAttrs(target, source, exclude = []){
-    var attrs = source.attributes
-    for (let i = 0, length = attrs.length; i < length; i++){
-      let name = attrs[i].name
+    let sourceAttrs = source.attributes
+    for (let i = sourceAttrs.length - 1; i >= 0; i--){
+      let name = sourceAttrs[i].name
       if(exclude.indexOf(name) < 0){ target.setAttribute(name, source.getAttribute(name)) }
+    }
+
+    let targetAttrs = target.attributes
+    for (let i = targetAttrs.length - 1; i >= 0; i--){
+      let name = targetAttrs[i].name
+      if(!source.hasAttribute(name)){ target.removeAttribute(name) }
     }
   },
 

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -460,3 +460,43 @@ describe('View + Component', function() {
     view.pushEvent('keyup', input, targetCtx, "click", {})
   })
 });
+
+describe('DOM', function() {
+  it('mergeAttrs attributes', function() {
+    const target = document.createElement('target')
+    target.type = 'checkbox'
+    target.id = 'foo'
+    target.setAttribute('checked', 'true')
+
+    const source = document.createElement('source')
+    source.type = 'checkbox'
+    source.id = 'bar'
+
+    expect(target.getAttribute('checked')).toEqual('true')
+    expect(target.id).toEqual('foo')
+
+    DOM.mergeAttrs(target, source);
+
+    expect(target.getAttribute('checked')).toEqual(null)
+    expect(target.id).toEqual('bar')
+  })
+
+  it('mergeAttrs with properties', function() {
+    const target = document.createElement('target')
+    target.type = 'checkbox'
+    target.id = 'foo'
+    target.checked = true;
+
+    const source = document.createElement('source')
+    source.type = 'checkbox'
+    source.id = 'bar'
+
+    expect(target.checked).toEqual(true)
+    expect(target.id).toEqual('foo')
+
+    DOM.mergeAttrs(target, source);
+
+    expect(target.checked).toEqual(true)
+    expect(target.id).toEqual('bar')
+  })
+});


### PR DESCRIPTION
This PR ensures that a property, if not present in the `source` element, it is removed from the `target` element.

```js
// target
<input checked="true" type="checkbox" />

// source
<input type="checkbox" />
```