### PR TITLE
External hard redirects

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -699,7 +699,7 @@ defmodule Phoenix.LiveView do
     put_redirect(socket, {:redirect, %{external: url}})
   end
 
-  def redirect(%Socket{} = socket, _) do
+  def redirect(%Socket{}, _) do
     raise ArgumentError, "expected :to or :external option in redirect/2"
   end
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -690,15 +690,17 @@ defmodule Phoenix.LiveView do
     * `:to` - the path to redirect to. It must always be a local path
     * `:external` - an external path to redirect to
   """
-  def redirect(%Socket{} = socket, opts) do
-    url =
-      cond do
-        to = opts[:to] -> validate_local_url!(to, "redirect/2")
-        external = opts[:external] -> external
-        true -> raise ArgumentError, "expected :to or :external option in redirect/2"
-      end
-
+  def redirect(%Socket{} = socket, to: url) do
+    validate_local_url!(url, "redirect/2")
     put_redirect(socket, {:redirect, %{to: url}})
+  end
+
+  def redirect(%Socket{} = socket, external: url) do
+    put_redirect(socket, {:redirect, %{external: url}})
+  end
+
+  def redirect(%Socket{} = socket, _) do
+    raise ArgumentError, "expected :to or :external option in redirect/2"
   end
 
   @doc """

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -278,7 +278,11 @@ defmodule Phoenix.LiveView.Channel do
     end
   end
 
-  defp handle_result({:reply, %{} = reply, %Socket{} = new_socket}, {:handle_event, 3, ref}, state) do
+  defp handle_result(
+         {:reply, %{} = reply, %Socket{} = new_socket},
+         {:handle_event, 3, ref},
+         state
+       ) do
     handle_changed(state, Utils.put_reply(new_socket, reply), ref)
   end
 

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -258,7 +258,7 @@ defmodule Phoenix.LiveView.Channel do
         {diff, new_state} = render_diff(new_state, new_socket)
         {:ok, diff, redir, new_state}
 
-      {:redirect, %{to: url} = opts} ->
+      {:redirect, %{to: _to} = opts} ->
         {:redirect, copy_flash(new_state, Utils.get_flash(new_socket), opts), new_state}
 
       {:redirect, %{external: url}} ->

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -258,8 +258,11 @@ defmodule Phoenix.LiveView.Channel do
         {diff, new_state} = render_diff(new_state, new_socket)
         {:ok, diff, redir, new_state}
 
-      {:redirect, %{to: _to} = opts} ->
+      {:redirect, %{to: url} = opts} ->
         {:redirect, copy_flash(new_state, Utils.get_flash(new_socket), opts), new_state}
+
+      {:redirect, %{external: url}} ->
+        {:redirect, copy_flash(new_state, Utils.get_flash(new_socket), %{to: url}), new_state}
 
       {:live, :redirect, %{to: _to} = opts} ->
         {:live_redirect, copy_flash(new_state, Utils.get_flash(new_socket), opts), new_state}

--- a/lib/phoenix_live_view/controller.ex
+++ b/lib/phoenix_live_view/controller.ex
@@ -47,7 +47,6 @@ defmodule Phoenix.LiveView.Controller do
         |> put_flash(LiveView.Utils.get_flash(socket))
         |> Phoenix.Controller.redirect(Map.to_list(opts))
 
-
       {:stop, %Socket{redirected: {:live, _, %{to: to}}} = socket} ->
         conn
         |> put_flash(LiveView.Utils.get_flash(socket))

--- a/lib/phoenix_live_view/controller.ex
+++ b/lib/phoenix_live_view/controller.ex
@@ -42,10 +42,11 @@ defmodule Phoenix.LiveView.Controller do
           Map.put(socket_assigns, :content, content)
         )
 
-      {:stop, %Socket{redirected: {:redirect, %{to: to}}} = socket} ->
+      {:stop, %Socket{redirected: {:redirect, opts}} = socket} ->
         conn
         |> put_flash(LiveView.Utils.get_flash(socket))
-        |> Phoenix.Controller.redirect(to: to)
+        |> Phoenix.Controller.redirect(Map.to_list(opts))
+
 
       {:stop, %Socket{redirected: {:live, _, %{to: to}}} = socket} ->
         conn

--- a/test/phoenix_live_view/integrations/live_view_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test.exs
@@ -203,6 +203,20 @@ defmodule Phoenix.LiveView.LiveViewTest do
       assert {:error, {:redirect, %{to: "/thermo"}}} = live(conn)
     end
 
+    test "external redirect when disconnected", %{conn: conn} do
+      conn = get(conn, "/redir?during=disconnected&kind=external&to=https://phoenixframework.org")
+      assert redirected_to(conn) == "https://phoenixframework.org"
+
+      {:error, {:redirect, %{to: "https://phoenixframework.org"}}} =
+        live(conn, "/redir?during=disconnected&kind=external&to=https://phoenixframework.org")
+    end
+
+    test "external redirect when connected", %{conn: conn} do
+      conn = get(conn, "/redir?during=connected&kind=external&to=https://phoenixframework.org")
+      assert html_response(conn, 200) =~ "parent_content"
+      assert {:error, {:redirect, %{to: "https://phoenixframework.org"}}} = live(conn)
+    end
+
     test "child push_redirect when disconnected", %{conn: conn} do
       conn = get(conn, "/redir?during=disconnected&kind=push_redirect&child_to=/thermo")
       assert redirected_to(conn) == "/thermo"
