### PR TITLE
Fix function references in guides

### DIFF
--- a/guides/client/form-bindings.md
+++ b/guides/client/form-bindings.md
@@ -20,8 +20,8 @@ saving, your template would use both `phx_change` and `phx_submit` bindings:
       <%= submit "Save" %>
     </form>
 
-*Reminder*: `form_for/3` is a `Phoenix.HTML` helper. Don't forget to include
-`use Phoenix.HTML` at the top of your LiveView, if using `Phoenix.HTML` helpers.
+*Reminder*: [`form_for/3`](`Phoenix.HTML.Form.form_for/3`) is a `Phoenix.HTML` helper.
+Don't forget to include `use Phoenix.HTML` at the top of your LiveView, if using `Phoenix.HTML` helpers.
 Also, if using `error_tag/2`, don't forget to `import MyAppWeb.ErrorHelpers`.
 
 Next, your LiveView picks up the events in `handle_event` callbacks:
@@ -56,8 +56,8 @@ Next, your LiveView picks up the events in `handle_event` callbacks:
 
 The validate callback simply updates the changeset based on all form input
 values, then assigns the new changeset to the socket. If the changeset
-changes, such as generating new errors, `c:render/1` is invoked and
-the form is re-rendered.
+changes, such as generating new errors, [`render/1`](`c:Phoenix.LiveView.render/1`)
+is invoked and the form is re-rendered.
 
 Likewise for `phx-submit` bindings, the same callback is invoked and
 persistence is attempted. On success, a `:noreply` tuple is returned and the

--- a/guides/server/live-navigation.md
+++ b/guides/server/live-navigation.md
@@ -23,8 +23,9 @@ or in a LiveView:
 
 The "patch" operations must be used when you want to navigate to the
 current LiveView, simply updating the URL and the current parameters,
-without mounting a new LiveView. When patch is used, the `c:handle_params/3`
-callback is invoked and the minimal set of changes are sent to the client.
+without mounting a new LiveView. When patch is used, the
+[`handle_params/3`](`c:Phoenix.LiveView.handle_params/3`) callback is
+invoked and the minimal set of changes are sent to the client.
 See the next section for more information.
 
 The "redirect" operations must be used when you want to dismount the
@@ -34,31 +35,41 @@ which is mounted in place of the current one within the current layout.
 While redirecting, a `phx-disconnected` class is added to the LiveView,
 which can be used to indicate to the user a new page is being loaded.
 
-At the end of the day, regardless if you invoke `link/2`, `live_patch/2`,
-and `live_redirect/2` from the client, or `redirect/2`, `push_patch/2`,
-and `push_redirect/2` from the server, the user will end-up on the same
-page. The difference between those is mostly the amount of data sent over
-the wire:
+At the end of the day, regardless if you invoke [`link/2`](`Phoenix.HTML.Link.link/2`),
+[`live_patch/2`](`Phoenix.LiveView.Helpers.live_patch/2`),
+and [`live_redirect/2`](`Phoenix.LiveView.Helpers.live_redirect/2`) from the client,
+or [`redirect/2`](`Phoenix.Controller.redirect/2`),
+[`push_patch/2`](`Phoenix.LiveView.push_patch/2`),
+and [`push_redirect/2`](`Phoenix.LiveView.push_redirect/2`) from the server,
+the user will end-up on the same page. The difference between those is mostly
+the amount of data sent over the wire:
 
-  * `link/2` and `redirect/2` do full page reloads
+  * [`link/2`](`Phoenix.HTML.Link.link/2`) and
+    [`redirect/2`](`Phoenix.Controller.redirect/2`) do full page reloads
 
-  * `live_redirect/2` and `push_redirect/2` mounts a new LiveView while
+  * [`live_redirect/2`](`Phoenix.LiveView.Helpers.live_redirect/2`) and
+  [`push_redirect/2`](`Phoenix.LiveView.push_redirect/2`) mounts a new LiveView while
     keeping the current layout
 
-  * `live_patch/2` and `push_patch/2` updates the current LiveView and
-    sends only the minimal diff while also maintaining the scroll position
+  * [`live_patch/2`](`Phoenix.LiveView.Helpers.live_patch/2`) and
+    [`push_patch/2`](`Phoenix.LiveView.push_patch/2`) updates the current LiveView
+    and sends only the minimal diff while also maintaining the scroll position
 
