### PR TITLE
Do not recover forms on first join

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -2778,7 +2778,7 @@ export class View {
   }
 
   formsForRecovery(html){
-    if(this.joinCount === 0){ return [] }
+    if(this.joinCount <= 1){ return [] }
 
     let phxChange = this.binding("change")
     let template = document.createElement("template")

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -237,19 +237,25 @@ describe("View + DOM", function() {
     view = new View(liveViewDOM(html), liveSocket)
     expect(view.formsForRecovery(html).length).toBe(0)
 
-    view.joinCount = 1
+    view.joinCount++
+    expect(view.formsForRecovery(html).length).toBe(0)
+
+    view.joinCount++
     expect(view.formsForRecovery(html).length).toBe(1)
 
     html = `<form phx-change="cg" phx-auto-recover="ignore"><input name="foo"></form>`
     view = new View(liveViewDOM(html), liveSocket)
+    view.joinCount = 2
     expect(view.formsForRecovery().length).toBe(0)
 
     html = `<form><input name="foo"></form>`
     view = new View(liveViewDOM(html), liveSocket)
+    view.joinCount = 2
     expect(view.formsForRecovery().length).toBe(0)
 
     html = `<form phx-change="cg"></form>`
     view = new View(liveViewDOM(html), liveSocket)
+    view.joinCount = 2
     expect(view.formsForRecovery().length).toBe(0)
   })
 


### PR DESCRIPTION
Fixes a tiny regression in 0904444e that prevents a LiveView with a form from completing the initial join.