### PR TITLE
Expand put_flash/3 caveats

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1614,11 +1614,12 @@ defmodule Phoenix.LiveView do
   @doc """
   Adds a flash message to the socket to be displayed on redirect.
 
-  *Note*: You must call this from on a socket returned from the live
-  view itself, components have access to a local flash but that is
-  not copied back to the top level.
+  *Note*: While you can use `put_flash/3` inside a `Phoenix.LiveComponent`,
+  components have their own `@flash` assigns. The `@flash` assign
+  in a component is only copied to its parent LiveView if the component
+  calls `push_redirect/2` or `push_patch/2`.
 
-  You ust also place the `Phoenix.Router.fetch_live_flash` plug in
+  *Note*: You must also place the `Phoenix.Router.fetch_live_flash/2` plug in
   your browser's pipeline in place of `fetch_flash` to be supported,
   for example:
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1614,7 +1614,11 @@ defmodule Phoenix.LiveView do
   @doc """
   Adds a flash message to the socket to be displayed on redirect.
 
-  *Note*: the `Phoenix.Router.fetch_live_flash` plug must be plugged in
+  *Note*: You must call this from on a socket returned from the live
+  view itself, components have access to a local flash but that is
+  not copied back to the top level.
+
+  You ust also place the `Phoenix.Router.fetch_live_flash` plug in
   your browser's pipeline in place of `fetch_flash` to be supported,
   for example:
 


### PR DESCRIPTION
This is not quite the right wording, and I expect it applies to other socket functions, but `put_flash` works inside a component, but only with the local flash in the components socket, its not updated back to the top level.

E.g. in a stateful component you can do:

```
def handle_event("save", %{}, socket) do
  {:noreply, socket |> put_flash(:info, "Saved!")}
end
```

And it will display in any `live_flash(@flash, :info)` in the component, but not reach the top level flash.

This came from a slack conversation about this, I think its at least worth mentioning this distinction.