### PR TITLE
When there is no template or render/1, add `@external_resource template`

### DIFF
--- a/lib/phoenix_live_view/renderer.ex
+++ b/lib/phoenix_live_view/renderer.ex
@@ -41,8 +41,9 @@ defmodule Phoenix.LiveView.Renderer do
 
         :ok
 
-
       {false, []} ->
+        template = Path.join(root, filename <> ".leex")
+
         message = ~s'''
         render/1 was not implemented for #{inspect(env.module)}.
 
@@ -54,12 +55,13 @@ defmodule Phoenix.LiveView.Renderer do
               """
             end
 
-        Or create a file at #{inspect(Path.join(root, filename <> ".leex"))} with the LiveView template.
+        Or create a file at #{inspect(template)} with the LiveView template.
         '''
 
         IO.warn(message, Macro.Env.stacktrace(env))
 
         quote do
+          @external_resource unquote(template)
           def render(_assigns) do
             raise unquote(message)
           end


### PR DESCRIPTION
This way, when the user creates the template the LV would automatically
be recompiled. (And since live_reload already worked here, the user will
see their template used.)