### PR TITLE
assign_new/3 that can check/update multiple keys

### DIFF
--- a/test/phoenix_live_view_test.exs
+++ b/test/phoenix_live_view_test.exs
@@ -234,6 +234,35 @@ defmodule Phoenix.LiveViewUnitTest do
                flash: %{}
              }
     end
+
+    test "can accept a list of keys; if any do not exist, then the function is called (it should return a map or keyword list which can be merged into existing assigns)" do
+      socket =
+        @socket
+        |> assign(existing: "existing", existing2: "existing2", existing3: "existing3")
+        # no-op
+        |> assign_new([:existing], fn -> [existing: "updated-existing"] end)
+        # changes :existing2, adds notexisting
+        |> assign_new([:existing2, :notexisting], fn ->
+          %{existing2: "changed-existing2", notexisting: "new-notexisting"}
+        end)
+        # adds :notexisting
+        |> assign_new([:notexisting2], fn -> %{notexisting2: "new-notexisting2"} end)
+        # no-op
+        |> assign_new([:existing, :existing2, :existing3, :notexisting], fn ->
+          [existing: nil]
+        end)
+
+      assert socket.assigns == %{
+               existing: "existing",
+               existing2: "changed-existing2",
+               existing3: "existing3",
+               notexisting: "new-notexisting",
+               notexisting2: "new-notexisting2",
+               live_module: Phoenix.LiveViewTest.ParamCounterLive,
+               live_action: nil,
+               flash: %{}
+             }
+    end
   end
 
   describe "redirect/2" do


### PR DESCRIPTION
This is related to #1158, I wanted to see if I could implement an `assign_new/2` that can update multiple assigns using one function that returns a map or keyword list.

But of course that is not possible, because you could not possibly know in advance which keys the function would return without calling the function.

So instead, I created a version of `assign_new/3` that takes a list of atoms as the second argument instead of a single atom. The function must then return either a keyword list or a map.

Examples:
```elixir
@socket
|> assign(existing: "existing", existing2: "existing2", existing3: "existing3")
# no-op
|> assign_new([:existing], fn -> [existing: "updated-existing"] end)
# changes :existing2 (should it?), adds notexisting
|> assign_new([:existing2, :notexisting], fn ->
%{existing2: "changed-existing2", notexisting: "new-notexisting"}
end)
# adds :notexisting4 (should it?)
|> assign_new([:notexisting3], fn -> %{notexisting4: "new-notexisting4"} end)
```

Two design questions came up (as seen in the examples above):
  1. Should it should update existing keys if the function is called (because a different key didn't exist)
  2. Should it add keys present in the function result that were not specified in the test condition?

In the current implementation, I answered Yes to both.

Note that this is my first time digging into the live view code and I'm also still fairly new to Elixir. If the patch doesn't look good, adds too much complexity, or doesn't seem helpful, ok to close. :-)