### PR TITLE
Additional reminder to include "use Phoenix.HTML"

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -444,6 +444,9 @@ defmodule Phoenix.LiveView do
         <%= submit "Save" %>
       </form>
 
+  *Reminder*: `form_for/3` is a `Phoenix.HTML` helper. Don't forget to include 
+  `use Phoenix.HTML` at the top of your LiveView, if using Phoenix.HTML helpers.
+
   Next, your LiveView picks up the events in `handle_event` callbacks:
 
       def render(assigns) ...

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -445,7 +445,7 @@ defmodule Phoenix.LiveView do
       </form>
 
   *Reminder*: `form_for/3` is a `Phoenix.HTML` helper. Don't forget to include 
-  `use Phoenix.HTML` at the top of your LiveView, if using Phoenix.HTML helpers.
+  `use Phoenix.HTML` at the top of your LiveView, if using `Phoenix.HTML` helpers.
 
   Next, your LiveView picks up the events in `handle_event` callbacks:
 


### PR DESCRIPTION
Hi,

There is already a note included for this at the top of the doc, but maybe a reminder in the form section could be helpful for the less experienced members of the community?

Thank you :)