### PR TITLE
improve installation.md docs

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -72,7 +72,6 @@ Then add the `Phoenix.LiveView.Router.fetch_live_flash` plug to your browser pip
 
 ```diff
 # lib/my_app_web/router.ex
-import Phoenix.LiveView.Router
 
 pipeline :browser do
   ...

--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -171,6 +171,8 @@ Ensure you have placed a CSRF meta tag inside the `<head>` tag in your layout (`
 <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
 ```
 
+LiveView no longer uses the default app layout. Instead, use `put_root_layout`. Note, however, that the layout given to `put_root_layout` must use `@inner_content` instead of `<%= render(@view_module, @view_template, assigns) %>` and that the root layout will also be used by regular views. Therefore, we recommend setting `put_root_layout` in a pipeline that is exclusive to LiveViews. Check the [Live Layouts](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#module-live-layouts) section of the docs.
+
 Enable connecting to a LiveView socket in your `app.js` file.
 
 ```javascript


### PR DESCRIPTION
Most common mistake users have when adding LiveView to an already generated project is forgetting about adding the combo `put_root_layout` + `@inner_content` to their project.

`Live Layouts` section of the docs is quite down the page, so I think adding a notice to it in the installation docs might help those that otherwise might spend some time wondering why their LiveView isn't connecting after doing everything in the installation instructions.

I see Phoenix is adding a `phx.gen.live` in the upcoming release which will take care of these things, so this might only be needed temporarily.