### PR TITLE
Optimize client rendering

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -219,7 +219,7 @@ export let Rendered = {
   recursiveCIDToString(components, cid, onlyCids){
     let component = components[cid] || logError(`no component for CID ${cid}`, components)
     let template = document.createElement("template")
-    template.innerHTML = this.toString(component, components)
+    template.innerHTML = this.toString(component, components, onlyCids)
     let container = template.content
     let skip = onlyCids && !onlyCids.has(cid)
     Array.from(container.childNodes).forEach(child => {

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -152,8 +152,7 @@ export let Rendered = {
 
   isComponentOnlyDiff(diff){
     if(!diff[COMPONENTS]){ return false }
-    let keys = Object.keys(diff).filter(k => k !== "title" && k !== COMPONENTS)
-    return keys.length === 0
+    return Object.keys(diff).filter(k => k !== "title" && k !== COMPONENTS).length === 0
   },
 
   mergeDiff(source, diff){
@@ -1110,9 +1109,7 @@ class DOMPatch {
   }
 
   undoRefs(){
-    DOM.all(this.container, `[${PHX_REF}]`, el => {
-      this.syncPendingRef(el, el)
-    })
+    DOM.all(this.container, `[${PHX_REF}]`, el => this.syncPendingRef(el, el))
   }
 
   perform(){
@@ -1135,7 +1132,6 @@ class DOMPatch {
     this.trackBefore("added", container)
     this.trackBefore("updated", container, container)
 
-    // console.log(diffHTML.outerHTML)
     liveSocket.time("morphdom", () => {
       morphdom(targetContainer, diffHTML, {
         childrenOnly: targetContainer.getAttribute(PHX_COMPONENT) === null,
@@ -1201,10 +1197,10 @@ class DOMPatch {
             return false
           } else {
             // we optimize append/prepend operations in two ways:
-            //   1) by tracking the previously
-            //     appended ids. If the ids don't change b/w patches, we know that we
-            //     are going to re-arrange the same appendPrependUpdates so we can
-            //     skip the post-morph append/prepend ops.
+            //   1) By tracking the previously appended ids. If the ids don't
+            //     change b/w patches, we know that we are going to re-arrange
+            //     the same appendPrependUpdates so we can skip the post-morph
+            //     append/prepend ops.
             //   2) for appends, we can skip post-morph re-arranging if the
             //     new content contains only new ids, because it will simply
             //     be appended to the container
@@ -1624,7 +1620,7 @@ export class View {
     if(diff.title){ DOM.putTitle(diff.title) }
     if(this.isJoinPending() || this.liveSocket.hasPendingLink()){ return this.pendingDiffs.push({diff, cid: cidAck, ref}) }
 
-    this.log("update", () => ["", {diff, cidAck, ref}])
+    this.log("update", () => ["", diff])
     this.rendered = Rendered.mergeDiff(this.rendered, diff)
     let phxChildrenAdded = false
 

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -484,7 +484,7 @@ export class LiveSocket {
   }
 
   withinTargets(phxTarget, callback){
-    if(/^(0|[1-9]\d+)$/.test(phxTarget)){
+    if(/^(0|[1-9](\d?)+)$/.test(phxTarget)){
       let myselfTarget = DOM.findFirstComponentNode(document, phxTarget)
       if(!myselfTarget){ throw new Error(`no phx-target's found matching @myself of ${phxTarget}`) }
       this.owner(myselfTarget , view => callback(view, myselfTarget))
@@ -1616,9 +1616,12 @@ export class View {
       patch.undoRefs()
     } else {
       time("fullPatch", () => {
-        let html = Rendered.toString(this.rendered, this.rendered[COMPONENTS], Rendered.componentCIDs(diff))
+        let html = time("toString", () => {
+          return Rendered.toString(this.rendered, this.rendered[COMPONENTS], Rendered.componentCIDs(diff))
+        })
         let patch = new DOMPatch(this, this.el, this.id, html, null, ref)
         phxChildrenAdded = this.performPatch(patch)
+        patch.undoRefs()
       })
     }
 

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1200,13 +1200,20 @@ class DOMPatch {
             updates.push(fromEl)
             return false
           } else {
+            // we optimize append/prepend operations in two ways:
+            //   1) by tracking the previously
+            //     appended ids. If the ids don't change b/w patches, we know that we
+            //     are going to re-arrange the same appendPrependUpdates so we can
+            //     skip the post-morph append/prepend ops.
+            //   2) for appends, we can skip post-morph re-arranging if the
+            //     new content contains only new ids, because it will simply
+            //     be appended to the container
             if(DOM.isPhxUpdate(toEl, phxUpdate, ["append", "prepend"])){
+              let isAppend = toEl.getAttribute(phxUpdate) === "append"
               let idsBefore = Array.from(fromEl.children).map(child => child.id)
               let newIds = Array.from(toEl.children).map(child => child.id)
               onUpdated[toEl.id] = (el) => DOM.putPrivate(el, "prev-new", newIds)
               let prevNew = DOM.private(fromEl, "prev-new") || []
-
-              let isAppend = toEl.getAttribute(phxUpdate) === "append"
               let isOnlyNewIds = isAppend && !newIds.find(id => idsBefore.indexOf(id) >= 0)
 
               if(!(isOnlyNewIds || prevNew.toString() === newIds.toString())){

--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -462,7 +462,7 @@ defmodule Phoenix.LiveView.Diff do
         socket = Utils.clear_changed(%{socket | fingerprints: component_prints})
         {socket, pending_components, Map.put(component_diffs, cid, diff), components}
       else
-        {socket, pending_components, component_diffs, components}
+        {socket, pending_components, Map.put(component_diffs, cid, %{}), components}
       end
 
     id_to_components = Map.put(id_to_components, id, dump_component(socket, cid))

--- a/test/phoenix_live_view/diff_test.exs
+++ b/test/phoenix_live_view/diff_test.exs
@@ -392,7 +392,7 @@ defmodule Phoenix.LiveView.DiffTest do
              }
 
       {_socket, full_render, _components} = render(rendered, socket.fingerprints, components)
-      assert full_render == %{0 => 0}
+      assert full_render == %{0 => 0, :c => %{0 => %{}}}
     end
 
     test "explicit block tracking" do
@@ -520,7 +520,7 @@ defmodule Phoenix.LiveView.DiffTest do
       {socket, full_render, components} =
         render(rendered, previous_socket.fingerprints, previous_components)
 
-      assert full_render == %{0 => 0}
+      assert full_render == %{0 => 0, :c => %{0 => %{}}}
       assert socket.fingerprints == previous_socket.fingerprints
       assert components == previous_components
 


### PR DESCRIPTION
Various optimizations:

- for a component with a single HTML root, we can skip patching the `data-phx-component` parent node, which requires marking all non-component siblings and skipped when we morph. This avoid traversing unnecessary child nodes

- fixes an issue where a diff for a component-only update caused the entire LV container to be patched

- the server now computes all the component cids that are touched when a diff is calculated, and sends them to the client with a component diff. This allows us to avoid computing LiveView template content that is not part of the component update.

- optimizes append/prepend updates by no longer cloning the entire LV DOM container, walking the children, then converting the computed string for morphdom to re-parse and walk