### PR TITLE
Reminder in docs to import AppWeb.ErrorHelpers

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -446,7 +446,7 @@ defmodule Phoenix.LiveView do
 
   *Reminder*: `form_for/3` is a `Phoenix.HTML` helper. Don't forget to include
   `use Phoenix.HTML` at the top of your LiveView, if using `Phoenix.HTML` helpers.
-  Also, if using `error_tag/2`, don't forget to `import AppWeb.ErrorHelpers`.
+  Also, if using `error_tag/2`, don't forget to `import MyAppWeb.ErrorHelpers`.
 
   Next, your LiveView picks up the events in `handle_event` callbacks:
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -446,6 +446,7 @@ defmodule Phoenix.LiveView do
 
   *Reminder*: `form_for/3` is a `Phoenix.HTML` helper. Don't forget to include
   `use Phoenix.HTML` at the top of your LiveView, if using `Phoenix.HTML` helpers.
+  Also, if using `error_tag/2`, don't forget to `import AppWeb.ErrorHelpers`.
 
   Next, your LiveView picks up the events in `handle_event` callbacks:
 


### PR DESCRIPTION
Added a reminder in docs to import AppWeb.ErrorHelpers when using error_tag/2.

Thank you.