### PR TITLE
fix router when action and :as specified

### DIFF
--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -173,6 +173,7 @@ defmodule Phoenix.LiveView.Router do
     |> Module.split()
     |> Enum.drop_while(&(not String.ends_with?(&1, "Live")))
     |> Enum.map(&(&1 |> String.replace_suffix("Live", "") |> Macro.underscore()))
+    |> Enum.reject(&(&1 == ""))
     |> Enum.join("_")
     |> case do
       "" ->

--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -157,23 +157,22 @@ defmodule Phoenix.LiveView.Router do
       |> Keyword.put(:router, router)
       |> Keyword.put(:action, action)
 
-    {as_helper, as_action} = inferred_as(live_view, action)
+    {as_helper, as_action} = inferred_as(live_view, opts[:as], action)
 
     {as_action,
      alias: false,
-     as: opts[:as] || as_helper,
+     as: as_helper,
      private: Map.put(private, :phoenix_live_view, {live_view, opts}),
      metadata: Map.put(metadata, :phoenix_live_view, {live_view, action})}
   end
 
-  defp inferred_as(live_view, nil), do: {:live, live_view}
+  defp inferred_as(live_view, as, nil), do: {as || :live, live_view}
 
-  defp inferred_as(live_view, action) do
+  defp inferred_as(live_view, nil, action) do
     live_view
     |> Module.split()
     |> Enum.drop_while(&(not String.ends_with?(&1, "Live")))
     |> Enum.map(&(&1 |> String.replace_suffix("Live", "") |> Macro.underscore()))
-    |> Enum.reject(&(&1 == ""))
     |> Enum.join("_")
     |> case do
       "" ->
@@ -187,6 +186,8 @@ defmodule Phoenix.LiveView.Router do
     end
   end
 
+  defp inferred_as(_live_view, as, action), do: {as, action}
+  
   defp cookie_flash(%Plug.Conn{cookies: %{@cookie_key => token}} = conn) do
     endpoint = Phoenix.Controller.endpoint_module(conn)
 


### PR DESCRIPTION
`live "/", PageLive, :index, as: :xxx`
would compile with error "** (ArgumentError) could not infer :as option because a live action was given and the LiveView does not have a "Live" suffix. Please pass :as explicitly or make sure your LiveView is named like "FooLive" or "FooLive.Index"