### PR TITLE
Fix bug in LiveViewTest's handling of attributes during DOM patching 

### DIFF
--- a/lib/phoenix_live_view/test/dom.ex
+++ b/lib/phoenix_live_view/test/dom.ex
@@ -81,6 +81,8 @@ defmodule Phoenix.LiveViewTest.DOM do
 
   def child_nodes({_, _, nodes}), do: nodes
 
+  def attrs({_, attrs, _}), do: attrs
+
   def inner_html!(html, id), do: html |> by_id!(id) |> child_nodes()
 
   def component_id(html_tree), do: Floki.attribute(html_tree, @phx_component) |> List.first()
@@ -250,9 +252,11 @@ defmodule Phoenix.LiveViewTest.DOM do
     {updated_existing_children, updated_appended} =
       Enum.reduce(dup_ids, {children_before, appended_children}, fn dup_id, {before, appended} ->
         patched_before =
-          walk(before, fn {tag, attrs, _} = node ->
+          walk(before, fn {tag, _, _} = node ->
             cond do
-              attribute(node, "id") == dup_id -> {tag, attrs, inner_html!(appended, dup_id)}
+              attribute(node, "id") == dup_id ->
+                new_node = by_id!(appended, dup_id)
+                {tag, attrs(new_node), child_nodes(new_node)}
               true -> node
             end
           end)

--- a/test/phoenix_live_view/test/dom_test.exs
+++ b/test/phoenix_live_view/test/dom_test.exs
@@ -3,57 +3,185 @@ defmodule Phoenix.LiveViewTest.DOMTest do
 
   alias Phoenix.LiveViewTest.DOM
 
-  # >= 4432 characters
-  @too_big_session Enum.map(1..4432, fn _ -> "t" end) |> Enum.join()
+  describe "find_live_views" do
+    # >= 4432 characters
+    @too_big_session Enum.map(1..4432, fn _ -> "t" end) |> Enum.join()
 
-  test "finds views given html" do
-    assert DOM.find_live_views(
-             DOM.parse("""
-             <h1>top</h1>
-             <div data-phx-view="789"
-               data-phx-session="SESSION1"
-               id="phx-123"></div>
-             <div data-phx-parent-id="456"
+    test "finds views given html" do
+      assert DOM.find_live_views(
+               DOM.parse("""
+               <h1>top</h1>
+               <div data-phx-view="789"
+                 data-phx-session="SESSION1"
+                 id="phx-123"></div>
+               <div data-phx-parent-id="456"
+                   data-phx-view="789"
+                   data-phx-session="SESSION2"
+                   data-phx-static="STATIC2"
+                   id="phx-456"></div>
+               <div data-phx-session="#{@too_big_session}"
                  data-phx-view="789"
-                 data-phx-session="SESSION2"
-                 data-phx-static="STATIC2"
-                 id="phx-456"></div>
-             <div data-phx-session="#{@too_big_session}"
-               data-phx-view="789"
-               id="phx-458"></div>
-             <h1>bottom</h1>
-             """)
-           ) == [
-             {"phx-123", "SESSION1", nil},
-             {"phx-456", "SESSION2", "STATIC2"},
-             {"phx-458", @too_big_session, nil}
-           ]
+                 id="phx-458"></div>
+               <h1>bottom</h1>
+               """)
+             ) == [
+               {"phx-123", "SESSION1", nil},
+               {"phx-456", "SESSION2", "STATIC2"},
+               {"phx-458", @too_big_session, nil}
+             ]
 
-    assert DOM.find_live_views(["none"]) == []
+      assert DOM.find_live_views(["none"]) == []
+    end
+
+    test "returns main live view as first result" do
+      assert DOM.find_live_views(
+               DOM.parse("""
+               <h1>top</h1>
+               <div data-phx-view="789"
+                 data-phx-session="SESSION1"
+                 id="phx-123"></div>
+               <div data-phx-parent-id="456"
+                   data-phx-view="789"
+                   data-phx-session="SESSION2"
+                   data-phx-static="STATIC2"
+                   id="phx-456"></div>
+               <div data-phx-session="SESSIONMAIN"
+                 data-phx-view="789"
+                 data-phx-main="true"
+                 id="phx-458"></div>
+               <h1>bottom</h1>
+               """)
+             ) == [
+               {"phx-458", "SESSIONMAIN", nil},
+               {"phx-123", "SESSION1", nil},
+               {"phx-456", "SESSION2", "STATIC2"}
+             ]
+    end
   end
 
-  test "returns main live view as first result" do
-    assert DOM.find_live_views(
-             DOM.parse("""
-             <h1>top</h1>
-             <div data-phx-view="789"
-               data-phx-session="SESSION1"
-               id="phx-123"></div>
-             <div data-phx-parent-id="456"
-                 data-phx-view="789"
-                 data-phx-session="SESSION2"
-                 data-phx-static="STATIC2"
-                 id="phx-456"></div>
-             <div data-phx-session="SESSIONMAIN"
-               data-phx-view="789"
-               data-phx-main="true"
-               id="phx-458"></div>
-             <h1>bottom</h1>
-             """)
-           ) == [
-             {"phx-458", "SESSIONMAIN", nil},
-             {"phx-123", "SESSION1", nil},
-             {"phx-456", "SESSION2", "STATIC2"}
-           ]
+  describe "patch_id" do
+    test "updates deeply nested html" do
+      html = """
+      <div data-phx-session="SESSIONMAIN"
+                     data-phx-view="789"
+                     data-phx-main="true"
+                     id="phx-458">
+      <div id="foo">Hello</div>
+      <div id="list">
+        <div id="1">a</div>
+        <div id="2">a</div>
+        <div id="3">a</div>
+      </div>
+      </div>
+      """
+
+      inner_html = """
+      <div id="foo">Hello World</div>
+      <div id="list">
+        <div id="2" class="foo">a</div>
+        <div id="3">
+          <div id="5">inner</div>
+        </div>
+        <div id="4">a</div>
+      </div>
+      """
+
+      {new_html, _removed_cids} = DOM.patch_id("phx-458", DOM.parse(html), DOM.parse(inner_html))
+
+      new_html = DOM.to_html(new_html)
+
+      refute new_html =~ ~S(<div id="1">a</div>)
+      assert new_html =~ ~S(<div id="2" class="foo">a</div>)
+      assert new_html =~ ~S(<div id="3"><div id="5">inner</div></div>)
+      assert new_html =~ ~S(<div id="4">a</div>)
+    end
+
+    test "inserts new elements when phx-update=append" do
+      html = """
+      <div data-phx-session="SESSIONMAIN"
+                     data-phx-view="789"
+                     data-phx-main="true"
+                     id="phx-458">
+      <div id="list" phx-update="append">
+        <div id="1">a</div>
+        <div id="2">a</div>
+        <div id="3">a</div>
+      </div>
+      </div>
+      """
+
+      inner_html = """
+      <div id="list" phx-update="append">
+        <div id="4" class="foo">a</div>
+      </div>
+      """
+
+      {new_html, _removed_cids} = DOM.patch_id("phx-458", DOM.parse(html), DOM.parse(inner_html))
+
+      new_html = DOM.to_html(new_html)
+
+      assert new_html =~ ~S(<div id="1">a</div>)
+      assert new_html =~ ~S(<div id="2">a</div>)
+      assert new_html =~ ~S(<div id="3">a</div><div id="4" class="foo">a</div>)
+    end
+
+    test "inserts new elements when phx-update=prepend" do
+      html = """
+      <div data-phx-session="SESSIONMAIN"
+                     data-phx-view="789"
+                     data-phx-main="true"
+                     id="phx-458">
+      <div id="list" phx-update="append">
+        <div id="1">a</div>
+        <div id="2">a</div>
+        <div id="3">a</div>
+      </div>
+      </div>
+      """
+
+      inner_html = """
+      <div id="list" phx-update="prepend">
+        <div id="4">a</div>
+      </div>
+      """
+
+      {new_html, _removed_cids} = DOM.patch_id("phx-458", DOM.parse(html), DOM.parse(inner_html))
+
+      new_html = DOM.to_html(new_html)
+
+      assert new_html =~ ~S(<div id="4">a</div><div id="1">a</div>)
+      assert new_html =~ ~S(<div id="2">a</div>)
+      assert new_html =~ ~S(<div id="3">a</div>)
+    end
+
+    test "updates existing elements when phx-update=append" do
+      html = """
+      <div data-phx-session="SESSIONMAIN"
+                     data-phx-view="789"
+                     data-phx-main="true"
+                     id="phx-458">
+      <div id="list" phx-update="append">
+        <div id="1">a</div>
+        <div id="2">a</div>
+        <div id="3">a</div>
+      </div>
+      </div>
+      """
+
+      inner_html = """
+      <div id="list" phx-update="append">
+        <div id="1" class="foo">b</div>
+        <div id="2">b</div>
+      </div>
+      """
+
+      {new_html, _removed_cids} = DOM.patch_id("phx-458", DOM.parse(html), DOM.parse(inner_html))
+
+      new_html = DOM.to_html(new_html)
+
+      assert new_html =~ ~S(<div id="1" class="foo">b</div>)
+      assert new_html =~ ~S(<div id="2">b</div>)
+      assert new_html =~ ~S(<div id="3">a</div>)
+    end
   end
 end


### PR DESCRIPTION
This PR fixes a sort of subtle bug in LiveViewTest.

When we have an element with `phx-update="append"` and we update the attributes of a child node, they are not correctly patched

e.g if I try to do a dom patch of 
```html
<div id="foo" phx-update="append">
  <div id="bar"></div>
</div>
```
with 
```html
<div id="foo" phx-update="append">
  <div id="bar" class="class">something</div>
</div>
```

`DOM.patch_id` will result in the following
```html
<div id="foo" phx-update="append">
  <div id="bar">something</div>
</div>
```

I also included some tests including an initially failing test for this particular bug.