### PR TITLE
Add configurable warning for lv version mismatch between client and server

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -9,6 +9,7 @@ See the hexdocs at `https://hexdocs.pm/phoenix_live_view` for documentation.
 
 import morphdom from "morphdom"
 
+const PACKAGE_INFO = require('../package.json');
 const CONSECUTIVE_RELOADS = "consecutive-reloads"
 const MAX_RELOADS = 10
 const RELOAD_JITTER = [1000, 3000]
@@ -1968,7 +1969,7 @@ export class View {
         session: this.getSession(),
         static: this.getStatic(),
         flash: this.flash,
-        lv_version: __PACKAGE_VERSION__
+        lv_version: PACKAGE_INFO.version
       }
     })
     this.showLoader(this.liveSocket.loaderTimeout)

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1968,7 +1968,7 @@ export class View {
         session: this.getSession(),
         static: this.getStatic(),
         flash: this.flash,
-        lv_version: __PACKAGE_VERSION__
+        vsn: this.parent ? undefined : PACKAGE_VSN
       }
     })
     this.showLoader(this.liveSocket.loaderTimeout)

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -9,6 +9,7 @@ See the hexdocs at `https://hexdocs.pm/phoenix_live_view` for documentation.
 
 import morphdom from "morphdom"
 
+const PACKAGE_INFO = require('../package.json');
 const CONSECUTIVE_RELOADS = "consecutive-reloads"
 const MAX_RELOADS = 10
 const RELOAD_JITTER = [1000, 3000]
@@ -1967,7 +1968,8 @@ export class View {
         params: this.connectParams(),
         session: this.getSession(),
         static: this.getStatic(),
-        flash: this.flash
+        flash: this.flash,
+        lv_version: PACKAGE_INFO.version
       }
     })
     this.showLoader(this.liveSocket.loaderTimeout)

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -9,7 +9,6 @@ See the hexdocs at `https://hexdocs.pm/phoenix_live_view` for documentation.
 
 import morphdom from "morphdom"
 
-const PACKAGE_INFO = require('../package.json');
 const CONSECUTIVE_RELOADS = "consecutive-reloads"
 const MAX_RELOADS = 10
 const RELOAD_JITTER = [1000, 3000]
@@ -1969,7 +1968,7 @@ export class View {
         session: this.getSession(),
         static: this.getStatic(),
         flash: this.flash,
-        lv_version: PACKAGE_INFO.version
+        lv_version: __PACKAGE_VERSION__
       }
     })
     this.showLoader(this.liveSocket.loaderTimeout)

--- a/assets/package.json
+++ b/assets/package.json
@@ -30,6 +30,9 @@
     "webpack-cli": "^2.0.10"
   },
   "jest": {
-    "testRegex": "/test/.*_test\\.js$"
+    "testRegex": "/test/.*_test\\.js$",
+    "globals": {
+      "__PACKAGE_VERSION__": "test_mock_version"
+    }
   }
 }

