### PR TITLE
Add detail to phx-click metadata

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -659,6 +659,7 @@ export class LiveSocket {
           screenY: e.screenY,
           offsetX: e.offsetX,
           offsetY: e.offsetY,
+          detail: e.detail || 1,
         }
 
         this.debounce(target, e, () => {


### PR DESCRIPTION
The `detail` property on click events returns the click count. This value resets after a short timeout, so it's generally `1` for single-clicks, `2` for double-clicks, and occasionally `3` if you click really fast. Support from [IE9+](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail).

It's very useful for detecting double-clicks with a simple pattern-match:
```elixir
def handle_event("click", %{"detail" => 2}, socket) do
# ...
end
```