### PR TITLE
Add telemetry events for LiveComponent.handle_event/3

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1911,6 +1911,54 @@ defmodule Phoenix.LiveView do
               params: unsigned_params
             }
 
+    * `[:phoenix, :live_component, :handle_event, :start]` - Dispatched by a `Phoenix.LiveComponent` immediately before `c:handle_event/3` is invoked.
+
+      * Measurement:
+
+            %{system_time: System.monotonic_time}
+
+      * Metadata:
+
+            %{
+              socket: Phoenix.LiveView.Socket.t,
+              component: atom,
+              event: String.t(),
+              params: unsigned_params
+            }
+
+
+    * `[:phoenix, :live_component, :handle_event, :stop]` - Dispatched by a `Phoenix.LiveComponent` when the `c:handle_event/3` callback completes successfully.
+
+      * Measurement:
+
+            %{duration: native_time}
+
+      * Metadata:
+
+            %{
+              socket: Phoenix.LiveView.Socket.t,
+              component: atom,
+              event: String.t(),
+              params: unsigned_params
+            }
+
+    * `[:phoenix, :live_component, :handle_event, :exception]` - Dispatched by a `Phoenix.LiveComponent` when an exception is raised in the `c:handle_event/3` callback.
+
+      * Measurement:
+
+            %{duration: native_time}
+
+      * Metadata:
+
+            %{
+              socket: Phoenix.LiveView.Socket.t,
+              kind: atom,
+              reason: term,
+              component: atom,
+              event: String.t(),
+              params: unsigned_params
+            }
+
   '''
 
   alias Phoenix.LiveView.Socket


### PR DESCRIPTION
This wraps `Phoenix.LiveComponent.handle_event/3` in a `:telemetry.span` which adds the following new events:

* `[:phoenix, :live_component, :handle_event, :start]`
* `[:phoenix, :live_component, :handle_event, :stop]`
* `[:phoenix, :live_component, :handle_event, :exception]`

A couple things to note... 

* I added `component` to the event metadata because it didn't seem like I could get the component off of the socket
* `metadata.reason` on the exception case is being returned as `{:case_clause, "boom"}`. It looks like if the subscriber want's the Elixir `CaseClauseError` version, the caller would have to run it through `Exception.normalize/3`.
* I grouped all of the `handle_event` tests in a single describe block. If you want to see the changes to add telemetry to handle_event in isolation, look at the first commit.