### PR TITLE
phoenix_live_component.ex: Clarify stateful lifecycle

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -78,8 +78,16 @@ defmodule Phoenix.LiveComponent do
       end
 
   In stateful components, `c:mount/1` is called only once, when the
-  component is first rendered. Then for each rendering, the optional
+  component is first rendered. For each rendering, the optional
   `c:preload/1` and `c:update/2` callbacks are called before `c:render/1`.
+  
+  So on first render, the following callbacks will be invoked:
+
+      preload(list_of_assigns) -> mount(socket) -> update(assigns, socket) -> render(assigns)
+      
+  On subsequent renders, these callbacks will be invoked:
+  
+      preload(list_of_assigns) -> update(assigns, socket) -> render(assigns)
 
   ## Targeting Component Events
 


### PR DESCRIPTION
I like how the stateless component has this little lifecycle graph and thought it'd be nice here too.

It wasn't clear to me from the docs if `update` was called between the first mount and the first render or not, so I checked and figured I'd clarify.

I was surprised that `preload` was called before `mount`, but that's what my debug output told me.

Line 86 is a bit long but it seemed preferable to breaking it.