### PR TITLE
Clarification for LiveComponent inner_content

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -310,8 +310,9 @@ defmodule Phoenix.LiveComponent do
 
   Where the `:entry` assign was injected into the `do/end` block.
 
-  To get `@inner_content` as shown in the component render function above
-  you will need to pull it from the assigns in update like so:
+  Note the `@inner_content` assign is also passed to `c:update/2`
+  along all other assigns. So if you have a custom `update/2`
+  implementation, make sure to assign it to the socket like so:
 
       def update(%{inner_content: inner_content}, socket) do
         {:ok, assign(socket, inner_content: inner_content)}

--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -310,6 +310,13 @@ defmodule Phoenix.LiveComponent do
 
   Where the `:entry` assign was injected into the `do/end` block.
 
+  To get `@inner_content` as shown in the component render function above
+  you will need to pull it from the assigns in update like so:
+
+      def update(%{inner_content: inner_content}, socket) do
+        {:ok, assign(socket, inner_content: inner_content)}
+      end
+
   The approach above is the preferred one when passing blocks to `do/end`.
   However, if you are outside of a .leex template and you want to invoke a
   component passing `do/end` blocks, you will have to explicitly handle the


### PR DESCRIPTION
Following the [docs](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveComponent.html#content) today w/ phoenix 1.5.1 and LV 0.12.1 I found that my components `inner_content` wasn't in assigns and at first I didn't understand why. I thought to add this minor clarification so people who might follow will have a more clear understanding of "where" this `inner_content` comes from.

Here was the original error I ran into for reference

![Screen Shot 2020-04-26 at 8 18 07 AM](https://user-images.githubusercontent.com/147411/80308788-7b32ea80-8796-11ea-956e-75f0d5dd0605.png)

