### PR TITLE
Fix event overview table in live_view docs

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -385,7 +385,7 @@ defmodule Phoenix.LiveView do
   | Binding                | Attributes |
   |------------------------|------------|
   | [Params](#module-click-events) | `phx-value-*` |
-  | [Click Events](#module-click-events) | `phx-click`, `phx-capture-click` | `phx-target` |
+  | [Click Events](#module-click-events) | `phx-click`, `phx-capture-click` `phx-target` |
   | [Focus/Blur Events](#module-focus-and-blur-events) | `phx-blur`, `phx-focus`, `phx-target` |
   | [Form Events](#module-form-events) | `phx-change`, `phx-submit`, `phx-target`, `data-phx-error-for`, `phx-disable-with` |
   | [Key Events](#module-key-events) | `phx-window-keydown`, `phx-window-keyup` |


### PR DESCRIPTION
The documentation is currently oddly formatted on hexdocs (see image) due to an extra pipe.

![image](https://user-images.githubusercontent.com/10086452/75111387-67092a80-5639-11ea-82a3-adf4b7cfcd83.png)