### PR TITLE
Allow redirects from mount

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -506,7 +506,7 @@ defmodule Phoenix.LiveView do
       def handle_event("save", %{"user" => user_params}, socket) do
         case Accounts.create_user(user_params) do
           {:ok, user} ->
-            {:stop,
+            {:noreply,
              socket
              |> put_flash(:info, "user created")
              |> redirect(to: Routes.user_path(AppWeb.Endpoint, AppWeb.User.ShowView, user))}
@@ -522,7 +522,7 @@ defmodule Phoenix.LiveView do
   the form is re-rendered.
 
   Likewise for `phx-submit` bindings, the same callback is invoked and
-  persistence is attempted. On success, a `:stop` tuple is returned and the
+  persistence is attempted. On success, a `:noreply` tuple is returned and the
   socket is annotated for redirect with `Phoenix.LiveView.redirect/2` to
   the new user page, otherwise the socket assigns are updated with the errored
   changeset to be re-rendered for the client.
@@ -1277,7 +1277,7 @@ defmodule Phoenix.LiveView do
               session :: map,
               socket :: Socket.t()
             ) ::
-              {:ok, Socket.t()} | {:ok, Socket.t(), keyword()} | {:stop, Socket.t()}
+              {:ok, Socket.t()} | {:ok, Socket.t(), keyword()}
 
   @callback render(assigns :: Socket.assigns()) :: Phoenix.LiveView.Rendered.t()
 
@@ -1285,16 +1285,16 @@ defmodule Phoenix.LiveView do
             when reason: :normal | :shutdown | {:shutdown, :left | :closed | term}
 
   @callback handle_params(Socket.unsigned_params(), uri :: String.t(), socket :: Socket.t()) ::
-              {:noreply, Socket.t()} | {:stop, Socket.t()}
+              {:noreply, Socket.t()}
 
   @callback handle_event(event :: binary, Socket.unsigned_params(), socket :: Socket.t()) ::
-              {:noreply, Socket.t()} | {:stop, Socket.t()}
+              {:noreply, Socket.t()}
 
   @callback handle_call(msg :: term, {pid, reference}, socket :: Socket.t()) ::
-              {:noreply, Socket.t()} | {:reply, term, Socket.t()} | {:stop, Socket.t()}
+              {:noreply, Socket.t()} | {:reply, term, Socket.t()}
 
   @callback handle_info(msg :: term, socket :: Socket.t()) ::
-              {:noreply, Socket.t()} | {:stop, Socket.t()}
+              {:noreply, Socket.t()}
 
   @optional_callbacks mount: 3,
                       terminate: 2,

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -133,10 +133,7 @@ defmodule Phoenix.LiveView.Channel do
         end
 
       {:noreply, %Socket{} = new_socket} ->
-        case handle_changed(state, new_socket, nil) do
-          {:noreply, new_state} -> {:noreply, new_state}
-          {:stop, reason, new_state} -> {:stop, reason, new_state}
-        end
+        handle_changed(state, new_socket, nil) do
 
       other ->
         handle_result(other, {:handle_call, 3, nil}, state)

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -133,7 +133,7 @@ defmodule Phoenix.LiveView.Channel do
         end
 
       {:noreply, %Socket{} = new_socket} ->
-        handle_changed(state, new_socket, nil) do
+        handle_changed(state, new_socket, nil)
 
       other ->
         handle_result(other, {:handle_call, 3, nil}, state)

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -126,7 +126,12 @@ defmodule Phoenix.LiveView.Static do
           | extended_attrs
         ]
 
-        {:ok, to_rendered_content_tag(socket, tag, view, attrs), socket.assigns}
+        try do
+          {:ok, to_rendered_content_tag(socket, tag, view, attrs), socket.assigns}
+        catch
+          :throw, {:phoenix, :child_redirect, redir_opts, flash} ->
+            {:stop, socket |> rewrite_redir(redir_opts) |> Utils.merge_flash(flash)}
+        end
 
       {:stop, socket} ->
         {:stop, socket}
