### PR TITLE
Share component statics

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -173,8 +173,10 @@ export class Rendered {
 
     for(let cid in diff[COMPONENTS]){
       let pointer = diff[COMPONENTS][cid][STATIC]
-      while(typeof(pointer) === "number"){ pointer = this.rendered[COMPONENTS][pointer][STATIC] }
-      this.rendered[COMPONENTS][cid][STATIC] = pointer
+      if(typeof(pointer) === "number"){
+        while(typeof(pointer) === "number"){ pointer = this.rendered[COMPONENTS][pointer][STATIC] }
+        this.rendered[COMPONENTS][cid][STATIC] = pointer
+      }
     }
   }
 

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -171,36 +171,10 @@ export class Rendered {
   expandStatics(diff){
     if(isEmpty(this.rendered[COMPONENTS])){ return }
 
-    // if components = Map.get(rendered, @components) do
-    //   components =
-    //     diff
-    //     |> Map.get(@components, %{})
-    //     |> Enum.reduce(components, fn {cid, cdiff}, acc ->
-    //       case cdiff do
-    //         %{@static => pointer} when is_integer(pointer) ->
-    //           put_in(acc[cid][@static], find_static(pointer, acc))
-
-    //         %{} ->
-    //           acc
-    //       end
-    //     end)
-
-    //   Map.put(rendered, @components, components)
-
     for(let cid in diff[COMPONENTS]){
-      let cdiff = diff[COMPONENTS][cid]
-      let pointer = cdiff[STATIC]
-      if(typeof(pointer) === "number"){
-        this.rendered[COMPONENTS][cid][STATIC] = this.findStatic(pointer)
-      }
-    }
-  }
-
-  findStatic(pointer){
-    if(typeof(pointer) === "number"){ // cid
-      return this.findStatic(this.rendered[COMPONENTS][pointer][STATIC])
-    } else { // array
-      return pointer
+      let pointer = diff[COMPONENTS][cid][STATIC]
+      while(typeof(pointer) === "number"){ pointer = this.rendered[COMPONENTS][pointer][STATIC] }
+      this.rendered[COMPONENTS][cid][STATIC] = pointer
     }
   }
 

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1585,7 +1585,7 @@ export class View {
     this.joinPending = true
     this.flash = null
 
-    this.log("join", () => ["", rendered])
+    this.log("join", () => ["", clone(rendered)])
     if(rendered.title){ DOM.putTitle(rendered.title) }
     Browser.dropLocal(this.name(), CONSECUTIVE_RELOADS)
     this.rendered = new Rendered(this.id, rendered)
@@ -1759,7 +1759,7 @@ export class View {
     if(diff.title){ DOM.putTitle(diff.title) }
     if(this.isJoinPending() || this.liveSocket.hasPendingLink()){ return this.pendingDiffs.push({diff, cid: cidAck, ref}) }
 
-    this.log("update", () => ["", diff])
+    this.log("update", () => ["", clone(diff)])
     this.rendered.mergeDiff(diff)
     let phxChildrenAdded = false
 

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -171,8 +171,25 @@ export class Rendered {
   expandStatics(diff){
     if(isEmpty(this.rendered[COMPONENTS])){ return }
 
-    for(let cid in diff){
-      let pointer = diff[cid]
+    // if components = Map.get(rendered, @components) do
+    //   components =
+    //     diff
+    //     |> Map.get(@components, %{})
+    //     |> Enum.reduce(components, fn {cid, cdiff}, acc ->
+    //       case cdiff do
+    //         %{@static => pointer} when is_integer(pointer) ->
+    //           put_in(acc[cid][@static], find_static(pointer, acc))
+
+    //         %{} ->
+    //           acc
+    //       end
+    //     end)
+
+    //   Map.put(rendered, @components, components)
+
+    for(let cid in diff[COMPONENTS]){
+      let cdiff = diff[COMPONENTS][cid]
+      let pointer = cdiff[STATIC]
       if(typeof(pointer) === "number"){
         this.rendered[COMPONENTS][cid][STATIC] = this.findStatic(pointer)
       }

--- a/assets/test/rendered_test.js
+++ b/assets/test/rendered_test.js
@@ -58,6 +58,85 @@ describe("Rendered", () => {
       let rendered = new Rendered("123", {})
       expect(rendered.isNewFingerprint()).toEqual(false)
     })
+
+    test("expands shared static from cids", () => {
+      const mountDiff = {
+        "0": {
+          "0": "<a data-phx-link=\"patch\" data-phx-link-state=\"push\" href=\"/posts/new\">New Post</a>",
+          "1": "",
+          "2": {"d": [[0], [1]], "s": ["", ""]},
+          "s": [
+            "<h1>Timeline</h1>\n\n<span>",
+            "</span>\n\n",
+            "\n<div id=\"posts\" phx-update=\"prepend\">\n",
+            "</div>\n\n"
+          ]
+        },
+        "c": {
+          "0": {
+            "0": "1005",
+            "1": "chris_mccord",
+            "2": "new",
+            "3": "0",
+            "4": "0",
+            "5": "0",
+            "6": "0",
+            "7": "<a data-phx-link=\"patch\" data-phx-link-state=\"push\" href=\"/posts/1005/edit\">\n        Edit\n      </a>",
+            "8": "<a data-confirm=\"Are you sure?\" href=\"#\" phx-click=\"delete\" phx-value-id=\"1005\">\n        <i class=\"far fa-trash-alt\"></i>\n      </a>",
+            "s": [
+              "<div id=\"post-",
+              "\" class=\"post\">\n  <div class=\"row\">\n    <div class=\"column column-10\">\n      <div class=\"post-avatar\"></div>\n    </div>\n    <div class=\"column column-90 post-body\">\n      <b>@",
+              "</b>\n      <br/>\n      ",
+              "\n    </div>\n  </div>\n\n  <div class=\"row\">\n    <div class=\"column\">\n      <a href=\"#\" phx-click=\"like\" phx-target=\"",
+              "\">\n        <i class=\"far fa-heart\"></i> ",
+              "\n      </a>\n    </div>\n    <div class=\"column\">\n      <a href=\"#\" phx-click=\"repost\" phx-target=\"",
+              "\">\n        <i class=\"far fa-retweet\"></i> ",
+              "\n      </a>\n    </div>\n    <div class=\"column\">\n      ",
+              "\n      ",
+              "\n    </div>\n  </div>\n</div>\n"
+            ]
+          },
+          "1": {
+            "0": "1004",
+            "1": "chris_mccord",
+            "2": "tesitnglkjsldkfjsf",
+            "3": "1",
+            "4": "3",
+            "5": "1",
+            "6": "8",
+            "7": "<a data-phx-link=\"patch\" data-phx-link-state=\"push\" href=\"/posts/1004/edit\">\n        Edit\n      </a>",
+            "8": "<a data-confirm=\"Are you sure?\" href=\"#\" phx-click=\"delete\" phx-value-id=\"1004\">\n        <i class=\"far fa-trash-alt\"></i>\n      </a>",
+            "s": 0
+          }
+        },
+        "s": ["<main>\n", "</main>\n"],
+        "title": "Listing Posts"
+      }
+      const updateDiff = {
+        "0": {"2": {"d": [[2]]}},
+        "c": {
+          "2": {
+            "0": "1006",
+            "1": "chris_mccord",
+            "2": "new",
+            "3": "2",
+            "4": "0",
+            "5": "2",
+            "6": "0",
+            "7": "<a data-phx-link=\"patch\" data-phx-link-state=\"push\" href=\"/posts/1006/edit\">\n        Edit\n      </a>",
+            "8": "<a data-confirm=\"Are you sure?\" href=\"#\" phx-click=\"delete\" phx-value-id=\"1006\">\n        <i class=\"far fa-trash-alt\"></i>\n      </a>",
+            "s": 1
+          }
+        }
+      }
+      let rendered = new Rendered("123", mountDiff)
+      expect(rendered.get()["c"]["0"][STATIC]).toEqual(rendered.get()["c"]["1"][STATIC])
+      rendered.mergeDiff(updateDiff)
+      let sharedStatic = rendered.get()["c"]["0"][STATIC]
+      expect(sharedStatic).toBeTruthy()
+      expect(sharedStatic).toEqual(rendered.get()["c"]["1"][STATIC])
+      expect(sharedStatic).toEqual(rendered.get()["c"]["2"][STATIC])
+    })
   })
 
   describe("toString", () => {

--- a/lib/phoenix_live_view/application.ex
+++ b/lib/phoenix_live_view/application.ex
@@ -1,4 +1,5 @@
 defmodule Phoenix.LiveView.Application do
+  @moduledoc false
   use Application
 
   require Logger

--- a/lib/phoenix_live_view/application.ex
+++ b/lib/phoenix_live_view/application.ex
@@ -1,0 +1,15 @@
+defmodule Phoenix.LiveView.Application do
+  use Application
+
+  require Logger
+
+  # TODO: Remove this whole module once we require Elixir v1.10+.
+  def start(_, _) do
+    if List.to_integer(:erlang.system_info(:otp_release)) < 21 do
+      Logger.error "Phoenix.LiveView requires Erlang/OTP 21+"
+      raise "Phoenix.LiveView requires Erlang/OTP 21+"
+    end
+
+    Supervisor.start_link([], strategy: :one_for_one)
+  end
+end

--- a/lib/phoenix_live_view/application.ex
+++ b/lib/phoenix_live_view/application.ex
@@ -7,7 +7,7 @@ defmodule Phoenix.LiveView.Application do
   # TODO: Remove this whole module once we require Elixir v1.10+.
   def start(_, _) do
     if List.to_integer(:erlang.system_info(:otp_release)) < 21 do
-      Logger.error "Phoenix.LiveView requires Erlang/OTP 21+"
+      Logger.error("Phoenix.LiveView requires Erlang/OTP 21+")
       raise "Phoenix.LiveView requires Erlang/OTP 21+"
     end
 

--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -103,7 +103,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
         receive do
           {^ref, {:ok, %{rendered: rendered}}} ->
             Process.demonitor(mon_ref, [:flush])
-            {%{view | pid: pid}, rendered}
+            {%{view | pid: pid}, DOM.merge_diff(%{}, rendered)}
 
           {^ref, {:error, %{live_redirect: opts}}} ->
             throw(stop_redirect(state, view.topic, {:live_redirect, opts}))
@@ -478,7 +478,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
 
     case fetch_view_by_topic(state, topic) do
       {:ok, view} ->
-        rendered = DOM.deep_merge(view.rendered, diff)
+        rendered = DOM.merge_diff(view.rendered, diff)
         new_view = %ClientProxy{view | rendered: rendered}
 
         %{state | views: Map.update!(state.views, topic, fn _ -> new_view end)}

--- a/lib/phoenix_live_view/test/dom.ex
+++ b/lib/phoenix_live_view/test/dom.ex
@@ -152,7 +152,7 @@ defmodule Phoenix.LiveViewTest.DOM do
     do: list
 
   def drop_cids(rendered, cids) do
-    update_in rendered[@components], &Map.drop(&1, cids)
+    update_in(rendered[@components], &Map.drop(&1, cids))
   end
 
   # Diff rendering

--- a/lib/phoenix_live_view/test/dom.ex
+++ b/lib/phoenix_live_view/test/dom.ex
@@ -151,6 +151,10 @@ defmodule Phoenix.LiveViewTest.DOM do
   defp find_static(list, _components) when is_list(list),
     do: list
 
+  def drop_cids(rendered, cids) do
+    update_in rendered[@components], &Map.drop(&1, cids)
+  end
+
   # Diff rendering
 
   def render_diff(rendered) do

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,8 @@ defmodule Phoenix.LiveView.MixProject do
 
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      mod: {Phoenix.LiveView.Application, []}
     ]
   end
 

--- a/test/phoenix_live_view/diff_test.exs
+++ b/test/phoenix_live_view/diff_test.exs
@@ -578,8 +578,8 @@ defmodule Phoenix.LiveView.DiffTest do
 
       assert socket.fingerprints == {rendered.fingerprint, %{}}
 
-      {_, cids_to_ids, 1} = components
-      assert cids_to_ids[0] == {MyComponent, "hello"}
+      {cid_to_component, _, 1} = components
+      assert {MyComponent, "hello", _, _, _} = cid_to_component[0]
 
       assert_received {:mount, %Socket{endpoint: __MODULE__, assigns: assigns}}
                       when assigns == %{flash: %{}, myself: 0}
@@ -896,9 +896,9 @@ defmodule Phoenix.LiveView.DiffTest do
 
       assert {^fingerprint, %{0 => _}} = socket.fingerprints
 
-      {_, cids_to_ids, 2} = components
-      assert cids_to_ids[0] == {MyComponent, "index_0"}
-      assert cids_to_ids[1] == {MyComponent, "index_1"}
+      {cid_to_component, _, 2} = components
+      assert {MyComponent, "index_0", _, _, _} = cid_to_component[0]
+      assert {MyComponent, "index_1", _, _, _} = cid_to_component[1]
 
       assert_received {:mount, %Socket{endpoint: __MODULE__}}
       assert_received {:update, %{from: :index_0}, %Socket{assigns: %{hello: "world"}}}
@@ -971,11 +971,11 @@ defmodule Phoenix.LiveView.DiffTest do
 
       assert {^fingerprint, %{0 => _}} = socket.fingerprints
 
-      {_, cids_to_ids, 4} = components
-      assert cids_to_ids[0] == {MyComponent, "foo-index_0"}
-      assert cids_to_ids[1] == {MyComponent, "foo-index_1"}
-      assert cids_to_ids[2] == {MyComponent, "bar-index_0"}
-      assert cids_to_ids[3] == {MyComponent, "bar-index_1"}
+      {cid_to_component, _, 4} = components
+      assert {MyComponent, "foo-index_0", _, _, _} = cid_to_component[0]
+      assert {MyComponent, "foo-index_1", _, _, _} = cid_to_component[1]
+      assert {MyComponent, "bar-index_0", _, _, _} = cid_to_component[2]
+      assert {MyComponent, "bar-index_1", _, _, _} = cid_to_component[3]
 
       for from <- [:index_0, :index_1, :index_0, :index_1] do
         assert_received {:mount, %Socket{endpoint: __MODULE__}}
@@ -1034,9 +1034,9 @@ defmodule Phoenix.LiveView.DiffTest do
 
       assert {^fingerprint, %{0 => _}} = socket.fingerprints
 
-      {_, cids_to_ids, 2} = components
-      assert cids_to_ids[0] == {MyComponent, "index_0"}
-      assert cids_to_ids[1] == {MyComponent, "index_1"}
+      {cid_to_component, _, 2} = components
+      assert {MyComponent, "index_0", _, _, _} = cid_to_component[0]
+      assert {MyComponent, "index_1", _, _, _} = cid_to_component[1]
 
       assert_received {:mount, %Socket{endpoint: __MODULE__}}
       assert_received {:update, %{from: :index_0}, %Socket{assigns: %{hello: "world"}}}
@@ -1085,8 +1085,8 @@ defmodule Phoenix.LiveView.DiffTest do
 
       assert {^fingerprint, %{0 => _}} = socket.fingerprints
 
-      {_, cids_to_ids, 1} = components
-      assert cids_to_ids[0] == {MyComponent, "index_1"}
+      {cid_to_component, _, 1} = components
+      assert {MyComponent, "index_1", _, _, _} = cid_to_component[0]
 
       assert_received {:mount, %Socket{endpoint: __MODULE__}}
       assert_received {:update, %{from: :index_1}, %Socket{assigns: %{hello: "world"}}}

--- a/test/phoenix_live_view/diff_test.exs
+++ b/test/phoenix_live_view/diff_test.exs
@@ -810,7 +810,7 @@ defmodule Phoenix.LiveView.DiffTest do
       assert full_render == %{
                0 => 1,
                :c => %{
-                 1 => %{0 => "another", 1 => "world", :s => ["FROM ", " ", "\n"]}
+                 1 => %{0 => "another", 1 => "world", :s => 0}
                }
              }
 
@@ -888,7 +888,7 @@ defmodule Phoenix.LiveView.DiffTest do
                  1 => %{
                    0 => "index_1",
                    1 => "world",
-                   :s => ["FROM ", " ", "\n"]
+                   :s => 0
                  }
                },
                :s => ["<div>\n  ", "\n</div>\n"]
@@ -953,17 +953,17 @@ defmodule Phoenix.LiveView.DiffTest do
                  1 => %{
                    0 => "index_1",
                    1 => "world",
-                   :s => ["FROM ", " ", "\n"]
+                   :s => 0
                  },
                  2 => %{
                    0 => "index_0",
                    1 => "world",
-                   :s => ["FROM ", " ", "\n"]
+                   :s => 0
                  },
                  3 => %{
                    0 => "index_1",
                    1 => "world",
-                   :s => ["FROM ", " ", "\n"]
+                   :s => 2
                  }
                },
                :s => ["<div>\n  ", "\n</div>\n"]
@@ -1026,7 +1026,7 @@ defmodule Phoenix.LiveView.DiffTest do
                  1 => %{
                    0 => "index_1",
                    1 => "world",
-                   :s => ["FROM ", " ", "\n"]
+                   :s => 0
                  }
                },
                :s => ["<div>\n  ", "\n</div>\n"]


### PR DESCRIPTION
This PR adds static sharing between components, a great idea proposed by @henrik in #912.

In order to support this, the client needs two changes:

1. After every diff, we need to traverse the components keys resolving any integer static that we may find. You can find the code that does this in the [Elixir client here](https://github.com/phoenixframework/phoenix_live_view/blob/jv-share-c/lib/phoenix_live_view/test/dom.ex#L121-L146). Note the static references themselves can nest, so the `find_static` function has to be recursive. Also note this pass is also necessary on the initial render, so it is best to consider the initial render to be the same as: `Diff.merge_diff(%{}, initial_render)`

2. When the client submits the `cids_destroyed` event, the components must only be removed from the diff after the server acks. Here is the Elixir client version: https://github.com/phoenixframework/phoenix_live_view/pull/913/commits/1f74c12866d55f2274a41a6f7d24a2b3924bf652#diff-642af87ac9ef5b733729a1352f2f09e4R399-R401