### PR TITLE
Fixing static_change documentation

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -897,7 +897,7 @@ defmodule Phoenix.LiveView do
   assign on mount:
 
       def mount(params, session, socket) do
-        {:ok, assign(socket, static_changed?: static_changed?(socket))}
+        {:ok, assign(socket, static_change: static_changed?(socket))}
       end
 
   And then in your views:


### PR DESCRIPTION
The view has the assign as `@static_change` instead of `@static_changed?`. Fixing the docs to reflect that.