### PR TITLE
Add `phx-key` to list of bindings in docs

### DIFF
--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -18,7 +18,7 @@ callback, for example:
 | [Params](#click-events) | `phx-value-*` |
 | [Click Events](#click-events) | `phx-click`, `phx-capture-click` |
 | [Focus/Blur Events](#focus-and-blur-events) | `phx-blur`, `phx-focus`, `phx-window-blur`, `phx-window-focus` |
-| [Key Events](#key-events) | `phx-keydown`, `phx-keyup`, `phx-window-keydown`, `phx-window-keyup` |
+| [Key Events](#key-events) | `phx-keydown`, `phx-keyup`, `phx-window-keydown`, `phx-window-keyup`, `phx-key` |
 | [Form Events](form-bindings.md) | `phx-change`, `phx-submit`, `phx-feedback-for`, `phx-disable-with`, `phx-trigger-action`, `phx-auto-recover` |
 | [Rate Limiting](#rate-limiting-events-with-debounce-and-throttle) | `phx-debounce`, `phx-throttle` |
 | [DOM Patching](dom-patching.md) | `phx-update` |

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -277,7 +277,7 @@ defmodule Phoenix.LiveView do
   | [Params](bindings.md#click-events) | `phx-value-*` |
   | [Click Events](bindings.md#click-events) | `phx-click`, `phx-capture-click` |
   | [Focus/Blur Events](bindings.md#focus-and-blur-events) | `phx-blur`, `phx-focus`, `phx-window-blur`, `phx-window-focus` |
-  | [Key Events](bindings.md#key-events) | `phx-keydown`, `phx-keyup`, `phx-window-keydown`, `phx-window-keyup` |
+  | [Key Events](bindings.md#key-events) | `phx-keydown`, `phx-keyup`, `phx-window-keydown`, `phx-window-keyup`, `phx-key` |
   | [Form Events](form-bindings.md) | `phx-change`, `phx-submit`, `phx-feedback-for`, `phx-disable-with`, `phx-trigger-action`, `phx-auto-recover` |
   | [Rate Limiting](bindings.md#rate-limiting-events-with-debounce-and-throttle) | `phx-debounce`, `phx-throttle` |
   | [DOM Patching](dom-patching.md) | `phx-update` |


### PR DESCRIPTION
I noticed the documentation was missing `phx-key` in the list of key event bindings.