### PR TITLE
Add documentation about CSS & `open_browser`

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1117,6 +1117,10 @@ defmodule Phoenix.LiveViewTest do
   @doc """
   Open the default browser to display current HTML of `view_or_element`.
 
+  In order for CSS to render correctly, add this to your endpoint configuration in
+  config/test.exs: 
+      static_url: [path: "#{File.cwd!}/priv/static"]
+
   ## Examples
 
       view


### PR DESCRIPTION
I love `open_browser` but it personally took me way too long to figure out how to get CSS to load, and I had to dive into the discussion on the original PR to understand what I'm supposed to do.

This adds a bit of documentation about it.

To be honest, I'm still not 100% that this is the "right" way to load CSS.
1) Is my use of `File.cwd!` in a config file safe and correct?
2) How would you feel about updating the generators for config/test.exs to include this?