### PR TITLE
Fix bug where throttling keydown events would eat key presses

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1108,8 +1108,8 @@ export let DOM = {
           let newKeyDown = false;
           if(event.type === "keydown"){
             let prevKey = this.private(el, DEBOUNCE_PREV_KEY)
-            this.putPrivate(el, DEBOUNCE_PREV_KEY, event.which)
-            newKeyDown = prevKey !== event.which
+            this.putPrivate(el, DEBOUNCE_PREV_KEY, event.key)
+            newKeyDown = prevKey !== event.key
           } 
           
           if(!newKeyDown && this.private(el, THROTTLED)){

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1105,11 +1105,14 @@ export let DOM = {
         let currentCycle = this.incCycle(el, DEBOUNCE_TRIGGER, trigger)
         if(isNaN(timeout)){ return logError(`invalid throttle/debounce value: ${value}`) }
         if(throttle){
+          let newKeyDown = false;
           if(event.type === "keydown"){
             let prevKey = this.private(el, DEBOUNCE_PREV_KEY)
             this.putPrivate(el, DEBOUNCE_PREV_KEY, event.which)
-            if(prevKey !== event.which){ return callback() }
-          } else if(this.private(el, THROTTLED)){
+            newKeyDown = prevKey !== event.which
+          } 
+          
+          if(!newKeyDown && this.private(el, THROTTLED)){
             return false
           } else {
             callback()

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1105,7 +1105,7 @@ export let DOM = {
         let currentCycle = this.incCycle(el, DEBOUNCE_TRIGGER, trigger)
         if(isNaN(timeout)){ return logError(`invalid throttle/debounce value: ${value}`) }
         if(throttle){
-          let newKeyDown = false;
+          let newKeyDown = false
           if(event.type === "keydown"){
             let prevKey = this.private(el, DEBOUNCE_PREV_KEY)
             this.putPrivate(el, DEBOUNCE_PREV_KEY, event.key)

--- a/assets/test/debounce_test.js
+++ b/assets/test/debounce_test.js
@@ -22,6 +22,7 @@ let container = () => {
     <input type="text" name="throttle-200" phx-throttle="200" />
     <button id="throttle-200" phx-throttle="200" />+</button>
   </form>
+  <div id="throttle-keydown" phx-keydown="keydown" phx-throttle="200"></div>
   `
   return div
 }
@@ -238,3 +239,53 @@ describe("throttle", function() {
 })
 
 
+describe("throttle keydown", function() {
+  test("when the same key is pressed triggers immediately, then on timeout", done => {
+    let keyPresses = {}
+    let el = container().querySelector("#throttle-keydown")
+
+    el.addEventListener("keydown", e => {
+      DOM.debounce(el, e, "phx-debounce", 100, "phx-throttle", 200, () => {
+        keyPresses[e.key] = (keyPresses[e.key] || 0) + 1
+      })
+    })
+
+    let pressA = new KeyboardEvent("keydown", {key: "a", which: 65})
+    el.dispatchEvent(pressA)
+    el.dispatchEvent(pressA)
+    el.dispatchEvent(pressA)
+
+    expect(keyPresses["a"]).toBe(1)
+    after(250, () => {
+      expect(keyPresses["a"]).toBe(1)
+      el.dispatchEvent(pressA)
+      el.dispatchEvent(pressA)
+      el.dispatchEvent(pressA)
+      expect(keyPresses["a"]).toBe(2)
+      done()
+    })
+  })
+
+  test("when different key is pressed triggers immediately", done => {
+    let keyPresses = {}
+    let el = container().querySelector("#throttle-keydown")
+
+    el.addEventListener("keydown", e => {
+      DOM.debounce(el, e, "phx-debounce", 100, "phx-throttle", 200, () => {
+        keyPresses[e.key] = (keyPresses[e.key] || 0) + 1
+      })
+    })
+
+    let pressA = new KeyboardEvent("keydown", {key: "a", which: 65})
+    let pressB = new KeyboardEvent("keydown", {key: "b", which: 66})
+
+    el.dispatchEvent(pressA)
+    el.dispatchEvent(pressB)
+    el.dispatchEvent(pressA)
+    el.dispatchEvent(pressB)
+
+    expect(keyPresses["a"]).toBe(2)
+    expect(keyPresses["b"]).toBe(2)
+    done()
+  })
+})

--- a/assets/test/debounce_test.js
+++ b/assets/test/debounce_test.js
@@ -250,7 +250,7 @@ describe("throttle keydown", function() {
       })
     })
 
-    let pressA = new KeyboardEvent("keydown", {key: "a", which: 65})
+    let pressA = new KeyboardEvent("keydown", {key: "a"})
     el.dispatchEvent(pressA)
     el.dispatchEvent(pressA)
     el.dispatchEvent(pressA)
@@ -276,8 +276,8 @@ describe("throttle keydown", function() {
       })
     })
 
-    let pressA = new KeyboardEvent("keydown", {key: "a", which: 65})
-    let pressB = new KeyboardEvent("keydown", {key: "b", which: 66})
+    let pressA = new KeyboardEvent("keydown", {key: "a"})
+    let pressB = new KeyboardEvent("keydown", {key: "b"})
 
     el.dispatchEvent(pressA)
     el.dispatchEvent(pressB)


### PR DESCRIPTION
There was a bug in the code that handles throttling keydown events, if you set a `phx-throttle` on that event, and continuously press the same key, only the first keypress will be registered, even if you wait past the timeout.

This PR fixes the issue -- we were returning too early from a nested if. I also added a test demonstrating the bug. Please let me know if you'd prefer me to split the commit with the test out so we have a commit with a failing test!

While I was at it, I switched to using `KeyboardEvent.key` instead of `KeyboardEvent.which` in order to track the keys being pressed. MDN says that [which is deprecated](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/which). I'm not sure what LiveView's attitude towards browser compatibility is -- if `which` is the best choice for some reason I don't understand please let me know and I'll remove that commit!

Thanks  