### PR TITLE
Add telemetry events

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1779,7 +1779,9 @@ defmodule Phoenix.LiveView do
 
     * `[:phoenix, :live_view, :mount, :start]` - Dispatched by a `Phoenix.LiveView` immediately before `c:mount/3` is invoked
 
-      * Measurement: `%{system_time: System.monotonic_time}`
+      * Measurement:
+
+            %{system_time: System.monotonic_time}
 
       * Metadata:
 
@@ -1792,7 +1794,9 @@ defmodule Phoenix.LiveView do
 
     * `[:phoenix, :live_view, :mount, :stop]` - Dispatched by a `Phoenix.LiveView` when the `c:mount/3` callback completes successfully.
 
-      * Measurement: `%{duration: native_time}`
+      * Measurement:
+
+            %{duration: native_time}
 
       * Metadata:
 
@@ -1819,7 +1823,9 @@ defmodule Phoenix.LiveView do
 
     * `[:phoenix, :live_view, :handle_params, :start]` - Dispatched by a `Phoenix.LiveView` immediately before `c:handle_params/3` is invoked
 
-      * Measurement: `%{system_time: System.monotonic_time}`
+      * Measurement:
+
+            %{system_time: System.monotonic_time}
 
       * Metadata:
 
@@ -1832,7 +1838,9 @@ defmodule Phoenix.LiveView do
 
     * `[:phoenix, :live_view, :handle_params, :stop]` - Dispatched by a `Phoenix.LiveView` when the `c:handle_params/3` callback completes successfully.
 
-      * Measurement: `%{duration: native_time}`
+      * Measurement:
+
+            %{duration: native_time}
 
       * Metadata:
 
@@ -1844,7 +1852,9 @@ defmodule Phoenix.LiveView do
 
     * `[:phoenix, :live_view, :handle_params, :exception]` - Dispatched by a `Phoenix.LiveView` when the `c:handle_params/3` callback completes successfully.
 
-      * Measurement: `%{duration: native_time}`
+      * Measurement:
+
+            %{duration: native_time}
 
       * Metadata:
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1413,34 +1413,6 @@ defmodule Phoenix.LiveView do
   other developers will be more comfortable by explicitly handling those cases.
   In both scenarios, LiveView has you covered.
 
