### PR TITLE
Clarify usage of enableLatencySim in docs

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -179,12 +179,15 @@ import LiveSocket from "phoenix_live_view"
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
 let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}});
 
-// connect if there are any LiveViews on the page
+// Connect if there are any LiveViews on the page
 liveSocket.connect()
 
-// expose liveSocket on window for web console debug logs and latency simulation:
+// Expose liveSocket on window for web console debug logs and latency simulation:
 // >> liveSocket.enableDebug()
 // >> liveSocket.enableLatencySim(1000)
+// The latency simulator is enabled for the duration of the browser session.
+// Call disableLatencySim() to disable:
+// >> liveSocket.disableLatencySim()
 window.liveSocket = liveSocket
 ```
 


### PR DESCRIPTION
When I first used `liveSocket.enableLatencySim(1000)` it was hard to figure it out that it was still enabled as I did enabled it on the app.js file directly. I did try to disable it with `liveSocket.enableLatencySim(0)`. 😄 

In my case I used the phoenix project generator `--live`. Perhaps, we could add the comment to the `app.js` as well when generated as well.