### PR TITLE
Add `phx-window-key` events to docs

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -406,7 +406,7 @@ defmodule Phoenix.LiveView do
   | [Click Events](#module-click-events) | `phx-click`, `phx-capture-click` | `phx-target` |
   | [Focus/Blur Events](#module-focus-and-blur-events) | `phx-blur`, `phx-focus`, `phx-target` |
   | [Form Events](#module-form-events) | `phx-change`, `phx-submit`, `phx-target`, `data-phx-error-for`, `phx-disable-with` |
-  | [Key Events](#module-key-events) | `phx-keydown`, `phx-keyup`, `phx-target` |
+  | [Key Events](#module-key-events) | `phx-window-keydown`, `phx-window-keyup` |
   | [Rate Limiting](#module-rate-limiting-events-with-debounce-and-throttle) | `phx-debounce`, `phx-throttle` |
   | [DOM Patching](#module-dom-patching-and-temporary-assigns) | `phx-update` |
   | [JS Interop](#module-js-interop-and-client--controlled-dom) | `phx-hook` |


### PR DESCRIPTION
Using `phx-keydown` and `phx-keyup` with `phx-target="window"` has been
replaced with `phx-window-keydown` and `phx-window-keyup` as of `v0.7.0`