-An easy rule of thumb is to stick with `live_redirect/2` and `push_redirect/2`
-and use the patch helpers only in the cases where you want to minimize the
+An easy rule of thumb is to stick with
+[`live_redirect/2`](`Phoenix.LiveView.Helpers.live_redirect/2`) and
+[`push_redirect/2`](`Phoenix.LiveView.push_redirect/2`) and use the patch
+helpers only in the cases where you want to minimize the
 amount of data sent when navigating within the same LiveView (for example,
 if you want to change the sorting of a table while also updating the URL).
 
 ## `handle_params/3`
 
-The `c:handle_params/3` callback is invoked after `c:mount/3` and before
-the initial render. It is also invoked every time `live_patch/2` or
-`push_patch/2` are used. It receives the request parameters as first
-argument, the url as second, and the socket as third.
+The [`handle_params/3`](`c:Phoenix.LiveView.handle_params/3`) callback is invoked
+after [`mount/3`](`c:Phoenix.LiveView.mount/3`) and before the initial render.
+It is also invoked every time [`live_patch/2`](`Phoenix.LiveView.Helpers.live_patch/2`)
+or [`push_patch/2`](`Phoenix.LiveView.push_patch/2`) are used.
+It receives the request parameters as first argument, the url as second,
+and the socket as third.
 
 For example, imagine you have a `UserTable` LiveView to show all users in
 the system and you define it in the router as:
@@ -69,9 +80,10 @@ Now to add live sorting, you could do:
 
     <%= live_patch "Sort by name", to: Routes.live_path(@socket, UserTable, %{sort_by: "name"}) %>
 
-When clicked, since we are navigating to the current LiveView, `c:handle_params/3`
-will be invoked. Remember you should never trust the received params, so you must
-use the callback to validate the user input and change the state accordingly:
+When clicked, since we are navigating to the current LiveView,
+[`handle_params/3`](`c:Phoenix.LiveView.handle_params/3`) will be invoked.
+Remember you should never trust the received params, so you must use the callback to
+validate the user input and change the state accordingly:
 
     def handle_params(params, _uri, socket) do
       socket =
@@ -83,23 +95,30 @@ use the callback to validate the user input and change the state accordingly:
       {:noreply, load_users(socket)}
     end
 
-As with other `handle_*` callback, changes to the state inside `c:handle_params/3`
-will trigger a server render.
+As with other `handle_*` callback, changes to the state inside
+[`handle_params/3`](`c:Phoenix.LiveView.handle_params/3`) will trigger a server render.
 
-Note the parameters given to `c:handle_params/3` are the same as the ones given
-to `c:mount/3`. So how do you decide which callback to use to load data?
-Generally speaking, data should always be loaded on `c:mount/3`, since `c:mount/3`
-is invoked once per LiveView life-cycle. Only the params you expect to be changed
-via `live_patch/2` or `push_patch/2` must be loaded on `c:handle_params/3`.
+Note the parameters given to [`handle_params/3`](`c:Phoenix.LiveView.handle_params/3`)
+are the same as the ones given to [`mount/3`](`c:Phoenix.LiveView.mount/3`).
+So how do you decide which callback to use to load data?
+Generally speaking, data should always be loaded on [`mount/3`](`c:Phoenix.LiveView.mount/3`),
+since [`mount/3`](`c:Phoenix.LiveView.mount/3`) is invoked once per LiveView life-cycle.
+Only the params you expect to be changed via
+[`live_patch/2`](`Phoenix.LiveView.Helpers.live_patch/2`) or
+[`push_patch/2`](`Phoenix.LiveView.push_patch/2`) must be loaded on
+[`handle_params/3`](`c:Phoenix.LiveView.handle_params/3`).
 
 For example, imagine you have a blog. The URL for a single post is:
 "/blog/posts/:post_id". In the post page, you have comments and they are paginated.
