### PR TITLE
fix regression introduced by #913

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -86,7 +86,10 @@ defmodule Phoenix.LiveView.Channel do
     %{"cids" => cids} = msg.payload
 
     new_components =
-      Enum.reduce(cids, state.components, fn cid, acc -> Diff.delete_component(cid, acc) end)
+      case state.components do
+        {%{}, %{}, _} -> Diff.new_components
+        _ -> Enum.reduce(cids, state.components, fn cid, acc -> Diff.delete_component(cid, acc) end)
+      end
 
     {:noreply, reply(%{state | components: new_components}, msg.ref, :ok, %{})}
   end


### PR DESCRIPTION
The last component optimization introduced by #913 causes the following bug :
When a new rendering within a liveview results in something that has no more stateful components, the deferred "cids_destroyed" event failed because components map has been reset.