### PR TITLE
Refactor appendPrependUpdates

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1329,13 +1329,19 @@ class DOMAppendPrependUpdate {
       if (siblingId) {
         maybe(document.getElementById(siblingId), sibling => {
           maybe(document.getElementById(id), child => {
-            sibling.insertAdjacentElement("afterend", child)
+            let isInRightPlace = child.previousElementSibling && child.previousElementSibling.id == sibling.id
+            if (!isInRightPlace) {
+              sibling.insertAdjacentElement("afterend", child)
+            }
           })
         })
       } else {
         // This is the first element in the container
         maybe(document.getElementById(id), child => {
-          el.insertAdjacentElement("afterbegin", child)
+          let isInRightPlace = child.previousElementSibling == null
+          if (!isInRightPlace) {
+            el.insertAdjacentElement("afterbegin", child)
+          }
         })
       }
     })

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1303,7 +1303,6 @@ class DOMAppendPrependUpdate {
     let modifiedIds = []
 
     Array.from(fromEl.children).forEach(child => {
-      // TODO make sure these all have IDs
       idsBefore.push(child.id)
       if (idsAfter.indexOf(child.id) >= 0) {
         modifiedIds.push([child.id, child.previousElementSibling && child.previousElementSibling.id])

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1302,10 +1302,12 @@ class DOMAppendPrependUpdate {
 
     let modifiedIds = []
 
-    Array.from(fromEl.children).forEach(child => {
-      idsBefore.push(child.id)
-      if (idsAfter.indexOf(child.id) >= 0) {
-        modifiedIds.push([child.id, child.previousElementSibling && child.previousElementSibling.id])
+    fromEl.childNodes.forEach(child => {
+      if (child.id) { // all of our children should be elements with ids
+        idsBefore.push(child.id)
+        if (idsAfter.indexOf(child.id) >= 0) {
+          modifiedIds.push([child.id, child.previousElementSibling && child.previousElementSibling.id])
+        }
       }
     })
 

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -398,6 +398,12 @@ describe("View + DOM", function() {
       )
       expect(childIds()).toEqual([1,2,3,4,5,6,7,8,9])
 
+      // Update all elements in reverse order
+      updateDynamics(view,
+        [["9", "9"], ["8", "8"],  ["7", "7"], ["6", "6"], ["5", "5"], ["4", "4"], ["3", "3"], ["2", "2"], ["1", "1"]]
+      )
+      expect(childIds()).toEqual([1,2,3,4,5,6,7,8,9])
+
       // Make sure we don't have a memory leak when doing updates
       let initalCount = countChildNodes()
       updateDynamics(view,
@@ -453,6 +459,12 @@ describe("View + DOM", function() {
       // Sandwich an update between two new elements
       updateDynamics(view,
         [["8", "8"], ["7", "modified"],  ["9", "9"]]
+      )
+      expect(childIds()).toEqual([8,9,6,7,4,5,2,3,1])
+
+      // Update all elements in reverse order
+      updateDynamics(view,
+        [["1", "1"], ["3", "3"],  ["2", "2"], ["5", "5"], ["4", "4"], ["7", "7"], ["6", "6"], ["9", "9"], ["8", "8"]]
       )
       expect(childIds()).toEqual([8,9,6,7,4,5,2,3,1])
 

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -397,6 +397,23 @@ describe("View + DOM", function() {
         [["8", "8"], ["7", "modified"],  ["9", "9"]]
       )
       expect(childIds()).toEqual([1,2,3,4,5,6,7,8,9])
+
+      // Make sure we don't have a memory leak when doing updates
+      let initalCount = countChildNodes()
+      updateDynamics(view,
+        [["1", "1"], ["2", "2"],  ["3", "3"]]
+      )
+      updateDynamics(view,
+        [["1", "1"], ["2", "2"],  ["3", "3"]]
+      )
+      updateDynamics(view,
+        [["1", "1"], ["2", "2"],  ["3", "3"]]
+      )
+      updateDynamics(view,
+        [["1", "1"], ["2", "2"],  ["3", "3"]]
+      )
+
+      expect(countChildNodes()).toBe(initalCount)
     })
 
     test("prepend", async () => {


### PR DESCRIPTION
This PR (mostly) fixes https://github.com/phoenixframework/phoenix_live_view/issues/978

Previously, when doing an append/prepend we would re-append every single child node of the container on each update. Instead, I factored out a class to handle the post-morphdom patching and improved the algorithm.

We now track the elements that were modified, along with their previous sibling, and any new ids added.

We can then fix the ordering by inserting each element next to the correct sibling. Since we are going in the original order they get put back in the right place.

If we are doing an append, our new elements are already at the bottom. If we are doing a prepend, we move them back to the top

I haven't run formal benchmarks, but I enabled profiling in my test game with a 750-element grid and "post-morph append/prepend restoration" goes from ~30ms to 0-1ms.

That said, there's still performance improvement to be had!

As I laid out in https://github.com/phoenixframework/phoenix_live_view/issues/978#issuecomment-660533639 we're still asking morphdom to patch the subtree of the `phx-update` component with the last thing we appended even on updates that are changing the dynamics of another part of the liveview. With this PR we end up doing a lot less work, but we will still do the morphdom processing and touch the last element updated on every update.

While I think it would be ideal to add a `PHX_SKIP` to container elements that shouldn't be touched on an update, this is hard because as Jose said
> Unfortunately it is not straight-forward for us to annotate that those dynamics are inside a prepend and append. There is no relationship between the rendered structure and the DOM and it is not trivial do build one.

I haven't done a good job profiling this exact thing -- I think that components would isolate you from having things outside their dom tree updated, so timing the same updates with and without components might help figure out how much of an issue this actually is.

One more thing -- I think the approach in this PR opens things up for a user to be able to mark elements to be deleted and/or re-arranged when using `phx-update`. Not sure if this is something you're considering but I have personally have really wanted to make an existing element rise to the top of a list if some data changes (e.g. a list of conversations in a chat app)