### PR TITLE
Change the error example in LiveView mount

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -211,8 +211,8 @@ defmodule Phoenix.LiveView do
             {:ok, temperature} ->
               {:ok, assign(socket, temperature: temperature, user_id: user_id)}
 
-            {:error, reason} ->
-              {:error, reason}
+            {:error, _reason} ->
+              {:ok, redirect(socket, to: "/error")}
           end
         end
 


### PR DESCRIPTION
Having just come across this myself and not knowing the idiomatic thing to
do, I thought it would be a good idea to change the example.

In the current example, it returns `{:error, reason}` which would raise.
Personally, I think it would be better if Phoenix LiveView offered a
first class way of dealing with errors in mount/3. For now, I would
suggest that we have an example that redirects to an error page or shows
how to render an error.

This change redirects to some random "/error" page. If there is a
suggestion for a better exmaple, I am happy to change it.