### PR TITLE
fix(debounce): reset debounce on user input

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1036,6 +1036,9 @@ export let DOM = {
             el.form.removeEventListener("submit", clearTimer)
           }
           el.removeEventListener("blur", this.private(el, DEBOUNCE_BLUR_TIMER))
+          if (!throttle) {
+            el.removeEventListener("keydown", clearTimer)
+          }
           this.deletePrivate(el, DEBOUNCE_BLUR_TIMER)
           this.deletePrivate(el, DEBOUNCE_TIMER)
           if(!throttle){ callback() }
@@ -1046,6 +1049,9 @@ export let DOM = {
         }
         this.putPrivate(el, DEBOUNCE_TIMER, setTimeout(debounceCallback, timeout))
         el.addEventListener("blur", blurCallback)
+        if (!throttle) {
+          el.addEventListener("keydown", clearTimer)
+        }
         this.putPrivate(el, DEBOUNCE_BLUR_TIMER, blurCallback)
         if(el.form){
           el.form.addEventListener(PHX_CHANGE_EVENT, clearTimer)

--- a/assets/test/debounce_test.js
+++ b/assets/test/debounce_test.js
@@ -8,6 +8,12 @@ let simulateInput = (input, val) => {
   DOM.dispatchEvent(input, "input")
 }
 
+let simulateKeyDown = (input, val) => {
+  input.value = input.value + val;
+  DOM.dispatchEvent(input, "keydown")
+  DOM.dispatchEvent(input, "input")
+}
+
 let container = () => {
   let div = document.createElement("div")
   div.innerHTML = `
@@ -58,19 +64,26 @@ describe("debounce", function() {
     el.addEventListener("input", e => {
       DOM.debounce(el, e, "phx-debounce", 100, "phx-throttle", 200, () => calls++)
     })
-    simulateInput(el, "one")
-    simulateInput(el, "two")
-    simulateInput(el, "three")
-    after(100, () => {
-      expect(calls).toBe(1)
-      expect(el.value).toBe("three")
-      simulateInput(el, "four")
-      simulateInput(el, "five")
-      simulateInput(el, "six")
-      after(100, () => {
-        expect(calls).toBe(2)
-        expect(el.value).toBe("six")
-        done()
+    simulateKeyDown(el, "1")
+    simulateKeyDown(el, "2")
+    simulateKeyDown(el, "3")
+    after(50, () => {
+      expect(calls).toBe(0)
+      simulateKeyDown(el, "4")
+      after(50, () => {
+        expect(calls).toBe(0)
+        after(50, () => {
+          expect(calls).toBe(1)
+          expect(el.value).toBe("1234")
+          simulateKeyDown(el, "5")
+          simulateKeyDown(el, "6")
+          simulateKeyDown(el, "7")
+          after(150, () => {
+            expect(calls).toBe(2)
+            expect(el.value).toBe("1234567")
+            done()
+          })
+        })
       })
     })
   })


### PR DESCRIPTION
If a user interacts with an input with a phx-debounce on it, the timer
is now cleared. This ensures that the debounce will not trigger until
after the user input has stopped.