### PR TITLE
Do not allow graceful closes

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1411,7 +1411,6 @@ export class View {
     this.flash = flash
     this.parent = parentView
     this.root = parentView ? parentView.root : this
-    this.gracefullyClosed = false
     this.el = el
     this.id = this.el.id
     this.view = this.el.getAttribute(PHX_VIEW)
@@ -1466,16 +1465,12 @@ export class View {
       callback()
       for(let id in this.viewHooks){ this.destroyHook(this.viewHooks[id]) }
     }
-    if(this.hasGracefullyClosed()){
-      this.log("destroyed", () => ["the server view has gracefully closed"])
-      onFinished()
-    } else {
-      this.log("destroyed", () => ["the child has been removed from the parent"])
-      this.channel.leave()
-        .receive("ok", onFinished)
-        .receive("error", onFinished)
-        .receive("timeout", onFinished)
-    }
+
+    this.log("destroyed", () => ["the child has been removed from the parent"])
+    this.channel.leave()
+      .receive("ok", onFinished)
+      .receive("error", onFinished)
+      .receive("timeout", onFinished)
   }
 
   setContainerClasses(...classes){
@@ -1795,18 +1790,13 @@ export class View {
     this.onChannel("live_redirect", (redir) => this.onLiveRedirect(redir))
     this.onChannel("session", ({token}) => this.el.setAttribute(PHX_SESSION, token))
     this.channel.onError(reason => this.onError(reason))
-    this.channel.onClose(() => this.onGracefulClose())
+    this.channel.onClose(() => this.onError({reason: "closed"}))
   }
 
   destroyAllChildren(){
     for(let id in this.root.children[this.id]){
       this.getChildById(id).destroy()
     }
-  }
-
-  onGracefulClose(){
-    this.gracefullyClosed = true
-    this.destroyAllChildren()
   }
 
   onLiveRedirect(redir){
@@ -1828,8 +1818,6 @@ export class View {
   onRedirect({to, flash}){ this.liveSocket.redirect(to, flash) }
 
   isDestroyed(){ return this.destroyed }
-
-  hasGracefullyClosed(){ return this.gracefullyClosed }
 
   join(callback){
     if(!this.parent){

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -9,8 +9,6 @@ See the hexdocs at `https://hexdocs.pm/phoenix_live_view` for documentation.
 
 import morphdom from "morphdom"
 
-const CLIENT_STALE = "stale"
-const JOIN_CRASHED = "join crashed"
 const CONSECUTIVE_RELOADS = "consecutive-reloads"
 const MAX_RELOADS = 10
 const RELOAD_JITTER = [1000, 3000]
@@ -1833,14 +1831,11 @@ export class View {
   }
 
   onJoinError(resp){
-    if(resp.reason === CLIENT_STALE){ return this.liveSocket.reloadWithJitter(this) }
-    if(resp.reason === JOIN_CRASHED){ return this.liveSocket.reloadWithJitter(this) }
     if(resp.redirect || resp.live_redirect){ this.channel.leave() }
     if(resp.redirect){ return this.onRedirect(resp.redirect) }
     if(resp.live_redirect){ return this.onLiveRedirect(resp.live_redirect) }
-    this.parent && this.parent.ackJoin(this)
-    this.displayError()
     this.log("error", () => ["unable to join", resp])
+    return this.liveSocket.reloadWithJitter(this)
   }
 
   onError(reason){

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -287,7 +287,6 @@ describe("View", function() {
     let el = liveViewDOM()
     let view = new View(el, liveSocket)
     expect(view.liveSocket).toBe(liveSocket)
-    expect(view.gracefullyClosed).toEqual(false)
     expect(view.parent).toBeUndefined()
     expect(view.el).toBe(el)
     expect(view.id).toEqual("container")


### PR DESCRIPTION
Only redirects and live redirects are valid
ways to terminate a LiveView connection and
they already call .leave() explicitly on the
client.