### PR TITLE
Limit max entries for External uploads, S3 example

### DIFF
--- a/guides/client/uploads-external.md
+++ b/guides/client/uploads-external.md
@@ -99,7 +99,7 @@ def mount(_params, _session, socket) do
   {:ok,
     socket
     |> assign(:uploaded_files, [])
-    |> allow_upload(:avatar, accept: :any, max_entries: 3, external: &presign_upload/2)}
+    |> allow_upload(:avatar, accept: :any, max_entries: 1, external: &presign_upload/2)}
 end
 
 defp presign_upload(entry, socket) do


### PR DESCRIPTION
It doesn't seem to work with multiple file inputs as we get "too many files" error in preflight response.