### PR TITLE
Clarify assign/2|3 docs details

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -570,14 +570,14 @@ defmodule Phoenix.LiveView do
   @doc """
   Adds key value pairs to socket assigns.
 
-  A single key value pair may be passed, or a keyword list
-  of assigns may be provided to be merged into existing
-  socket assigns.
+  A single key value pair may be passed, or a keyword list or a map
+  of assigns may be provided to be merged into existing socket assigns.
 
   ## Examples
 
       iex> assign(socket, :name, "Elixir")
       iex> assign(socket, name: "Elixir", logo: "💧")
+      iex> assign(socket, %{name: "Elixir"})
   """
   def assign(%Socket{} = socket, key, value) do
     validate_assign_key!(key)

--- a/test/phoenix_live_view_test.exs
+++ b/test/phoenix_live_view_test.exs
@@ -185,9 +185,17 @@ defmodule Phoenix.LiveViewUnitTest do
     test "keeps whole maps in changes" do
       socket = assign(@socket, existing: %{foo: :bar})
       socket = Utils.clear_changed(socket)
+
       socket = assign(socket, existing: %{foo: :baz})
+      assert socket.assigns.existing == %{foo: :baz}
       assert socket.changed.existing == %{foo: :bar}
+
       socket = assign(socket, existing: %{foo: :bat})
+      assert socket.assigns.existing == %{foo: :bat}
+      assert socket.changed.existing == %{foo: :bar}
+
+      socket = assign(socket, %{existing: %{foo: :bam}})
+      assert socket.assigns.existing == %{foo: :bam}
       assert socket.changed.existing == %{foo: :bar}
     end
   end


### PR DESCRIPTION
The docs already shows there exists `assign/2`. This should be more obvious as example also given.