-  ## Telemetry
-
-  LiveView currently exposes the following events:
-
-    * `[:phoenix_live_view, :mount, :start]` - Dispatched by a `Phoenix.LiveView` immediately before `c:mount/3` is invoked
-
-      * Measurement: `%{system_time: System.monotonic_time}`
-
-      * Metadata: `%{socket: Phoenix.LiveView.Socket.t}`
-
-    * `[:phoenix_live_view, :mount, :stop]` - Dispatched by a `Phoenix.LiveView` when the `c:mount/3` callback completes successfully.
-
-      * Measurement: `%{duration: native_time}`
-
-      * Metadata: `%{socket: Phoenix.LiveView.Socket.t}`
-
-    * `[:phoenix_live_view, :mount, :exception]` - Dispatched by a `Phoenix.LiveView` when the `c:mount/3` callback completes successfully.
-
-      * Measurement: `%{duration: native_time}`
-
-      * Metadata:
-
-            %{
-              socket: Phoenix.LiveView.Socket.t,
-              kind: atom,
-              reason: term
-            }
-
   ## Using Gettext for internationalization
 
   For internationalization with [gettext](https://hexdocs.pm/gettext/Gettext.html),
@@ -1800,6 +1772,35 @@ defmodule Phoenix.LiveView do
     * `:hibernate_after` (optional) - the idle time in milliseconds allowed in
     the LiveView before compressing its own memory and state.
     Defaults to 15000ms (15 seconds)
+
+  ## Telemetry
+
+  LiveView currently exposes the following events:
+
+    * `[:phoenix_live_view, :mount, :start]` - Dispatched by a `Phoenix.LiveView` immediately before `c:mount/3` is invoked
+
+      * Measurement: `%{system_time: System.monotonic_time}`
+
+      * Metadata: `%{socket: Phoenix.LiveView.Socket.t}`
+
+    * `[:phoenix_live_view, :mount, :stop]` - Dispatched by a `Phoenix.LiveView` when the `c:mount/3` callback completes successfully.
+
+      * Measurement: `%{duration: native_time}`
+
+      * Metadata: `%{socket: Phoenix.LiveView.Socket.t}`
+
+    * `[:phoenix_live_view, :mount, :exception]` - Dispatched by a `Phoenix.LiveView` when the `c:mount/3` callback completes successfully.
+
+      * Measurement: `%{duration: native_time}`
+
+      * Metadata:
+
+            %{
+              socket: Phoenix.LiveView.Socket.t,
+              kind: atom,
+              reason: term
+            }
+
   '''
 
   alias Phoenix.LiveView.Socket

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1781,13 +1781,27 @@ defmodule Phoenix.LiveView do
 
       * Measurement: `%{system_time: System.monotonic_time}`
 
-      * Metadata: `%{socket: Phoenix.LiveView.Socket.t}`
+      * Metadata:
+
+            %{
+              socket: Phoenix.LiveView.Socket.t,
+              params: unsigned_params | :not_mounted_at_router,
+              session: map
+            }
+
 
     * `[:phoenix, :live_view, :mount, :stop]` - Dispatched by a `Phoenix.LiveView` when the `c:mount/3` callback completes successfully.
 
       * Measurement: `%{duration: native_time}`
 
-      * Metadata: `%{socket: Phoenix.LiveView.Socket.t}`
+      * Metadata:
+
+            %{
+              socket: Phoenix.LiveView.Socket.t,
+              params: unsigned_params | :not_mounted_at_router,
+              session: map
+            }
+
 
     * `[:phoenix, :live_view, :mount, :exception]` - Dispatched by a `Phoenix.LiveView` when the `c:mount/3` callback completes successfully.
 
@@ -1798,7 +1812,9 @@ defmodule Phoenix.LiveView do
             %{
               socket: Phoenix.LiveView.Socket.t,
               kind: atom,
-              reason: term
+              reason: term,
+              params: unsigned_params | :not_mounted_at_router,
+              session: map
             }
 
     * `[:phoenix, :live_view, :handle_params, :start]` - Dispatched by a `Phoenix.LiveView` immediately before `c:handle_params/3` is invoked

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1777,19 +1777,19 @@ defmodule Phoenix.LiveView do
 
   LiveView currently exposes the following events:
 
-    * `[:phoenix_live_view, :mount, :start]` - Dispatched by a `Phoenix.LiveView` immediately before `c:mount/3` is invoked
+    * `[:phoenix, :live_view, :mount, :start]` - Dispatched by a `Phoenix.LiveView` immediately before `c:mount/3` is invoked
 
       * Measurement: `%{system_time: System.monotonic_time}`
 
       * Metadata: `%{socket: Phoenix.LiveView.Socket.t}`
 
-    * `[:phoenix_live_view, :mount, :stop]` - Dispatched by a `Phoenix.LiveView` when the `c:mount/3` callback completes successfully.
+    * `[:phoenix, :live_view, :mount, :stop]` - Dispatched by a `Phoenix.LiveView` when the `c:mount/3` callback completes successfully.
 
       * Measurement: `%{duration: native_time}`
 
       * Metadata: `%{socket: Phoenix.LiveView.Socket.t}`
 
-    * `[:phoenix_live_view, :mount, :exception]` - Dispatched by a `Phoenix.LiveView` when the `c:mount/3` callback completes successfully.
+    * `[:phoenix, :live_view, :mount, :exception]` - Dispatched by a `Phoenix.LiveView` when the `c:mount/3` callback completes successfully.
 
       * Measurement: `%{duration: native_time}`
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1413,6 +1413,34 @@ defmodule Phoenix.LiveView do
   other developers will be more comfortable by explicitly handling those cases.
   In both scenarios, LiveView has you covered.
 
+  ## Telemetry
+
+  LiveView currently exposes the following events:
+
+    * `[:phoenix_live_view, :mount, :start]` - Dispatched by a `Phoenix.LiveView` immediately before `c:mount/3` is invoked
+
+      * Measurement: `%{system_time: System.monotonic_time}`
+
+      * Metadata: `%{socket: Phoenix.LiveView.Socket.t}`
+
+    * `[:phoenix_live_view, :mount, :stop]` - Dispatched by a `Phoenix.LiveView` when the `c:mount/3` callback completes successfully.
+
+      * Measurement: `%{duration: native_time}`
+
+      * Metadata: `%{socket: Phoenix.LiveView.Socket.t}`
+
+    * `[:phoenix_live_view, :mount, :exception]` - Dispatched by a `Phoenix.LiveView` when the `c:mount/3` callback completes successfully.
+
+      * Measurement: `%{duration: native_time}`
+
+      * Metadata:
+
+            %{
+              socket: Phoenix.LiveView.Socket.t,
+              kind: atom,
+              reason: term
+            }
+
   ## Using Gettext for internationalization
 
   For internationalization with [gettext](https://hexdocs.pm/gettext/Gettext.html),

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1805,13 +1805,26 @@ defmodule Phoenix.LiveView do
 
       * Measurement: `%{system_time: System.monotonic_time}`
 
-      * Metadata: `%{socket: Phoenix.LiveView.Socket.t}`
+      * Metadata:
+
+            %{
+              socket: Phoenix.LiveView.Socket.t,
+              params: unsigned_params,
+              uri: String.t()
+            }
+
 
     * `[:phoenix, :live_view, :handle_params, :stop]` - Dispatched by a `Phoenix.LiveView` when the `c:handle_params/3` callback completes successfully.
 
       * Measurement: `%{duration: native_time}`
 
-      * Metadata: `%{socket: Phoenix.LiveView.Socket.t}`
+      * Metadata:
+
+            %{
+              socket: Phoenix.LiveView.Socket.t,
+              params: unsigned_params,
+              uri: String.t()
+            }
 
     * `[:phoenix, :live_view, :handle_params, :exception]` - Dispatched by a `Phoenix.LiveView` when the `c:handle_params/3` callback completes successfully.
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1851,7 +1851,9 @@ defmodule Phoenix.LiveView do
             %{
               socket: Phoenix.LiveView.Socket.t,
               kind: atom,
-              reason: term
+              reason: term,
+              socket: Phoenix.LiveView.Socket.t,
+              params: unsigned_params
             }
 
   '''

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1866,6 +1866,51 @@ defmodule Phoenix.LiveView do
               params: unsigned_params
             }
 
