### PR TITLE
Fix syntax error in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -97,7 +97,7 @@ defmodule Phoenix.LiveView.MixProject do
         Phoenix.LiveViewTest.Element,
         Phoenix.LiveViewTest.Upload,
         Phoenix.LiveViewTest.View
-      ]
+      ],
       "Live EEx Engine": [
         Phoenix.LiveView.Engine,
         Phoenix.LiveView.Component,


### PR DESCRIPTION
This PR fix syntax error in mix.exs.

**Before**
```
> mix deps.get
** (SyntaxError) mix.exs:101:7: syntax error before: "Live EEx Engine"
    (elixir 1.11.2) lib/code.ex:1172: Code.compile_file/2
    (mix 1.11.2) lib/mix/cli.ex:42: Mix.CLI.load_mix_exs/0
    (mix 1.11.2) lib/mix/cli.ex:29: Mix.CLI.proceed/1
```

**After**
```
> mix deps.get
Resolving Hex dependencies...
Dependency resolution completed:
...
```
