### PR TITLE
Add `phx-remove` binding

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1362,7 +1362,7 @@ class DOMPatch {
   }
 
   markPrunableContentForRemoval(){
-    DOM.all(this.container, `[phx-update=append] > *, [phx-update=prepend] > *`, el => {
+    DOM.all(this.container, `[${this.binding(PHX_UPDATE)}=append] > *, [${this.binding(PHX_UPDATE)}=prepend] > *`, el => {
       el.setAttribute(PHX_REMOVE, "")
     })
   }

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -24,7 +24,6 @@ const PHX_TRACK_STATIC = "track-static"
 const PHX_LINK_STATE = "data-phx-link-state"
 const PHX_REF = "data-phx-ref"
 const PHX_SKIP = "data-phx-skip"
-const PHX_REMOVE = "data-phx-remove"
 const PHX_PAGE_LOADING = "page-loading"
 const PHX_CONNECTED_CLASS = "phx-connected"
 const PHX_DISCONNECTED_CLASS = "phx-disconnected"
@@ -50,6 +49,7 @@ const PHX_HOOK = "hook"
 const PHX_DEBOUNCE = "debounce"
 const PHX_THROTTLE = "throttle"
 const PHX_UPDATE = "update"
+const PHX_REMOVE = "remove"
 const PHX_KEY = "key"
 const PHX_PRIVATE = "phxPrivate"
 const PHX_AUTO_RECOVER = "auto-recover"
@@ -1363,7 +1363,7 @@ class DOMPatch {
 
   markPrunableContentForRemoval(){
     DOM.all(this.container, `[${this.binding(PHX_UPDATE)}=append] > *, [${this.binding(PHX_UPDATE)}=prepend] > *`, el => {
-      el.setAttribute(PHX_REMOVE, "")
+      el.setAttribute(this.binding(PHX_REMOVE), "")
     })
   }
 
@@ -1411,7 +1411,7 @@ class DOMPatch {
           this.trackAfter("discarded", el)
         },
         onBeforeNodeDiscarded: (el) => {
-          if(el.getAttribute && el.getAttribute(PHX_REMOVE) !== null){ return true }
+          if(el.getAttribute && el.getAttribute(this.binding(PHX_REMOVE)) !== null){ return true }
           if(el.parentNode !== null && DOM.isPhxUpdate(el.parentNode, this.binding(PHX_UPDATE), ["append", "prepend"]) && el.id){ return false }
           if(this.skipCIDSibling(el)){ return false }
           this.trackBefore("discarded", el)

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -328,6 +328,20 @@ describe("View + DOM", function() {
       view.update(updateDiff, [])
     }
 
+    test("ignore", async () => {
+      let view = createView({
+        "0": {"d": [["1", "1"]], "s": [`\n<div id="`, `">`, `</div>\n`]},
+        "s": [`<div id="list" phx-update="ignore">`, `</div>`]
+      })
+      expect(childIds()).toEqual([1])
+
+      // Append two elements
+      updateDynamics(view,
+        [["2", "2"], ["3", "3"]]
+      )
+      expect(childIds()).toEqual([1])
+    })
+
     test("replace", async () => {
       let view = createView({
           "0": {"d": [["1", "1"]], "s": [`\n<div id="`, `">`, `</div>\n`]},
@@ -475,18 +489,38 @@ describe("View + DOM", function() {
       expect(countChildNodes()).toBe(initalCount)
     })
 
-    test("ignore", async () => {
+    test("removing elements", async () => {
       let view = createView({
-        "0": {"d": [["1", "1"]], "s": [`\n<div id="`, `">`, `</div>\n`]},
-        "s": [`<div id="list" phx-update="ignore">`, `</div>`]
+        "0": {"d": [["", "1", "1"]], "s": [`\n<div `, ` id="`, `">`, `</div>\n`]},
+        "1": "hello",
+        "s": [`<div id="list" phx-update="append">`, `</div><div>`,`</div>`]
       })
       expect(childIds()).toEqual([1])
 
-      // Append two elements
+      // Append four elements
       updateDynamics(view,
-        [["2", "2"], ["3", "3"]]
+        [["", "2", "2"], ["", "3", "3"], ["", "4", "4"], ["", "5", "5"]]
       )
-      expect(childIds()).toEqual([1])
+      expect(childIds()).toEqual([1,2,3,4,5])
+
+      // Remove an element
+      updateDynamics(view,
+        [["phx-remove", "2", ""]]
+      )
+      expect(childIds()).toEqual([1,3,4,5])
+
+       // Remove an element while updating retains order
+      updateDynamics(view,
+        [["", "4", "4"], ["", "1", "1"], ["phx-remove", "3", ""]]
+      )
+      expect(childIds()).toEqual([1,4,5])
+
+      // Updating another dynamic
+      view.update({
+        "1": "hello world"
+      }, [])
+
+      expect(childIds()).toEqual([1,4,5])
     })
   })
 })

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -306,17 +306,12 @@ describe("View + DOM", function() {
     let childIds = () => Array.from(document.getElementById("list").children).map(child => parseInt(child.id))
     let countChildNodes = () => document.getElementById("list").childNodes.length
 
-    let createView = (updateType, initialDynamics) => {
+    let createView = (joinDiff) => {
       let liveSocket = new LiveSocket("/live", Socket)
       let el = liveViewDOM()
       let view = new View(el, liveSocket)
 
       stubChannel(view)
-
-      let joinDiff = {
-        "0": {"d": initialDynamics, "s": [`\n<div id="`, `">`, `</div>\n`]},
-        "s": [`<div id="list" phx-update="${updateType}">`, `</div>`]
-      }
 
       view.onJoin({rendered: joinDiff})
 
@@ -334,7 +329,10 @@ describe("View + DOM", function() {
     }
 
     test("replace", async () => {
-      let view = createView("replace", [["1", "1"]])
+      let view = createView({
+          "0": {"d": [["1", "1"]], "s": [`\n<div id="`, `">`, `</div>\n`]},
+          "s": [`<div id="list" phx-update="replace">`, `</div>`]
+        })
       expect(childIds()).toEqual([1])
 
       updateDynamics(view,
@@ -344,7 +342,10 @@ describe("View + DOM", function() {
     })
 
     test("append", async () => {
-      let view = createView("append", [["1", "1"]])
+      let view = createView({
+        "0": {"d": [["1", "1"]], "s": [`\n<div id="`, `">`, `</div>\n`]},
+        "s": [`<div id="list" phx-update="append">`, `</div>`]
+      })
       expect(childIds()).toEqual([1])
 
       // Append two elements
@@ -408,7 +409,10 @@ describe("View + DOM", function() {
     })
 
     test("prepend", async () => {
-      let view = createView("prepend", [["1", "1"]])
+      let view = createView({
+        "0": {"d": [["1", "1"]], "s": [`\n<div id="`, `">`, `</div>\n`]},
+        "s": [`<div id="list" phx-update="prepend">`, `</div>`]
+      })
       expect(childIds()).toEqual([1])
 
       // Append two elements
@@ -472,7 +476,10 @@ describe("View + DOM", function() {
     })
 
     test("ignore", async () => {
-      let view = createView("ignore", [["1", "1"]])
+      let view = createView({
+        "0": {"d": [["1", "1"]], "s": [`\n<div id="`, `">`, `</div>\n`]},
+        "s": [`<div id="list" phx-update="ignore">`, `</div>`]
+      })
       expect(childIds()).toEqual([1])
 
       // Append two elements


### PR DESCRIPTION
This PR adds the ability to set the attribute `phx-remove` on an element that's inside a container with `phx-update="append"/"prepend"`. This element will then be removed from the DOM.

I'd like to add something like `phx-top` and `phx-bottom` for reordering as well, but want to keep this initial PR small. Let me know if you like this direction, and I will update the docs accordingly.