+    * `[:phoenix, :live_view, :handle_event, :start]` - Dispatched by a `Phoenix.LiveView` immediately before `c:handle_event/3` is invoked.
+
+      * Measurement:
+
+            %{system_time: System.monotonic_time}
+
+      * Metadata:
+
+            %{
+              socket: Phoenix.LiveView.Socket.t,
+              event: String.t(),
+              params: unsigned_params
+            }
+
+
+    * `[:phoenix, :live_view, :handle_event, :stop]` - Dispatched by a `Phoenix.LiveView` when the `c:handle_event/3` callback completes successfully.
+
+      * Measurement:
+
+            %{duration: native_time}
+
+      * Metadata:
+
+            %{
+              socket: Phoenix.LiveView.Socket.t,
+              event: String.t(),
+              params: unsigned_params
+            }
+
+    * `[:phoenix, :live_view, :handle_event, :exception]` - Dispatched by a `Phoenix.LiveView` when an exception is raised in the `c:handle_event/3` callback.
+
+      * Measurement:
+
+            %{duration: native_time}
+
+      * Metadata:
+
+            %{
+              socket: Phoenix.LiveView.Socket.t,
+              kind: atom,
+              reason: term,
+              event: String.t(),
+              params: unsigned_params
+            }
+
   '''
 
   alias Phoenix.LiveView.Socket

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1801,6 +1801,30 @@ defmodule Phoenix.LiveView do
               reason: term
             }
 
+    * `[:phoenix, :live_view, :handle_params, :start]` - Dispatched by a `Phoenix.LiveView` immediately before `c:handle_params/3` is invoked
+
+      * Measurement: `%{system_time: System.monotonic_time}`
+
+      * Metadata: `%{socket: Phoenix.LiveView.Socket.t}`
+
+    * `[:phoenix, :live_view, :handle_params, :stop]` - Dispatched by a `Phoenix.LiveView` when the `c:handle_params/3` callback completes successfully.
+
+      * Measurement: `%{duration: native_time}`
+
+      * Metadata: `%{socket: Phoenix.LiveView.Socket.t}`
+
+    * `[:phoenix, :live_view, :handle_params, :exception]` - Dispatched by a `Phoenix.LiveView` when the `c:handle_params/3` callback completes successfully.
+
+      * Measurement: `%{duration: native_time}`
+
+      * Metadata:
+
+            %{
+              socket: Phoenix.LiveView.Socket.t,
+              kind: atom,
+              reason: term
+            }
+
   '''
 
   alias Phoenix.LiveView.Socket

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1777,7 +1777,7 @@ defmodule Phoenix.LiveView do
 
   LiveView currently exposes the following events:
 
-    * `[:phoenix, :live_view, :mount, :start]` - Dispatched by a `Phoenix.LiveView` immediately before `c:mount/3` is invoked
+    * `[:phoenix, :live_view, :mount, :start]` - Dispatched by a `Phoenix.LiveView` immediately before `c:mount/3` is invoked.
 
       * Measurement:
 
@@ -1807,7 +1807,7 @@ defmodule Phoenix.LiveView do
             }
 
 
-    * `[:phoenix, :live_view, :mount, :exception]` - Dispatched by a `Phoenix.LiveView` when the `c:mount/3` callback completes successfully.
+    * `[:phoenix, :live_view, :mount, :exception]` - Dispatched by a `Phoenix.LiveView` when an exception is raised in the `c:mount/3` callback.
 
       * Measurement: `%{duration: native_time}`
 
@@ -1821,7 +1821,7 @@ defmodule Phoenix.LiveView do
               session: map
             }
 
-    * `[:phoenix, :live_view, :handle_params, :start]` - Dispatched by a `Phoenix.LiveView` immediately before `c:handle_params/3` is invoked
+    * `[:phoenix, :live_view, :handle_params, :start]` - Dispatched by a `Phoenix.LiveView` immediately before `c:handle_params/3` is invoked.
 
       * Measurement:
 
@@ -1850,7 +1850,7 @@ defmodule Phoenix.LiveView do
               uri: String.t()
             }
 
-    * `[:phoenix, :live_view, :handle_params, :exception]` - Dispatched by a `Phoenix.LiveView` when the `c:handle_params/3` callback completes successfully.
+    * `[:phoenix, :live_view, :handle_params, :exception]` - Dispatched by a `Phoenix.LiveView` when the when an exception is raised in the `c:handle_params/3` callback.
 
       * Measurement:
 
@@ -1862,8 +1862,8 @@ defmodule Phoenix.LiveView do
               socket: Phoenix.LiveView.Socket.t,
               kind: atom,
               reason: term,