@@ -221,6 +226,10 @@ defmodule Phoenix.LiveView.Static do
     socket =
       Utils.maybe_call_mount!(socket, view, [:not_mounted_at_router, mount_session, socket])
 
+    if socket.redirected do
+      throw {:phoenix, :child_redirect, Utils.redirect_opts(socket), Utils.get_flash(socket)}
+    end
+
     if exports_handle_params?(view) do
       raise ArgumentError, "handle_params/3 is not allowed on child LiveViews, only at the root"
     end
@@ -285,16 +294,26 @@ defmodule Phoenix.LiveView.Static do
       {:stop, %Socket{redirected: nil}} ->
         Utils.raise_bad_stop_and_no_redirect!()
 
-      {:stop, %Socket{redirected: {:live, _, _}}} ->
-        Utils.raise_bad_stop_and_live_redirect!()
+      {:stop, %Socket{redirected: {:live, :redirect, opts}} = socket} ->
+        {:stop, rewrite_redir(socket, opts)}
+
+      {:stop, %Socket{redirected: {:live, {_, _}, _opts}}} ->
+        Utils.raise_bad_stop_and_live_patch!()
 
       {:stop, %Socket{} = new_socket} ->
         {:stop, new_socket}
     end
   end
 
-  defp mount_handle_params(socket, view, params, uri) do
+  defp rewrite_redir(%Socket{} = socket, live_redir_opts) do
+    %Socket{socket | redirected: {:redirect, live_redir_opts}}
+  end
+
+  defp mount_handle_params(%Socket{redirected: mount_redir} = socket, view, params, uri) do
     cond do
+      mount_redir ->
+        {:stop, socket}
+
       not exports_handle_params?(view) ->
         {:noreply, socket}
 

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -227,7 +227,7 @@ defmodule Phoenix.LiveView.Static do
       Utils.maybe_call_mount!(socket, view, [:not_mounted_at_router, mount_session, socket])
 
     if socket.redirected do
-      throw {:phoenix, :child_redirect, Utils.redirect_opts(socket), Utils.get_flash(socket)}
+      throw {:phoenix, :child_redirect, redirect_opts(socket), Utils.get_flash(socket)}
     end
 
     if exports_handle_params?(view) do
@@ -308,6 +308,11 @@ defmodule Phoenix.LiveView.Static do
   defp rewrite_redir(%Socket{} = socket, live_redir_opts) do
     %Socket{socket | redirected: {:redirect, live_redir_opts}}
   end
+
+  defp redirect_opts(%Socket{redirected: {:redirect, opts}}), do: opts
+  defp redirect_opts(%Socket{redirected: {:live, :redirect, opts}}), do: opts
+  defp redirect_opts(%Socket{redirected: {:live, {_, _} = _patch, opts}}), do: opts
+  defp redirect_opts(%Socket{}), do: raise(ArgumentError, "no redirect present")
 
   defp mount_handle_params(%Socket{redirected: mount_redir} = socket, view, params, uri) do
     cond do

--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -122,7 +122,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
       "url" => mount_url(view),
       "params" => view.connect_params,
       "caller" => state.caller,
-      "joins" => 0,
+      "joins" => 0
     }
 
     spec = {Phoenix.LiveView.Channel, {params, {self(), ref}, socket}}
@@ -508,6 +508,12 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
               |> put_view(child_view, pid, rendered)
               |> put_child(view, id, child_view.session_token)
               |> recursive_detect_added_or_removed_children(child_view, acc.html)
+
+            {:error, %{live_redirect: %{to: to}}} ->
+              throw({:stop, {:redirect, view, to}, acc})
+
+            {:error, %{redirect: %{to: to}}} ->
+              throw({:stop, {:redirect, view, to}, acc})
 
             {:error, reason} ->
               raise "failed to mount view: #{Exception.format_exit(reason)}"

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -336,6 +336,9 @@ defmodule Phoenix.LiveViewTest do
             end
         end
 
+      {:error, reason} ->
+        {:error, reason}
+
       :ignore ->
         receive do
           {^ref, {%_{} = exception, [_ | _] = stack}} -> reraise(exception, stack)

