### PR TITLE
Make docs regarding testing hidden fields more consistent

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -482,7 +482,7 @@ defmodule Phoenix.LiveViewTest do
 
       assert view
             |> form("#term", user: %{name: "hello"})
-            |> render_submit(%{"hidden_value" => "example"}) =~ "Name updated"
+            |> render_submit(%{user: %{"hidden_field" => "example"}}) =~ "Name updated"
 
   """
   def render_submit(element, value \\ %{})
@@ -539,7 +539,7 @@ defmodule Phoenix.LiveViewTest do
 
       refute view
             |> form("#term", user: %{name: "hello"})
-            |> render_change(%{"hidden_value" => "example"}) =~ "can't be blank"
+            |> render_change(%{user: %{"hidden_field" => "example"}}) =~ "can't be blank"
 
   """
   def render_change(element, value \\ %{})


### PR DESCRIPTION
The previous example that was given for `render_submit` and `render_change` can result in making a mistake if you copy/paste the example (it is highly likely that the *hidden_field* is inside the *user* object).