### PR TITLE
Improve `live_component` docs.

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -173,7 +173,7 @@ defmodule Phoenix.LiveComponent do
   for each card, passing the card struct as argument to CardComponent:
 
       <%= for card <- @cards do %>
-        <%= live_component CardComponent, card: card, board_id: @id %>
+        <%= live_component @socket, CardComponent, card: card, board_id: @id %>
       <% end %>
 
   Now, when the user submits a form inside the CardComponent to update the
@@ -240,7 +240,7 @@ defmodule Phoenix.LiveComponent do
   only by passing the IDs:
 
       <%= for card_id <- @card_ids do %>
-        <%= live_component CardComponent, card_id: card_id, board_id: @id %>
+        <%= live_component @socket, CardComponent, card_id: card_id, board_id: @id %>
       <% end %>
 
   Now, each CardComponent loads their own card. Of course, doing so per

--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -39,7 +39,7 @@ defmodule Phoenix.LiveComponent do
 
   First `c:mount/1` is called only with the socket. `mount/1` can be used
   to set any initial state. Then `c:update/2` is invoked with all of the
-  assigns given to `live_component/2`. The default implementation of
+  assigns given to `live_component/3`. The default implementation of
   `c:update/2` simply merges all assigns into the socket. Then, after the
   component is updated, `c:render/1` is called with all assigns.
 
@@ -51,7 +51,7 @@ defmodule Phoenix.LiveComponent do
 
   ## Stateful components life-cycle
 
-  A stateful component is a component that receives an `:id` on `live_component/2`:
+  A stateful component is a component that receives an `:id` on `live_component/3`:
 
       <%= live_component @socket, HeroComponent, id: :hero, content: @content %>
 
@@ -169,7 +169,7 @@ defmodule Phoenix.LiveComponent do
   ### LiveView as the source of truth
 
   If the LiveView is the source of truth, the LiveView will be responsible
-  for fetching all of the cards in a board. Then it will call `live_component/2`
+  for fetching all of the cards in a board. Then it will call `live_component/3`
   for each card, passing the card struct as argument to CardComponent:
 
       <%= for card <- @cards do %>


### PR DESCRIPTION
There were a couple of examples where `live_component` is called without `@socket`. As far as I can see this is no longer supported behaviour? This PR updates those two references, and optionally, updates `live_component/2` to `live_component/3` as assigns are given pretty much everywhere.

Originates from a confused person in the liveview channel on elixir slack.