-              socket: Phoenix.LiveView.Socket.t,
-              params: unsigned_params
+              params: unsigned_params,
+              uri: String.t()
             }
 
     * `[:phoenix, :live_view, :handle_event, :start]` - Dispatched by a `Phoenix.LiveView` immediately before `c:handle_event/3` is invoked.

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -232,7 +232,8 @@ defmodule Phoenix.LiveView.Channel do
                 " was not mounted at the router with the live/3 macro under URL #{inspect(url)}"
 
       true ->
-        Utils.call_handle_params!(socket, view, params, url)
+        socket
+        |> Utils.call_handle_params!(view, params, url)
         |> mount_handle_params_result(state, :mount)
     end
   end

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -213,15 +213,19 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   defp call_live_view_handle_event!(%Socket{} = socket, event, val) do
-    :telemetry.span([:phoenix, :live_view, :handle_event], %{socket: socket, event: event, params: val}, fn ->
-      case socket.view.handle_event(event, val, socket) do
-        {:noreply, %Socket{} = socket} ->
-          {{:noreply, socket}, %{socket: socket, event: event, params: val}}
+    :telemetry.span(
+      [:phoenix, :live_view, :handle_event],
+      %{socket: socket, event: event, params: val},
+      fn ->
+        case socket.view.handle_event(event, val, socket) do
+          {:noreply, %Socket{} = socket} ->
+            {{:noreply, socket}, %{socket: socket, event: event, params: val}}
 
-        other ->
-          raise_bad_callback_response!(other, socket.view, :handle_event, 3)
+          other ->
+            raise_bad_callback_response!(other, socket.view, :handle_event, 3)
+        end
       end
-    end)
+    )
   end
 
   defp maybe_call_mount_handle_params(%{socket: socket} = state, router, url, params) do

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -667,7 +667,7 @@ defmodule Phoenix.LiveView.Channel do
       )
 
     socket
-    |> Utils.maybe_call_mount!(view, [params, Map.merge(socket_session, session), socket])
+    |> Utils.maybe_call_live_view_mount!(view, params, Map.merge(socket_session, session))
     |> build_state(phx_socket)
     |> maybe_call_mount_handle_params(router, url, params)
     |> reply_mount(from)

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -73,8 +73,8 @@ defmodule Phoenix.LiveView.Channel do
       {:internal, params, action, _} ->
         socket = socket |> assign_action(action) |> Utils.clear_flash()
 
-        params
-        |> view.handle_params(url, socket)
+        socket
+        |> Utils.call_handle_params!(view, params, url)
         |> handle_result({:handle_params, 3, msg.ref}, state)
 
       {:external, _uri} ->
@@ -232,8 +232,7 @@ defmodule Phoenix.LiveView.Channel do
                 " was not mounted at the router with the live/3 macro under URL #{inspect(url)}"
 
       true ->
-        params
-        |> view.handle_params(url, socket)
+        Utils.call_handle_params!(socket, view, params, url)
         |> mount_handle_params_result(state, :mount)
     end
   end
@@ -256,8 +255,9 @@ defmodule Phoenix.LiveView.Channel do
         %{socket: new_socket} = new_state = drop_redirect(new_state)
         uri = build_uri(new_state, to)
 
-        params
-        |> new_socket.view.handle_params(uri, assign_action(new_socket, action))
+        new_socket
+        |> assign_action(action)
+        |> Utils.call_handle_params!(new_socket.view, params, uri)
         |> mount_handle_params_result(new_state, {:live_patch, opts})
     end
   end
@@ -453,21 +453,12 @@ defmodule Phoenix.LiveView.Channel do
   defp sync_handle_params_with_live_redirect(state, params, action, %{to: to} = opts, ref) do
     %{socket: socket} = state
 
-    case socket.view.handle_params(params, build_uri(state, to), assign_action(socket, action)) do
-      {:noreply, %Socket{} = new_socket} ->
-        handle_changed(state, new_socket, ref, opts)
+    {:noreply, %Socket{} = new_socket} =
+      socket
+      |> assign_action(action)
+      |> Utils.call_handle_params!(socket.view, params, build_uri(state, to))
 
-      other ->
-        raise ArgumentError, """
-        invalid return from #{inspect(socket.view)}.handle_params/3 callback.
-
-        Expected one of:
-
-            {:noreply, %Socket{}}
-
-        Got: #{inspect(other)}
-        """
-    end
+    handle_changed(state, new_socket, ref, opts)
   end
 
   defp push_live_patch(state, nil), do: state

--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -530,7 +530,7 @@ defmodule Phoenix.LiveView.Diff do
       )
       |> Utils.assign(:flash, %{})
 
-    Utils.maybe_call_mount!(socket, component, [socket])
+    Utils.maybe_call_live_component_mount!(socket, component)
   end
 
   defp configure_socket_for_component(socket, assigns, private, prints) do

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -241,7 +241,7 @@ defmodule Phoenix.LiveView.Static do
     socket = put_in(socket.private[:conn_session], conn_session)
 
     socket =
