### PR TITLE
update doc, add missing step in installation

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -70,14 +70,20 @@ end
 
 Then add the `Phoenix.LiveView.Router.fetch_live_flash` plug to your browser pipeline, in place of `:fetch_flash`:
 
+
 ```diff
 # lib/my_app_web/router.ex
+defmodule MyAppWeb.router do
+  use MyAppWeb, :router
++ import Phoenix.LiveView.Router
 
-pipeline :browser do
-  ...
-  plug :fetch_session
-- plug :fetch_flash
-+ plug :fetch_live_flash
+  pipeline :browser do
+    ...
+    plug :fetch_session
+-   plug :fetch_flash
++   plug :fetch_live_flash
+    ...
+  end
 end
 ```
 


### PR DESCRIPTION
This import is needed, otherwise on startup, `mix phx.server` will fail with an error stating it can't find the function `fetch_live_flash`. The error looks like this:

```
== Compilation error in file lib/my_web_app/router.ex ==
** (CompileError) lib/my_web_app/router.ex: undefined function fetch_live_flash/2
    (elixir 1.10.2) src/elixir_locals.erl:114: anonymous fn/3 in :elixir_locals.ensure_no_undefined_local/3
    (stdlib 3.12) erl_eval.erl:680: :erl_eval.do_apply/6
    (elixir 1.10.2) lib/kernel/parallel_compiler.ex:304: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/7
```


In looking at the example Live View app, as seen in this commit: [phoenix_live_view_example#415f3a](https://github.com/chrismccord/phoenix_live_view_example/blob/c68368049bc39ac73fe0d66a435499f8a4415f3a/lib/demo_web/router.ex#L4) it seems necessary to add this.

This is also noted in the docs here: [Phoenix.LiveView.html#put_flash/3](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#put_flash/3), however it isn't a great first time experience to have to read all of the docs just to get started.