### PR TITLE
Add data-ref with css lifecycle classes

### DIFF
--- a/assets/css/live_view.css
+++ b/assets/css/live_view.css
@@ -65,3 +65,14 @@
   background: #ffe6f0!important;
 }
 
+/* Loading states */
+.phx-loading[phx-click] {
+  opacity: 0.5;
+  transition: opacity 1s ease-out;
+}
+
+.phx-loading-show { display: none; }
+.phx-loading-hide { display: block; }
+.phx-loading > .phx-loading-show { display: block; }
+.phx-loading > .phx-loading-hide { display: none; }
+

--- a/assets/css/live_view.css
+++ b/assets/css/live_view.css
@@ -66,13 +66,13 @@
 }
 
 /* Loading states */
-.phx-loading[phx-click] {
+.phx-click-loading {
   opacity: 0.5;
   transition: opacity 1s ease-out;
 }
 
 .phx-loading-show { display: none; }
 .phx-loading-hide { display: block; }
-.phx-loading > .phx-loading-show { display: block; }
-.phx-loading > .phx-loading-hide { display: none; }
+.phx-submit-loading > .phx-loading-show { display: block; }
+.phx-submit-loading > .phx-loading-hide { display: none; }
 

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -74,7 +74,7 @@ function detectDuplicateIds() {
 }
 
 export let debug = (view, kind, msg, obj) => {
-  if (DEBUG) {
+  if(DEBUG){
     console.log(`${view.id} ${kind}: ${msg} - `, obj)
   }
 }
@@ -871,7 +871,6 @@ export let DOM = {
 
   disableForm(form, prefix){
     let disableWith = `${prefix}${PHX_DISABLE_WITH}`
-    form.classList.add(PHX_LOADING_CLASS)
     DOM.all(form, `[${disableWith}]`, el => {
       let value = el.getAttribute(disableWith)
       el.setAttribute(`${disableWith}-restore`, el.innerText)
@@ -889,7 +888,6 @@ export let DOM = {
 
   restoreDisabledForm(form, prefix){
     let disableWith = `${prefix}${PHX_DISABLE_WITH}`
-    form.classList.remove(PHX_LOADING_CLASS)
 
     DOM.all(form, `[${disableWith}]`, el => {
       let value = el.getAttribute(`${disableWith}-restore`)
@@ -1155,6 +1153,7 @@ class DOMPatch {
     let fromRef = parseInt(fromRefAttr)
     if(this.ref !== null && this.ref >= fromRef){
       fromEl.removeAttribute(PHX_REF)
+      fromEl.classList.remove(PHX_LOADING_CLASS)
       return true
     } else {
       return false
@@ -1366,7 +1365,7 @@ export class View {
   }
 
   update(diff, cid, ref){
-    if(isEmpty(diff)){ return }
+    if(isEmpty(diff) && ref === null){ return }
     if(diff.title){ DOM.putTitle(diff.title) }
     if(this.joinPending || this.liveSocket.hasPendingLink()){ return this.pendingDiffs.push({diff, cid, ref}) }
 
@@ -1489,7 +1488,7 @@ export class View {
     if(typeof(payload.cid) !== "number"){ delete payload.cid }
     return(
       this.channel.push(event, payload, PUSH_TIMEOUT).receive("ok", resp => {
-        if(resp.diff){ this.update(resp.diff, payload.cid, ref) }
+        if(resp.diff || ref !== null){ this.update(resp.diff || {}, payload.cid, ref) }
         if(resp.redirect){ this.onRedirect(resp.redirect) }
         if(resp.live_patch){ this.onLivePatch(resp.live_patch) }
         if(resp.live_redirect){ this.onLiveRedirect(resp.live_redirect) }
@@ -1500,6 +1499,7 @@ export class View {
 
   putRef(el){
     let newRef = this.ref++
+    el.classList.add(PHX_LOADING_CLASS)
     el.setAttribute(PHX_REF, newRef)
     return newRef
   }

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1486,13 +1486,11 @@ export class View {
     if(typeof(payload.cid) !== "number"){ delete payload.cid }
     return(
       this.channel.push(event, payload, PUSH_TIMEOUT).receive("ok", resp => {
-        setTimeout(() => {
-          if(resp.diff){ this.update(resp.diff, payload.cid, ref) }
-          if(resp.redirect){ this.onRedirect(resp.redirect) }
-          if(resp.live_patch){ this.onLivePatch(resp.live_patch) }
-          if(resp.live_redirect){ this.onLiveRedirect(resp.live_redirect) }
-          onReply(resp)
-        }, 5000)
+        if(resp.diff){ this.update(resp.diff, payload.cid, ref) }
+        if(resp.redirect){ this.onRedirect(resp.redirect) }
+        if(resp.live_patch){ this.onLivePatch(resp.live_patch) }
+        if(resp.live_redirect){ this.onLiveRedirect(resp.live_redirect) }
+        onReply(resp)
       })
     )
   }

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1262,6 +1262,7 @@ export class View {
     Browser.dropLocal(this.name(), CONSECUTIVE_RELOADS)
     this.rendered = rendered
     let html = Rendered.toString(this.rendered)
+    this.dropPendingRefs()
     let forms = this.formsForRecovery(html)
 
     if(this.joinCount > 1 && forms.length > 0){
@@ -1276,6 +1277,8 @@ export class View {
       this.onJoinComplete(resp, html)
     }
   }
+
+  dropPendingRefs(){ DOM.all(this.el, `[${PHX_REF}]`, el => el.removeAttribute(PHX_REF)) }
 
   formsForRecovery(html){
     let phxChange = this.binding("change")

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -61,7 +61,7 @@ describe('View + DOM', function() {
     }
     view.channel = channelStub
 
-    view.pushWithReply({ target: el.querySelector('form') }, null, { value: 'increment=1' })
+    view.pushWithReply(null, { target: el.querySelector('form') }, { value: 'increment=1' })
   })
 
   test('pushWithReply with update', function() {
@@ -85,7 +85,7 @@ describe('View + DOM', function() {
     }
     view.channel = channelStub
 
-    view.pushWithReply({ target: el.querySelector('form') }, null, { value: 'increment=1' })
+    view.pushWithReply(null, { target: el.querySelector('form') }, { value: 'increment=1' })
 
     expect(view.el.querySelector('form')).toBeTruthy()
   })
@@ -247,7 +247,7 @@ describe('View + DOM', function() {
 
     view.submitForm(form, form, { target: form })
     expect(DOM.private(form, 'phx-has-submitted')).toBeTruthy()
-    expect(form.classList.contains('phx-loading')).toBeTruthy()
+    expect(form.classList.contains('phx-submit-loading')).toBeTruthy()
     expect(form.querySelector('button').dataset.phxDisabled).toBeTruthy()
     expect(form.querySelector('input').dataset.phxReadonly).toBeTruthy()
   })

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -61,7 +61,7 @@ describe('View + DOM', function() {
     }
     view.channel = channelStub
 
-    view.pushWithReply({ target: el.querySelector('form') }, { value: 'increment=1' })
+    view.pushWithReply({ target: el.querySelector('form') }, null, { value: 'increment=1' })
   })
 
   test('pushWithReply with update', function() {
@@ -85,7 +85,7 @@ describe('View + DOM', function() {
     }
     view.channel = channelStub
 
-    view.pushWithReply({ target: el.querySelector('form') }, { value: 'increment=1' })
+    view.pushWithReply({ target: el.querySelector('form') }, null, { value: 'increment=1' })
 
     expect(view.el.querySelector('form')).toBeTruthy()
   })

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1056,10 +1056,11 @@ defmodule Phoenix.LiveView do
   or additive UX around the user's input values as they fill out a form.
   For these use cases, the `phx-change` input does not concern itself
   with disabling input editing while an event to the server is in flight.
-  When a `phx-change` event is sent to the server, a `"_target"` param
-  will be in the root payload containing the keyspace of the input name
-  which triggered the change event. For example, if the following input
-  triggered a change event:
+  When a `phx-change` event is sent to the server the input tag and parent
+  form tag receive the `phx-change-loading` css class, then the payload is
+  pushed to the server with a `"_target"` param in the root payload
+  containing the keyspace of the input name which triggered the change event.
+  For example, if the following input triggered a change event:
 
       <input name="user[username]"/>
 
@@ -1075,11 +1076,11 @@ defmodule Phoenix.LiveView do
 
     1. The form's inputs are set to `readonly`
     2. Any submit button on the form is disabled
-    3. The form receives the `"phx-loading"` class
+    3. The form receives the `"phx-submit-loading"` class
 
   On completion of server processing of the `phx-submit` event:
 
-    1. The submitted form is reactivated and loses the `"phx-loading"` class
+    1. The submitted form is reactivated and loses the `"phx-submit-loading"` class
     2. The last input with focus is restored (unless another input has received focus)
     3. Updates are patched to the DOM as usual
 
@@ -1133,6 +1134,28 @@ defmodule Phoenix.LiveView do
     - `"phx-error"` - applied when an error occurs on the server. Note, this
       class will be applied in conjunction with `"phx-disconnected"` if connection
       to the server is lost.
+
+  All `phx-` event bindings apply their own css classes when pushed. For example
+  the following markup:
+
+      <button phx-click="clicked" phx-window-keydown="key">...</button>
+
+  In the case of forms, when a `phx-change` is sent to the server, the input element
+  which emitted the change receives the `phx-change-loading` class, along wiht the
+  parent form tag.
+
+  On click, would receive the `phx-click-loading` class, and on keydown would receive
+  the `phx-keydown-loading` class. The css loading classes are maintained until an
+  acknowledgement is received on the client for the pushed event. The following events
+  receive css loadng classes:
+
+    - `phx-click` - `phx-click-loading`
+    - `phx-change` - `phx-change-loading`
+    - `phx-submit` - `phx-submit-loading`
+    - `phx-focus` - `phx-focus-loading`
+    - `phx-blur` - `phx-blur-loading`
+    - `phx-window-keydown` - `phx-keydown-loading`
+    - `phx-window-keyup` - `phx-keyup-loading`
 
   ### JS Interop and client-controlled DOM
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1157,6 +1157,30 @@ defmodule Phoenix.LiveView do
     - `phx-window-keydown` - `phx-keydown-loading`
     - `phx-window-keyup` - `phx-keyup-loading`
 
+  For live page navigation via `live_redirect` and `live_patch`, the JavaScript
+  events `"phx:page-loading-start"` and `"phx:page-loading-stop"` are dispatched
+  on the window. Additionally, any `phx-` event may dispatch page loading events
+  by annotating the DOM element with `phx-page-loading`.
+  This is useful for showing main page loading status, for example:
+
+      // app.js
+      import NProgress from "nprogress"
+      window.addEventListener("phx:page-loading-start", info => NProgress.start())
+      window.addEventListener("phx:page-loading-stop", info => NProgress.done())
+
+  The `info` object will contain a `kind` key, with values one of:
+
+    - `"redirect"` - the event was triggered by a redirect
+    - `"patch"` - the event was triggered by a patch
+    - `"initial"` - the event was triggered by initial page load
+    - `"element"` - the event was triggered by a `phx-` bound element, such as `phx-click`
+
+  For all kinds of page loading events, all but `"element"` will receive an additional `to`
+  key in the info metadata pointing to the href associated with the page load.
+
+  In the case of an `"element"` page loading, the info will contain a `"target"` key containing
+  the DOM element which triggered the page loading state.
+
   ### JS Interop and client-controlled DOM
 
   To handle custom client-side JavaScript when an element is added, updated,

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1157,11 +1157,11 @@ defmodule Phoenix.LiveView do
     - `phx-window-keydown` - `phx-keydown-loading`
     - `phx-window-keyup` - `phx-keyup-loading`
 
-  For live page navigation via `live_redirect` and `live_patch`, the JavaScript
-  events `"phx:page-loading-start"` and `"phx:page-loading-stop"` are dispatched
-  on the window. Additionally, any `phx-` event may dispatch page loading events
-  by annotating the DOM element with `phx-page-loading`.
-  This is useful for showing main page loading status, for example:
+  For live page navigation via `live_redirect` and `live_patch`, as well as form
+  submits via `phx-submit`, the JavaScript events `"phx:page-loading-start"` and
+  `"phx:page-loading-stop"` are dispatched on window. Additionally, any `phx-`
+  event may dispatch page loading events by annotating the DOM element with
+  `phx-page-loading`. This is useful for showing main page loading status, for example:
 
       // app.js
       import NProgress from "nprogress"

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -305,7 +305,11 @@ defmodule Phoenix.LiveView.Channel do
       Diff.with_component(socket, cid, %{}, components, fn component_socket, component ->
         case component.handle_event(event, val, component_socket) do
           {:noreply, %Socket{redirected: redirected, assigns: assigns} = component_socket} ->
-            {component_socket, {redirected, assigns.flash}}
+            if redirected do
+              {Utils.clear_flash(component_socket), {redirected, assigns.flash}}
+            else
+              {component_socket, {redirected, assigns.flash}}
+            end
 
           other ->
             raise ArgumentError, """
@@ -317,7 +321,7 @@ defmodule Phoenix.LiveView.Channel do
         end
       end)
 
-    new_socket = Utils.merge_flash(socket, flash)
+    new_socket = if redirected, do: Utils.merge_flash(socket, flash), else: socket
     new_state = push_render(%{state | socket: new_socket, components: new_components}, diff, ref)
 
     if redirected do


### PR DESCRIPTION
Closes #569 #89

This likely also removes the need for `phx-disable-with`, though we could still keep it as a convenience. For example, the following css rules in your app.css:

```css
.phx-loading-show { display: none; }
.phx-loading-hide { display: block; }
.phx-loading > .phx-loading-show { display: block; }
.phx-loading > .phx-loading-hide { display: none; }
```

Could replace today's code:

```eex
  <div>
      <%= submit "Save", phx_disable_with: "Saving..." %>
  </div>
```

With:

```eex
  <div class="phx-loading-hide">
    <%= submit "Save" %>
  </div>
  <div class="phx-loading-show">
    <%= submit "Saving...", disabled: true %>
  </div>
```

Slightly more verbose but much more flexible. I am also fine keeping disable-width as a text-only replacement convenience as the css will work either way.