### PR TITLE
Display file on compile warning in sigil

### DIFF
--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -321,6 +321,7 @@ defmodule Phoenix.LiveView.Helpers do
   defmacro sigil_L({:<<>>, meta, [expr]}, []) do
     options = [
       engine: Phoenix.LiveView.Engine,
+      file: __CALLER__.file,
       line: __CALLER__.line + 1,
       indentation: meta[:indentation] || 0
     ]


### PR DESCRIPTION
Include the file in compile warnings within the ~L sigil, fixing https://github.com/phoenixframework/phoenix_live_view/issues/1075

Before:
```
warning: trailing commas are not allowed inside function/macro call arguments
  nofile:303
```

After:

```
warning: trailing commas are not allowed inside function/macro call arguments
  test/phoenix_live_view/diff_test.exs:303
```