### PR TITLE
Doc clarification: `assign_new` will not have access to `Plug.Conn` assigns

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -529,12 +529,11 @@ defmodule Phoenix.LiveView do
 
   ## Referencing parent assigns
 
-  When a LiveView is mounted in a disconnected state, the Plug.Conn assigns
+  When a LiveView is mounted in a disconnected state, the `Plug.Conn` assigns
   will be available for reference via `assign_new/3`, allowing assigns to
-  be shared for the initial HTTP request. On connected mount, `assign_new/3`
-  will be invoked, and the LiveView will use its session to rebuild the
-  originally shared assign. Likewise, nested LiveView children have access
-  to their parent's assigns on mount using `assign_new`, which allows
+  be shared for the initial HTTP request. The `Plug.Conn` assigns will not be
+  available during the connected mount. Likewise, nested LiveView children have
+  access to their parent's assigns on mount using `assign_new`, which allows
   assigns to be shared down the nested LiveView tree.
 
   ## Examples


### PR DESCRIPTION
This clears up my confusion from #1091. Thanks!