### PR TITLE
Fix textarea being patched by LV while focused

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1535,7 +1535,7 @@ class DOMPatch {
   }
 
   forceFocusedSelectUpdate(fromEl, toEl){
-    return fromEl.multiple === true || fromEl.innerHTML != toEl.innerHTML
+    return fromEl.multiple === true || (fromEl.type === "select" && fromEl.innerHTML != toEl.innerHTML)
   }
 
   isCIDPatch(){ return this.cidPatch }


### PR DESCRIPTION
Fix https://github.com/phoenixframework/phoenix_live_view/issues/1139

This commit fix the issue so that textarea has been patched even though is focused.

### Before
![2020-10-01 21 27 06](https://user-images.githubusercontent.com/27698968/94848615-eb702700-042c-11eb-8d09-68097d7095d7.gif)


### After
![2020-10-01 21 01 02](https://user-images.githubusercontent.com/27698968/94846142-5455a000-0429-11eb-9023-bc86bb514085.gif)