### PR TITLE
Account for redirects during XMLHttpRequest

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -483,7 +483,7 @@ export class LiveSocket {
     this.main.destroy()
     this.main.showLoader(this.loaderTimeout)
 
-    Browser.fetchPage(href, (status, html) => {
+    Browser.fetchPage(href, (status, url, html) => {
       if(status !== 200){ return this.redirect(href) }
 
       let template = document.createElement("template")
@@ -491,7 +491,8 @@ export class LiveSocket {
       let el = template.content.childNodes[0]
       if(!el || !this.isPhxView(el)){ return this.redirect(href) }
 
-      this.joinRootView(el, href, flash, (newMain, joinCount) => {
+      let location = url.origin + url.pathname
+      this.joinRootView(el, location, flash, (newMain, joinCount) => {
         if(joinCount !== 1){ return }
         if(!this.commitPendingLink(linkRef)){
           newMain.destroy()
@@ -895,7 +896,7 @@ export let Browser = {
       if(req.readyState !== 4){ return }
       if(req.getResponseHeader(LINK_HEADER) !== "live-link"){ return callback(400) }
       if(req.status !== 200){ return callback(req.status) }
-      callback(200, req.responseText)
+      callback(200, new URL(req.responseURL), req.responseText)
     }
     req.send()
   },


### PR DESCRIPTION
Please see https://github.com/phoenixframework/phoenix_live_view/issues/871

This PR accounts for redirects during XMLHttpRequests for live-links. The strategy is to use the `responseURL` instead of the original `href` when joining the live view after the fetch. This avoids a state where the `href` and actual URL corresponding to the LiveView that we want to join gets out of sync because of redirects during the XMLHttpRequest.

I parse the URL before using it to safely discard query params. However, `new URL` is not available on IE so if that is a supported target we should perhaps just use direct string manipulation instead?