### PR TITLE
Improve docs for render_hook.

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -54,28 +54,28 @@ defmodule Phoenix.LiveViewTest do
   browser and assert on the rendered side effect of the event, use the
   `render_*` functions:
 
-    * `render_click/1` - sends a phx-click event and value and
-      returns the rendered result of the `handle_event/3` callback.
+    * `render_click/1` - sends a phx-click event and value, returning
+      the rendered result of the `handle_event/3` callback.
 
-    * `render_focus/2` - sends a phx-focus event and value and
-      returns the rendered result of the `handle_event/3` callback.
+    * `render_focus/2` - sends a phx-focus event and value, returning
+      the rendered result of the `handle_event/3` callback.
 
-    * `render_blur/1` - sends a phx-blur event and value and
-      returns the rendered result of the `handle_event/3` callback.
+    * `render_blur/1` - sends a phx-blur event and value, returning
+      the rendered result of the `handle_event/3` callback.
 
-    * `render_submit/1` - sends a form phx-submit event and value and
-      returns the rendered result of the `handle_event/3` callback.
+    * `render_submit/1` - sends a form phx-submit event and value, returning
+      the rendered result of the `handle_event/3` callback.
 
-    * `render_change/1` - sends a form phx-change event and value and
-      returns the rendered result of the `handle_event/3` callback.
+    * `render_change/1` - sends a form phx-change event and value, returning
+      the rendered result of the `handle_event/3` callback.
 
-    * `render_keydown/1` - sends a form phx-keydown event and value and
-      returns the rendered result of the `handle_event/3` callback.
+    * `render_keydown/1` - sends a form phx-keydown event and value, returning
+      the rendered result of the `handle_event/3` callback.
 
-    * `render_keyup/1` - sends a form phx-keyup event and value and
-      returns the rendered result of the `handle_event/3` callback.
+    * `render_keyup/1` - sends a form phx-keyup event and value, returning
+      the rendered result of the `handle_event/3` callback.
 
-    * `render_hook/3` - sends a hook event and value and returns
+    * `render_hook/3` - sends a hook event and value, returning
       the rendered result of the `handle_event/3` callback.
 
   For example:

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -75,6 +75,9 @@ defmodule Phoenix.LiveViewTest do
     * `render_keyup/1` - sends a form phx-keyup event and value and
       returns the rendered result of the `handle_event/3` callback.
 
+    * `render_hook/3` - sends a hook event and value and returns
+      the rendered result of the `handle_event/3` callback.
+
   For example:
 
       {:ok, view, _html} = live(conn, "/thermo")


### PR DESCRIPTION
Hello! The event summary is missing an entry for `render_hook` and I overlooked it as I was looking for a more generic "render_event" :joy:. This adds it!

I optionally improved the grammar here, as `event and value and returns` reads a bit weird, I'm happy to drop this commit if you prefer though.