### PR TITLE
Clarify component docs

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -330,8 +330,8 @@ defmodule Phoenix.LiveComponent do
 
   The above approach is the preferred one when passing blocks to `do/end`.
   However, if you are outside of a .leex template and you want to invoke a
-  component passing `do/end` blocks, you will have to explicitly handle the
-  assigns by giving it a clause:
+  component passing a `do/end` block, you will have to explicitly handle the
+  assigns by giving it a `->` clause:
 
       live_component @socket, GridComponent, entries: @entries do
         new_assigns -> "New entry: " <> new_assigns[:entry]

--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -238,7 +238,7 @@ defmodule Phoenix.LiveView.Helpers do
       raise ArgumentError, """
       cannot use live_component do/end blocks because we could not find existing assigns.
 
-      Please pass a function clause to do/end instead, for example:
+      Please pass a `->` clause to do/end instead, for example:
 
           live_component @socket, GridComponent, entries: @entries do
             new_assigns -> "New entry: " <> new_assigns[:entry]


### PR DESCRIPTION
Took me a few seconds to realise "a clause" meant "a function clause", so this could save the next person a few cycles :) Matches the phrasing in #1065.