### PR TITLE
remove leading # when looking up hash target through getElementById

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -980,7 +980,7 @@ export let Browser = {
     if(this.canPushState()){
       if(to !== window.location.href){
         history[kind + "State"](meta, "", to || null) // IE will coerce undefined to string
-        let hashEl = this.getHashTargetEl(window.location.hash)
+        let hashEl = this.getHashTargetEl()
 
         if(hashEl) {
           hashEl.scrollIntoView()
@@ -1008,9 +1008,10 @@ export let Browser = {
 
   localKey(namespace, subkey){ return `${namespace}-${subkey}` },
 
-  getHashTargetEl(hash){
-    if(hash.toString() === ""){ return }
-    return document.getElementById(hash) || document.querySelector(`a[name="${hash.substring(1)}"]`)
+  getHashTargetEl() {
+    let hash = window.location.hash.toString().substring(1)
+    if(hash === ""){ return }
+    return document.getElementById(hash) || document.querySelector(`a[name="${hash}"]`)
   }
 }
 

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -980,7 +980,7 @@ export let Browser = {
     if(this.canPushState()){
       if(to !== window.location.href){
         history[kind + "State"](meta, "", to || null) // IE will coerce undefined to string
-        let hashEl = this.getHashTargetEl()
+        let hashEl = this.getHashTargetEl(window.location.hash)
 
         if(hashEl) {
           hashEl.scrollIntoView()
@@ -1008,8 +1008,8 @@ export let Browser = {
 
   localKey(namespace, subkey){ return `${namespace}-${subkey}` },
 
-  getHashTargetEl() {
-    let hash = window.location.hash.toString().substring(1)
+  getHashTargetEl(maybeHash) {
+    let hash = maybeHash.toString().substring(1)
     if(hash === ""){ return }
     return document.getElementById(hash) || document.querySelector(`a[name="${hash}"]`)
   }


### PR DESCRIPTION
fixes #1136 

Since `getHashTargetEl` is single purpose, I don't see why the caller should need to provide the argument. This allows keeping the edge case check simple, i.e. it avoids `hash === "" || hash === "#"` (thanks to IE11). 

I have only tested this in the 'raw', non-minified form.