-      Utils.maybe_call_mount!(socket, view, [:not_mounted_at_router, mount_session, socket])
+      Utils.maybe_call_live_view_mount!(socket, view, :not_mounted_at_router, mount_session)
 
     if redir = socket.redirected do
       throw({:phoenix, :child_redirect, redir, Utils.get_flash(socket)})
@@ -299,7 +299,7 @@ defmodule Phoenix.LiveView.Static do
     mount_params = if socket.router, do: params, else: :not_mounted_at_router
 
     socket
-    |> Utils.maybe_call_mount!(view, [mount_params, session, socket])
+    |> Utils.maybe_call_live_view_mount!(view, mount_params, session)
     |> mount_handle_params(view, params, uri)
     |> case do
       {:noreply, %Socket{redirected: {:live, _, _}} = socket} ->

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -310,13 +310,6 @@ defmodule Phoenix.LiveView.Static do
 
       {:noreply, %Socket{redirected: nil} = new_socket} ->
         {:ok, new_socket}
-
-      other ->
-        raise ArgumentError, """
-        invalid result returned from #{inspect(view)}.handle_params/3.
-
-        Expected {:noreply, socket}, got: #{inspect(other)}
-        """
     end
   end
 
@@ -333,7 +326,7 @@ defmodule Phoenix.LiveView.Static do
         Utils.live_link_info!(socket, view, uri)
 
       true ->
-        view.handle_params(params, uri, socket)
+        Utils.call_handle_params!(socket, view, params, uri)
     end
   end
 

--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -256,7 +256,7 @@ defmodule Phoenix.LiveView.Utils do
     arity = length(args)
 
     if function_exported?(view, :mount, arity) do
