### PR TITLE
Call beforeDestroy on children hooks when the element is being destroyed

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1524,7 +1524,10 @@ export class View {
     clearTimeout(this.loaderTimer)
     let onFinished = () => {
       callback()
-      for(let id in this.viewHooks){ this.destroyHook(this.viewHooks[id]) }
+      for(let id in this.viewHooks){
+        this.viewHooks[id].__trigger__("beforeDestroy")
+        this.destroyHook(this.viewHooks[id])
+      }
     }
 
     this.log("destroyed", () => ["the child has been removed from the parent"])


### PR DESCRIPTION
This solves the problem described in issue #969 . This adds calling `beforeDestroy` on the hook of all children being removed when a parent is being removed too.

Just added the call to that function on the iteration that also calls `destroy()`.

Don't know if there are any tests that should be updated too.