### PR TITLE
detect “select-one” and “select-multiple” input types

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1911,7 +1911,8 @@ class DOMPatch {
   }
 
   forceFocusedSelectUpdate(fromEl, toEl){
-    return fromEl.multiple === true || (fromEl.type === "select" && fromEl.innerHTML != toEl.innerHTML)
+    let isSelect = ["select", "select-one", "select-multiple"].find((t) => t === fromEl.type)
+    return fromEl.multiple === true || (isSelect && fromEl.innerHTML != toEl.innerHTML)
   }
 
   isCIDPatch(){ return this.cidPatch }


### PR DESCRIPTION
The [HTML spec](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement) refers to the html select type being either a "select-one" or "select-multiple". This PR detects those, while keeping the original "select" to not break any backward compatibility. 