### PR TITLE
Improved docs for LiveTest.render_hook/3

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -711,7 +711,10 @@ defmodule Phoenix.LiveViewTest do
   end
 
   @doc """
-  Sends a hook event to the view and returns the rendered result.
+  Sends a hook event to the view or an element and returns the rendered result.
+
+  The `element` is created with `element/3` and must point to a single
+  element on the page with a `phx-target` attribute in it.
 
   It returns the contents of the whole LiveView or an `{:error, redirect}`
   tuple.
@@ -721,6 +724,12 @@ defmodule Phoenix.LiveViewTest do
       {:ok, view, html} = live(conn, "/thermo")
       assert html =~ "The temp is: 30℉"
       assert render_hook(view, :refresh, %{deg: 32}) =~ "The temp is: 32℉"
+
+      {:ok, view, _html} = live(conn, "/thermo")
+      assert view
+             |> element("#thermo-component")
+             |> render_hook(:refresh, %{deg: 32}) =~ "The temp is: 32℉"
+
   """
   def render_hook(view_or_element, event, value \\ %{})
 

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -713,9 +713,6 @@ defmodule Phoenix.LiveViewTest do
   @doc """
   Sends a hook event to the view or an element and returns the rendered result.
 
-  The `element` is created with `element/3` and must point to a single
-  element on the page with a `phx-target` attribute in it.
-
   It returns the contents of the whole LiveView or an `{:error, redirect}`
   tuple.
 
@@ -724,6 +721,10 @@ defmodule Phoenix.LiveViewTest do
       {:ok, view, html} = live(conn, "/thermo")
       assert html =~ "The temp is: 30℉"
       assert render_hook(view, :refresh, %{deg: 32}) =~ "The temp is: 32℉"
+
+  If you are pushing events from a hook to a component, then you must pass
+  an `element`, created with `element/3`, as first argument and it must point
+  to a single element on the page with a `phx-target` attribute in it:
 
       {:ok, view, _html} = live(conn, "/thermo")
       assert view


### PR DESCRIPTION
As discussed with @josevalim in #861 I've added some improvements to the docs of a `render_hook/3` function so it would be more clear that you can call it on the `element()` and that the element needs to have a `phx-target` attribute assigned.

I would also like to add an argument type handler to the `handle_params/3`, ([check Jose's reply](https://github.com/phoenixframework/phoenix_live_view/issues/861#issuecomment-624944502)), but since I'm fairly new to Elixir I'm not exactly sure where would be the right place for this improvement to be implemented. I was reading a lot about typespecs and was checking the repo, but still not sure. If you would be so kind to point me in the right direction, I'd be more than happy to implement that as well.