### PR TITLE
Register "popstate" event handler using window.addEventListener

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -748,7 +748,7 @@ export class LiveSocket {
 
   bindNav(){
     if(!Browser.canPushState()){ return }
-    window.onpopstate = (event) => {
+    window.addEventListener("popstate", event => {
       if(!this.registerNewLocation(window.location)){ return }
       let {type, id, root} = event.state || {}
       let href = window.location.href
@@ -760,7 +760,7 @@ export class LiveSocket {
           if(root){ this.replaceRootHistory() }
         })
       }
-    }
+    }, false)
     window.addEventListener("click", e => {
       let target = closestPhxBinding(e.target, PHX_LIVE_LINK)
       let type = target && target.getAttribute(PHX_LIVE_LINK)


### PR DESCRIPTION
The purpose of this PR is to allow other `popstate` event handlers to be registered in user code before LiveSocket's. LiveSocket currently registers its `popstate` event handler using `window.onpopstate`. The problem with this is it takes precedence over all other event handlers and there can only be one. The solution is to register the `popstate` event handler using `window.addEventListener`, which allows multiple event handlers to be registered and executed in the order in which they were registered.

### Background

I have a content editing page implemented as a LiveView. If the user attempts to navigate away without saving their work, I would like to warn them and give them the option to stay on the page.

I tried to address this by creating a `beforeunload` JavaScript event handler in a hook.

I specify a `BeforeUnload` hook on a dom element with a data attribute indicating whether the content has changed or not. For example:

```html
<div phx-hook="BeforeUnload"
     data-changes-made="<%= !Enum.empty?(@changeset.changes) %>">
```

I then create a hook to register a `beforeunload` event handler.

```javascript
Hooks.BeforeUnload = {
  mounted() {
    var el = this.el
    this.beforeUnload = function(e) {
      if (el.dataset.changesMade == "true") {
        e.preventDefault();
        e.returnValue = "";
      }
    }
    window.addEventListener("beforeunload", this.beforeUnload)
  },
  destroyed() {
    window.removeEventListener("beforeunload", this.beforeUnload);
  }
}
```

This works great for page reloads and navigating away to non-LiveView pages, but doesn’t work when navigating between LiveView pages. For example, hitting the back button when the page was reached through another LiveView. This is because LiveView navigates to the page over the same websocket, thus no browser-level unload occurs.

Since LiveView uses the browser's History API to manage the navigation between LiveViews, it seems reasonable that I could intercept the `popstate` event to keep the browser from navigating away when the back button is pressed. For example, I could register a `popstate` event handler before the socket connects and use that event handler to call a hook registered function that determines whether it is okay to navigate away or not.

It could look like this:

```javascript
Hooks.PopState = {
  mounted() {
    var el = this.el
    var currentLocation = window.location.toString()
    window.stopPopState = function() {
      if (el.dataset.changesMade != "true" ||
        window.location.toString() === currentLocation) {
        return false
      }
      return !confirm("Are you sure you want to leave without saving your changes?")
    }
  },
  destroyed() {
    window.stopPopState = null
  }
}

window.addEventListener("popstate", e => {
  if (window.stopPopState && window.stopPopState()) {
    e.preventDefault();
    e.stopImmediatePropagation()
    history.go(1);
  }
})

let liveSocket = new LiveSocket("/live", Socket, {...}
liveSocket.connect()
```

The problem with this approach is that LiveSocket registers its `popstate` handler using `window.onpopstate`, which gives it precedence over all other `popstate` event handlers. Meaning by the time any other `popstate` event handler is called, the deed will have been done.

I propose we instead use `addEventListener` to register the `popstate` event handler in LiveSocket. This will leave open the possibility of user code handling the `popstate` event before it reaches LiveSocket's `popstate` event handler.
