### PR TITLE
optimise and refactor DOMAppendPrependUpdate to DOMPostMorphRestorer

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1274,13 +1274,13 @@ export let DOM = {
 }
 
 class DOMPostMorphRestorer {
-  constructor(container, currentChildren, updateType) {
-    let idsAfter = new Set([...container.children].map(child => child.id))
+  constructor(containerBefore, containerAfter, updateType) {
     let idsBefore = new Set()
+    let idsAfter = new Set([...containerAfter.children].map(child => child.id))
 
     let elementsToModify = []
 
-    Array.from(currentChildren).forEach(child => {
+    Array.from(containerBefore.children).forEach(child => {
       if (child.id) { // all of our children should be elements with ids
         idsBefore.add(child.id)
         if (idsAfter.has(child.id)) {
@@ -1290,7 +1290,7 @@ class DOMPostMorphRestorer {
       }
     })
 
-    this.containerId = container.id
+    this.containerId = containerAfter.id
     this.updateType = updateType
     this.elementsToModify = elementsToModify
     this.elementIdsToAdd = [...idsAfter].filter(id => !idsBefore.has(id))
@@ -1463,7 +1463,7 @@ class DOMPatch {
             return false
           } else {
             if(DOM.isPhxUpdate(toEl, phxUpdate, ["append", "prepend"])){
-              appendPrependUpdates.push(new DOMPostMorphRestorer(toEl, fromEl.children, toEl.getAttribute(phxUpdate)))
+              appendPrependUpdates.push(new DOMPostMorphRestorer(fromEl, toEl, toEl.getAttribute(phxUpdate)))
             }
             DOM.syncAttrsToProps(toEl)
             this.trackBefore("updated", fromEl, toEl)

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1273,10 +1273,10 @@ export let DOM = {
   }
 }
 
-class DOMAppendPrependUpdate {
   constructor(fromEl, toEl, updateType) {
     let idsAfter = Array.from(toEl.children).map(child => child.id)
     let idsBefore = []
+class DOMPostMorphRestorer {
 
     let modifiedIds = []
 
@@ -1462,7 +1462,7 @@ class DOMPatch {
             return false
           } else {
             if(DOM.isPhxUpdate(toEl, phxUpdate, ["append", "prepend"])){
-              appendPrependUpdates.push(new DOMAppendPrependUpdate(fromEl, toEl, toEl.getAttribute(phxUpdate)))
+              appendPrependUpdates.push(new DOMPostMorphRestorer(fromEl, toEl, toEl.getAttribute(phxUpdate)))
             }
             DOM.syncAttrsToProps(toEl)
             this.trackBefore("updated", fromEl, toEl)

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1280,11 +1280,12 @@ class DOMPostMorphRestorer {
 
     let elementsToModify = []
 
-    fromEl.childNodes.forEach(child => {
+    Array.from(currentChildren).forEach(child => {
       if (child.id) { // all of our children should be elements with ids
-        idsBefore.push(child.id)
-        if (idsAfter.indexOf(child.id) >= 0) {
-          modifiedIds.push([child.id, child.previousElementSibling && child.previousElementSibling.id])
+        idsBefore.add(child.id)
+        if (idsAfter.has(child.id)) {
+          let previousElementId = child.previousElementSibling && child.previousElementSibling.id
+          elementsToModify.push({elementId: child.id, previousElementId: previousElementId})
         }
       }
     })

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1273,10 +1273,10 @@ export let DOM = {
   }
 }
 
-    let idsAfter = Array.from(toEl.children).map(child => child.id)
-    let idsBefore = []
 class DOMPostMorphRestorer {
   constructor(container, currentChildren, updateType) {
+    let idsAfter = new Set([...container.children].map(child => child.id))
+    let idsBefore = new Set()
 
     let modifiedIds = []
 

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1273,10 +1273,10 @@ export let DOM = {
   }
 }
 
-  constructor(fromEl, toEl, updateType) {
     let idsAfter = Array.from(toEl.children).map(child => child.id)
     let idsBefore = []
 class DOMPostMorphRestorer {
+  constructor(container, currentChildren, updateType) {
 
     let modifiedIds = []
 
@@ -1462,7 +1462,7 @@ class DOMPatch {
             return false
           } else {
             if(DOM.isPhxUpdate(toEl, phxUpdate, ["append", "prepend"])){
-              appendPrependUpdates.push(new DOMPostMorphRestorer(fromEl, toEl, toEl.getAttribute(phxUpdate)))
+              appendPrependUpdates.push(new DOMPostMorphRestorer(toEl, fromEl.children, toEl.getAttribute(phxUpdate)))
             }
             DOM.syncAttrsToProps(toEl)
             this.trackBefore("updated", fromEl, toEl)


### PR DESCRIPTION
hi! while discussing @mveytsman's PR #1087, @mveytsman, @7hoenix, @cthulahoops and i refactored and optimised the `DomAppendPrependUpdate` class so that #1087 can better implement `phx-remove`.

## optimisation
we used a set for `idsAfter` to make it faster to check for membership inside the loop. so 
`idsAfter.indexOf(child.id) >= 0` becomes `idsAfter.has(child.id)`, thus changing the loop from quadratic to linear-ish time.

## profiling
we profiled our changes using a new phoenix app with liveview. using the `phx-update=append` binding in the default `page_live.html.eex`

i made the following changes in the default `page_live.ex`:
```elixir
# i added this
@num_children 5_000
@num_children_to_change 5_000
@initial  1..@num_children |> Enum.to_list() |> Enum.map(fn x -> %{id: x, text: x} end)
@final 1..@num_children_to_change |> Enum.to_list() |> Enum.map(fn x -> %{id: x, text: "#{x}!!!"} end

# and modified mount/3 and handle_event/3
@impl true
def mount(_params, _session, socket) do
  {:ok, assign(socket, query: "", results: %{}, messages: @initial)}
end

@impl true
def handle_event("suggest", %{"q" => query}, socket) do
  {:noreply, assign(socket, results: search(query), query: query, messages: @final)}
end
```

### results from liveview's profiler for `full patch complete`
| number of `#chat-messages`' child nodes | number of `phx-update=appends` | total time on master | total time on our branch | 
| --- | --- | --- | --- |
| 10_000 | 10_000 | 3595ms |  398ms |
| 5_000 | 5_000 | 893ms | 221ms |
| 2_500 | 2_500 | 299ms | 140ms |
| 10_000 |  100 | 98ms | 85ms | 
| 10_000 | 1_000 | 695ms | 96ms | 
| 10_000 | 5_000 | 1259ms | 280ms |
| 20_000 | 1_000 | 366ms | 194ms |
| 30_000 | 1_000 | 369ms | 212ms |

thanks in advance for your feedback

p.s. thanks @cthulahoops for working on this PR comment with me!