### PR TITLE
Support collocation for any template engine

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -360,16 +360,24 @@ defmodule Phoenix.LiveComponent do
 
   In this case, the solution is to not use `content_tag` and rely on LiveEEx
   to build the markup.
+
+  ## Options
+
+    * `:collocated_extension` - configures the extension (with leading '.')
+      of any collocated template. Defaults: ".leex"
+    * `:collocated_engine` - configures the extension of any collocated template.
+      Defaults: Phoenix.LiveView.Engine
   """
 
   alias Phoenix.LiveView.Socket
 
-  defmacro __using__(_) do
-    quote do
+  defmacro __using__(opts) do
+    quote bind_quoted: [opts: opts] do
       import Phoenix.LiveView
       import Phoenix.LiveView.Helpers
       require Phoenix.LiveView.Renderer
       @behaviour Phoenix.LiveComponent
+      @compile {:live_view, opts}
       @before_compile Phoenix.LiveView.Renderer
 
       @doc false

--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -368,6 +368,7 @@ defmodule Phoenix.LiveComponent do
     quote do
       import Phoenix.LiveView
       import Phoenix.LiveView.Helpers
+      require Phoenix.LiveView.Renderer
       @behaviour Phoenix.LiveComponent
       @before_compile Phoenix.LiveView.Renderer
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -259,6 +259,15 @@ defmodule Phoenix.LiveView do
         end
       end
 
+  If you use a custom templating engine, you can collocate templates with
+  the corresponding LiveView by passing options to `Phoenix.LiveView`:
+
+      defmodule AppWeb.ThermostatLive do
+        use Phoenix.LiveView,
+          collocated_engine: SomeLibrary.FooEngine,
+          collocated_extension: ".foo",
+      end
+
   In all cases, each assign in the template will be accessible as `@assign`.
 
   ## Assigns and LiveEEx Templates
@@ -1446,6 +1455,10 @@ defmodule Phoenix.LiveView do
     * `:namespace` - configures the namespace the `LiveView` is in
     * `:container` - configures the container the `LiveView` will be wrapped in
     * `:layout` - configures the layout the `LiveView` will be rendered in
+    * `:collocated_extension` - configures the extension (with leading '.')
+      of any collocated template. Defaults: ".leex"
+    * `:collocated_engine` - configures the extension of any collocated template.
+      Defaults: Phoenix.LiveView.Engine
 
   """
   defmacro __using__(opts) do
@@ -1454,6 +1467,7 @@ defmodule Phoenix.LiveView do
       import Phoenix.LiveView.Helpers
       require Phoenix.LiveView.Renderer
       @behaviour Phoenix.LiveView
+      @compile {:live_view, opts}
       @before_compile Phoenix.LiveView.Renderer
 
       @doc false

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1452,6 +1452,7 @@ defmodule Phoenix.LiveView do
     quote bind_quoted: [opts: opts] do
       import Phoenix.LiveView
       import Phoenix.LiveView.Helpers
+      require Phoenix.LiveView.Renderer
       @behaviour Phoenix.LiveView
       @before_compile Phoenix.LiveView.Renderer
 

--- a/test/phoenix_live_view/integrations/collocated_test.exs
+++ b/test/phoenix_live_view/integrations/collocated_test.exs
@@ -3,7 +3,16 @@ defmodule Phoenix.LiveView.CollocatedTest do
   use Phoenix.ConnTest
 
   import Phoenix.LiveViewTest
-  alias Phoenix.LiveViewTest.{Endpoint, CollocatedLive, CollocatedComponent}
+
+  alias Phoenix.LiveViewTest.{
+    Endpoint,
+    CollocatedLive,
+    CollocatedLiveSpecifyingExtension,
+    CollocatedLiveSpecifyingEngine,
+    CollocatedComponent,
+    CollocatedComponentSpecifyingExtension,
+    CollocatedComponentSpecifyingEngine
+  }
 
   @endpoint Endpoint
 
@@ -13,8 +22,30 @@ defmodule Phoenix.LiveView.CollocatedTest do
     assert render(view) =~ "Hello collocated world from live!\n</div>"
   end
 
