### PR TITLE
Fix handle_params callback link in doc

### DIFF
--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -13,7 +13,8 @@ defmodule Phoenix.LiveView.Helpers do
   @doc """
   Generates a link that will patch the current LiveView.
 
-  When navigating to the current LiveView, `c:handle_params/3` is
+  When navigating to the current LiveView,
+  [`handle_params/3`](`c:Phoenix.LiveView.handle_params/3`) is
   immediately invoked to handle the change of params and URL state.
   Then the new state is pushed to the client, without reloading the
   whole page while also maintaining the current scroll position.

--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -14,7 +14,7 @@ defmodule Phoenix.LiveView.Helpers do
   Generates a link that will patch the current LiveView.
 
   When navigating to the current LiveView,
-  [`handle_params/3`](`c:Phoenix.LiveView.handle_params/3`) is
+  `c:Phoenix.LiveView.handle_params/3` is
   immediately invoked to handle the change of params and URL state.
   Then the new state is pushed to the client, without reloading the
   whole page while also maintaining the current scroll position.


### PR DESCRIPTION
Just a tiny fix for a broken link, see the doc for https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.Helpers.html#live_patch/2

Disclaimer - I could not figure out how to generate the docs, sorry, I'm very much new to these repos... So this is a "blind" fix but maybe someone could let me know how to generate the docs? Or confirm/fix my change directly if needed, thank you! 🙇 

![image](https://user-images.githubusercontent.com/11039634/94012328-99ebea80-fde3-11ea-904a-c4b13125ebfd.png)
