### PR TITLE
Add recommended Elixir x Erlang combinations to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,17 @@ jobs:
     name: mix test (OTP ${{matrix.otp}} | Elixir ${{matrix.elixir}})
     strategy:
       matrix:
-        otp: [21.x, 22.x]
-        elixir: [1.8.x, 1.9.x, 1.10.x]
+        include:
+          - otp: 21.3.8.16
+            elixir: 1.7.4
+          - otp: 21.3.8.16
+            elixir: 1.8.2
+          - otp: 21.3.8.16
+            elixir: 1.9.4
+          - otp: 21.3.8.16
+            elixir: 1.10.3
+          - otp: 23.0.2
+            elixir: 1.10.3
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Quoting @josevalim:
> I would still advise folks to go with:
> * For each Elixir version, add a run with earliest supported Erlang/OTP
> * For the last Elixir version, also test the latest supported Erlang/OTP

Please refer to the original discussion on https://github.com/dashbitco/broadway/pull/188 for the full rationale.

In addition to adhere to @josevalim recommendation, it reduces the number of jobs from 6 to 5, making it more [environment friendly](https://github.com/elixir-lang/elixir/pull/10129#discussion_r446139904).