### PR TITLE
Implement `reset_assigns` to fix issues with temporary assigns.

### DIFF
--- a/guides/client/dom-patching.md
+++ b/guides/client/dom-patching.md
@@ -96,11 +96,10 @@ Imagine you want to show an error message when the input is less than
     ~L"""
     <%= if @too_short do %>
       Input too short...
-    <% else %>
-      Searched for: <%= @search %>
-    % end %>
+    <% end %>
+    Searched for: <%= @search %>
 
-    <form><input phx-change="search" name="term" /></form>
+    <form phx-change="search"><input name="term" /></form>
     """
   end
 

--- a/guides/client/dom-patching.md
+++ b/guides/client/dom-patching.md
@@ -134,3 +134,7 @@ after the input has 3 or more characters.
 The mistake here is using `:temporary_assigns` to reset or control
 UI state, while `:temporary_assigns` should rather be used when we
 don't have (or don't want to keep) certain data around.
+
+This example can be made to work by using `:reset_assigns` instead
+of `:temporary_assigns`. This works like `:temporary_assigns` but
+the reset is rendered, so it can be used to control UI state.

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -666,7 +666,19 @@ defmodule Phoenix.LiveView.Channel do
       end
 
     diff = Diff.render_private(socket, diff)
-    {:diff, diff, %{state | socket: Utils.clear_changed(socket), components: components}}
+
+    socket =
+      socket
+      |> Utils.clear_changed()
+      |> Utils.apply_temporary_assigns()
+      |> Utils.apply_reset_assigns()
+
+    {:diff, diff,
+     %{
+       state
+       | socket: socket,
+         components: components
+     }}
   end
 
   defp reply(state, ref, status, payload) do

--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -560,7 +560,13 @@ defmodule Phoenix.LiveView.Diff do
           traverse(socket, rendered, prints, pending, components, changed?)
 
         diff = if linked_cid, do: Map.put(diff, @static, linked_cid), else: diff
-        socket = Utils.clear_changed(%{socket | fingerprints: component_prints})
+
+        socket =
+          %{socket | fingerprints: component_prints}
+          |> Utils.clear_changed()
+          |> Utils.apply_temporary_assigns()
+          |> Utils.apply_reset_assigns()
+
         {socket, pending, diff, components}
       else
         {socket, pending, %{}, components}

--- a/test/support/live_views/general.ex
+++ b/test/support/live_views/general.ex
@@ -194,17 +194,27 @@ defmodule Phoenix.LiveViewTest.ChildLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.OptsLive do
+defmodule Phoenix.LiveViewTest.AssignsLive do
   use Phoenix.LiveView
 
-  def render(assigns), do: ~L|<%= @description %>. <%= @canary %>|
+  def render(assigns), do: ~L|foo: <%= @foo %> / bar: <%= @bar %>|
 
   def mount(_params, %{"opts" => opts}, socket) do
-    {:ok, assign(socket, description: "long description", canary: "canary"), opts}
+    {:ok, assign(socket, foo: "foo", bar: "bar"), opts}
   end
 
-  def handle_call({:exec, func}, _from, socket) do
-    func.(socket)
+  def handle_call(:get_assigns, _from, socket) do
+    {:reply, socket.assigns, socket}
+  end
+
+  def handle_event("assign", %{"foo" => foo}, socket) do
+    socket = assign(socket, :foo, foo)
+    {:noreply, socket}
+  end
+
+  def handle_event("assign", %{"bar" => bar}, socket) do
+    socket = assign(socket, :bar, bar)
+    {:noreply, socket}
   end
 end
 

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -36,7 +36,7 @@ defmodule Phoenix.LiveViewTest.Router do
 
     live "/same-child", SameChildLive
     live "/root", RootLive
-    live "/opts", OptsLive
+    live "/assigns", AssignsLive
     live "/time-zones", AppendLive
     live "/shuffle", ShuffleLive
     live "/components", WithComponentLive


### PR DESCRIPTION
This PR addresses the conversation in https://github.com/phoenixframework/phoenix_live_view/issues/1169#issuecomment-707063093 it also fixes https://github.com/phoenixframework/phoenix_live_view/issues/1180 and makes the sample code in https://github.com/phoenixframework/phoenix_live_view/pull/1170 much cleaner.

We introduce a new mount option called `reset_assigns` which acts like `temporary_assigns` except the changes are rendered, so it can be used to control UI state.

The motivating example is the one added in https://github.com/phoenixframework/phoenix_live_view/commit/66e60ae3a428cf9338905989878c49121f3c65f5 .

```elixir
  def render(assigns) do
    ~L"""
    <%= if @too_short do %>
      Input too short...
    <% end %>
    Searched for: <%= @search %>

    <form phx-change="search"><input name="term" /></form>
    """
  end

  def mount(_params, _session, socket) do
    {:ok,
     assign(socket, too_short: false, search: ""),
     temporary_assigns: [too_short: false]}
  end

  def handle_event("search", %{"term" => term}, socket) do
    # do not search if user provides less then 3 chars
    if String.length(term) >= 3 do
      {:noreply, assign(socket, search: term)}
    else
      {:noreply, assign(socket, too_short: true, search: term)}
    end
  end
```

As the docs say

> However, once a temporary assign resets to its original value,
it won't be re-rendered, unless we explicitly assign it to something
else. This means that the LiveView will never re-render the
`if` block and we will continue to show "Input too short..." even
after the input has 3 or more characters.

Unlike `temporary_assigns`, `reset_assigns` uses `assign` when a value changes back to the default, so we will get updates in the render, and the above example will work as intended. `reset_assigns` also works correctly when using prepend/append and fixes the issue noted in #1169 .

We kept `temporary_assigns` for backwards compatibility, but it's hard to think of a use case where it's preferable to `reset_assigns`.

If you think this PR is a good start we will write documentation explaining reset assigns with the above example, and examples in prepend/append.

(co-authored by @janiceshiu @cthulahoops)

I'm not sure why some tests are failing, but it looks unrelated to this PR.