### PR TITLE
Fix function reference for aligning with Phoenix

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -458,7 +458,7 @@ defmodule Phoenix.LiveView do
       def handle_event("validate", %{"user" => params}, socket) do
         changeset =
           %User{}
-          |> Accounts.change_user(params)
+          |> Account.changeset(params)
           |> Map.put(:action, :insert)
 
         {:noreply, assign(socket, changeset: changeset)}


### PR DESCRIPTION
Accounts.change_xxxx in auto-generated Phoenix 1.4 code seems to generally accept only one parameter.

Calling Account.changeset/2 instead fixes this, even though it bypasses the context. This might be a bit unelegant, but I tried to get a fix working that works for auto-generated Phoenix 1.4 code.

Thank you.