### PR TITLE
Fix checkboxes and select on updates.

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -29,6 +29,7 @@ const PHX_MAIN_VIEW_SELECTOR = `[data-phx-main=true]`
 const PHX_ERROR_FOR = "data-phx-error-for"
 const PHX_HAS_FOCUSED = "phx-has-focused"
 const FOCUSABLE_INPUTS = ["text", "textarea", "number", "email", "password", "search", "tel", "url"]
+const CHECKABLE_INPUTS = ["checkbox", "radio"]
 const PHX_HAS_SUBMITTED = "phx-has-submitted"
 const PHX_SESSION = "data-phx-session"
 const PHX_STATIC = "data-phx-static"
@@ -971,7 +972,7 @@ export let DOM = {
   isFormInput(el){ return /^(?:input|select|textarea|button)$/i.test(el.tagName) },
 
   syncAttrsToProps(el){
-    if(el instanceof HTMLInputElement && el.type.toLocaleLowerCase() === "checkbox"){
+    if(el instanceof HTMLInputElement && CHECKABLE_INPUTS.indexOf(el.type.toLocaleLowerCase()) >= 0){
       el.checked = el.getAttribute("checked") !== null
     }
   },
@@ -1512,7 +1513,7 @@ export class View {
     if(el.value !== undefined){
       meta.value = el.value
 
-      if (el.tagName === "INPUT" && el.type === "checkbox" && !el.checked) {
+      if (el.tagName === "INPUT" && CHECKABLE_INPUTS.indexOf(el.type) >= 0 && !el.checked) {
         delete meta.value
       }
     }

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -951,7 +951,7 @@ export let DOM = {
   },
 
   mergeFocusedInput(target, source){
-    // skip selects because FF with rest highlighted index for any setAttribute
+    // skip selects because FF will reset highlighted index for any setAttribute
     if(!(target instanceof HTMLSelectElement)){ DOM.mergeAttrs(target, source, ["value"]) }
     if(source.readOnly){
       target.setAttribute("readonly", true)

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -690,9 +690,9 @@ export class LiveSocket {
             if(DOM.isTextualInput(input)){
               DOM.putPrivate(input, PHX_HAS_FOCUSED, true)
             } else {
-              this.setActiveElement(input)
+              if(!(input instanceof HTMLSelectElement)){ this.setActiveElement(input) }
+              input.blur()
             }
-            if(!DOM.isTextualInput(input)){ input.blur() }
             view.pushInput(input, targetCtx, phxEvent, e.target)
           })
         })


### PR DESCRIPTION
Sync checkbox checked props with server attr on updates.
Skip focused select attribute merge because FF has
quirky UI behavior when any setAttribute is called
on the select while in a hover state. Closes #615

// @snewcomer 