### PR TITLE
Add telemetry for missing LiveView callbacks

### DIFF
--- a/guides/server/telemetry.md
+++ b/guides/server/telemetry.md
@@ -144,6 +144,141 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
             event: String.t(),
             params: unsigned_params
           }
+  * `[:phoenix, :live_view, :handle_call, :start]` - Dispatched by a `Phoenix.LiveView`
+    immediately before [`handle_call/3`](`c:Phoenix.LiveView.handle_call/3`) is invoked.
+
+    * Measurement:
+
+          %{system_time: System.monotonic_time}
+
+    * Metadata:
+
+          %{
+            socket: Phoenix.LiveView.Socket.t,
+            message: term,
+            from: GenServer.from
+          }
+
+
+  * `[:phoenix, :live_view, :handle_call, :stop]` - Dispatched by a `Phoenix.LiveView`
+    when the [`handle_call/3`](`c:Phoenix.LiveView.handle_call/3`) callback completes successfully.
+
+    * Measurement:
+
+          %{duration: native_time}
+
+    * Metadata:
+
+         %{
+            socket: Phoenix.LiveView.Socket.t,
+            message: term,
+            from: GenServer.from
+          }
+
+  * `[:phoenix, :live_view, :handle_call, :exception]` - Dispatched by a `Phoenix.LiveView`
+    when an exception is raised in the [`handle_call/3`](`c:Phoenix.LiveView.handle_call/3`) callback.
+
+    * Measurement:
+
+          %{duration: native_time}
+
+    * Metadata:
+
+          %{
+            socket: Phoenix.LiveView.Socket.t,
+            kind: atom,
+            reason: term,
+            message: term,
+            from: GenServer.from
+          }
+
+  * `[:phoenix, :live_view, :handle_info, :start]` - Dispatched by a `Phoenix.LiveView`
+    immediately before [`handle_info/2`](`c:Phoenix.LiveView.handle_info/2`) is invoked.
+
+    * Measurement:
+
+          %{system_time: System.monotonic_time}
+
+    * Metadata:
+
+          %{
+            socket: Phoenix.LiveView.Socket.t,
+            message: term
+          }
+  
+  * `[:phoenix, :live_view, :handle_info, :stop` - Dispatched by a `Phoenix.LiveView`
+    when the [`handle_info/2`](`c:Phoenix.LiveView.handle_info/2`) callback completes successfully..
+
+    * Measurement:
+
+          %{system_time: System.monotonic_time}
+
+    * Metadata:
+
+          %{
+            socket: Phoenix.LiveView.Socket.t,
+            message: term
+          }
+
+  * `[:phoenix, :live_view, :handle_info, :exception]` - Dispatched by a `Phoenix.LiveView`
+    when an exception is raised in the [`handle_info/2`](`c:Phoenix.LiveView.handle_info/2`) callback.
+
+    * Measurement:
+
+          %{duration: native_time}
+
+    * Metadata:
+
+          %{
+            socket: Phoenix.LiveView.Socket.t,
+            kind: atom,
+            reason: term,
+            message: term
+          }
+
+  * `[:phoenix, :live_view, :handle_cast, :start]` - Dispatched by a `Phoenix.LiveView`
+    immediately before [`handle_cast/2`](`c:Phoenix.LiveView.handle_cast/2`) is invoked.
+
+    * Measurement:
+
+          %{system_time: System.monotonic_time}
+
+    * Metadata:
+
+          %{
+            socket: Phoenix.LiveView.Socket.t,
+            message: term
+          }
+  
+  * `[:phoenix, :live_view, :handle_cast, :stop` - Dispatched by a `Phoenix.LiveView`
+    when the [`handle_cast/2`](`c:Phoenix.LiveView.handle_cast/2`) callback completes successfully..
+
+    * Measurement:
+
+          %{system_time: System.monotonic_time}
+
+    * Metadata:
+
+          %{
+            socket: Phoenix.LiveView.Socket.t,
+            message: term
+          }
+
+  * `[:phoenix, :live_view, :handle_cast, :exception]` - Dispatched by a `Phoenix.LiveView`
+    when an exception is raised in the [`handle_cast/2`](`c:Phoenix.LiveView.handle_cast/2`) callback.
+
+    * Measurement:
+
+          %{duration: native_time}
+
+    * Metadata:
+
+          %{
+            socket: Phoenix.LiveView.Socket.t,
+            kind: atom,
+            reason: term,
+            message: term
+          }
 
   * `[:phoenix, :live_component, :handle_event, :start]` - Dispatched by a `Phoenix.LiveComponent`
     immediately before [`handle_event/3`](`c:Phoenix.LiveComponent.handle_event/3`) is invoked.

--- a/test/support/live_views/general.ex
+++ b/test/support/live_views/general.ex
@@ -59,9 +59,11 @@ defmodule Phoenix.LiveViewTest.ThermostatLive do
 
   def handle_event("dec", _, socket), do: {:noreply, update(socket, :val, &(&1 - 1))}
 
-  def handle_call({:set, var, val}, _, socket) do
-    {:reply, :ok, assign(socket, var, val)}
-  end
+  def handle_call({:set, var, val}, _, socket), do: {:reply, :ok, assign(socket, var, val)}
+
+  def handle_info({:set, var, val}, socket), do: {:noreply, assign(socket, var, val)}
+
+  def handle_cast({:set, var, val}, socket), do: {:noreply, assign(socket, var, val)}
 end
 
 defmodule Phoenix.LiveViewTest.ClockLive do
@@ -301,4 +303,7 @@ defmodule Phoenix.LiveViewTest.ErrorsLive do
   def handle_params(_params, _session, socket), do: {:noreply, socket}
 
   def handle_event("crash", _params, _socket), do: raise("boom handle_event")
+  def handle_call(:crash, _from, _socket), do: raise("boom handle_event")
+  def handle_info(:crash, _socket), do: raise("boom handle_info")
+  def handle_cast(:crash, _socket), do: raise("boom handle_cast")
 end


### PR DESCRIPTION
This adds telemetry spans for 
- `handle_call/3`,
- `handle_info/2`,
- `handle_cast/2`

inside of LiveViews

As future work, I think it would be great to have some telemetry around file uploads, but could use some guidance here: does it make sense to have the entire file upload be one big span or chunk it up into multiple telemetry events, e.g. emit an event as we progress?

cc @mcrumm :smile: 