-You use `live_patch/2` to update the shown comments every time the user paginates,
-updating the URL to "/blog/posts/:post_id?page=X". In this example, you will access
-`"post_id"` on `c:mount/3` and the page of comments on `c:handle_params/3`.
+You use [`live_patch/2`](`Phoenix.LiveView.Helpers.live_patch/2`) to update the shown
+comments every time the user paginates, updating the URL to "/blog/posts/:post_id?page=X".
+In this example, you will access `"post_id"` on [`mount/3`](`c:Phoenix.LiveView.mount/3`) and
+the page of comments on [`handle_params/3`](`c:Phoenix.LiveView.handle_params/3`).
 
 Furthermore, it is very important to not access the same parameters on both
-`c:mount/3` and `c:handle_params/3`. For example, do NOT do this:
+[`mount/3`](`c:Phoenix.LiveView.mount/3`) and
+[`handle_params/3`](`c:Phoenix.LiveView.handle_params/3`).
+For example, do NOT do this:
 
     def mount(%{"post_id" => post_id}, session, socket) do
       # do something with post_id
@@ -109,8 +128,10 @@ Furthermore, it is very important to not access the same parameters on both
       # do something with post_id and page
     end
 
-If you do that, because `c:mount/3` is called once and `c:handle_params/3` multiple
-times, the "post_id" read on mount can get out of sync with the one in `c:handle_params/3`.
+If you do that, because [`mount/3`](`c:Phoenix.LiveView.mount/3`) is called once and
+[`handle_params/3`](`c:Phoenix.LiveView.handle_params/3`) multiple times, the "post_id"
+read on mount can get out of sync with the one in
+[`handle_params/3`](`c:Phoenix.LiveView.handle_params/3`).
 So once a parameter is read on mount, it should not be read elsewhere. Instead, do this:
 
     def mount(%{"post_id" => post_id}, session, socket) do

--- a/guides/server/security-model.md
+++ b/guides/server/security-model.md
@@ -14,8 +14,8 @@ HTTP request via Plugs, such as this:
     plug :ensure_user_authenticated
     plug :ensure_user_confirmed
 
-Then the `c:mount/3` callback of your LiveView should execute those same
-verifications:
+Then the [`mount/3`](`c:Phoenix.LiveView.mount/3`) callback of your LiveView
+should execute those same verifications:
 
     def mount(params, %{"user_id" => user_id} = _session, socket) do
       socket = assign(socket, current_user: Accounts.get_user!(user_id))
@@ -30,9 +30,9 @@ verifications:
       {:ok, socket}
     end
 
-Given almost all `c:mount/3` actions in your application will have to
-perform these exact steps, we recommend creating a function called
-`assign_defaults/2` or similar, putting it in a new module like
+Given almost all [`mount/3`](`c:Phoenix.LiveView.mount/3`) actions in your
+application will have to perform these exact steps, we recommend creating a
+function called `assign_defaults/2` or similar, putting it in a new module like
 `MyAppWeb.LiveHelpers`, and modifying `lib/my_app_web.ex` so all
 LiveViews automatically import it:
 
@@ -43,7 +43,7 @@ LiveViews automatically import it:
       end
     end
 
-Then make sure to call it in every LiveView's `c:mount/3`:
+Then make sure to call it in every LiveView's [`mount/3`](`c:Phoenix.LiveView.mount/3`):
 
     def mount(params, session, socket) do
       {:ok, assign_defaults(session, socket)}
@@ -67,7 +67,8 @@ Where `MyAppWeb.LiveHelpers` can be something like:
 
 One possible concern in this approach is that in regular HTTP requests the
 current user will be fetched twice: once in the HTTP request and again on
-`mount`. You can address this by using the `assign_new` function, that will
+[`mount/3`](`c:Phoenix.LiveView.mount/3`). You can address this by using the
+[`assign_new/3`](`Phoenix.LiveView.assign_new/3`) function, that will
 reuse any of the connection assigns from the HTTP request:
 
     def assign_defaults(%{"user_id" => user_id}, socket) do
@@ -83,9 +84,9 @@ reuse any of the connection assigns from the HTTP request:
 ## Events considerations
 
 It is also important to keep in mind that LiveViews are stateful. Therefore,
-if you load any data on `c:mount/3` and the data itself changes, the data
-won't be automatically propagated to the LiveView, unless you broadcast
-those events with `Phoenix.PubSub`.
+if you load any data on [`mount/3`](`c:Phoenix.LiveView.mount/3`) and the data
+itself changes, the data won't be automatically propagated to the LiveView,
+unless you broadcast those events with `Phoenix.PubSub`.
 
 Generally speaking, the simplest and safest approach is to perform authorization
 whenever there is an action. For example, imagine that you have a LiveView
