### PR TITLE
Allow to specify pid for send_update/3 & send_update_after/4 

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1129,7 +1129,8 @@ defmodule Phoenix.LiveView do
   match the `:id` associated with the component) and the component must be
   mounted within the current LiveView.
 
-  If this call is executed asynchronously, the `pid` parameter has to be specified.
+  If this call is executed from a process which is not a LiveView
+  nor a LiveComponent, the `pid` parameter has to be specified.
 
   When the component receives the update, the optional
   [`preload/1`](`c:Phoenix.LiveComponent.preload/1`) callback is invoked, then

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -15,14 +15,14 @@ defmodule Phoenix.LiveView.Channel do
     GenServer.start_link(__MODULE__, from, opts)
   end
 
-  def send_update(module, id, assigns) do
-    send(self(), {@prefix, :send_update, {module, id, assigns}})
+  def send_update(pid \\ self(), module, id, assigns) do
+    send(pid, {@prefix, :send_update, {module, id, assigns}})
   end
 
-  def send_update_after(module, id, assigns, time_in_milliseconds)
+  def send_update_after(pid \\ self(), module, id, assigns, time_in_milliseconds)
       when is_integer(time_in_milliseconds) do
     Process.send_after(
-      self(),
+      pid,
       {@prefix, :send_update, {module, id, assigns}},
       time_in_milliseconds
     )

--- a/test/phoenix_live_view/integrations/components_test.exs
+++ b/test/phoenix_live_view/integrations/components_test.exs
@@ -265,6 +265,18 @@ defmodule Phoenix.LiveView.ComponentTest do
              ] = view |> element("#jose") |> render() |> DOM.parse()
     end
 
+    test "updates child from independent pid", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/components")
+
+      Phoenix.LiveView.send_update(view.pid, StatefulComponent, [id: "chris", name: "NEW-chris", from: self()])
+      Phoenix.LiveView.send_update_after(view.pid, StatefulComponent, [id: "jose", name: "NEW-jose", from: self()], 10)
+
+
+      assert_receive {:updated, %{id: "chris", name: "NEW-chris"}}
+      assert_receive {:updated, %{id: "jose", name: "NEW-jose"}}
+      refute_receive {:updated, _}
+    end
+
     test "updates without :id raise", %{conn: conn} do
       Process.flag(:trap_exit, true)
       {:ok, view, _html} = live(conn, "/components")

--- a/test/phoenix_live_view/integrations/components_test.exs
+++ b/test/phoenix_live_view/integrations/components_test.exs
@@ -270,8 +270,6 @@ defmodule Phoenix.LiveView.ComponentTest do
 
       Phoenix.LiveView.send_update(view.pid, StatefulComponent, [id: "chris", name: "NEW-chris", from: self()])
       Phoenix.LiveView.send_update_after(view.pid, StatefulComponent, [id: "jose", name: "NEW-jose", from: self()], 10)
-
-
       assert_receive {:updated, %{id: "chris", name: "NEW-chris"}}
       assert_receive {:updated, %{id: "jose", name: "NEW-jose"}}
       refute_receive {:updated, _}


### PR DESCRIPTION
Implementation of #1244 

I did not run the formatter since there was quite a few unformated files and I did not want to pollute the PR.