### PR TITLE
Update installation guide with `/live` location

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -312,3 +312,7 @@ import NProgress from "nprogress"
 window.addEventListener("phx:page-loading-start", info => NProgress.start())
 window.addEventListener("phx:page-loading-stop", info => NProgress.done())
 ```
+
+## Location for LiveView modules
+
+By convention your LiveView modules and `leex` templates should be placed in `lib/my_web_app/live/` directory.


### PR DESCRIPTION
I followed this guide and at the end didn't know the expected location for placing live views. So it seemed arbitrary. At first I considered to call it `live`, but ended up with `live_views`.

During development, I noticed that LiveReload was not working for my live views. I spent some time to figure out why was it so and finally discovered that 'dev.exs' config expects a different directory name.

Communicating this convention might be helpful and hopefully save another person from repeating my mistake.