### PR TITLE
Allow assert_push_event/3 tests for mount/3

### DIFF
--- a/test/phoenix_live_view/integrations/event_test.exs
+++ b/test/phoenix_live_view/integrations/event_test.exs
@@ -50,6 +50,13 @@ defmodule Phoenix.LiveView.EventTest do
       assert_push_event(view, "my-event", %{two: 2})
       assert render(view) =~ "count: 0"
     end
+
+    test "sends updates in root and child mounts", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/events-in-mount")
+
+      assert_push_event(view, "root-mount", %{root: "foo"})
+      assert_push_event(view, "child-mount", %{child: "bar"})
+    end
   end
 
   describe "replies" do

--- a/test/support/live_views/events.ex
+++ b/test/support/live_views/events.ex
@@ -23,3 +23,37 @@ defmodule Phoenix.LiveViewTest.EventsLive do
 
   def handle_info({:run, func}, socket), do: func.(socket)
 end
+
+defmodule Phoenix.LiveViewTest.EventsInMountLive.Root do
+  use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
+
+  def render(assigns) do
+    ~L"<%= live_render @socket, Phoenix.LiveViewTest.EventsInMountLive.Child, id: :child_live %>"
+  end
+
+  def mount(_params, _session, socket) do
+    socket =
+      if connected?(socket),
+        do: push_event(socket, "root-mount", %{root: "foo"}),
+        else: socket
+
+    {:ok, socket}
+  end
+end
+
+defmodule Phoenix.LiveViewTest.EventsInMountLive.Child do
+  use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
+
+  def render(assigns) do
+    ~L"hello!"
+  end
+
+  def mount(_params, _session, socket) do
+    socket =
+      if connected?(socket),
+        do: push_event(socket, "child-mount", %{child: "bar"}),
+        else: socket
+
+    {:ok, socket}
+  end
+end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -84,6 +84,7 @@ defmodule Phoenix.LiveViewTest.Router do
 
     # integration events
     live "/events", EventsLive
+    live "/events-in-mount", EventsInMountLive.Root
 
     # integration components
     live "/component_in_live", ComponentInLive.Root


### PR DESCRIPTION
This pull requests intends to allow the use of `assert_push_event/3` to test events pushed during `mount/3`

Given the following `mount/3` implementation
```elixir
@impl true
def mount(_params, _session, socket) do
  socket =
    if connected?(socket),
      do: push_event(socket, "test", %{"foo" => "bar"}),
      else: socket
  {:ok, socket}
end
```

Right now we are not able to successfully run the following test:
```elixir
test "event in mount", %{conn: conn} do
  {:ok, page_live, _disconnected_html} = live(conn, "/")

  assert_push_event(page_live, "test", %{"foo" => "bar"}, 2_000)
end
```