### PR TITLE
Fix crash on array in params

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -409,6 +409,8 @@ defmodule Phoenix.LiveView.Channel do
 
   defp gather_keys([], acc), do: acc
 
+  defp gather_keys([%{} = map], acc), do: gather_keys(map, acc)
+
   defp gather_keys(nil, acc), do: acc
 
   defp handle_changed(state, %Socket{} = new_socket, ref, pending_live_patch \\ nil) do


### PR DESCRIPTION
Similar to issue #324, LiveView is still crashing when an array is present on params. 

For example, when we have an input with [] in name, like below:
```html
<input type="text" name="order_item[addons][][name]" value="<%= addon_type.name %>">
```

LiveView crash on for submission.
```
** (FunctionClauseError) no function clause matching in Phoenix.LiveView.Channel.gather_keys/2
    (phoenix_live_view 0.14.2) lib/phoenix_live_view/channel.ex:410: Phoenix.LiveView.Channel.gather_keys([%{"name" => nil}], ["addons", "order_item"])
    (phoenix_live_view 0.14.2) lib/phoenix_live_view/channel.ex:404: Phoenix.LiveView.Channel.decode_merge_target/1
    (phoenix_live_view 0.14.2) lib/phoenix_live_view/channel.ex:395: Phoenix.LiveView.Channel.decode_event_type/2
    (phoenix_live_view 0.14.2) lib/phoenix_live_view/channel.ex:87: Phoenix.LiveView.Channel.handle_info/2
    (stdlib 3.11.2) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib 3.11.2) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib 3.11.2) proc_lib.erl:249: :proc_lib.init_p_do_apply/3

```

This pull request fixes this issue.