### PR TITLE
Add last Elixir and Erlang/OTP versions to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-elixir@v1.0.0
+    - uses: actions/setup-elixir@v1.3.0
       with:
         otp-version: ${{matrix.otp}}
         elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         otp: [21.x, 22.x]
-        elixir: [1.8.x, 1.9.x]
+        elixir: [1.8.x, 1.9.x, 1.10.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: mix test (OTP ${{matrix.otp}} | Elixir ${{matrix.elixir}})
     strategy:
       matrix:
-        otp: [21.x, 22.x]
+        otp: [21.x, 22.x, 23.x]
         elixir: [1.8.x, 1.9.x, 1.10.x]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This pull request should be merged after https://github.com/phoenixframework/phoenix_live_view/pull/999 from which it differs only by the addition of the last Erlang/OTP version to CI matrix.

I chose to split the original pull request in two because some tests are failing with Erlang/OTP 23, which, as of now, seems not to be supported by Elixir 1.10, according to [Compatibility and Deprecations — Elixir v1.10.3](https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp).