### PR TITLE
Invert adding import and fetch_live_flash installation steps

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -41,21 +41,7 @@ config :my_app, MyAppWeb.Endpoint,
    ]
 ```
 
-Next, add the `Phoenix.LiveView.Router.fetch_live_flash` plug to your browser pipeline, in place of `:fetch_flash`:
-
-```diff
-# lib/my_app_web/router.ex
-import Phoenix.LiveView.Router
-
-pipeline :browser do
-  ...
-  plug :fetch_session
-- plug :fetch_flash
-+ plug :fetch_live_flash
-end
-```
-
-Then add the following imports to your web file in `lib/my_app_web.ex`:
+Next, add the following imports to your web file in `lib/my_app_web.ex`:
 
 ```elixir
 # lib/my_app_web.ex
@@ -79,6 +65,20 @@ def router do
     ...
     import Phoenix.LiveView.Router
   end
+end
+```
+
+Then add the `Phoenix.LiveView.Router.fetch_live_flash` plug to your browser pipeline, in place of `:fetch_flash`:
+
+```diff
+# lib/my_app_web/router.ex
+import Phoenix.LiveView.Router
+
+pipeline :browser do
+  ...
+  plug :fetch_session
+- plug :fetch_flash
++ plug :fetch_live_flash
 end
 ```
 


### PR DESCRIPTION
Not a big change, but my editor compiles the project on save and when following the installation guide I thought I did something wrong in the `:fetch_live_flash` step since the compilation failed and I had to double check.
Inverting these two steps fixes the issue.