### PR TITLE
Revert "Retain ES6 syntax when being imported as a module"

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,14 +4,10 @@
   "description": "The Phoenix LiveView JavaScript client.",
   "license": "MIT",
   "main": "./priv/static/phoenix_live_view.js",
-  "module": "./assets/js/phoenix_live_view.js",
   "author": "Chris McCord <chris@chrismccord.com> (http://www.phoenixframework.org)",
   "repository": {
     "type": "git",
     "url": "git://github.com/phoenixframework/phoenix_live_view.git"
-  },
-  "dependencies": {
-    "morphdom": "2.6.1"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
Reverts phoenixframework/phoenix_live_view#961