### PR TITLE
Fix DOM memory leak in phx-update=append/prepend

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1352,7 +1352,7 @@ class DOMPatch {
         },
         onBeforeNodeDiscarded: (el) => {
           if(el.getAttribute && el.getAttribute(PHX_REMOVE) !== null){ return true }
-          if(el.parentNode !== null && DOM.isPhxUpdate(el.parentNode, phxUpdate, ["append", "prepend"])){ return false }
+          if(el.parentNode !== null && DOM.isPhxUpdate(el.parentNode, phxUpdate, ["append", "prepend"]) && el.id){ return false }
           if(this.skipCIDSibling(el)){ return false }
           this.trackBefore("discarded", el)
           return true

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1352,8 +1352,17 @@ class DOMPatch {
         },
         onBeforeNodeDiscarded: (el) => {
           if(el.getAttribute && el.getAttribute(PHX_REMOVE) !== null){ return true }
-          if(el.parentNode !== null && DOM.isPhxUpdate(el.parentNode, phxUpdate, ["append", "prepend"]) && el.id){ return false }
           if(this.skipCIDSibling(el)){ return false }
+          if(el.parentNode !== null && DOM.isPhxUpdate(el.parentNode, phxUpdate, ["append", "prepend"]) && el.nodeType == Node.ELEMENT_NODE){
+            if (el.id) {
+              return false
+            } else {
+              logError(`When using phx-update="append" or "prepend", a DOM ID must be set
+                for each child..\n\n` +
+                `got: "${el.innerHTML.trim()}"\n\n` +
+                `it will be discarded\n\n`)          
+            }
+          }
           this.trackBefore("discarded", el)
           return true
         },

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -611,7 +611,7 @@ describe("View + Component", function() {
     expect(view.el.innerHTML.trim()).toBe(`<div phx-click=\"show-rect\" data-phx-component=\"0\" id=\"container-0-0\">Menu</div><h2>2</h2>`)
 
     view.update(updateDiff, [])
-    expect(view.el.innerHTML.trim().replace("\n", "")).toBe(`<h1>1</h1><div phx-click=\"show-rect\" data-phx-component=\"0\" id=\"container-0-0\">Menu</div><h2>2</h2>`)
+    expect(view.el.innerHTML.trim().replace(/\n/g, "")).toBe(`<h1>1</h1><div phx-click=\"show-rect\" data-phx-component=\"0\" id=\"container-0-0\">Menu</div><h2>2</h2>`)
   })
 
   test("respects nested components", () => {


### PR DESCRIPTION
This is my attempt to fix https://github.com/phoenixframework/phoenix_live_view/issues/1078

I discuss other approaches in the issue linked above, but I believe this is the cleanest. There are two small downsides here:

We'd force you to have ids on all root inside a `phx-update="append"/"prepend"`. I think this makes more sense than skipping dom nodes that aren't elements because post-morphdom reordering depends on elements having ids, and will behave unexpectedly without them anyway.

We'd also still have a weird looking DOM tree after the first render with all the newline text nodes at the bottom. E.g.
```html
<div id="list" phx-update="append"  phx-hook="CountChildNodes">
  
    <div id="0">0</div>
  
    <div id="1">0</div>
  
</div>
```

gets rewritten to

```html
<div id="list" phx-update="append">
    <div id="0">0</div>  
    <div id="1">0</div>


  
</div>
```
I think this is aesthetically displeasing, but not an actual issue.

I'm relatively new to this project and I'd love some feedback to help get this PR over the line:

1) Is this the best approach to the problem in terms of performance and user expectation?
2) Should I make some doc updates and/or emit a warning if you have a node without an id that isn't an empty text node inside a `phx-update="append"/"prepend"`?