### PR TITLE
Avoid sending blank diff

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -441,6 +441,9 @@ defmodule Phoenix.LiveView.Channel do
   defp push_noop(state, nil = _ref), do: state
   defp push_noop(state, ref), do: reply(state, ref, :ok, %{})
 
+  defp push_render(state, diff, ref) when diff == %{} do
+    push_noop(state, ref)
+  end
   defp push_render(state, diff, nil = _ref), do: push(state, "diff", diff)
   defp push_render(state, diff, ref), do: reply(state, ref, :ok, %{diff: diff})
 


### PR DESCRIPTION
I noticed my LiveView client-side would sometimes get messages like `[null,null,"lv:phx-FfXBbBfjffgfdQVi","diff",{}]`

I'm not sure on the full implications, but it seemed safe to skip sending those diffs in my testing of my app? I think the cause in my case was doing some assigns that caused the socket to be changed, but did not ultimately lead to a change in the rendered content. I could put together a reproduction if it's helpful.

Even if my understanding is correct so far, I also wasn't sure if this should be fixed further up the chain.