### PR TITLE
Improve Event Capturing docs

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -375,9 +375,11 @@ defmodule Phoenix.LiveView do
       `clientX`, a keydown event's `keyCode`, etc.
 
   The `phx-capture-click` event is just like `phx-click`, but instead of the click event
-  bubbling up to the closest `phx-click` element, event capturing is used, where the
-  events propagate inwards from the clicked element. This is useful when wanting to bind a click
-  events without receiving bubbled events from child UI elements.
+  being displatched to the closest `phx-click` element as it bubbles up through the DOM, the event
+  is dispatched as it propagates from the top of the DOM tree down to the target element. This is
+  useful when wanting to bind click events without receiving bubbled events from child UI elements.
+  Since capturing happens before bubbling, this can also be important for preparing or preventing
+  behaviour that will be applied during the bubbling phase.
 
   ### Focus and Blur Events
 


### PR DESCRIPTION
> events propagate inwards from the clicked element

Just a minor clarification that the event starts at `window` and goes down the DOM tree to the target element.