### PR TITLE
Improve LiveViewTest.__live__/2 error

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -250,6 +250,10 @@ defmodule Phoenix.LiveViewTest do
       {:sent, 302} ->
         error_redirect_conn(conn)
 
+      {:sent, _} ->
+        raise ArgumentError,
+              "request to #{conn.request_path} received unexpected #{status} response"
+
       {_, _} ->
         raise ArgumentError, """
         a request has not yet been sent.

--- a/test/phoenix_live_view/integrations/live_view_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test.exs
@@ -67,6 +67,14 @@ defmodule Phoenix.LiveView.LiveViewTest do
       end
     end
 
+    test "live mount with unexpected status", %{conn: conn} do
+      assert_raise ArgumentError, ~r/unexpected 404 response/, fn ->
+        conn
+        |> get("/not_found")
+        |> live()
+      end
+    end
+
     test "push_redirect when disconnected", %{conn: conn} do
       conn = get(conn, "/redir?during=disconnected&kind=push_redirect&to=/thermo")
       assert redirected_to(conn) == "/thermo"

--- a/test/support/controller.ex
+++ b/test/support/controller.ex
@@ -23,4 +23,10 @@ defmodule Phoenix.LiveViewTest.Controller do
     |> put_layout({Phoenix.LiveViewTest.AssignsLayoutView, :app})
     |> live_render(Phoenix.LiveViewTest.DashboardLive)
   end
+
+  def not_found(conn, _) do
+    conn
+    |> put_status(:not_found)
+    |> text("404")
+  end
 end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -27,6 +27,7 @@ defmodule Phoenix.LiveViewTest.Router do
     # controller test
     get "/controller/:type", Controller, :incoming
     get "/widget", Controller, :widget
+    get "/not_found", Controller, :not_found
 
     # router test
     live "/router/thermo_defaults/:id", DashboardLive


### PR DESCRIPTION
Addresses #798 

If the conn passed to LiveViewTest.__live__/2 has a `:sent` state but status code other than 200 or 302, raise ArgumentError with explanatory message instead of treating the request as unsent.