### PR TITLE
Add instructions to run javascript tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,4 +165,12 @@ $ mix deps.get
 $ mix test
 ```
 
+Running the Javascript tests:
+```bash
+$ cd assets
+$ npm run test
+# to automatically run tests for files that have been changed
+$ npm run test.watch
+```
+
 JS contributions are very welcome, but please do not include an updated `priv/static/phoenix_live_view.js` in pull requests. The maintainers will update it as part of the release process.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ We appreciate any contribution to LiveView.
 
 Please see the Phoenix [Code of Conduct](https://github.com/phoenixframework/phoenix/blob/master/CODE_OF_CONDUCT.md) and [Contributing](https://github.com/phoenixframework/phoenix/blob/master/CONTRIBUTING.md) guides.
 
-Running the tests:
+Running the Elixir tests:
 
 ```bash
 $ mix deps.get


### PR DESCRIPTION
hi! while working on another PR for live view with @mveytsman, @7hoenix, and @cthulahoops, I realised that I didn't know how to run Javascript tests. @mveytsman checked and noticed that `mix test` only ran the Elixir tests. he kindly gave me instructions to run the Javascript tests. I've added these instructions to the docs.

thanks in advance for your feedback!
