### PR TITLE
Replace mount_url with Plug.Conn.request_url

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -282,7 +282,7 @@ defmodule Phoenix.LiveViewTest do
       live_module: live_module,
       endpoint: endpoint,
       session: maybe_get_session(conn),
-      url: mount_url(endpoint, path),
+      url: Plug.Conn.request_url(conn),
       test_supervisor: fetch_test_supervisor!()
     }
 
@@ -352,10 +352,6 @@ defmodule Phoenix.LiveViewTest do
       _ -> %{}
     end
   end
-
-  defp mount_url(_endpoint, nil), do: nil
-  defp mount_url(endpoint, "/"), do: endpoint.url()
-  defp mount_url(endpoint, path), do: Path.join(endpoint.url(), path)
 
   defp rebuild_path(%Plug.Conn{request_path: request_path, query_string: ""}),
     do: request_path

--- a/test/phoenix_live_view/integrations/flash_test.exs
+++ b/test/phoenix_live_view/integrations/flash_test.exs
@@ -10,7 +10,7 @@ defmodule Phoenix.LiveView.FlashIntegrationTest do
 
   setup do
     conn =
-      Phoenix.ConnTest.build_conn()
+      Phoenix.ConnTest.build_conn(:get, "http://www.example.com/", nil)
       |> Phoenix.ConnTest.bypass_through(Router, [:browser])
       |> get("/")
 
@@ -133,7 +133,7 @@ defmodule Phoenix.LiveView.FlashIntegrationTest do
       result =
         render_click(flash_live, "push_patch", %{"to" => "/flash-root?foo", "info" => "ok!"})
 
-      assert result =~ "uri[http://localhost:4000/flash-root?foo]"
+      assert result =~ "uri[http://www.example.com/flash-root?foo]"
       assert result =~ "root[ok!]:info"
 
       assert assert_patch(flash_live, "/flash-root?foo") == :ok
@@ -147,7 +147,7 @@ defmodule Phoenix.LiveView.FlashIntegrationTest do
       result =
         render_click(flash_live, "push_patch", %{"to" => "/flash-root?foo", "info" => "ok!"})
 
-      assert result =~ "uri[http://localhost:4000/flash-root?foo]"
+      assert result =~ "uri[http://www.example.com/flash-root?foo]"
       assert result =~ "root[ok!]:info"
       assert result =~ "root[]:error"
 
@@ -199,7 +199,7 @@ defmodule Phoenix.LiveView.FlashIntegrationTest do
       render_click(flash_child, "push_patch", %{"to" => "/flash-root?patch", "info" => "ok!"})
 
       result = render(flash_live)
-      assert result =~ "uri[http://localhost:4000/flash-root?patch]"
+      assert result =~ "uri[http://www.example.com/flash-root?patch]"
       assert result =~ "root[ok!]"
     end
 
@@ -293,7 +293,7 @@ defmodule Phoenix.LiveView.FlashIntegrationTest do
       })
 
       result = render(flash_live)
-      assert result =~ "uri[http://localhost:4000/flash-root?patch]"
+      assert result =~ "uri[http://www.example.com/flash-root?patch]"
       assert result =~ "root[ok!]"
     end
   end
@@ -329,7 +329,7 @@ defmodule Phoenix.LiveView.FlashIntegrationTest do
     result =
       render_click(flash_live, "push_patch", %{"to" => "/flash-root?patch", "info" => "ok!"})
 
-    assert result =~ "uri[http://localhost:4000/flash-root?patch]"
+    assert result =~ "uri[http://www.example.com/flash-root?patch]"
     assert result =~ "root[ok!]:info"
 
     result = render_click(flash_live, "lv:clear-flash", %{key: "info"})
@@ -338,7 +338,7 @@ defmodule Phoenix.LiveView.FlashIntegrationTest do
     result =
       render_click(flash_live, "push_patch", %{"to" => "/flash-root?patch", "info" => "ok!"})
 
-    assert result =~ "uri[http://localhost:4000/flash-root?patch]"
+    assert result =~ "uri[http://www.example.com/flash-root?patch]"
     assert result =~ "root[ok!]:info"
 
     result = render_click(flash_live, "lv:clear-flash")

--- a/test/phoenix_live_view/integrations/params_test.exs
+++ b/test/phoenix_live_view/integrations/params_test.exs
@@ -13,7 +13,7 @@ defmodule Phoenix.LiveView.ParamsTest do
 
   setup do
     conn =
-      Phoenix.ConnTest.build_conn()
+      Phoenix.ConnTest.build_conn(:get, "http://www.example.com/", nil)
       |> Plug.Test.init_test_session(%{})
       |> put_session(:test_pid, self())
 
@@ -155,13 +155,13 @@ defmodule Phoenix.LiveView.ParamsTest do
                       %{socket: %{connected?: true}} = metadata}
 
       assert metadata.params == %{"id" => "123", "foo" => "bar"}
-      assert metadata.uri == "http://localhost:4000/counter/123?foo=bar"
+      assert metadata.uri == "http://www.example.com/counter/123?foo=bar"
 
       assert_receive {:event, [:phoenix, :live_view, :handle_params, :stop], %{duration: _},
                       %{socket: %{connected?: true}}}
 
       assert metadata.params == %{"id" => "123", "foo" => "bar"}
-      assert metadata.uri == "http://localhost:4000/counter/123?foo=bar"
+      assert metadata.uri == "http://www.example.com/counter/123?foo=bar"
     end
 
     test "telemetry events are emitted on exception", %{conn: conn} do
@@ -309,7 +309,7 @@ defmodule Phoenix.LiveView.ParamsTest do
       assert html =~ escape(~s|%{"from" => "rehandled_params", "id" => "123"}|)
       assert html =~ "The value is: 1000"
 
-      assert_receive {:handle_params, "http://localhost:4000/counter/123?from=rehandled_params",
+      assert_receive {:handle_params, "http://www.example.com/counter/123?from=rehandled_params",
                       %{val: 1}, %{"from" => "rehandled_params", "id" => "123"}}
     end
   end
@@ -338,7 +338,7 @@ defmodule Phoenix.LiveView.ParamsTest do
 
       :ok = GenServer.call(counter_live.pid, {:push_patch, next})
 
-      assert_receive {:handle_params, "http://localhost:4000/counter/123?from=handle_params",
+      assert_receive {:handle_params, "http://www.example.com/counter/123?from=handle_params",
                       %{val: 1}, %{"from" => "handle_params", "id" => "123"}}
     end
 


### PR DESCRIPTION
This still breaks one test for me locally (test/phoenix_live_view/integrations/live_view_test.exs:296), but I'm not really sure why it wasn't breaking for the same reason previously.

Closes #1161 