### PR TITLE
Open browser with layout and styles

### DIFF
--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -381,7 +381,13 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
   end
 
   def handle_call(:html, _from, state) do
-    {:reply, {:ok, state.html}, state}
+    %{root_view: %{endpoint: endpoint}} = state
+
+    static_path =
+      endpoint.config(:otp_app)
+      |> Application.app_dir("priv/static")
+
+    {:reply, {:ok, {state.html, static_path}}, state}
   end
 
   def handle_call({:live_children, topic}, from, state) do

--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -85,6 +85,12 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
       topic: Phoenix.LiveView.Utils.random_id()
     }
 
+    # We build an absolute path to any relative
+    # static assets through the root LiveView's endpoint.
+    static_path =
+      endpoint.config(:otp_app)
+      |> Application.app_dir("priv/static")
+
     state = %{
       join_ref: 0,
       ref: 0,
@@ -95,6 +101,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
       replies: %{},
       root_view: nil,
       html: root_html,
+      static_path: static_path,
       session: session,
       test_supervisor: test_supervisor,
       url: url,
@@ -381,13 +388,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
   end
 
   def handle_call(:html, _from, state) do
-    %{root_view: %{endpoint: endpoint}} = state
-
-    static_path =
-      endpoint.config(:otp_app)
-      |> Application.app_dir("priv/static")
-
-    {:reply, {:ok, {state.html, static_path}}, state}
+    {:reply, {:ok, {state.html, state.static_path}}, state}
   end
 
   def handle_call({:live_children, topic}, from, state) do

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1170,6 +1170,7 @@ defmodule Phoenix.LiveViewTest do
     end
     |> Floki.traverse_and_update(fn
       {"script", _, _} -> nil
+      {"a", _, _} = link -> link
       {el, attrs, children} -> {el, maybe_prefix_static_path(attrs, static_path), children}
       el -> el
     end)

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1186,7 +1186,7 @@ defmodule Phoenix.LiveViewTest do
   end
 
   defp prefix_static_path(<<"//" <> _::binary>> = url, _prefix), do: url
-  defp prefix_static_path(<<"/" <> _::binary>> = path, prefix), do: Path.join([prefix, path])
+  defp prefix_static_path(<<"/" <> _::binary>> = path, prefix), do: "file://#{Path.join([prefix, path])}"
   defp prefix_static_path(url, _), do: url
 
   defp write_tmp_html_file(html) do

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1178,7 +1178,7 @@ defmodule Phoenix.LiveViewTest do
     end
   end
 
-  defp maybe_rewrite_stylesheet(link, ""), do: link
+  defp maybe_rewrite_stylesheet(link, nil), do: link
 
   defp maybe_rewrite_stylesheet(link, prefix) do
     [link] = Floki.attr([link], ~S<[rel="stylesheet"]>, "href", fn

--- a/test/phoenix_live_view/integrations/elements_test.exs
+++ b/test/phoenix_live_view/integrations/elements_test.exs
@@ -664,10 +664,9 @@ defmodule Phoenix.LiveView.ElementsTest do
 
   describe "open_browser" do
     setup do
-      static_path = Application.app_dir(:phoenix_live_view, "priv/static")
       open_fun = fn path ->
         assert content = File.read!(path)
-        assert content =~ "<link rel=\"stylesheet\" href=\"#{static_path}/custom/app.css\"/>"
+        assert content =~ ~r[<link rel="stylesheet" href=".*\/phoenix_live_view\/priv\/static\/custom\/app\.css"\/>]
         assert content =~ "<link rel=\"stylesheet\" href=\"//example.com/a.css\"/>"
         assert content =~ "<link rel=\"stylesheet\" href=\"https://example.com/b.css\"/>"
         assert content =~ "body { background-color: #eee; }"

--- a/test/phoenix_live_view/integrations/elements_test.exs
+++ b/test/phoenix_live_view/integrations/elements_test.exs
@@ -664,9 +664,12 @@ defmodule Phoenix.LiveView.ElementsTest do
 
   describe "open_browser" do
     setup do
+      static_path = Application.app_dir(:phoenix_live_view, "priv/static")
       open_fun = fn path ->
         assert content = File.read!(path)
-        assert content =~ "<link rel=\"stylesheet\" href=\"/custom/app.css\"/>"
+        assert content =~ "<link rel=\"stylesheet\" href=\"#{static_path}/custom/app.css\"/>"
+        assert content =~ "<link rel=\"stylesheet\" href=\"//example.com/a.css\"/>"
+        assert content =~ "<link rel=\"stylesheet\" href=\"https://example.com/b.css\"/>"
         assert content =~ "body { background-color: #eee; }"
         refute content =~ "<script>"
         path

--- a/test/support/endpoint.ex
+++ b/test/support/endpoint.ex
@@ -31,6 +31,7 @@ defmodule Phoenix.LiveViewTest.Endpoint do
   def config(:live_view), do: [signing_salt: "112345678212345678312345678412"]
   def config(:secret_key_base), do: String.duplicate("57689", 50)
   def config(:cache_static_manifest_latest), do: Process.get(:cache_static_manifest_latest)
+  def config(:otp_app), do: :phoenix_live_view
   def config(:pubsub_server), do: Phoenix.LiveView.PubSub
   def config(:render_errors), do: [view: __MODULE__]
   def config(which), do: super(which)

--- a/test/support/layout_view.ex
+++ b/test/support/layout_view.ex
@@ -33,6 +33,8 @@ defmodule Phoenix.LiveViewTest.LayoutView do
     <html>
       <head>
         <link rel="stylesheet" href="/custom/app.css"/>
+        <link rel="stylesheet" href="//example.com/a.css"/>
+        <link rel="stylesheet" href="https://example.com/b.css"/>
         <style>body { background-color: #eee; }</style>
         <script>console.log("script")</script>
       </head>


### PR DESCRIPTION
I made two small tweaks to the initial implementation. The first is obviously to implement relative path rewriting for stylesheets. The second is to use the full page html when we get the root LiveView and inject the updated stylesheet tags. This gets us the layout as well.

I'd been toying with this for a minute, but in light of #1279 I definitely wanted to get some feedback :)

Before and after from `mix phx.new --live`:

2020-12-18 Edit: Incorporating @leandrocp changes in #1281 we can rewrite the relative image paths, too :)

|**Before**|**After**|
| :---: | :---: |
| ![screenshot](https://user-images.githubusercontent.com/168677/102564787-01d36980-4091-11eb-8e23-3993c860cdc6.png) |  ![screenshot](https://user-images.githubusercontent.com/168677/102642876-30922400-4113-11eb-9729-630c29ece77f.png) |

// @leandrocp @mveytsman 

