### PR TITLE
Start LiveViewTest.UploadClient Supervised

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -981,18 +981,28 @@ defmodule Phoenix.LiveViewTest do
   end
 
   def __start_upload_client__(socket_builder, view, form_selector, name, entries, cid) do
-    {:ok, pid} =
-      UploadClient.start_link(
-        socket_builder: socket_builder,
-        test_supervisor: fetch_test_supervisor!(),
-        cid: cid
-      )
+    spec = %{
+      id: make_ref(),
+      start:
+        {UploadClient, :start_link,
+         [[socket_builder: socket_builder, cid: cid]]},
+      restart: :temporary
+    }
+
+    {:ok, pid} = Supervisor.start_child(fetch_test_supervisor!(), spec)
 
     Upload.new(pid, view, form_selector, name, entries, cid)
   end
 
   def __start_external_upload_client__(view, form_selector, name, entries, cid) do
-    {:ok, pid} = UploadClient.start_link(test_supervisor: fetch_test_supervisor!(), cid: cid)
+    spec = %{
+      id: make_ref(),
+      start:
+        {UploadClient, :start_link,
+         [[cid: cid]]},
+      restart: :temporary
+    }
+    {:ok, pid} = Supervisor.start_child(fetch_test_supervisor!(), spec)
     Upload.new(pid, view, form_selector, name, entries, cid)
   end
 

--- a/lib/phoenix_live_view/test/upload_client.ex
+++ b/lib/phoenix_live_view/test/upload_client.ex
@@ -30,7 +30,6 @@ defmodule Phoenix.LiveViewTest.UploadClient do
   end
 
   def init(opts) do
-    test_sup = Keyword.fetch!(opts, :test_supervisor)
     cid = Keyword.fetch!(opts, :cid)
 
     socket =
@@ -43,7 +42,7 @@ defmodule Phoenix.LiveViewTest.UploadClient do
           nil
       end
 
-    {:ok, %{socket: socket, cid: cid, test_supervisor: test_sup, upload_ref: nil, config: %{}, entries: %{}}}
+    {:ok, %{socket: socket, cid: cid, upload_ref: nil, config: %{}, entries: %{}}}
   end
 
   def handle_call(:allow_acknowledged, _from, state) do

--- a/test/phoenix_live_view/upload_channel_test.exs
+++ b/test/phoenix_live_view/upload_channel_test.exs
@@ -305,7 +305,6 @@ defmodule Phoenix.LiveView.UploadChannelTest do
       @tag allow: [max_entries: 1, chunk_size: 20, accept: :any]
       test "consume_uploaded_entries executes function against all entries, cleans up tmp file, and shuts down",
            %{lv: lv} do
-        Process.flag(:trap_exit, true)
         parent = self()
         avatar = file_input(lv, "form", :avatar, [%{name: "foo.jpeg", content: "123"}])
         avatar_pid = avatar.pid
@@ -331,7 +330,6 @@ defmodule Phoenix.LiveView.UploadChannelTest do
       test "consume_uploaded_entry executes function, cleans up tmp file, and shuts down", %{
         lv: lv
       } do
-        Process.flag(:trap_exit, true)
         parent = self()
         avatar = file_input(lv, "form", :avatar, [%{name: "foo.jpeg", content: "123"}])
         avatar_pid = avatar.pid
@@ -376,8 +374,6 @@ defmodule Phoenix.LiveView.UploadChannelTest do
 
       @tag allow: [max_entries: 1, chunk_size: 20, accept: :any]
       test "consume_uploaded_entries raises when upload is still in progress", %{lv: lv} do
-        Process.flag(:trap_exit, true)
-
         avatar =
           file_input(lv, "form", :avatar, [
             %{name: "foo.jpeg", content: String.duplicate("0", 100)}
@@ -399,8 +395,6 @@ defmodule Phoenix.LiveView.UploadChannelTest do
 
       @tag allow: [max_entries: 1, chunk_size: 20, accept: :any]
       test "consume_uploaded_entry raises when upload is still in progress", %{lv: lv} do
-        Process.flag(:trap_exit, true)
-
         avatar =
           file_input(lv, "form", :avatar, [
             %{name: "foo.jpeg", content: String.duplicate("0", 100)}
@@ -424,8 +418,6 @@ defmodule Phoenix.LiveView.UploadChannelTest do
 
       @tag allow: [max_entries: 1, chunk_size: 20, accept: :any]
       test "cancel_upload in progress", %{lv: lv} do
-        Process.flag(:trap_exit, true)
-
         avatar =
           file_input(lv, "form", :avatar, [
             %{name: "foo.jpeg", content: String.duplicate("0", 100)}
@@ -495,7 +487,6 @@ defmodule Phoenix.LiveView.UploadChannelTest do
 
     @tag allow: [accept: :any]
     test "liveview exits when duplicate name registered for another cid", %{lv: lv} do
-      Process.flag(:trap_exit, true)
       avatar = file_input(lv, "#upload0", :avatar, build_entries(1))
       assert render_upload(avatar, "myfile1.jpeg", 1) =~ "component:myfile1.jpeg:1%"
 


### PR DESCRIPTION
This is my attempt at fixing: https://github.com/phoenixframework/phoenix_live_view/issues/1269

The issue is that the UploadClient will exit under normal operation, but it's started linked to the test process and kills the test.

In this PR I'm starting it supervised the way we do the client proxy.

I've also removed the `trap_exit`s from the the test as these are no longer needed -- we're monitoring the pids we need and they aren't linked to the test.

There's still one more place where we have a trap exit that I'm not sure about in the tests...