+  test "supports collocated views with custom extension" do
+    {:ok, view, html} = live_isolated(build_conn(), CollocatedLiveSpecifyingExtension)
+    assert html =~ "Hello collocated world from template with .foo extension!\n</div>"
+    assert render(view) =~ "Hello collocated world from template with .foo extension!\n</div>"
+  end
+
+  test "supports collocated views with custom engine" do
+    {:ok, view, html} = live_isolated(build_conn(), CollocatedLiveSpecifyingEngine)
+    assert html =~ "Hello collocated world from live,\ncompiled by FooEngine!"
+    assert render(view) =~ "Hello collocated world from live,\ncompiled by FooEngine!"
+  end
+
   test "supports collocated components" do
     assert render_component(CollocatedComponent, world: "world") =~
              "Hello collocated world from component!\n"
+  end
+
+  test "supports collocated components with custom extension" do
+    assert render_component(CollocatedComponentSpecifyingExtension, world: "world") =~
+             "Hello collocated world from component with .foo extension!\n"
+  end
+
+  test "supports collocated components with custom engine" do
+    assert render_component(CollocatedComponentSpecifyingEngine, world: "world") =~
+             "Hello collocated world from component,\ncompiled by FooEngine!"
   end
 end

--- a/test/support/foo_engine.ex
+++ b/test/support/foo_engine.ex
@@ -1,0 +1,6 @@
+defmodule Phoenix.LiveViewTest.FooEngine do
+  def compile(template, path) do
+    (File.read!(template) <> "compiled by FooEngine!")
+    |> EEx.compile_string(engine: Phoenix.LiveView.Engine, file: path, line: 1)
+  end
+end

--- a/test/support/live_views/collocated.ex
+++ b/test/support/live_views/collocated.ex
@@ -6,6 +6,30 @@ defmodule Phoenix.LiveViewTest.CollocatedLive do
   end
 end
 
+defmodule Phoenix.LiveViewTest.CollocatedLiveSpecifyingExtension do
+  use Phoenix.LiveView, collocated_extension: ".foo"
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, world: "world")}
+  end
+end
+
+defmodule Phoenix.LiveViewTest.CollocatedLiveSpecifyingEngine do
+  use Phoenix.LiveView, collocated_engine: Phoenix.LiveViewTest.FooEngine
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, world: "world")}
+  end
+end
+
 defmodule Phoenix.LiveViewTest.CollocatedComponent do
   use Phoenix.LiveComponent
+end
+
+defmodule Phoenix.LiveViewTest.CollocatedComponentSpecifyingExtension do
+  use Phoenix.LiveComponent, collocated_extension: ".foo"
+end
+
+defmodule Phoenix.LiveViewTest.CollocatedComponentSpecifyingEngine do
+  use Phoenix.LiveComponent, collocated_engine: Phoenix.LiveViewTest.FooEngine
 end

--- a/test/support/live_views/collocated_component_specifying_engine.html.leex
+++ b/test/support/live_views/collocated_component_specifying_engine.html.leex
@@ -1,0 +1,1 @@
+Hello collocated <%= @world %> from component,

--- a/test/support/live_views/collocated_component_specifying_extension.html.foo
+++ b/test/support/live_views/collocated_component_specifying_extension.html.foo
@@ -1,0 +1,1 @@
+Hello collocated <%= @world %> from component with .foo extension!

--- a/test/support/live_views/collocated_live_specifying_engine.html.leex
+++ b/test/support/live_views/collocated_live_specifying_engine.html.leex
@@ -1,0 +1,1 @@
+Hello collocated <%= @world %> from live,

--- a/test/support/live_views/collocated_live_specifying_extension.html.foo
+++ b/test/support/live_views/collocated_live_specifying_extension.html.foo
@@ -1,0 +1,1 @@
+Hello collocated <%= @world %> from template with .foo extension!


### PR DESCRIPTION
Allow users to specify which Phoenix LiveView engine to use and what file extension to expect on collocated views.