### PR TITLE
Fix syntax error in documentation

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -98,7 +98,7 @@ defmodule Phoenix.LiveViewTest do
   messages, simply message the view and use the `render` function to test the
   result:
 
-      send(view.pid, {:set_temp: 50})
+      send(view.pid, {:set_temp, 50})
       assert render(view) =~ "The temperature is: 50℉"
 
   ## Testing components


### PR DESCRIPTION
Just a tiny issue I noticed while browsing the documentation.