### PR TITLE
fix npm polyfill command not referencing right package

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ All current Chrome, Safari, Firefox, and MS Edge are supported.
 IE11 support is available with the following polyfills:
 
 ```console
-$ npm install --save --prefix assets mdn-polyfills url-search-params-polyfill formdata-polyfill child-replace-with-polyfill classlist-polyfill @webcomponents/template shim-keyboard-event-key core-js/features/set
+$ npm install --save --prefix assets mdn-polyfills url-search-params-polyfill formdata-polyfill child-replace-with-polyfill classlist-polyfill @webcomponents/template shim-keyboard-event-key core-js
 ```
 
 Note: The `shim-keyboard-event-key` polyfill is also required for [MS Edge 12-18](https://caniuse.com/#feat=keyboardevent-key).


### PR DESCRIPTION
Running the provided command currently yields:
```
npm ERR! code ENOLOCAL
npm ERR! Could not install from "core-js/features/set" as it does not contain a package.json file
```
I'm not sure this is the right fix, but it passes and appears to find the needed `set` polyfill.