@@ -113,7 +114,7 @@ Another security consideration is how to disconnect all instances of a given
 live user. For example, imagine the user logs outs, its account is terminated,
 or any other reason.
 
-Luckily, it is possible to identify all LiveView sockets by setting a "live_socket_id"
+Luckily, it is possible to identify all LiveView sockets by setting a `live_socket_id`
 in the session. For example, when signing in a user, you could do:
 
     conn
@@ -127,10 +128,10 @@ ID by broadcasting on the topic:
     MyAppWeb.Endpoint.broadcast("users_socket:#{user.id}", "disconnect", %{})
 
 Once a LiveView is disconnected, the client will attempt to reestablish
-the connection, re-executing the `c:mount/3` callback. In this case,
-if the user is no longer logged in or it no longer has access to its
-current resource, `c:mount/3` will fail and the user will be redirected
-to the proper page.
+the connection, re-executing the [`mount/3`](`c:Phoenix.LiveView.mount/3`) callback.
+In this case, if the user is no longer logged in or it no longer has access to its
+current resource, [`mount/3`](`c:Phoenix.LiveView.mount/3`) will fail and the user
+will be redirected to the proper page.
 
 This is the same mechanism provided by `Phoenix.Channel`s. Therefore, if
 your application uses both channels and LiveViews, you can use the same

--- a/guides/server/telemetry.md
+++ b/guides/server/telemetry.md
@@ -2,7 +2,8 @@
 
 LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/telemetry) events:
 
-  * `[:phoenix, :live_view, :mount, :start]` - Dispatched by a `Phoenix.LiveView` immediately before `c:mount/3` is invoked.
+  * `[:phoenix, :live_view, :mount, :start]` - Dispatched by a `Phoenix.LiveView`
+    immediately before [`mount/3`](`c:Phoenix.LiveView.mount/3`) is invoked.
 
     * Measurement:
 
@@ -17,7 +18,8 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
           }
 
 
-  * `[:phoenix, :live_view, :mount, :stop]` - Dispatched by a `Phoenix.LiveView` when the `c:mount/3` callback completes successfully.
+  * `[:phoenix, :live_view, :mount, :stop]` - Dispatched by a `Phoenix.LiveView`
+    when the [`mount/3`](`c:Phoenix.LiveView.mount/3`) callback completes successfully.
 
     * Measurement:
 
@@ -32,7 +34,8 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
           }
 
 
-  * `[:phoenix, :live_view, :mount, :exception]` - Dispatched by a `Phoenix.LiveView` when an exception is raised in the `c:mount/3` callback.
+  * `[:phoenix, :live_view, :mount, :exception]` - Dispatched by a `Phoenix.LiveView`
+    when an exception is raised in the [`mount/3`](`c:Phoenix.LiveView.mount/3`) callback.
 
     * Measurement: `%{duration: native_time}`
 
@@ -46,7 +49,8 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
             session: map
           }
 
-  * `[:phoenix, :live_view, :handle_params, :start]` - Dispatched by a `Phoenix.LiveView` immediately before `c:handle_params/3` is invoked.
+  * `[:phoenix, :live_view, :handle_params, :start]` - Dispatched by a `Phoenix.LiveView`
+    immediately before [`handle_params/3`](`c:Phoenix.LiveView.handle_params/3`) is invoked.
 
     * Measurement:
 
@@ -61,7 +65,8 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
           }
 
 
-  * `[:phoenix, :live_view, :handle_params, :stop]` - Dispatched by a `Phoenix.LiveView` when the `c:handle_params/3` callback completes successfully.
+  * `[:phoenix, :live_view, :handle_params, :stop]` - Dispatched by a `Phoenix.LiveView`
+    when the [`handle_params/3`](`c:Phoenix.LiveView.handle_params/3`) callback completes successfully.
 
     * Measurement:
 
@@ -75,7 +80,8 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
             uri: String.t()
           }
 
