### PR TITLE
Fix doc

### DIFF
--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -35,7 +35,7 @@ defmodule Phoenix.LiveView.Router do
 
       live "/articles", ArticleLive.Index, :index
       live "/articles/new", ArticleLive.Index, :new
-      live "/articles/1/edit", ArticleLive.Index, :edit
+      live "/articles/:id/edit", ArticleLive.Index, :edit
 
   When an action is given, the generated route helpers are named after
   the LiveView itself (in the same way as for a controller). For the example


### PR DESCRIPTION
The example hard-codes the article ID, but should use a segment
matcher (e.g. `:id`). A hard-coded ID would technically work,
but then the later example will fail:
  `article_index_path(@socket, :edit, 123)`