--- a/assets/package.json
+++ b/assets/package.json
@@ -32,7 +32,7 @@
   "jest": {
     "testRegex": "/test/.*_test\\.js$",
     "globals": {
-      "__PACKAGE_VERSION__": "test_mock_version"
+      "PACKAGE_VSN": "test_mock_version"
     }
   }
 }

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -614,7 +614,7 @@ describe("View", function() {
     stubChannel(view)
 
     expect(view.channel.params()).toEqual({
-      "flash": undefined, "params": {"_mounts": 0}, "session": "abc123", "static": null, "url": undefined}
+      "flash": undefined, "params": { "_mounts": 0 }, "session": "abc123", "static": null, "url": undefined, "lv_version": __PACKAGE_VERSION__}
     )
 
     el.innerHTML += `<link rel="stylesheet" href="/css/app-123.css?vsn=d" phx-track-static="">`
@@ -623,7 +623,7 @@ describe("View", function() {
     el.innerHTML += `<img src="/img/untracked.png">`
 
     expect(view.channel.params()).toEqual({
-      "flash": undefined, "session": "abc123", "static": null, "url": undefined,
+      "flash": undefined, "session": "abc123", "static": null, "url": undefined, "lv_version": __PACKAGE_VERSION__,
       "params": {
         "_mounts": 0,
         "_track_static": [

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -614,7 +614,7 @@ describe("View", function() {
     stubChannel(view)
 
     expect(view.channel.params()).toEqual({
-      "flash": undefined, "params": { "_mounts": 0 }, "session": "abc123", "static": null, "url": undefined, "lv_version": __PACKAGE_VERSION__}
+      "flash": undefined, "params": { "_mounts": 0 }, "session": "abc123", "static": null, "url": undefined, "lv_version": PACKAGE_VSN}
     )
 
     el.innerHTML += `<link rel="stylesheet" href="/css/app-123.css?vsn=d" phx-track-static="">`
@@ -623,7 +623,7 @@ describe("View", function() {
     el.innerHTML += `<img src="/img/untracked.png">`
 
     expect(view.channel.params()).toEqual({
-      "flash": undefined, "session": "abc123", "static": null, "url": undefined, "lv_version": __PACKAGE_VERSION__,
+      "flash": undefined, "session": "abc123", "static": null, "url": undefined, "lv_version": PACKAGE_VSN,
       "params": {
         "_mounts": 0,
         "_track_static": [

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -614,7 +614,7 @@ describe("View", function() {
     stubChannel(view)
 
     expect(view.channel.params()).toEqual({
-      "flash": undefined, "params": { "_mounts": 0 }, "session": "abc123", "static": null, "url": undefined, "lv_version": PACKAGE_VSN}
+      "flash": undefined, "params": { "_mounts": 0 }, "session": "abc123", "static": null, "url": undefined, "vsn": PACKAGE_VSN}
     )
 
     el.innerHTML += `<link rel="stylesheet" href="/css/app-123.css?vsn=d" phx-track-static="">`
@@ -623,7 +623,7 @@ describe("View", function() {
     el.innerHTML += `<img src="/img/untracked.png">`
 
     expect(view.channel.params()).toEqual({
-      "flash": undefined, "session": "abc123", "static": null, "url": undefined, "lv_version": PACKAGE_VSN,
+      "flash": undefined, "session": "abc123", "static": null, "url": undefined, "vsn": PACKAGE_VSN,
       "params": {
         "_mounts": 0,
         "_track_static": [

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -1,4 +1,6 @@
 const path = require('path')
+const webpack = require('webpack')
+const package = require("./package.json")
 
 module.exports = {
   entry: './js/phoenix_live_view.js',
@@ -27,5 +29,9 @@ module.exports = {
       }
     ]
   },
-  plugins: []
+  plugins: [
+    new webpack.DefinePlugin({
+      __PACKAGE_VERSION__: JSON.stringify(package.version)
+    })
+  ]
 }

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -31,7 +31,7 @@ module.exports = {
   },
   plugins: [
     new webpack.DefinePlugin({
-      __PACKAGE_VERSION__: JSON.stringify(package.version)
+      PACKAGE_VSN: JSON.stringify(package.version)
     })
   ]
 }

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -725,7 +725,7 @@ defmodule Phoenix.LiveView.Channel do
   ## Mount
 
   defp mount(%{"session" => session_token} = params, from, phx_socket) do
-    check_version_match(phx_socket, phx_socket.endpoint)
+    check_version_match(params, phx_socket.endpoint)
 
     case Static.verify_session(phx_socket.endpoint, session_token, params["static"]) do
       {:ok, verified} ->

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -6,6 +6,7 @@ defmodule Phoenix.LiveView.Channel do
 
   alias Phoenix.LiveView.{Socket, Utils, Diff, Static, Upload, UploadConfig}
   alias Phoenix.Socket.Message
+  import Phoenix.LiveView.MixProject, only: [project: 0]
 
   @prefix :phoenix
 
@@ -780,14 +781,14 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   defp check_version_match(params) do
-    server_version = Application.spec(:phoenix_live_view, :vsn) |> List.to_string()
+    server_version = Keyword.get(project(), :version, :not_found)
     client_version = Map.get(params, "lv_version", :not_found)
     should_display_warning = Application.get_env(:phoenix_live_view, :warn_version_mismatch, true)
 
     if should_display_warning && server_version != client_version do
       Logger.warn("""
       There is a mismatch between the LiveView version on the server (#{server_version}) and the client (#{client_version}).
-      The client side can be synced to match by running `npm install --prefix assets`.
+      The client side can be updated to match by running `npm install --prefix assets`.
       """)
     end
   end

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -725,7 +725,9 @@ defmodule Phoenix.LiveView.Channel do
   ## Mount
 
   defp mount(%{"session" => session_token} = params, from, phx_socket) do
-    check_version_match(params, phx_socket.endpoint)
+    unless Map.has_key?(phx_socket, :parent_pid) do
+      check_version_match(params, phx_socket.endpoint)
+    end
 
     case Static.verify_session(phx_socket.endpoint, session_token, params["static"]) do
       {:ok, verified} ->
@@ -781,7 +783,7 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   defp check_version_match(params, phx_endpoint) do
-    client_version = Map.get(params, "lv_version", :not_found)
+    client_version = Map.get(params, "vsn", :not_found)
     should_display_warning = Application.fetch_env!(:phoenix_live_view, :warn_version_mismatch)
 
     if should_display_warning && @version != client_version do

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -783,7 +783,6 @@ defmodule Phoenix.LiveView.Channel do
   defp check_version_match(params, phx_endpoint) do
     client_version = Map.get(params, "lv_version", :not_found)
     should_display_warning = Application.fetch_env!(:phoenix_live_view, :warn_version_mismatch)
-    Application.get_all_env(:phoenix_live_view) |> IO.inspect(label: "get_all_env")
 
     if should_display_warning && @version != client_version do
       Logger.warn("""

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -6,7 +6,6 @@ defmodule Phoenix.LiveView.Channel do
 
   alias Phoenix.LiveView.{Socket, Utils, Diff, Static, Upload, UploadConfig}
   alias Phoenix.Socket.Message
-  import Phoenix.LiveView.MixProject, only: [project: 0]
 
   @prefix :phoenix
 
@@ -781,14 +780,14 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   defp check_version_match(params) do
-    server_version = Keyword.get(project(), :version, :not_found)
+    server_version = Application.spec(:phoenix_live_view, :vsn) |> List.to_string()
     client_version = Map.get(params, "lv_version", :not_found)
     should_display_warning = Application.get_env(:phoenix_live_view, :warn_version_mismatch, true)
 
     if should_display_warning && server_version != client_version do
       Logger.warn("""
       There is a mismatch between the LiveView version on the server (#{server_version}) and the client (#{client_version}).
-      The client side can be updated to match by running `npm install --prefix assets`.
+      The client side can be synced to match by running `npm install --prefix assets`.
       """)
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,8 @@ defmodule Phoenix.LiveView.MixProject do
   def application do
     [
       extra_applications: [:logger],
-      mod: {Phoenix.LiveView.Application, []}
+      mod: {Phoenix.LiveView.Application, []},
+      env: [warn_version_mismatch: true]
     ]
   end
 


### PR DESCRIPTION
This PR warns on a version mismatch between the client and server versions of LiveView, as reported on issue #929 . The client sends its version to the server as part on the connection and as part of the mounting process it is checked against the server version. This results in a repeated warning every time there is a new socket connection, I decided to go this way since it was really easy to pass the version as an extra connection param.

This is can also be turned off by adding `config :phoenix_live_view, :warn_version_mismatch, false` on the configuration of the project using LV. If no config found, it defaults to true.

In the PR I only changed the readable `live_view.js`, not sure how the minified version should be updated in a PR since master could change at any time. Open to comments if there is a preferred way to do the warning.