-  * `[:phoenix, :live_view, :handle_params, :exception]` - Dispatched by a `Phoenix.LiveView` when the when an exception is raised in the `c:handle_params/3` callback.
+  * `[:phoenix, :live_view, :handle_params, :exception]` - Dispatched by a `Phoenix.LiveView`
+    when the when an exception is raised in the [`handle_params/3`](`c:Phoenix.LiveView.handle_params/3`) callback.
 
     * Measurement:
 
@@ -91,7 +97,8 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
             uri: String.t()
           }
 
-  * `[:phoenix, :live_view, :handle_event, :start]` - Dispatched by a `Phoenix.LiveView` immediately before `c:handle_event/3` is invoked.
+  * `[:phoenix, :live_view, :handle_event, :start]` - Dispatched by a `Phoenix.LiveView`
+    immediately before [`handle_event/3`](`c:Phoenix.LiveView.handle_event/3`) is invoked.
 
     * Measurement:
 
@@ -106,7 +113,8 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
           }
 
 
-  * `[:phoenix, :live_view, :handle_event, :stop]` - Dispatched by a `Phoenix.LiveView` when the `c:handle_event/3` callback completes successfully.
+  * `[:phoenix, :live_view, :handle_event, :stop]` - Dispatched by a `Phoenix.LiveView`
+    when the [`handle_event/3`](`c:Phoenix.LiveView.handle_event/3`) callback completes successfully.
 
     * Measurement:
 
@@ -120,7 +128,8 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
             params: unsigned_params
           }
 
-  * `[:phoenix, :live_view, :handle_event, :exception]` - Dispatched by a `Phoenix.LiveView` when an exception is raised in the `c:handle_event/3` callback.
+  * `[:phoenix, :live_view, :handle_event, :exception]` - Dispatched by a `Phoenix.LiveView`
+    when an exception is raised in the [`handle_event/3`](`c:Phoenix.LiveView.handle_event/3`) callback.
 
     * Measurement:
 
@@ -136,7 +145,8 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
             params: unsigned_params
           }
 
-  * `[:phoenix, :live_component, :handle_event, :start]` - Dispatched by a `Phoenix.LiveComponent` immediately before `c:handle_event/3` is invoked.
+  * `[:phoenix, :live_component, :handle_event, :start]` - Dispatched by a `Phoenix.LiveComponent`
+    immediately before [`handle_event/3`](`c:Phoenix.LiveView.handle_event/3`) is invoked.
 
     * Measurement:
 
@@ -152,7 +162,8 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
           }
 
 
-  * `[:phoenix, :live_component, :handle_event, :stop]` - Dispatched by a `Phoenix.LiveComponent` when the `c:handle_event/3` callback completes successfully.
+  * `[:phoenix, :live_component, :handle_event, :stop]` - Dispatched by a `Phoenix.LiveComponent`
+    when the [`handle_event/3`](`c:Phoenix.LiveView.handle_event/3`) callback completes successfully.
 
     * Measurement:
 
@@ -167,7 +178,8 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
             params: unsigned_params
           }
 
-  * `[:phoenix, :live_component, :handle_event, :exception]` - Dispatched by a `Phoenix.LiveComponent` when an exception is raised in the `c:handle_event/3` callback.
+  * `[:phoenix, :live_component, :handle_event, :exception]` - Dispatched by a `Phoenix.LiveComponent`
+    when an exception is raised in the [`handle_event/3`](`c:Phoenix.LiveView.handle_event/3`) callback.
 
     * Measurement:
 


### PR DESCRIPTION
Replacing raw function names by actual references to the functions/callbacks in .md files (guides) to make navigation easier and avoid callbacks appearing as `c:mount/3` in the markdown.

I replaced quite extensively, even at some places where it might not have been needed within the context. I figured it couldn't harm, but let me know if this was overkill :wink:

(Sorry, a bit hard to review due to re-arranging line breaks... Maybe better to turn the whitespace diff off or review the rendered markdown)

### Before
![Screenshot from 2020-08-21 09-14-59](https://user-images.githubusercontent.com/11598866/90850003-9b249480-e3ab-11ea-8607-e08d3dbda9bf.png)

### After
![Screenshot from 2020-08-21 09-14-17](https://user-images.githubusercontent.com/11598866/90850009-9c55c180-e3ab-11ea-9c92-b0c82cc1095a.png)
