### PR TITLE
Use element name instead of id for phx-feedback-for

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1542,7 +1542,7 @@ export let DOM = {
 
   discardError(container, el, phxFeedbackFor){
     let field = el.getAttribute && el.getAttribute(phxFeedbackFor)
-    let input = field && container.querySelector(`#${field}`)
+    let input = field && container.querySelector(`#${field}, [name="${field}"]`)
     if(!input){ return }
 
     if(!(this.private(input, PHX_HAS_FOCUSED) || this.private(input.form, PHX_HAS_SUBMITTED))){
@@ -1551,8 +1551,8 @@ export let DOM = {
   },
 
   showError(inputEl, phxFeedbackFor){
-    if(inputEl.id){
-      this.all(inputEl.form, `[${phxFeedbackFor}="${inputEl.id}"]`, (el) => {
+    if(inputEl.id || inputEl.name){
+      this.all(inputEl.form, `[${phxFeedbackFor}="${inputEl.id}"], [${phxFeedbackFor}="${inputEl.name}"]`, (el) => {
         this.removeClass(el, PHX_NO_FEEDBACK_CLASS)
       })
     }

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1542,6 +1542,7 @@ export let DOM = {
 
   discardError(container, el, phxFeedbackFor){
     let field = el.getAttribute && el.getAttribute(phxFeedbackFor)
+    // TODO: Remove id lookup after we update Phoenix to use input_name instead of input_id
     let input = field && container.querySelector(`#${field}, [name="${field}"]`)
     if(!input){ return }
 

--- a/guides/client/form-bindings.md
+++ b/guides/client/form-bindings.md
@@ -68,7 +68,8 @@ changeset to be re-rendered for the client.
 ## `phx-feedback-for`
 
 For proper form error tag updates, the error tag must specify which
-input it belongs to. This is accomplished with the `phx-feedback-for` attribute, which specifies the name (or id, for backwards compatibility) of the input it belongs to.
+input it belongs to. This is accomplished with the `phx-feedback-for` attribute,
+which specifies the name (or id, for backwards compatibility) of the input it belongs to.
 Failing to add the `phx-feedback-for` attribute will result in displaying error
 messages for form fields that the user has not changed yet (e.g. required
 fields further down on the page).

--- a/guides/client/form-bindings.md
+++ b/guides/client/form-bindings.md
@@ -68,7 +68,7 @@ changeset to be re-rendered for the client.
 ## `phx-feedback-for`
 
 For proper form error tag updates, the error tag must specify which
-input it belongs to. This is accomplished with the `phx-feedback-for` attribute.
+input it belongs to. This is accomplished with the `phx-feedback-for` attribute, which specifies the name (or id, for backwards compatibility) of the input it belongs to.
 Failing to add the `phx-feedback-for` attribute will result in displaying error
 messages for form fields that the user has not changed yet (e.g. required
 fields further down on the page).
@@ -81,7 +81,7 @@ For example, your `MyAppWeb.ErrorHelpers` may use this function:
       |> Enum.map(fn error ->
         content_tag(:span, translate_error(error),
           class: "invalid-feedback",
-          phx_feedback_for: input_id(form, field)
+          phx_feedback_for: input_name(form, field)
         )
       end)
     end


### PR DESCRIPTION
This PR closes https://github.com/phoenixframework/phoenix_live_view/issues/1109. I've tested this with @alexslade's test repo and errors now work as expected.

I realized that https://github.com/phoenixframework/phoenix_live_view/commit/95d5c7ccd0ac66e04b15c7b6128d44b60767e682 inadvertently addressed Jose's comment here: https://github.com/phoenixframework/phoenix_live_view/pull/1113#issuecomment-669501592

If we switch to using input name for phx-feedback-for, we get errors for radio buttons to show up correctly when you focus an element, because `showError` will show any hidden errors after the `pushInput`.

I've also kept support for id for backwards compatibility.