### PR TITLE
Implement phx-remove

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1405,7 +1405,7 @@ class DOMPatch {
   }
 
   markPrunableContentForRemoval(){
-    DOM.all(this.container, `[phx-update=append] > *, [phx-update=prepend] > *`, el => {
+    DOM.all(this.container, `[${this.binding(PHX_UPDATE)}=append] > *, [${this.binding(PHX_UPDATE)}=prepend] > *`, el => {
       el.setAttribute(PHX_REMOVE, "")
     })
   }

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -24,7 +24,6 @@ const PHX_TRACK_STATIC = "track-static"
 const PHX_LINK_STATE = "data-phx-link-state"
 const PHX_REF = "data-phx-ref"
 const PHX_SKIP = "data-phx-skip"
-const PHX_REMOVE = "data-phx-remove"
 const PHX_PAGE_LOADING = "page-loading"
 const PHX_CONNECTED_CLASS = "phx-connected"
 const PHX_DISCONNECTED_CLASS = "phx-disconnected"
@@ -50,6 +49,7 @@ const PHX_HOOK = "hook"
 const PHX_DEBOUNCE = "debounce"
 const PHX_THROTTLE = "throttle"
 const PHX_UPDATE = "update"
+const PHX_REMOVE = "remove"
 const PHX_KEY = "key"
 const PHX_PRIVATE = "phxPrivate"
 const PHX_AUTO_RECOVER = "auto-recover"
@@ -1406,7 +1406,7 @@ class DOMPatch {
 
   markPrunableContentForRemoval(){
     DOM.all(this.container, `[${this.binding(PHX_UPDATE)}=append] > *, [${this.binding(PHX_UPDATE)}=prepend] > *`, el => {
-      el.setAttribute(PHX_REMOVE, "")
+      el.setAttribute(this.binding(PHX_REMOVE), "")
     })
   }
 
@@ -1458,7 +1458,7 @@ class DOMPatch {
           this.trackAfter("discarded", el)
         },
         onBeforeNodeDiscarded: (el) => {
-          if(el.getAttribute && el.getAttribute(PHX_REMOVE) !== null){ return true }
+          if(el.getAttribute && el.getAttribute(this.binding(PHX_REMOVE)) !== null){ return true }
           if(el.parentNode !== null && DOM.isPhxUpdate(el.parentNode, this.binding(PHX_UPDATE), ["append", "prepend"]) && el.id){ return false }
           if(this.skipCIDSibling(el)){ return false }
           this.trackBefore("discarded", el)

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1426,7 +1426,7 @@ class DOMPatch {
     let appendPrependUpdates = []
 
     let diffHTML = liveSocket.time("premorph container prep", () => {
-      return this.buildDiffHTML(container, html, phxUpdate, targetContainer)
+      return this.buildDiffHTML(container, html, targetContainer)
     })
 
     this.trackBefore("added", container)
@@ -1459,7 +1459,7 @@ class DOMPatch {
         },
         onBeforeNodeDiscarded: (el) => {
           if(el.getAttribute && el.getAttribute(PHX_REMOVE) !== null){ return true }
-          if(el.parentNode !== null && DOM.isPhxUpdate(el.parentNode, phxUpdate, ["append", "prepend"]) && el.id){ return false }
+          if(el.parentNode !== null && DOM.isPhxUpdate(el.parentNode, this.binding(PHX_UPDATE), ["append", "prepend"]) && el.id){ return false }
           if(this.skipCIDSibling(el)){ return false }
           this.trackBefore("discarded", el)
           return true
@@ -1472,9 +1472,9 @@ class DOMPatch {
           updates.push(el)
         },
         onBeforeElUpdated: (fromEl, toEl) => {
-          DOM.cleanChildNodes(toEl, phxUpdate)
+          DOM.cleanChildNodes(toEl, this.binding(PHX_UPDATE))
           if(this.skipCIDSibling(toEl)){ return false }
-          if(fromEl.getAttribute(phxUpdate) === "ignore"){
+          if(fromEl.getAttribute(this.binding(PHX_UPDATE)) === "ignore"){
             this.trackBefore("updated", fromEl, toEl)
             DOM.mergeAttrs(fromEl, toEl)
             updates.push(fromEl)
@@ -1556,7 +1556,7 @@ class DOMPatch {
   // - for patches of a component with multiple root nodes, the
   //   parent node becomes the target container and non-component
   //   siblings are marked as skip.
-  buildDiffHTML(container, html, phxUpdate, targetContainer){
+  buildDiffHTML(container, html, targetContainer){
     let isCIDPatch = this.isCIDPatch()
     let isCIDWithSingleRoot = isCIDPatch && targetContainer.getAttribute(PHX_COMPONENT) === this.targetCID.toString()
     if(!isCIDPatch || isCIDWithSingleRoot){
@@ -1581,6 +1581,8 @@ class DOMPatch {
       return diffContainer.outerHTML
     }
   }
+
+  binding(kind){ return this.liveSocket.binding(kind)}
 }
 
 export class View {

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -490,6 +490,122 @@ describe("View + DOM", function() {
       )
       expect(childIds()).toEqual([1])
     })
+
+    describe("phx-remove", () => {
+      test("removing an already-present child element works", async () => {
+        let view = createView({
+          "0": {"d": [["1","", "1"], ["2", "","2"], ["3", "", "3"]], "s": [`\n<div id="`,`"`, `>`, `</div>\n`]},
+          "s": [`<div id="list" phx-update="append">`, `</div>`]
+        })
+        expect(childIds()).toEqual([1, 2, 3])
+
+        updateDynamics(view,
+          [["2", "phx-remove", "div contents are ignored"]]
+        )
+        expect(childIds()).toEqual([1,3])
+      })
+
+      test("doesn't error when removing from an empty state", async() => {
+        let view = createView({
+          "0": {"d": [], "s": [`\n<div id="`,`"`, `>`, `</div>\n`]},
+          "s": [`<div id="list" phx-update="append">`, `</div>`]
+        })
+        expect(childIds()).toEqual([])
+
+        updateDynamics(view,
+          [["1", "phx-remove", "div contents are ignored"]]
+        )
+        expect(childIds()).toEqual([])
+      })
+
+      test("remove an already-present child element when it is the only child works", async () => {
+        let view = createView({
+          "0": {"d": [["1","", "1"]], "s": [`\n<div id="`,`"`, `>`, `</div>\n`]},
+          "s": [`<div id="list" phx-update="append">`, `</div>`]
+        })
+        expect(childIds()).toEqual([1])
+
+        updateDynamics(view,
+          [["1", "phx-remove", "div contents are ignored"]]
+        )
+        expect(childIds()).toEqual([])
+      })
+
+      test("remove an already-present child element that itself has children", async() => {
+        let view = createView({
+          "0": {
+            "d": [["1", "", `<div id="1-child">hi</div>`]],
+            "s": [`\n<div id="`,`"`, `>`, `</div>\n`]
+          },
+          "s": [`<div id="list" phx-update="append">`, `</div>`]
+        })
+        expect(childIds()).toEqual([1])
+        expect(document.getElementById("1-child")).toBeDefined()
+
+        updateDynamics(view,
+          [["1", "phx-remove", "lalala"]]
+        )
+
+        expect(childIds()).toEqual([])
+        expect(document.getElementById("1-child")).toBeNull();
+      })
+
+      test("remove something that doesn't exist", async () => {
+        let view = createView({
+          "0": {"d": [["1","", "1"]], "s": [`\n<div id="`,`"`, `>`, `</div>\n`]},
+          "s": [`<div id="list" phx-update="append">`, `</div>`]
+        })
+        expect(childIds()).toEqual([1])
+
+        updateDynamics(view,
+          [["7", "phx-remove", "div contents are ignored"]]
+        )
+
+        expect(childIds()).toEqual([1])
+      })
+
+      test("add and remove at the same time", async () => {
+        let view = createView({
+          "0": {"d": [["1", "", "1"]], "s": [`\n<div id="`,`"`, `>`, `</div>\n`]},
+          "s": [`<div id="list" phx-update="append">`, `</div>`]
+        })
+        expect(childIds()).toEqual([1])
+
+        updateDynamics(view,
+          [["1", "phx-remove", "div contents are ignored"], ["2", "", "hello"]]
+        )
+
+        expect(childIds()).toEqual([2])
+      })
+
+      test("modify last element and remove at the same time", async () => {
+        let view = createView({
+          "0": {"d": [["1", "", "1"], ["2", "", "2"], ["3", "", "3"]], "s": [`\n<div id="`,`"`, `>`, `</div>\n`]},
+          "s": [`<div id="list" phx-update="append">`, `</div>`]
+        })
+        expect(childIds()).toEqual([1, 2, 3])
+
+        updateDynamics(view,
+          [["2", "phx-remove", "div contents are ignored"], ["3", "", "hello"]]
+        )
+
+        expect(childIds()).toEqual([1, 3])
+      })
+
+      test("modify first element and remove at the same time", async () => {
+        let view = createView({
+          "0": {"d": [["1", "", "1"], ["2", "", "2"], ["3", "", "3"]], "s": [`\n<div id="`,`"`, `>`, `</div>\n`]},
+          "s": [`<div id="list" phx-update="append">`, `</div>`]
+        })
+        expect(childIds()).toEqual([1, 2, 3])
+
+        updateDynamics(view,
+          [["2", "phx-remove", "div contents are ignored"], ["1", "", "hello"]]
+        )
+
+        expect(childIds()).toEqual([1, 3])
+      })
+    })
   })
 })
 

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -308,17 +308,12 @@ describe("View + DOM", function() {
     let childIds = () => Array.from(document.getElementById("list").children).map(child => parseInt(child.id))
     let countChildNodes = () => document.getElementById("list").childNodes.length
 
-    let createView = (updateType, initialDynamics) => {
+    let createView = (joinDiff) => {
       let liveSocket = new LiveSocket("/live", Socket)
       let el = liveViewDOM()
       let view = new View(el, liveSocket)
 
       stubChannel(view)
-
-      let joinDiff = {
-        "0": {"d": initialDynamics, "s": [`\n<div id="`, `">`, `</div>\n`]},
-        "s": [`<div id="list" phx-update="${updateType}">`, `</div>`]
-      }
 
       view.onJoin({rendered: joinDiff})
 
@@ -336,7 +331,10 @@ describe("View + DOM", function() {
     }
 
     test("replace", async () => {
-      let view = createView("replace", [["1", "1"]])
+      let view = createView({
+          "0": {"d": [["1", "1"]], "s": [`\n<div id="`, `">`, `</div>\n`]},
+          "s": [`<div id="list" phx-update="replace">`, `</div>`]
+        })
       expect(childIds()).toEqual([1])
 
       updateDynamics(view,
@@ -346,7 +344,10 @@ describe("View + DOM", function() {
     })
 
     test("append", async () => {
-      let view = createView("append", [["1", "1"]])
+      let view = createView({
+        "0": {"d": [["1", "1"]], "s": [`\n<div id="`, `">`, `</div>\n`]},
+        "s": [`<div id="list" phx-update="append">`, `</div>`]
+      })
       expect(childIds()).toEqual([1])
 
       // Append two elements
@@ -410,7 +411,10 @@ describe("View + DOM", function() {
     })
 
     test("prepend", async () => {
-      let view = createView("prepend", [["1", "1"]])
+      let view = createView({
+        "0": {"d": [["1", "1"]], "s": [`\n<div id="`, `">`, `</div>\n`]},
+        "s": [`<div id="list" phx-update="prepend">`, `</div>`]
+      })
       expect(childIds()).toEqual([1])
 
       // Append two elements
@@ -474,7 +478,10 @@ describe("View + DOM", function() {
     })
 
     test("ignore", async () => {
-      let view = createView("ignore", [["1", "1"]])
+      let view = createView({
+        "0": {"d": [["1", "1"]], "s": [`\n<div id="`, `">`, `</div>\n`]},
+        "s": [`<div id="list" phx-update="ignore">`, `</div>`]
+      })
       expect(childIds()).toEqual([1])
 
       // Append two elements

--- a/guides/client/dom-patching.md
+++ b/guides/client/dom-patching.md
@@ -78,3 +78,41 @@ to the container as well as to each child:
 
 When the client receives new messages, it now knows to append to the
 old content rather than replace it.
+
+### Removing an element
+
+Elements can be removed from the container by setting the `phx-remove`
+attribute on the elements to be removed. This is only supported when
+the update type is `append` or `prepend`.
+
+Suppose that a user can delete a message.
+
+  def handle_event("delete_message", %{"message_id" => message_id}, socket) do
+    {:noreply, assign(socket, :deleted_message_id, message_id)}
+  end
+
+Our template now becomes:
+
+  <div id="chat-messages" phx-update="append">
+    <%= if @deleted_message_id do %>
+      <p id="<%= @deleted_message_id %>" phx-remove></div>
+    <% else %>
+      <%= for message <- @messages do %>
+        <p id="<%= message.id %>">
+          <span><%= message.username %>:</span> <%= message.text %>
+        </p>
+      <% end %>
+    <% end %>
+  </div>
+
+We also need to initialize the `deleted_message_id` as a temporary assign, so
+our mount function is now:
+
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(socket, :messages, load_last_20_messages())
+     |> assign(:deleted_message_id, nil),
+     temporary_assigns: [messages: [], deleted_message_id: nil]
+    }
+  end


### PR DESCRIPTION
This supersedes #1087.

We've encountered a bug dealing with multiple elixir comprehensions in a single html element which we've opened as #1169, but would like to investigate separately.

We've documented how to use this in https://github.com/phoenixframework/phoenix_live_view/compare/master...cthulahoops:add-phx-remove-nicer?expand=1#diff-05a7adb031599b219ecf32e8e75b6ba4