### PR TITLE
Docs: Add "Avoiding issues by adding a form ID" section

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -620,6 +620,12 @@ defmodule Phoenix.LiveView do
           end
       end
 
+  ### Avoiding issues by adding a form ID
+  
+  We strongly recommend putting a unique HTML "id" attribute on forms.
+  
+  When DOM siblings change, elements without an ID will be replaced rather than moved, which can cause issues such as form fields losing focus.
+
   ### Number inputs
 
   Number inputs are a special case in LiveView forms. On programmatic updates,


### PR DESCRIPTION
As discussed in #909.

Wasn't sure where to put it exactly, but this seemed a reasonable place.

Think it's good for it to have its own header both for linkability and so it stands out a bit.