### PR TITLE
Update PhoenixLiveView.send_update/2 docs

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -2166,7 +2166,7 @@ defmodule Phoenix.LiveView do
   own state, as well as messaging between components mounted in the same
   LiveView.
 
-  **Note:** `send_update/2` Cannot update a LiveComponent that is mounted in a
+  **Note:** `send_update/2` cannot update a LiveComponent that is mounted in a
   different LiveView. To update a component in a different LiveView you must
   send a message to the LiveView process that the LiveComponent is mounted
   within (often via `Phoenix.PubSub`).

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -2147,17 +2147,29 @@ defmodule Phoenix.LiveView do
   end
 
   @doc """
-  Asynchronously updates a component with new assigns.
+  Asynchronously updates a `Phoenix.LiveComponent` with new assigns.
 
-  Requires a stateful component with a matching `:id` to send
-  the update to. Following the optional `preload/1` callback being invoked,
-  the updated values are merged with the component's assigns and `update/2`
-  is called for the updated component(s).
+  The component that is updated must be stateful (the `:id` in the assigns must
+  match the `:id` associated with the component) and the component must be
+  mounted within the current LiveView.
+
+  When the component receives the update, the optional
+  [`preload/1`](`c:Phoenix.LiveComponent.preload/1`) callback is invoked, then
+  the updated values are merged with the component's assigns and
+  [`update/2`](`c:Phoenix.LiveComponent.update/2`) is called for the updated
+  component(s).
 
   While a component may always be updated from the parent by updating some
-  parent assigns which will re-render the child, thus invoking `update/2` on
-  the child component, `send_update/2` is useful for updating a component
-  that entirely manages its own state, as well as messaging between components.
+  parent assigns which will re-render the child, thus invoking
+  [`update/2`](`c:Phoenix.LiveComponent.update/2`) on the child component,
+  `send_update/2` is useful for updating a component that entirely manages its
+  own state, as well as messaging between components mounted in the same
+  LiveView.
+
+  **Note:** `send_update/2` Cannot update a LiveComponent that is mounted in a
+  different LiveView. To update a component in a different LiveView you must
+  send a message to the LiveView process that the LiveComponent is mounted
+  within (often via `Phoenix.PubSub`).
 
   ## Examples
 


### PR DESCRIPTION
Make it more clear that `send_update/2` operates on a `Phoenix.LiveComponent` and that it can only update components mounted on the parent LiveView.

I also made the mentioned callback links link to the actual callbacks. This makes it more clear exactly which callback is being referenced. Additionally if the documentation was left as it was and a `LiveView.preload/1` function was added, then an improper link would have been created.

I also separated the paragraph that talks about the implementation from the one that talks about the requirements since the combined paragraph would have felt rather long. The paragraph about the implementation was reworded to make it more clear what the subject was (the component being sent the message).

Made it more clear that the `:id` must be passed in the assigns.

I also considered linking the PubSub example in https://hexdocs.pm/phoenix_live_view Phoenix.LiveComponent.html#module-liveview-as-the-source-of-truth but there wasn't an existing link directly to the example and it doesn't seem common to create links to sections in another module's `@moduledoc` (and it might be brittle if the section name changes in the future).

This PR was inspired by a thread on the ElixirForum: https://elixirforum.com/t/intended-use-of-liveview-send-update-2/31352