### PR TITLE
Change to Event Targeting Behaviour

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -25,6 +25,7 @@ const PHX_DISCONNECTED_CLASS = "phx-disconnected"
 const PHX_ERROR_CLASS = "phx-error"
 const PHX_PARENT_ID = "data-phx-parent-id"
 const PHX_VIEW_SELECTOR = `[${PHX_VIEW}]`
+const PHX_OWNER_SELECTOR= `[${PHX_COMPONENT}], [${PHX_VIEW}]`
 const PHX_MAIN_VIEW_SELECTOR = `[data-phx-main=true]`
 const PHX_ERROR_FOR = "data-phx-error-for"
 const PHX_HAS_FOCUSED = "phx-has-focused"
@@ -577,7 +578,7 @@ export class LiveSocket {
         }
         let phxEvent = target && target.getAttribute(click)
         if(!phxEvent){ return }
-        if(target.getAttribute("href") === "#"){ e.preventDefault() }
+        e.preventDefault()
 
         let meta = {
           altKey: e.altKey,
@@ -1489,7 +1490,7 @@ export class View {
     if(target.getAttribute(this.binding("target"))){
       return this.closestComponentID(targetCtx)
     } else {
-      return null
+      return this.closestComponentID(targetCtx)
     }
   }
 

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "phoenix_live_view",
-  "version": "0.4.1",
+  "version": "0.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -82,10 +82,13 @@ defmodule Phoenix.LiveComponent do
   ## Targeting Component Events
 
   Stateful components can also implement the `c:handle_event/3` callback
-  that works exactly the same as in LiveView. For a client event to
-  reach a component, the tag must be annotated with a `phx-target`
-  annotation which must be a query selector to an element inside the
-  component. For example, if the `UserComponent` above is started with
+  that works exactly the same as in LiveView. By default, events emitted inside
+  a stateful component's markup will be sent to that component for handling.
+  For a client event to reach a different component, the tag must be annotated
+  with a `phx-target` annotation which must be a query selector to an element
+  inside the target component.
+
+  For example, if the `UserComponent` above is started with
   the `:id` of `13`, it will have the DOM ID of `user-13`. Using a query
   selector, we can sent an event to it with:
 
@@ -104,6 +107,12 @@ defmodule Phoenix.LiveComponent do
       <a href="#" phx-click="close" phx-target="#modal, #sidebar">
         Dismiss
       </a>
+
+  Events emitted from inside a stateless component will bubble up the DOM
+  to the next stateful component or live view. To target an event at the
+  parent live view explicitly, set the `phx-target-parent` attribute; no
+  DOM ID is required, the parent live view of the target element will receive
+  the event.
 
   ### Preloading and update
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -403,10 +403,10 @@ defmodule Phoenix.LiveView do
   | Binding                | Attributes |
   |------------------------|------------|
   | [Params](#module-click-events) | `phx-value-*` |
-  | [Click Events](#module-click-events) | `phx-click`, `phx-capture-click` | `phx-target` |
-  | [Focus/Blur Events](#module-focus-and-blur-events) | `phx-blur`, `phx-focus`, `phx-target` |
-  | [Form Events](#module-form-events) | `phx-change`, `phx-submit`, `phx-target`, `data-phx-error-for`, `phx-disable-with` |
-  | [Key Events](#module-key-events) | `phx-keydown`, `phx-keyup`, `phx-target` |
+  | [Click Events](#module-click-events) | `phx-click`, `phx-capture-click` | `phx-target`, `phx-target-parent` |
+  | [Focus/Blur Events](#module-focus-and-blur-events) | `phx-blur`, `phx-focus`, `phx-target`, `phx-target-parent` |
+  | [Form Events](#module-form-events) | `phx-change`, `phx-submit`, `phx-target`, `phx-target-parent`, `data-phx-error-for`, `phx-disable-with` |
+  | [Key Events](#module-key-events) | `phx-keydown`, `phx-keyup`, `phx-target`, `phx-target-parent` |
   | [Rate Limiting](#module-rate-limiting-events-with-debounce-and-throttle) | `phx-debounce`, `phx-throttle` |
   | [DOM Patching](#module-dom-patching-and-temporary-assigns) | `phx-update` |
   | [JS Interop](#module-js-interop-and-client--controlled-dom) | `phx-hook` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "phoenix_live_view",
+  "version": "0.7.1",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
This change reflects the behaviour described in the Elixir Forum thread [LiveView Event Targeting in 0.5x](https://elixirforum.com/t/liveview-event-targeting-in-0-5x/28354). Basically, the current event targeting behaviour specifies that events will, by default, be handled by the LiveView that rendered the DOM element that emitted the event. 

This presents difficulties when writing stateful components (i.e, a component that implements `handle_event/3`), as it's necessary to ensure that every event is targeted using the `phx-target` attribute. It's also necessary to set a DOM ID for a parent element within the markup rendered by the component, which then acts as the `phx-target` value. This is complicated further when rendering non-unique components, such as a list item, as the DOM ID used must then also be unique, and so there's a burden on the developer to generate and specify a unique DOM ID per-component, and ensure that all events are correctly targeted using `phx-target` attributes.

This PR changes this behaviour in the following ways:

- Emitted events are, by default, bubbled up to the nearest stateful component or live view.
- Stateful components receive the `data-phx-stateful` attribute, which makes them eligible to receive events.
- Events can be targeted at the parent live view explicitly by using the `phx-target-parent` attribute, no value is required.

I believe this approach reduces the cognitive load on developers, and the likelihood for error, the hypothesis being that developers would expect events emitted from inside their stateful components to be routed to that component automatically, and routing them to the parent live view actually represents an unusual requirement that should not be the default.

I realise that this may not represent the desired behaviour of the maintainers, but I'd be interested in starting a discussion. As an avid user of LiveView, this change represents a behaviour that would greatly simplify my use case, which is what's provoked this PR.