### PR TITLE
Add tests for passing _target on Element API

### DIFF
--- a/test/phoenix_live_view/integrations/elements_test.exs
+++ b/test/phoenix_live_view/integrations/elements_test.exs
@@ -390,6 +390,14 @@ defmodule Phoenix.LiveView.ElementsTest do
       assert view |> element("#empty-form") |> render_change(%{"foo" => "bar"})
       assert last_event(view) =~ ~s|form-change: %{"foo" => "bar"}|
     end
+
+    test "render_change with _target", %{live: view} do
+      assert view |> element("#form") |> render_change(%{_target: ["foo"], foo: "bar"})
+      assert last_event(view) =~ ~s|form-change: %{"_target" => ["foo"], "foo" => "bar"|
+
+      assert view |> element("#form") |> render_change(%{"_target" => ["foo", "bar"], foo: "bar"})
+      assert last_event(view) =~ ~s|form-change: %{"_target" => ["foo", "bar"], "foo" => "bar"|
+    end
   end
 
   describe "render_submit" do

--- a/test/support/live_views/elements.ex
+++ b/test/support/live_views/elements.ex
@@ -105,7 +105,7 @@ defmodule Phoenix.LiveViewTest.ElementsLive do
   end
 
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, :event, nil)}
+    {:ok, assign(socket, event: nil, target: nil)}
   end
 
   def handle_params(params, _uri, socket) do


### PR DESCRIPTION
I was unsure of how to test `render_change` with a `_target` using the new Element API and I couldn't find a test as an example, so I wrote this PR. But the question is actually if it is the responsibility of the developer to manually pass the `_target` on `render_change` or if LiveViewTest should pass it along automatically, considering that Element API is like a high-level integration test API. Does that make sense?