### PR TITLE
Fix open browser with layout and styles by injecting static path to all links

### DIFF
--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -85,6 +85,13 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
       topic: Phoenix.LiveView.Utils.random_id()
     }
 
+    # We build an absolute path to any relative
+    # static assets through the root LiveView's endpoint.
+    static_path =
+      :otp_app
+      |> endpoint.config()
+      |> Application.app_dir("priv/static")
+
     state = %{
       join_ref: 0,
       ref: 0,
@@ -95,6 +102,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
       replies: %{},
       root_view: nil,
       html: root_html,
+      static_path: static_path,
       session: session,
       test_supervisor: test_supervisor,
       url: url,
@@ -381,7 +389,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
   end
 
   def handle_call(:html, _from, state) do
-    {:reply, {:ok, state.html}, state}
+    {:reply, {:ok, {state.html, state.static_path}}, state}
   end
 
   def handle_call({:live_children, topic}, from, state) do

--- a/test/phoenix_live_view/integrations/elements_test.exs
+++ b/test/phoenix_live_view/integrations/elements_test.exs
@@ -666,7 +666,7 @@ defmodule Phoenix.LiveView.ElementsTest do
     setup do
       open_fun = fn path ->
         assert content = File.read!(path)
-        assert content =~ "<link rel=\"stylesheet\" href=\"/custom/app.css\"/>"
+        assert content =~ ~r[<link rel="stylesheet" href=".*\/phoenix_live_view\/priv\/static\/custom\/app\.css"\/>]
         assert content =~ "body { background-color: #eee; }"
         refute content =~ "<script>"
         path

--- a/test/support/endpoint.ex
+++ b/test/support/endpoint.ex
@@ -31,6 +31,7 @@ defmodule Phoenix.LiveViewTest.Endpoint do
   def config(:live_view), do: [signing_salt: "112345678212345678312345678412"]
   def config(:secret_key_base), do: String.duplicate("57689", 50)
   def config(:cache_static_manifest_latest), do: Process.get(:cache_static_manifest_latest)
+  def config(:otp_app), do: :phoenix_live_view
   def config(:pubsub_server), do: Phoenix.LiveView.PubSub
   def config(:render_errors), do: [view: __MODULE__]
   def config(which), do: super(which)


### PR DESCRIPTION
Another approach to fix the links on the rendered html used by `open_browser`. For reference, see #1279 and #1280

I've tried @mveytsman approach to leverage [base](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) with a local path but I couldn't make it work safely, turns out the paths must be relative to make it work and the `base href` must end with a slash. Ie:

Works:
```
<base href="file:///Users/me/project/">
<img src="custom/app.css"/>
```

Doesn't work:
```
<base href="file:///Users/me/project/">
<img src="/custom/app.css"/>
// or
<base href="file:///Users/me/project">
<img src="/custom/app.css"/>
```

So the approach here is to traverse all `href` and `src` attrs to inject the prefix using @mcrumm code.

Working on this fix made me realize if we should present the whole page when calling `open_browser(element)` or limit to display only the html of that `element`. _That's why I removed `maybe_wrap_html` in favor of `call(view_or_element, :html)`_. Thoughts?

Result of calling `open_browser(page_live)`:

<img width="1640" alt="Screen Shot 2020-12-18 at 11 17 13 AM" src="https://user-images.githubusercontent.com/36407/102638022-def29500-4124-11eb-99fa-16df1e6460a2.png">