-      :telemetry.span([:phoenix_live_view, :mount], %{socket: socket}, fn ->
+      :telemetry.span([:phoenix, :live_view, :mount], %{socket: socket}, fn ->
         case apply(view, :mount, args) do
           {:ok, %Socket{} = socket, opts} when is_list(opts) ->
             validate_mount_redirect!(socket.redirected)

--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -293,10 +293,10 @@ defmodule Phoenix.LiveView.Utils do
   been exported. Raises an `ArgumentError` on unexpected return types.
   """
   def call_handle_params!(%Socket{} = socket, view, params, uri) do
-    :telemetry.span([:phoenix, :live_view, :handle_params], %{socket: socket}, fn ->
+    :telemetry.span([:phoenix, :live_view, :handle_params], %{socket: socket, params: params, uri: uri}, fn ->
       case view.handle_params(params, uri, socket) do
         {:noreply, %Socket{} = socket} ->
-          {{:noreply, socket}, %{socket: socket}}
+          {{:noreply, socket}, %{socket: socket, params: params, uri: uri}}
 
         other ->
           raise ArgumentError, """

--- a/mix.exs
+++ b/mix.exs
@@ -40,6 +40,7 @@ defmodule Phoenix.LiveView.MixProject do
     [
       {:phoenix, "~> 1.4.17 or ~> 1.5.2"},
       {:phoenix_html, "~> 2.14"},
+      {:telemetry, github: "beam-telemetry/telemetry", override: true},
       {:jason, "~> 1.0", optional: true},
       {:ex_doc, "~> 0.22", only: :docs},
       {:floki, "~> 0.26.0", only: :test},

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule Phoenix.LiveView.MixProject do
     [
       {:phoenix, "~> 1.4.17 or ~> 1.5.2"},
       {:phoenix_html, "~> 2.14"},
-      {:telemetry, github: "beam-telemetry/telemetry", override: true},
+      {:telemetry, "~> 0.4.2 or ~> 0.5"},
       {:jason, "~> 1.0", optional: true},
       {:ex_doc, "~> 0.22", only: :docs},
       {:floki, "~> 0.26.0", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -13,5 +13,5 @@
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.1.2", "496c303bdf1b2e98a9d26e89af5bba3ab487ba3a3735f74bf1f4064d2a845a3e", [:mix], [], "hexpm", "1f13f9f0f3e769a667a6b6828d29dec37497a082d195cc52dbef401a9b69bf38"},
   "plug": {:hex, :plug, "1.10.0", "6508295cbeb4c654860845fb95260737e4a8838d34d115ad76cd487584e2fc4d", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.1.1 or ~> 1.2", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: true]}], "hexpm", "422a9727e667be1bf5ab1de03be6fa0ad67b775b2d84ed908f3264415ef29d4a"},
   "plug_crypto": {:hex, :plug_crypto, "1.1.2", "bdd187572cc26dbd95b87136290425f2b580a116d3fb1f564216918c9730d227", [:mix], [], "hexpm", "6b8b608f895b6ffcfad49c37c7883e8df98ae19c6a28113b02aa1e9c5b22d6b5"},
-  "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm", "4738382e36a0a9a2b6e25d67c960e40e1a2c95560b9f936d8e29de8cd858480f"},
+  "telemetry": {:git, "https://github.com/beam-telemetry/telemetry.git", "b13bad0a7c037e9817ed76f9b0bb6ccdcdd682d0", []},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -13,5 +13,5 @@
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.1.2", "496c303bdf1b2e98a9d26e89af5bba3ab487ba3a3735f74bf1f4064d2a845a3e", [:mix], [], "hexpm", "1f13f9f0f3e769a667a6b6828d29dec37497a082d195cc52dbef401a9b69bf38"},
   "plug": {:hex, :plug, "1.10.0", "6508295cbeb4c654860845fb95260737e4a8838d34d115ad76cd487584e2fc4d", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.1.1 or ~> 1.2", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: true]}], "hexpm", "422a9727e667be1bf5ab1de03be6fa0ad67b775b2d84ed908f3264415ef29d4a"},
   "plug_crypto": {:hex, :plug_crypto, "1.1.2", "bdd187572cc26dbd95b87136290425f2b580a116d3fb1f564216918c9730d227", [:mix], [], "hexpm", "6b8b608f895b6ffcfad49c37c7883e8df98ae19c6a28113b02aa1e9c5b22d6b5"},
-  "telemetry": {:git, "https://github.com/beam-telemetry/telemetry.git", "b13bad0a7c037e9817ed76f9b0bb6ccdcdd682d0", []},
+  "telemetry": {:hex, :telemetry, "0.4.2", "2808c992455e08d6177322f14d3bdb6b625fbcfd233a73505870d8738a2f4599", [:rebar3], [], "hexpm", "2d1419bd9dda6a206d7b5852179511722e2b18812310d304620c7bd92a13fcef"},
 }

--- a/test/phoenix_live_view/integrations/live_view_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test.exs
@@ -393,39 +393,43 @@ defmodule Phoenix.LiveView.LiveViewTest do
       assert render_hook(view, :save, %{temp: 20}) =~ "The temp is: 20"
     end
 
-    test "render_* with a successful handle_event callback emits telemetry metrics",  %{conn: conn} do
+    test "render_* with a successful handle_event callback emits telemetry metrics", %{conn: conn} do
       attach_telemetry([:phoenix, :live_view, :handle_event])
 
       {:ok, view, _} = live(conn, "/thermo")
       render_submit(view, :save, %{temp: 20})
 
-      assert_receive {:event, [:phoenix, :live_view, :handle_event, :start], %{system_time: _}, metadata}
+      assert_receive {:event, [:phoenix, :live_view, :handle_event, :start], %{system_time: _},
+                      metadata}
 
       assert metadata.socket.connected?
       assert metadata.event == "save"
       assert metadata.params == %{"temp" => "20"}
 
-      assert_receive {:event, [:phoenix, :live_view, :handle_event, :stop], %{duration: _}, metadata}
+      assert_receive {:event, [:phoenix, :live_view, :handle_event, :stop], %{duration: _},
+                      metadata}
 
       assert metadata.socket.connected?
       assert metadata.event == "save"
       assert metadata.params == %{"temp" => "20"}
     end
 
-    test "render_* with crashing handle_event callback emits telemetry metrics",  %{conn: conn} do
+    test "render_* with crashing handle_event callback emits telemetry metrics", %{conn: conn} do
       Process.flag(:trap_exit, true)
       attach_telemetry([:phoenix, :live_view, :handle_event])
 
       {:ok, view, _} = live(conn, "/errors")
       catch_exit(render_submit(view, :crash, %{"foo" => "bar"}))
 
-      assert_receive {:event, [:phoenix, :live_view, :handle_event, :start], %{system_time: _}, metadata}
+      assert_receive {:event, [:phoenix, :live_view, :handle_event, :start], %{system_time: _},
+                      metadata}
 
       assert metadata.socket.connected?
       assert metadata.event == "crash"
       assert metadata.params == %{"foo" => "bar"}
 
-      assert_receive {:event, [:phoenix, :live_view, :handle_event, :exception], %{duration: _}, metadata}
+      assert_receive {:event, [:phoenix, :live_view, :handle_event, :exception], %{duration: _},
+                      metadata}
 
       assert metadata.socket.connected?
       assert metadata.kind == :error

--- a/test/phoenix_live_view/integrations/params_test.exs
+++ b/test/phoenix_live_view/integrations/params_test.exs
@@ -41,13 +41,15 @@ defmodule Phoenix.LiveView.ParamsTest do
 
       get(conn, "/counter/123", query1: "query1", query2: "query2")
 
-      assert_receive {:event, [:phoenix, :live_view, :handle_params, :start], %{system_time: _}, metadata}
+      assert_receive {:event, [:phoenix, :live_view, :handle_params, :start], %{system_time: _},
+                      metadata}
 
       refute metadata.socket.connected?
       assert metadata.params == %{"query1" => "query1", "query2" => "query2", "id" => "123"}
       assert metadata.uri == "http://www.example.com/counter/123"
 
-      assert_receive {:event, [:phoenix, :live_view, :handle_params, :stop], %{duration: _}, metadata}
+      assert_receive {:event, [:phoenix, :live_view, :handle_params, :stop], %{duration: _},
+                      metadata}
 
       refute metadata.socket.connected?
       assert metadata.params == %{"query1" => "query1", "query2" => "query2", "id" => "123"}
@@ -61,13 +63,15 @@ defmodule Phoenix.LiveView.ParamsTest do
         get(conn, "/errors", crash_on: "disconnected_handle_params")
       end
 
-      assert_receive {:event, [:phoenix, :live_view, :handle_params, :start], %{system_time: _}, metadata}
+      assert_receive {:event, [:phoenix, :live_view, :handle_params, :start], %{system_time: _},
+                      metadata}
 
       refute metadata.socket.connected?
       assert metadata.params == %{"crash_on" => "disconnected_handle_params"}
       assert metadata.uri == "http://www.example.com/errors"
 
-      assert_receive {:event, [:phoenix, :live_view, :handle_params, :exception], %{duration: _}, metadata}
+      assert_receive {:event, [:phoenix, :live_view, :handle_params, :exception], %{duration: _},
+                      metadata}
 
       refute metadata.socket.connected?
       assert metadata.params == %{"crash_on" => "disconnected_handle_params"}

--- a/test/phoenix_live_view/integrations/params_test.exs
+++ b/test/phoenix_live_view/integrations/params_test.exs
@@ -1,8 +1,9 @@
 defmodule Phoenix.LiveView.ParamsTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   use Phoenix.ConnTest
 
   import Phoenix.LiveViewTest
+  import Phoenix.LiveView.TelemetryTestHelpers
 
   alias Phoenix.LiveView
   alias Phoenix.LiveViewTest.Endpoint
@@ -33,6 +34,32 @@ defmodule Phoenix.LiveView.ParamsTest do
 
       assert response =~
                escape(~s|mount: %{"id" => "123", "query1" => "query1", "query2" => "query2"}|)
+    end
+
+    test "telemetry events are emitted on success", %{conn: conn} do
+      attach_telemetry([:phoenix, :live_view, :handle_params])
+
+      get(conn, "/counter/123", query1: "query1", query2: "query2")
+
+      assert_receive {:event, [:phoenix, :live_view, :handle_params, :start], %{system_time: _},
+                      %{socket: %Phoenix.LiveView.Socket{connected?: false}}}
+
+      assert_receive {:event, [:phoenix, :live_view, :handle_params, :stop], %{duration: _},
+                      %{socket: %Phoenix.LiveView.Socket{connected?: false}}}
+    end
+
+    test "telemetry events are emitted on exception", %{conn: conn} do
+      attach_telemetry([:phoenix, :live_view, :handle_params])
+
+      assert_raise Plug.Conn.WrapperError, ~r/boom/, fn ->
+        get(conn, "/errors", crash_on: "disconnected_handle_params")
+      end
+
+      assert_receive {:event, [:phoenix, :live_view, :handle_params, :start], %{system_time: _},
+                      %{socket: %Phoenix.LiveView.Socket{connected?: false}}}
+
+      assert_receive {:event, [:phoenix, :live_view, :handle_params, :exception], %{duration: _},
+                      %{socket: %Phoenix.LiveView.Socket{connected?: false}}}
     end
 
     test "hard redirects", %{conn: conn} do
@@ -100,6 +127,30 @@ defmodule Phoenix.LiveView.ParamsTest do
         |> live("/counter/123?q1=1")
 
       assert html =~ escape(~s|%{"id" => "123", "q1" => "1"}|)
+    end
+
+    test "telemetry events are emitted on success", %{conn: conn} do
+      attach_telemetry([:phoenix, :live_view, :handle_params])
+
+      live(conn, "/counter/123")
+
+      assert_receive {:event, [:phoenix, :live_view, :handle_params, :start], %{system_time: _},
+                      %{socket: %{connected?: true}}}
+
+      assert_receive {:event, [:phoenix, :live_view, :handle_params, :stop], %{duration: _},
+                      %{socket: %{connected?: true}}}
+    end
+
+    test "telemetry events are emitted on exception", %{conn: conn} do
+      attach_telemetry([:phoenix, :live_view, :handle_params])
+
+      assert catch_exit(live(conn, "/errors?crash_on=connected_handle_params"))
+
+      assert_receive {:event, [:phoenix, :live_view, :handle_params, :start], %{system_time: _},
+                      %{socket: %Phoenix.LiveView.Socket{connected?: true}}}
+
+      assert_receive {:event, [:phoenix, :live_view, :handle_params, :exception], %{duration: _},
+                      %{socket: %Phoenix.LiveView.Socket{connected?: true}}}
     end
 
     test "hard redirects", %{conn: conn} do

--- a/test/support/live_views/general.ex
+++ b/test/support/live_views/general.ex
@@ -292,3 +292,10 @@ defmodule Phoenix.LiveViewTest.AssignsNotInSocketLive do
   def mount(_params, _session, socket), do: {:ok, socket}
   defp boom(socket), do: socket.assigns.boom
 end
+
+defmodule Phoenix.LiveViewTest.ErrorInMountLive do
+  use Phoenix.LiveView
+
+  def render(assigns), do: ~L|<div>I crash in mount</div>|
+  def mount(_params, _session, _socket), do: raise("boom")
+end

--- a/test/support/live_views/general.ex
+++ b/test/support/live_views/general.ex
@@ -316,5 +316,5 @@ defmodule Phoenix.LiveViewTest.ErrorsLive do
 
   def handle_params(_params, _session, socket), do: {:noreply, socket}
 
-  def handle_event("crash", _params, _socket), do: raise "boom handle_event"
+  def handle_event("crash", _params, _socket), do: raise("boom handle_event")
 end

--- a/test/support/live_views/general.ex
+++ b/test/support/live_views/general.ex
@@ -293,9 +293,26 @@ defmodule Phoenix.LiveViewTest.AssignsNotInSocketLive do
   defp boom(socket), do: socket.assigns.boom
 end
 
-defmodule Phoenix.LiveViewTest.ErrorInMountLive do
+defmodule Phoenix.LiveViewTest.ErrorsLive do
   use Phoenix.LiveView
 
+  alias Phoenix.LiveView.Socket
+
   def render(assigns), do: ~L|<div>I crash in mount</div>|
-  def mount(_params, _session, _socket), do: raise("boom")
+
+  def mount(%{"crash_on" => "disconnected_mount"}, _, %Socket{connected?: false}),
+    do: raise("boom disconnected mount")
+
+  def mount(%{"crash_on" => "connected_mount"}, _, %Socket{connected?: true}),
+    do: raise("boom connected mount")
+
+  def mount(_params, _session, socket), do: {:ok, socket}
+
+  def handle_params(%{"crash_on" => "disconnected_handle_params"}, _, %Socket{connected?: false}),
+    do: raise("boom disconnected handle_params")
+
+  def handle_params(%{"crash_on" => "connected_handle_params"}, _, %Socket{connected?: true}),
+    do: raise("boom connected handle_params")
+
+  def handle_params(_params, _session, socket), do: {:noreply, socket}
 end

--- a/test/support/live_views/general.ex
+++ b/test/support/live_views/general.ex
@@ -315,4 +315,6 @@ defmodule Phoenix.LiveViewTest.ErrorsLive do
     do: raise("boom connected handle_params")
 
   def handle_params(_params, _session, socket), do: {:noreply, socket}
+
+  def handle_event("crash", _params, _socket), do: raise "boom handle_event"
 end

--- a/test/support/live_views/params.ex
+++ b/test/support/live_views/params.ex
@@ -96,3 +96,11 @@ defmodule Phoenix.LiveViewTest.ActionLive do
     {:noreply, push_patch(socket, to: to)}
   end
 end
+
+defmodule Phoenix.LiveViewTest.ErrorInHandleParamsLive do
+  use Phoenix.LiveView
+
+  def render(assigns), do: ~L|<div>I crash in handle_params</div>|
+  def mount(_params, _session, socket), do: {:ok, socket}
+  def handle_params(_params, _uri, _socket), do: raise("boom")
+end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -57,6 +57,7 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/shuffle", ShuffleLive
     live "/components", WithComponentLive
     live "/assigns-not-in-socket", AssignsNotInSocketLive
+    live "/error-in-mount", ErrorInMountLive
 
     # integration layout
     scope "/" do

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -57,7 +57,7 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/shuffle", ShuffleLive
     live "/components", WithComponentLive
     live "/assigns-not-in-socket", AssignsNotInSocketLive
-    live "/error-in-mount", ErrorInMountLive
+    live "/errors", ErrorsLive
 
     # integration layout
     scope "/" do

--- a/test/support/telemetry_test_helpers.ex
+++ b/test/support/telemetry_test_helpers.ex
@@ -1,0 +1,27 @@
+defmodule Phoenix.LiveView.TelemetryTestHelpers do
+  @moduledoc false
+
+  import ExUnit.Callbacks, only: [on_exit: 1]
+
+  def attach_telemetry(prefix) when is_list(prefix) do
+    unique_name = :"PID#{System.unique_integer()}"
+    Process.register(self(), unique_name)
+
+    for suffix <- [:start, :stop, :exception] do
+      :telemetry.attach(
+        {suffix, unique_name},
+        prefix ++ [suffix],
+        fn event, measurements, metadata, :none ->
+          send(unique_name, {:event, event, measurements, metadata})
+        end,
+        :none
+      )
+    end
+
+    on_exit(fn ->
+      for suffix <- [:start, :stop] do
+        :telemetry.detach({suffix, unique_name})
+      end
+    end)
+  end
+end


### PR DESCRIPTION
This starts adding telemetry events for #676. It currently adds the following events:

* `[phoenix_live_view, :mount, :start]`
* `[phoenix_live_view, :mount, :stop]`
* `[phoenix_live_view, :mount, :exception]`

Notes
* This only instruments `Phoenix.LiveView.mount/3` and not `Phoenix.LiveComponent.mount/1`. Should we instrument LiveComponent's mount as well? If so, what should the event name be?
* This also uses the unreleased `:telemetry.span/3` function. I can update the PR once the updated telemetry lib is released.

Also, I'm curious what other events would you like implemented?