### PR TITLE
Remove "#" from `find_live_child` in documentation

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -799,7 +799,7 @@ defmodule Phoenix.LiveViewTest do
   ## Examples
 
       {:ok, view, _html} = live(conn, "/thermo")
-      assert clock_view = find_live_child(view, "#clock")
+      assert clock_view = find_live_child(view, "clock")
       assert render_click(clock_view, :snooze) =~ "snoozing"
   """
   def find_live_child(%View{} = parent, child_id) do


### PR DESCRIPTION
It looks like the "#" is not needed when calling `find_live_child` in tests.