### PR TITLE
Ensure the signing salt is a binary of sufficient length

### DIFF
--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -240,7 +240,7 @@ defmodule Phoenix.LiveView.Utils do
   def salt!(endpoint) when is_atom(endpoint) do
     salt = endpoint.config(:live_view)[:signing_salt]
 
-    if is_binary(salt) and byte_size(salt) >= 16 do
+    if is_binary(salt) and byte_size(salt) >= 8 do
       salt
     else
       raise ArgumentError, """

--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -238,17 +238,23 @@ defmodule Phoenix.LiveView.Utils do
   Returns the configured signing salt for the endpoint.
   """
   def salt!(endpoint) when is_atom(endpoint) do
-    endpoint.config(:live_view)[:signing_salt] ||
-      raise ArgumentError, """
-      no signing salt found for #{inspect(endpoint)}.
+    salt = endpoint.config(:live_view)[:signing_salt]
 
-      Add the following LiveView configuration to your config/config.exs:
+    if is_binary(salt) and byte_size(salt) >= 16 do
+      salt
+    else
+      raise ArgumentError, """
+      the signing salt for #{inspect(endpoint)} is missing or too short.
+
+      Add the following LiveView configuration to your config/runtime.exs
+      or config/config.exs:
 
           config :my_app, MyAppWeb.Endpoint,
               ...,
               live_view: [signing_salt: "#{random_encoded_bytes()}"]
 
       """
+    end
   end
 
   @doc """


### PR DESCRIPTION
The signing salt should not only be present, but be a binary of
sufficient length.

I have seen a case where, due to a mistake in the build pipeline
setup, the value was a blank string.