### PR TITLE
Fix incorrect behavior history.replaceState for IE

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -841,7 +841,7 @@ export let Browser = {
   pushState(kind, meta, to){
     if(this.canPushState()){
       if(to !== window.location.href){
-        history[kind + "State"](meta, "", to)
+        history[kind + "State"](meta, "", to || null)
         let hashEl = this.getHashTargetEl(window.location.hash)
 
         if(hashEl) {


### PR DESCRIPTION
Function call history[kind + "State"](meta, "", undefined) replaces url to /undefined in IE11 and Microsoft Edge 44.17763.1.0