### PR TITLE
Disable texture on form submit

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -2140,7 +2140,7 @@ export class View {
     let refGenerator = () => {
       let disables = DOM.all(formEl, `[${this.binding(PHX_DISABLE_WITH)}]`)
       let buttons = DOM.all(formEl, "button").filter(filterIgnored)
-      let inputs = DOM.all(formEl, "input").filter(filterIgnored)
+      let inputs = DOM.all(formEl, "input,textarea").filter(filterIgnored)
 
       buttons.forEach(button => {
         button.setAttribute(PHX_DISABLED, button.disabled)

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -28,6 +28,7 @@ function liveViewDOM() {
     <form>
       <label for="plus">Plus</label>
       <input id="plus" value="1" name="increment" />
+      <textarea id="note" name="note">2</textarea>
       <input type="checkbox" phx-click="toggle_me" />
       <button phx-click="inc_temperature">Inc Temperature</button>
     </form>
@@ -230,7 +231,7 @@ describe("View + DOM", function() {
       push(evt, payload, timeout) {
         expect(payload.type).toBe("form")
         expect(payload.event).toBeDefined()
-        expect(payload.value).toBe("increment=1&_target=increment")
+        expect(payload.value).toBe("increment=1&note=2&_target=increment")
         return {
           receive() {}
         }
@@ -242,7 +243,7 @@ describe("View + DOM", function() {
   })
 
   test("submitForm", function() {
-    expect.assertions(7)
+    expect.assertions(8)
 
     let liveSocket = new LiveSocket("/live", Socket)
     let el = liveViewDOM()
@@ -253,7 +254,7 @@ describe("View + DOM", function() {
       push(evt, payload, timeout) {
         expect(payload.type).toBe("form")
         expect(payload.event).toBeDefined()
-        expect(payload.value).toBe("increment=1")
+        expect(payload.value).toBe("increment=1&note=2")
         return {
           receive() {}
         }
@@ -266,6 +267,7 @@ describe("View + DOM", function() {
     expect(form.classList.contains("phx-submit-loading")).toBeTruthy()
     expect(form.querySelector("button").dataset.phxDisabled).toBeTruthy()
     expect(form.querySelector("input").dataset.phxReadonly).toBeTruthy()
+    expect(form.querySelector("textarea").dataset.phxReadonly).toBeTruthy()
   })
 
   describe("phx-trigger-action", () => {


### PR DESCRIPTION
I noticed that when submitting a form, LV will make all inputs and buttons `readonly` and `disabled` but doesn't care about `textarea` elements.

I didn't test for `select` elements but I guess it's the same issue there? I can add it if needed. 