@@ -246,6 +260,19 @@ defmodule Phoenix.LiveView.LiveViewTest do
       conn = get(conn, "/redir?during=connected&kind=redirect&child_to=/thermo?from_child=true")
       assert html_response(conn, 200) =~ "parent_content"
       assert {:error, {:redirect, %{to: "/thermo?from_child=true"}}} = live(conn)
+    end
+
+    test "child external redirect when disconnected", %{conn: conn} do
+      conn =
+        get(conn, "/redir?during=disconnected&kind=external&child_to=https://phoenixframework.org?from_child=true")
+
+      assert redirected_to(conn) == "https://phoenixframework.org?from_child=true"
+    end
+
+    test "child external redirect when connected", %{conn: conn} do
+      conn = get(conn, "/redir?during=connected&kind=external&child_to=https://phoenixframework.org?from_child=true")
+      assert html_response(conn, 200) =~ "parent_content"
+      assert {:error, {:redirect, %{to: "https://phoenixframework.org?from_child=true"}}} = live(conn)
     end
   end
 

--- a/test/phoenix_live_view/integrations/live_view_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test.exs
@@ -264,15 +264,25 @@ defmodule Phoenix.LiveView.LiveViewTest do
 
     test "child external redirect when disconnected", %{conn: conn} do
       conn =
-        get(conn, "/redir?during=disconnected&kind=external&child_to=https://phoenixframework.org?from_child=true")
+        get(
+          conn,
+          "/redir?during=disconnected&kind=external&child_to=https://phoenixframework.org?from_child=true"
+        )
 
       assert redirected_to(conn) == "https://phoenixframework.org?from_child=true"
     end
 
     test "child external redirect when connected", %{conn: conn} do
-      conn = get(conn, "/redir?during=connected&kind=external&child_to=https://phoenixframework.org?from_child=true")
+      conn =
+        get(
+          conn,
+          "/redir?during=connected&kind=external&child_to=https://phoenixframework.org?from_child=true"
+        )
+
       assert html_response(conn, 200) =~ "parent_content"
-      assert {:error, {:redirect, %{to: "https://phoenixframework.org?from_child=true"}}} = live(conn)
+
+      assert {:error, {:redirect, %{to: "https://phoenixframework.org?from_child=true"}}} =
+               live(conn)
     end
   end
 

--- a/test/phoenix_live_view_test.exs
+++ b/test/phoenix_live_view_test.exs
@@ -251,7 +251,7 @@ defmodule Phoenix.LiveViewUnitTest do
 
     test "allows external paths" do
       assert redirect(@socket, external: "http://foo.com/bar").redirected ==
-               {:redirect, %{to: "http://foo.com/bar"}}
+               {:redirect, %{external: "http://foo.com/bar"}}
     end
   end
 

--- a/test/support/live_views/general.ex
+++ b/test/support/live_views/general.ex
@@ -282,6 +282,7 @@ defmodule Phoenix.LiveViewTest.RedirLive do
 
   defp do_redirect(socket, "push_redirect", opts), do: push_redirect(socket, opts)
   defp do_redirect(socket, "redirect", opts), do: redirect(socket, opts)
+  defp do_redirect(socket, "external", to: url), do: redirect(socket, external: url)
   defp do_redirect(socket, "push_patch", opts), do: push_patch(socket, opts)
 end
 


### PR DESCRIPTION
# Issue

Invoking `Phoenix.LiveView.redirect/2` during a `Phoenix.LiveView.mount/3` with an external URL causes an `ArgumentError` to be raised during the subsequent render.

## Example

```elixir
defmodule MyView do
  use Phoenix.LiveView

  def mount(_params, _session, socket) do
    {:ok, redirect(socket, external: "https://phoenixframework.org")}
  end
end
```

## Analysis

`Phoenix.LiveView.redirect/2`when invoked with an external URL, e.g. `redirect(socket, external: url)` causes the the `socket` to be annotated with `{:redirect, %{to: url}` in its `redirected` field, making it structurally indistiguishable from a local redirect as invoked with the `:to` option. The subsequent invocation of `Phoenix.LiveView.Controller.live_render/3` then calls `Phoenix.Controller.redirect(conn, to: to)`, which raises an `ArgumentError` if the given `to` is a fully qualified URL and not just a path.

# Proposed solution

This PR proposes a solution comprised of the following details:
- Modify `Phoenix.LiveView.redirect/2` to annotate its `socket` argument with `{:redirect, %{external: url}}` in its `redirected` field, structurally distinguishing it from a local redirect.
- Modify `Phoenix.LiveView.Controller` to pass the same key defined in the socket's `redirected` field to `Phoenix.Controller.redirect/2`, which in turn recognizes an explicitly passed external URL as valid.
- Modify `Phoenix.LiveView.Channel` to combine `:from` and `:to` annotations from the socket back into a single `:to` key for the message passed back to the client, which responds as usual by setting `window.location` accordingly.
- Update tests to reflect structural changes to socket annotations
- Provide new integration tests for invoking `Phoenix.LiveView.redirect/2` with an external URL during mounting.