### PR TITLE
Move discardError to onNodeAdded

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1803,8 +1803,6 @@ class DOMPatch {
       morphdom(targetContainer, diffHTML, {
         childrenOnly: targetContainer.getAttribute(PHX_COMPONENT) === null,
         onBeforeNodeAdded: (el) => {
-          //input handling
-          DOM.discardError(targetContainer, el, phxFeedbackFor)
           this.trackBefore("added", el)
           return el
         },
@@ -1812,6 +1810,8 @@ class DOMPatch {
           if(DOM.isNowTriggerFormExternal(el, phxTriggerExternal)){
             externalFormTriggered = el
           }
+          //input handling
+          DOM.discardError(targetContainer, el, phxFeedbackFor)
           // nested view handling
           if(DOM.isPhxChild(el) && view.ownsElement(el)){
             this.trackAfter("phxChildAdded", el)


### PR DESCRIPTION
This closes https://github.com/phoenixframework/phoenix_live_view/issues/1282

The issue is that morphdom called `onBeforeNodeAdded` on the subtree that's being added but not on each individual element in the tree. So when we have a patch that adds a form to the page, we won't be calling `discarderror` on every element, just the form container.

`onNodeAdded` is called on every element in the subtree.

