### PR TITLE
use -> import of Phoenix.ConnTest + Plug.Conn

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -17,7 +17,8 @@ defmodule Phoenix.LiveViewTest do
   socket state, and the view continues statefully. The LiveView test functions
   support testing both disconnected and connected mounts separately, for example:
 
-      use Phoenix.ConnTest
+      import Plug.Conn
+      import Phoenix.ConnTest
       import Phoenix.LiveViewTest
       @endpoint MyEndpoint
 


### PR DESCRIPTION
Since this was deprecated, aligning it with the newer version