### PR TITLE
Retain ES6 syntax when being imported as a module

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,14 @@
   "description": "The Phoenix LiveView JavaScript client.",
   "license": "MIT",
   "main": "./priv/static/phoenix_live_view.js",
+  "module": "./assets/js/phoenix_live_view.js",
   "author": "Chris McCord <chris@chrismccord.com> (http://www.phoenixframework.org)",
   "repository": {
     "type": "git",
     "url": "git://github.com/phoenixframework/phoenix_live_view.git"
+  },
+  "dependencies": {
+    "morphdom": "2.6.1"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
Hello! This is a PR resulting while working with `phx-hook` to understand the ins-and-outs of the JS portion of liveview.

Due to the fact that the current `main` property in `package.json` points to the distributed version with no source maps, it's difficult to perform browser-based debugging.

With the following changes, you will allow other devs to go from:
<img width="745" alt="Screen Shot 2020-06-07 at 10 50 50 PM" src="https://user-images.githubusercontent.com/3430950/83991530-a458a600-a912-11ea-92ca-58e3d35a302d.png">

to this when debugging JS files via browser:
<img width="756" alt="Screen Shot 2020-06-07 at 10 59 54 PM" src="https://user-images.githubusercontent.com/3430950/83991547-ab7fb400-a912-11ea-8c8f-d5cf565ddcd2.png">

Since we are using webpack to transpile both application and module code, there isn't a need to import the distributed version of the file when bringing in `phoenix_live_view` as a module.

Debuggers do allow pretty-printing options for compressed JS files, but you still lose context since all variables will be named differently.

Thanks for this awesome library - really fun to work with phoenix and live view together!