--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -212,18 +212,18 @@ defmodule Phoenix.LiveView.Utils do
         {:ok, %Socket{redirected: nil} = socket} ->
           socket
 
-        {:stop, %Socket{redirected: redir} = socket} when not is_nil(redir) ->
-          socket
+        {:ok, %Socket{redirected: redir}} when not is_nil(redir) ->
+          raise ArgumentError, """
+          attempted to redirect from mount without stopping in #{inspect(view)}.mount/#{arity}.
+
+          A redirect from mount/#{arity} must issue a stop by returning: {:stop, socket}
+          """
 
         {:stop, %Socket{redirected: nil}} ->
           raise_bad_stop_and_no_redirect!()
 
-        {:ok, %Socket{redirected: redir}} when not is_nil(redir) ->
-          raise ArgumentError, """
-          attempted to redirect from mount without stopping in #{inspect(view)}.mount/#{length(args)}.
-
-          A redirect from mount/#{length(args)} must issue a stop by returning: {:stop, socket}
-          """
+        {:stop, %Socket{redirected: _} = socket} ->
+          socket
 
         other ->
           raise ArgumentError, """
@@ -264,16 +264,6 @@ defmodule Phoenix.LiveView.Utils do
       LiveView.assign(socket, assigns)
     end
   end
-
-  @doc """
-  Returns the redirect opts for all types of redirects.
-
-  Raises when no redirect is present.
-  """
-  def redirect_opts(%Socket{redirected: {:redirect, opts}}), do: opts
-  def redirect_opts(%Socket{redirected: {:live, :redirect, opts}}), do: opts
-  def redirect_opts(%Socket{redirected: {:live, {_, _} = _patch, opts}}), do: opts
-  def redirect_opts(%Socket{}), do: raise ArgumentError, "no redirect present"
 
   defp random_encoded_bytes do
     binary = <<

--- a/test/phoenix_live_view/integrations/live_view_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test.exs
@@ -127,7 +127,7 @@ defmodule Phoenix.LiveView.LiveViewTest do
 
       assert ExUnit.CaptureLog.capture_log(fn ->
                live(conn)
-             end) =~ "attempted to live patch while stopping"
+             end) =~ "a LiveView cannot be mounted while issuing a live patch to the client"
     end
 
     test "child redirect when disconnected", %{conn: conn} do

--- a/test/phoenix_live_view/integrations/params_test.exs
+++ b/test/phoenix_live_view/integrations/params_test.exs
@@ -40,7 +40,7 @@ defmodule Phoenix.LiveView.ParamsTest do
       assert conn
              |> put_serialized_session(
                :on_handle_params,
-               &{:stop, LiveView.redirect(&1, to: "/")}
+               &{:noreply, LiveView.redirect(&1, to: "/")}
              )
              |> get("/counter/123?from=handle_params")
              |> redirected_to() == "/"
@@ -49,7 +49,7 @@ defmodule Phoenix.LiveView.ParamsTest do
     test "hard redirect with flash message", %{conn: conn} do
       conn =
         put_serialized_session(conn, :on_handle_params, fn socket ->
-          {:stop, socket |> LiveView.put_flash(:info, "msg") |> LiveView.redirect(to: "/")}
+          {:noreply, socket |> LiveView.put_flash(:info, "msg") |> LiveView.redirect(to: "/")}
         end)
         |> fetch_flash()
         |> get("/counter/123?from=handle_params")
@@ -74,14 +74,6 @@ defmodule Phoenix.LiveView.ParamsTest do
              end)
              |> get("/counter/123?from=handle_params")
              |> redirected_to() == "/thermo/456"
-    end
-
-    test "raises on stop without redirect", %{conn: conn} do
-      assert_raise Plug.Conn.WrapperError, ~r"attempted to stop socket without redirecting", fn ->
-        conn
-        |> put_serialized_session(:on_handle_params, &{:stop, &1})
-        |> get("/counter/123?from=handle_params")
-      end
     end
 
     test "with encoded URL", %{conn: conn} do
@@ -153,28 +145,6 @@ defmodule Phoenix.LiveView.ParamsTest do
         end)
         |> get("/counter/123?from=handle_params")
         |> live()
-    end
-
-    test "raises on stop without redirect", %{conn: conn} do
-      assert ExUnit.CaptureLog.capture_log(fn ->
-               pid =
-                 spawn(fn ->
-                   conn
-                   |> put_serialized_session(:on_handle_params, fn socket ->
-                     if LiveView.connected?(socket) do
-                       {:stop, socket}
-                     else
-                       {:noreply, socket}
-                     end
-                   end)
-                   |> get("/counter/123?from=handle_params")
-                   |> live()
-                 end)
-
-               ref = Process.monitor(pid)
-
-               assert_receive {:DOWN, ^ref, :process, _, _}
-             end) =~ ~r"attempted to stop socket without redirecting"
     end
 
     test "with encoded URL", %{conn: conn} do
@@ -266,46 +236,6 @@ defmodule Phoenix.LiveView.ParamsTest do
       assert_receive {:handle_params, "http://localhost:4000/counter/123?from=rehandled_params",
                       %{val: 1}, %{"from" => "rehandled_params", "id" => "123"}}
     end
-
-    test "raises if stopping with push_patch", %{conn: conn} do
-      {:ok, counter_live, _html} = live(conn, "/counter/123")
-
-      next = fn socket ->
-        {:stop, LiveView.push_patch(socket, to: "/counter/123?from=handle_call")}
-      end
-
-      assert ExUnit.CaptureLog.capture_log(fn ->
-               catch_exit(GenServer.call(counter_live.pid, {:push_patch, next}))
-             end) =~ "a LiveView cannot be stopped while issuing a live patch"
-    end
-
-    test "raises on stop without redirect", %{conn: conn} do
-      {:ok, counter_live, _html} = live(conn, "/counter/123")
-      next = fn socket -> {:stop, socket} end
-
-      assert ExUnit.CaptureLog.capture_log(fn ->
-               catch_exit(GenServer.call(counter_live.pid, {:push_patch, next}))
-             end) =~ "attempted to stop socket without redirecting"
-    end
-
-    test "raises if stopping from handle_params", %{conn: conn} do
-      {:ok, counter_live, _html} = live(conn, "/counter/123")
-
-      next = fn socket ->
-        new_socket =
-          LiveView.assign(socket, :on_handle_params, fn socket ->
-            {:stop, LiveView.push_patch(socket, to: "/counter/123?from=rehandle_params")}
-          end)
-
-        {:reply, :ok, LiveView.push_patch(new_socket, to: "/counter/123?from=handle_params")}
-      end
-
-      assert ExUnit.CaptureLog.capture_log(fn ->
-               catch_exit(GenServer.call(counter_live.pid, {:push_patch, next}))
-               ref = Process.monitor(counter_live.pid)
-               assert_receive {:DOWN, ^ref, _, _, _}
-             end) =~ "a LiveView cannot be stopped while issuing a live patch"
-    end
   end
 
   describe "push_redirect" do
@@ -344,7 +274,7 @@ defmodule Phoenix.LiveView.ParamsTest do
       {:ok, counter_live, _html} = live(conn, "/counter/123")
 
       next = fn socket ->
-        {:stop, LiveView.push_redirect(socket, to: "/thermo/123")}
+        {:noreply, LiveView.push_redirect(socket, to: "/thermo/123")}
       end
 
       assert {{:shutdown, {:redirect, "/thermo/123"}}, _} =
@@ -357,7 +287,7 @@ defmodule Phoenix.LiveView.ParamsTest do
       next = fn socket ->
         new_socket =
           LiveView.assign(socket, :on_handle_params, fn socket ->
-            {:stop, LiveView.push_redirect(socket, to: "/thermo/123")}
+            {:noreply, LiveView.push_redirect(socket, to: "/thermo/123")}
           end)
 
         {:reply, :ok, LiveView.push_patch(new_socket, to: "/counter/123?from=handle_params")}

--- a/test/phoenix_live_view/integrations/params_test.exs
+++ b/test/phoenix_live_view/integrations/params_test.exs
@@ -270,7 +270,7 @@ defmodule Phoenix.LiveView.ParamsTest do
       assert_remove(counter_live, {:redirect, "/thermo/123"})
     end
 
-    test "allows stopping with push_redirect", %{conn: conn} do
+    test "shuts down with push_redirect", %{conn: conn} do
       {:ok, counter_live, _html} = live(conn, "/counter/123")
 
       next = fn socket ->
@@ -279,21 +279,6 @@ defmodule Phoenix.LiveView.ParamsTest do
 
       assert {{:shutdown, {:redirect, "/thermo/123"}}, _} =
                catch_exit(GenServer.call(counter_live.pid, {:push_redirect, next}))
-    end
-
-    test "allows stopping from handle_params with push_redirect", %{conn: conn} do
-      {:ok, counter_live, _html} = live(conn, "/counter/123")
-
-      next = fn socket ->
-        new_socket =
-          LiveView.assign(socket, :on_handle_params, fn socket ->
-            {:noreply, LiveView.push_redirect(socket, to: "/thermo/123")}
-          end)
-
-        {:reply, :ok, LiveView.push_patch(new_socket, to: "/counter/123?from=handle_params")}
-      end
-
-      assert :ok = GenServer.call(counter_live.pid, {:push_patch, next})
     end
   end
 

--- a/test/phoenix_live_view_test.exs
+++ b/test/phoenix_live_view_test.exs
@@ -102,14 +102,6 @@ defmodule Phoenix.LiveViewUnitTest do
       assert redirect(@socket, to: "/foo").redirected == {:redirect, %{to: "/foo"}}
     end
 
-    test "errors on disconnected child render" do
-      socket = %{@socket | connected?: false, parent_pid: self()}
-
-      assert_raise ArgumentError,
-                   ~r"cannot invoke redirect/2 from a disconnected child LiveView",
-                   fn -> redirect(socket, to: "/counter/123") end
-    end
-
     test "allows external paths" do
       assert redirect(@socket, external: "http://foo.com/bar").redirected ==
                {:redirect, %{to: "http://foo.com/bar"}}
@@ -128,14 +120,6 @@ defmodule Phoenix.LiveViewUnitTest do
 
       assert push_redirect(@socket, to: "/counter/123").redirected ==
                {:live, :redirect, %{kind: :push, to: "/counter/123"}}
-    end
-
-    test "errors on disconnected child render" do
-      socket = %{@socket | connected?: false, parent_pid: self()}
-
-      assert_raise ArgumentError,
-                   ~r"cannot invoke push_redirect/2 from a disconnected child LiveView",
-                   fn -> push_redirect(socket, to: "/counter/123") end
     end
   end
 
@@ -159,14 +143,6 @@ defmodule Phoenix.LiveViewUnitTest do
 
       assert push_patch(socket, to: "/counter/123").redirected ==
                {:live, {%{"id" => "123"}, nil}, %{kind: :push, to: "/counter/123"}}
-    end
-
-    test "errors on disconnected child render" do
-      socket = %{@socket | connected?: false, parent_pid: self()}
-
-      assert_raise ArgumentError,
-                   ~r"cannot invoke push_patch/2 from a disconnected child LiveView",
-                   fn -> push_patch(socket, to: "/counter/123") end
     end
   end
 end

--- a/test/support/live_views/general.ex
+++ b/test/support/live_views/general.ex
@@ -53,7 +53,7 @@ defmodule Phoenix.LiveViewTest.ThermostatLive do
   end
 
   def handle_event("redir", to, socket) do
-    {:stop, redirect(socket, to: to)}
+    {:noreply, redirect(socket, to: to)}
   end
 
   def handle_event("inactive", msg, socket) do
@@ -73,7 +73,7 @@ defmodule Phoenix.LiveViewTest.ThermostatLive do
   def handle_info(:noop, socket), do: {:noreply, socket}
 
   def handle_info({:redir, to}, socket) do
-    {:stop, redirect(socket, to: to)}
+    {:noreply, redirect(socket, to: to)}
   end
 
   def handle_call({:set, var, val}, _, socket) do
@@ -321,10 +321,10 @@ defmodule Phoenix.LiveViewTest.RedirLive do
   def mount(%{"to" => to, "kind" => kind, "during" => during}, _session, socket) do
     cond do
       during == "connected" and connected?(socket) ->
-        {:stop, do_redirect(socket, kind, to: to)}
+        {:ok, do_redirect(socket, kind, to: to)}
 
       during == "disconnected" and not connected?(socket) ->
-        {:stop, do_redirect(socket, kind, to: to)}
+        {:ok, do_redirect(socket, kind, to: to)}
 
       during == "connected" -> {:ok, assign(socket, title: "parent_content", child_params: nil)}
     end
@@ -341,10 +341,10 @@ defmodule Phoenix.LiveViewTest.RedirLive do
   def mount(_params, %{"child_redir" => %{"to" => to, "kind" => kind, "during" => during}}, socket) do
     cond do
       during == "connected" and connected?(socket) ->
-        {:stop, do_redirect(socket, kind, to: to)}
+        {:ok, do_redirect(socket, kind, to: to)}
 
       during == "disconnected" and not connected?(socket) ->
-        {:stop, do_redirect(socket, kind, to: to)}
+        {:ok, do_redirect(socket, kind, to: to)}
 
       during == "connected" -> {:ok, assign(socket, title: "child_content", child_params: nil)}
     end

--- a/test/support/live_views/general.ex
+++ b/test/support/live_views/general.ex
@@ -306,3 +306,51 @@ defmodule Phoenix.LiveViewTest.FlashChildLive do
 end
 
 
+defmodule Phoenix.LiveViewTest.RedirLive do
+  use Phoenix.LiveView
+
+  def render(assigns) do
+    ~L"""
+    Title: <%= @title %>
+    <%= if @child_params do %>
+      <%= live_render(@socket, __MODULE__, id: :child, session: %{"child_redir" => @child_params}) %>
+    <% end %>
+    """
+  end
+
+  def mount(%{"to" => to, "kind" => kind, "during" => during}, _session, socket) do
+    cond do
+      during == "connected" and connected?(socket) ->
+        {:stop, do_redirect(socket, kind, to: to)}
+
+      during == "disconnected" and not connected?(socket) ->
+        {:stop, do_redirect(socket, kind, to: to)}
+
+      during == "connected" -> {:ok, assign(socket, title: "parent_content", child_params: nil)}
+    end
+  end
+
+  def mount(%{"child_to" => to, "kind" => kind, "during" => during}, session, socket) when session == %{} do
+    if socket.parent_pid == nil do
+      {:ok, assign(socket, title: "parent_content", child_params: %{"to" => to, "kind" => kind, "during" => during})}
+    else
+      raise "cannot nest"
+    end
+  end
+
+  def mount(_params, %{"child_redir" => %{"to" => to, "kind" => kind, "during" => during}}, socket) do
+    cond do
+      during == "connected" and connected?(socket) ->
+        {:stop, do_redirect(socket, kind, to: to)}
+
+      during == "disconnected" and not connected?(socket) ->
+        {:stop, do_redirect(socket, kind, to: to)}
+
+      during == "connected" -> {:ok, assign(socket, title: "child_content", child_params: nil)}
+    end
+  end
+
+  defp do_redirect(socket, "push_redirect", opts), do: push_redirect(socket, opts)
+  defp do_redirect(socket, "redirect", opts), do: redirect(socket, opts)
+  defp do_redirect(socket, "push_patch", opts), do: push_patch(socket, opts)
+end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -42,6 +42,7 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/thermo-container", ThermostatLive, container: {:span, style: "thermo-flex<script>"}
     live "/", ThermostatLive, as: :live_root
     live "/clock", ClockLive
+    live "/redir", RedirLive
 
     live "/same-child", SameChildLive
     live "/root", RootLive


### PR DESCRIPTION
Kill `:stop` returns