### PR TITLE
Update installation.md to use latest version

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -13,7 +13,7 @@ installing from Hex, use the latest version from there:
 ```elixir
 def deps do
   [
-    {:phoenix_live_view, "~> 0.6.0"},
+    {:phoenix_live_view, "~> 0.7.1"},
     {:floki, ">= 0.0.0", only: :test}
   ]
 end


### PR DESCRIPTION
Not sure if y'all still want this file updated (or if it should really point you to install from gh), but `0.6.0` seems like an outdated version to point to.