### PR TITLE
work around document.activeElement being null in Internet Explorer 11

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -643,7 +643,8 @@ export class LiveSocket {
     if(document.activeElement === document.body){
       return this.activeElement || document.activeElement
     } else {
-      return document.activeElement
+      // document.activeElement can be null in Internet Explorer 11
+      return document.activeElement || document.body;
     }
   }
 
@@ -1968,7 +1969,8 @@ export class View {
     this.destroyAllChildren()
     this.log("error", () => ["view crashed", reason])
     this.liveSocket.onViewError(this)
-    document.activeElement.blur()
+    // document.activeElement can be null in Internet Explorer 11
+    if(document.activeElement){ document.activeElement.blur() }
     if(this.liveSocket.isUnloaded()){
       this.showLoader(BEFORE_UNLOAD_LOADER_TIMEOUT)
     } else {


### PR DESCRIPTION
fixes #948

When an activeElement is removed from the page in a particular fashion,
Internet Explorer 11 does not make the body the `activeElement` and
returns `null` instead. This causes failures down in the stack when
something tries to access the element .

This patch chooses the easy approach and guards the usage against
this bug, instead of trying to solve the issue when it occurs. After
IE11 support is dropped, the workaround can be easily removed.

The comments were added to ensure this is not accidentally cleaned
up (according to spec, `activeElement` should never be `null`).