### PR TITLE
Error message: fix typo and flesh out

### DIFF
--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -251,9 +251,9 @@ defmodule Phoenix.LiveView.Helpers do
 
       Please pass a function clause to do/end instead, for example:
 
-      live_component @socket, GridComponent, entries: @entries do
-        new_assigns -> "New entry: " <> new_assigns[:entry]
-      end
+          live_component @socket, GridComponent, entries: @entries do
+            new_assigns -> "New entry: " <> new_assigns[:entry]
+          end
       """
     end
 

--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -246,9 +246,15 @@ defmodule Phoenix.LiveView.Helpers do
   defp rewrite_do(do_block, caller) do
     unless Macro.Env.has_var?(caller, {:assigns, nil}) and
              Macro.Env.has_var?(caller, {:changed, Phoenix.LiveView.Engine}) do
-      raise ArgumentError,
-            "cannot use live_compoment do/end blocks because we could not find existing assigns. " <>
-              "Please pass a clause to do/end instead"
+      raise ArgumentError, """
+      cannot use live_component do/end blocks because we could not find existing assigns.
+
+      Please pass a function clause to do/end instead, for example:
+
+      live_component @socket, GridComponent, entries: @entries do
+        new_assigns -> "New entry: " <> new_assigns[:entry]
+      end
+      """
     end
 
     quote do


### PR DESCRIPTION
If you disagree with the full change, feel free to at least fix the "live_compoment" typo :)

Spotted that typo and then realised I didn't understand the error message, so I read up a little and then wrote something that I think I would have understood better.