### PR TITLE
Fix race condition on phx-trigger-action

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1441,7 +1441,10 @@ class DOMPatch {
           return el
         },
         onNodeAdded: (el) => {
-          if(DOM.isNowTriggerFormExternal(el, phxTriggerExternal)){ el.submit() }
+          if(DOM.isNowTriggerFormExternal(el, phxTriggerExternal)){
+            liveSocket.disconnect()
+            el.submit()
+          }
           // nested view handling
           if(DOM.isPhxChild(el) && view.ownsElement(el)){
             this.trackAfter("phxChildAdded", el)
@@ -1461,7 +1464,10 @@ class DOMPatch {
           return true
         },
         onElUpdated: (el) => {
-          if(DOM.isNowTriggerFormExternal(el, phxTriggerExternal)){ el.submit() }
+          if(DOM.isNowTriggerFormExternal(el, phxTriggerExternal)){
+            liveSocket.disconnect()
+            el.submit()
+          }
           updates.push(el)
         },
         onBeforeElUpdated: (fromEl, toEl) => {

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -281,6 +281,7 @@ describe("View + DOM", function() {
       let updatedHtml = `<form id="form" phx-submit="submit" phx-trigger-action><input type="text"></form>`
       view.update({s: [updatedHtml]}, [])
 
+      expect(liveSocket.socket.closeWasClean).toBe(true)
       expect(view.el.innerHTML).toBe("<form id=\"form\" phx-submit=\"submit\" phx-trigger-action=\"\"><input type=\"text\"></form>")
     })
 
@@ -298,6 +299,7 @@ describe("View + DOM", function() {
       let updatedHtml = `<form id="form" phx-submit="submit" phx-trigger-action><input type="text"></form>`
       view.update({s: [updatedHtml]}, [])
 
+      expect(liveSocket.socket.closeWasClean).toBe(true)
       expect(view.el.innerHTML).toBe("<form id=\"form\" phx-submit=\"submit\" phx-trigger-action=\"\"><input type=\"text\"></form>")
     })
   })

--- a/guides/client/form-bindings.md
+++ b/guides/client/form-bindings.md
@@ -152,23 +152,7 @@ fields on next render:
         end
     end
 
-### Forms triggering file downloads
-
-In scenarios where the LiveView is left open in the browser after form
-submission (ex: a form submitting to a controller to trigger a file download),
-it's important that `phx-trigger-action` is only set for the current DOM patch.
-If `phx-trigger-action` is left on the form after the initial form submission,
-any subsequent DOM patches will re-trigger the form submission.
-
-To prevent this, we need to set `trigger_submit: false` in temporary assigns in
-`c:mount/3`.
-
-    def mount(_params, _session, socket) do
-      {:ok, socket, [temporary_assigns: [trigger_submit: false]]}
-    end
-
-Now when `:trigger_submit` is set in `handle_event/3`, it will only be set for
-the next DOM patch and removed in subsequent patches.
+Once `phx-trigger-action` is true, LiveView disconnects and then submits the form.
 
 ## Recovery following crashes or disconnects
 


### PR DESCRIPTION
Once the action is submitted, the current LiveView
terminates, which would be detected as a crash by
the client which would then try to reconnect.
If reconnecting failed (for example, because the
page is a single use token), the form submission
would be cancelled without concluding.

This commit addresses this by always disconnecting
before triggering the action. The current behaviour
can still be achieved with hooks in forms with custom
JS (which already require hooks anyway).