### PR TITLE
Check for sub-inputs when a "phxFeedbackFor" element is a fieldset

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1161,12 +1161,21 @@ export let DOM = {
     return currentCycle
   },
 
+  hasFocused(el) {
+    if(el.tagName === "FIELDSET"){
+      let children = [...el.getElementsByTagName("input")]
+      return children.some((el) => this.private(el, PHX_HAS_FOCUSED))
+    } else {
+      return this.private(el, PHX_HAS_FOCUSED)
+    }
+  },
+
   discardError(container, el, phxFeedbackFor){
     let field = el.getAttribute && el.getAttribute(phxFeedbackFor)
     let input = field && container.querySelector(`#${field}`)
     if(!input){ return }
 
-    if(!(this.private(input, PHX_HAS_FOCUSED) || this.private(input.form, PHX_HAS_SUBMITTED))){
+    if(!(this.hasFocused(input) || this.private(input.form, PHX_HAS_SUBMITTED))){
       el.classList.add(PHX_NO_FEEDBACK_CLASS)
     }
   },


### PR DESCRIPTION
Here's a draft spike to get the conversation going on issue #1109 

This approach uses a wrapper fieldset, with a manually set ID, to show and hide errors/feedback on radio buttons at the right time. 

### Pros 
* It works
* It should work for multiple-choice checkboxes too (as long as none of them have the same ID as the ID you choose for the fieldset)

### Cons
* It requires on a fieldset, with an ID that matches the `phx_feedback_for` value that your Phoenix error_tag helper creates. (I had to set this manually in my test app) 
* Fieldsets already have their own semantic meaning, this might interfere with usage inside people's otherwise correct HTML. 
* It's not automatic, it relies on setup from the user. I can imagine people forgetting to setup the fieldset and support requests popping up. 

On balance, I don't like this approach. But I'd love some feedback, or other ideas. 