### PR TITLE
Bugfix: External Redirects

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -458,6 +458,16 @@ defmodule Phoenix.LiveView.Channel do
     root_pid = new_socket.root_pid
 
     case result do
+      {:redirect, %{external: to} = opts} ->
+        opts =
+          copy_flash(new_state, flash, opts)
+          |> Map.delete(:external)
+          |> Map.put(:to, to)
+
+        new_state
+        |> push_redirect(opts, ref)
+        |> stop_shutdown_redirect(:redirect, opts)
+
       {:redirect, %{to: _to} = opts} ->
         opts = copy_flash(new_state, flash, opts)
 
@@ -516,11 +526,6 @@ defmodule Phoenix.LiveView.Channel do
 
   defp push_redirect(state, opts, nil = _ref) do
     push(state, "redirect", opts)
-  end
-
-  defp push_redirect(state, %{external: to} = opts, ref) do
-    opts = Map.delete(opts, :external) |> Map.put(:to, to)
-    reply(state, ref, :ok, %{redirect: opts})
   end
 
   defp push_redirect(state, opts, ref) do

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -518,6 +518,11 @@ defmodule Phoenix.LiveView.Channel do
     push(state, "redirect", opts)
   end
 
+  defp push_redirect(state, %{external: to} = opts, ref) do
+    opts = Map.delete(opts, :external) |> Map.put(:to, to)
+    reply(state, ref, :ok, %{redirect: opts})
+  end
+
   defp push_redirect(state, opts, ref) do
     reply(state, ref, :ok, %{redirect: opts})
   end


### PR DESCRIPTION
#1122 Fixed external redirects during the `mount` phase, but seems to have broken them during the rest of the live_view lifecycle.

To recreate this issue, create a new phoenix app with version 1.5.5, passing the `--live` option, and see that on localhost:4000, external redirects to the dependency hex docs do not work

I resolved this issue by adding a function head for `push_redirect` to change the `external` key to `to`

Alternatively, a case clause could have been added to `handle_redirect/5` at channel.ex:456, but this would have required additional duplicated code.

I was unable to find a sane place to add a test for this, as there is no channel_test.exs file... Happy to add one if someone can point me in the right direction.