### PR TITLE
fix docs typo in live_view_test render_blur

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -60,7 +60,7 @@ defmodule Phoenix.LiveViewTest do
     * `render_focus/2` - sends a phx-focus event and value and
       returns the rendered result of the `handle_event/3` callback.
 
-    * `render_blur/1` - sends a phx-focus event and value and
+    * `render_blur/1` - sends a phx-blur event and value and
       returns the rendered result of the `handle_event/3` callback.
 
     * `render_submit/1` - sends a form phx-submit event and value and


### PR DESCRIPTION
Wrong description in the summary for `render_blur`, probably came from a suboptimal copy paste. 

(this is my first contribution to elixir :D )