### PR TITLE
Phoenix.LiveViewTest doesn't work without session

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -340,7 +340,7 @@ defmodule Phoenix.LiveViewTest do
       html: html,
       proxy: proxy,
       timeout: timeout,
-      session: Plug.Conn.get_session(conn),
+      session: get_session_if_available(conn),
       url: mount_url(endpoint, path)
     ]
 
@@ -358,6 +358,10 @@ defmodule Phoenix.LiveViewTest do
           {^ref, {:error, reason}} -> {:error, reason}
         end
     end
+  end
+
+  defp get_session_if_available(%Plug.Conn{private: private} = conn) do
+    if Map.get(private, :plug_session), do: Plug.Conn.get_session(conn), else: %{}
   end
 
   defp mount_url(_endpoint, nil), do: nil


### PR DESCRIPTION
Issue: https://github.com/phoenixframework/phoenix_live_view/issues/820

Calling the `live` macro in tests blows up if the session has not been fetched yet. This is a problem if the application is configured to not have any sessions.

Please let me me know if this is the right direction. Also I am struggling to write a test for it. How would I setup the conn without a fetched session?