### PR TITLE
Support user-defined metadata

### DIFF
--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -175,7 +175,7 @@ defmodule Phoenix.LiveView.Router do
      as: opts[:as] || as_helper,
      private: %{phoenix_live_view: {live_view, opts}},
      alias: false,
-     metadata: Map.merge(%{phoenix_live_view: {live_view, action}}, metadata)}
+     metadata: Map.put(metadata, :phoenix_live_view, {live_view, action})}
   end
 
   defp inferred_as(live_view, nil), do: {:live, live_view}

--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -158,6 +158,12 @@ defmodule Phoenix.LiveView.Router do
   def __live__(router, live_view, action, opts) when is_atom(action) and is_list(opts) do
     live_view = Phoenix.Router.scoped_alias(router, live_view)
 
+    {metadata, opts} = case opts[:metadata] do
+      nil -> {%{}, opts}
+      metadata ->
+        {metadata, Keyword.delete(opts, :metadata)}
+    end
+
     opts =
       opts
       |> Keyword.put(:router, router)
@@ -170,7 +176,7 @@ defmodule Phoenix.LiveView.Router do
      as: opts[:as] || as_helper,
      private: %{phoenix_live_view: {live_view, opts}},
      alias: false,
-     metadata: %{phoenix_live_view: {live_view, action}}}
+     metadata: Map.merge(%{phoenix_live_view: {live_view, action}}, metadata)}
   end
 
   defp inferred_as(live_view, nil), do: {:live, live_view}

--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -158,11 +158,7 @@ defmodule Phoenix.LiveView.Router do
   def __live__(router, live_view, action, opts) when is_atom(action) and is_list(opts) do
     live_view = Phoenix.Router.scoped_alias(router, live_view)
 
-    {metadata, opts} = case opts[:metadata] do
-      nil -> {%{}, opts}
-      metadata ->
-        {metadata, Keyword.delete(opts, :metadata)}
-    end
+    {metadata, opts} = Keyword.pop(opts, :metadata, %{})
 
     opts =
       opts

--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -71,6 +71,9 @@ defmodule Phoenix.LiveView.Router do
       using a LiveView without actions or default to the LiveView name when using
       actions.
 
+    * `:metadata` - a map to optional feed metadata used on telemetry events and route info
+      for example: `%{route_name: :foo, access: :user}`
+
   ## Examples
 
       defmodule MyApp.Router

--- a/test/phoenix_live_view/router_test.exs
+++ b/test/phoenix_live_view/router_test.exs
@@ -60,4 +60,14 @@ defmodule Phoenix.LiveView.RouterTest do
     assert Routes.foo_bar_nested_index_path(conn, :show) == "/router/foobarbaz/nested/show"
     assert Routes.custom_foo_bar_path(conn, :index) == "/router/foobarbaz/custom"
   end
+
+  test "user-defined metadata is available inside of metadata key" do
+    routes_with_metadata = Phoenix.LiveViewTest.Router.__routes__()
+      |> Enum.filter(fn r -> Regex.match?(~r/user_defined_metadata*/, r.helper) end)
+
+    assert length(routes_with_metadata) == 2
+
+    route = List.first(routes_with_metadata)
+    assert Map.has_key?(route.metadata, :route_name)
+  end
 end

--- a/test/phoenix_live_view/router_test.exs
+++ b/test/phoenix_live_view/router_test.exs
@@ -62,18 +62,12 @@ defmodule Phoenix.LiveView.RouterTest do
   end
 
   test "user-defined metadata is available inside of metadata key" do
-    assert Phoenix.Router.route_info(Phoenix.LiveViewTest.Router, "GET", "/opts-with-metadata", nil) == %{
-      log: :debug,
-      path_params: %{},
-      phoenix_live_view: {Phoenix.LiveViewTest.OptsLive, nil},
-      pipe_through: [],
-      plug: Phoenix.LiveView.Plug,
-      plug_opts: Phoenix.LiveViewTest.OptsLive,
-      route: "/opts-with-metadata",
-      route_name: "opts"
-    }
+    assert Phoenix.LiveViewTest.Router
+      |> Phoenix.Router.route_info("GET", "/opts-with-metadata", nil)
+      |> Map.get(:route_name) == "opts"
+
     assert Phoenix.LiveViewTest.Router
       |> Phoenix.Router.route_info("GET", "/widget-with-metadata", nil)
-      |> Map.has_key?(:route_name)
+      |> Map.get(:route_name) == "widget"
   end
 end

--- a/test/phoenix_live_view/router_test.exs
+++ b/test/phoenix_live_view/router_test.exs
@@ -62,12 +62,18 @@ defmodule Phoenix.LiveView.RouterTest do
   end
 
   test "user-defined metadata is available inside of metadata key" do
-    routes_with_metadata = Phoenix.LiveViewTest.Router.__routes__()
-      |> Enum.filter(fn r -> Regex.match?(~r/user_defined_metadata*/, r.helper) end)
-
-    assert length(routes_with_metadata) == 2
-
-    route = List.first(routes_with_metadata)
-    assert Map.has_key?(route.metadata, :route_name)
+    assert Phoenix.Router.route_info(Phoenix.LiveViewTest.Router, "GET", "/opts-with-metadata", nil) == %{
+      log: :debug,
+      path_params: %{},
+      phoenix_live_view: {Phoenix.LiveViewTest.OptsLive, nil},
+      pipe_through: [],
+      plug: Phoenix.LiveView.Plug,
+      plug_opts: Phoenix.LiveViewTest.OptsLive,
+      route: "/opts-with-metadata",
+      route_name: "opts"
+    }
+    assert Phoenix.LiveViewTest.Router
+      |> Phoenix.Router.route_info("GET", "/widget-with-metadata", nil)
+      |> Map.has_key?(:route_name)
   end
 end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -80,4 +80,9 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/flash-root", FlashLive
     live "/flash-child", FlashChildLive
   end
+
+  scope "/", as: :user_defined_metadata, alias: Phoenix.LiveViewTest do
+    get "/widget-with-metadata", Controller, :widget, metadata: %{route_name: "widget"}
+    live "/opts-with-metadata", OptsLive,  metadata: %{route_name: "opts"}
+  end
 end


### PR DESCRIPTION
It is on allowing the same behavior for the metadata key, as phoenix does.

Passing metadata to `Phoenix.LiveView.Router.live/4` set metadata as part of the privates while doing it in `Phoenix.Router.get/4` is merged with metadata key useful to telemetry feeds, as Phoenix documentation says.