### PR TITLE
Fix static_path in open_browser

### DIFF
--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -87,9 +87,17 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
 
     # We build an absolute path to any relative
     # static assets through the root LiveView's endpoint.
+    priv_dir = :otp_app |> endpoint.config() |> Application.app_dir("priv")
+    static_url = endpoint.config(:static_url) || []
+
     static_path =
-      endpoint.config(:otp_app)
-      |> Application.app_dir("priv/static")
+      case Keyword.get(static_url, :path) do
+        nil ->
+          Path.join(priv_dir, "static")
+
+        path ->
+          priv_dir
+      end
 
     state = %{
       join_ref: 0,

--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -95,7 +95,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
         nil ->
           Path.join(priv_dir, "static")
 
-        path ->
+        _path ->
           priv_dir
       end
 

--- a/test/phoenix_live_view/integrations/elements_test.exs
+++ b/test/phoenix_live_view/integrations/elements_test.exs
@@ -666,7 +666,8 @@ defmodule Phoenix.LiveView.ElementsTest do
     setup do
       open_fun = fn path ->
         assert content = File.read!(path)
-        assert content =~ ~r[<link rel="stylesheet" href=".*\/phoenix_live_view\/priv\/static\/custom\/app\.css"\/>]
+        assert content =~ ~r[<link rel="stylesheet" href="file:.*phoenix_live_view\/priv\/css\/custom\.css"\/>]
+        assert content =~ ~r[<link rel="stylesheet" href="file:.*phoenix_live_view\/priv\/static\/css\/app\.css"\/>]
         assert content =~ "<link rel=\"stylesheet\" href=\"//example.com/a.css\"/>"
         assert content =~ "<link rel=\"stylesheet\" href=\"https://example.com/b.css\"/>"
         assert content =~ "body { background-color: #eee; }"

--- a/test/support/endpoint.ex
+++ b/test/support/endpoint.ex
@@ -25,15 +25,17 @@ defmodule Phoenix.LiveViewTest.Endpoint do
 
   socket "/live", Phoenix.LiveView.Socket
 
-  defoverridable url: 0, script_name: 0, config: 1, config: 2
+  defoverridable url: 0, script_name: 0, config: 1, config: 2, static_path: 1
   def url(), do: "http://localhost:4000"
   def script_name(), do: []
+  def static_path(path), do: "/static" <> path
   def config(:live_view), do: [signing_salt: "112345678212345678312345678412"]
   def config(:secret_key_base), do: String.duplicate("57689", 50)
   def config(:cache_static_manifest_latest), do: Process.get(:cache_static_manifest_latest)
   def config(:otp_app), do: :phoenix_live_view
   def config(:pubsub_server), do: Phoenix.LiveView.PubSub
   def config(:render_errors), do: [view: __MODULE__]
+  def config(:static_url), do: [path: "/static"]
   def config(which), do: super(which)
   def config(which, default), do: super(which, default)
 end

--- a/test/support/layout_view.ex
+++ b/test/support/layout_view.ex
@@ -1,5 +1,6 @@
 defmodule Phoenix.LiveViewTest.LayoutView do
   use Phoenix.View, root: ""
+  alias Phoenix.LiveViewTest.Router.Helpers, as: Routes
   import Phoenix.LiveView.Helpers
 
   def render("app.html", assigns) do
@@ -32,7 +33,8 @@ defmodule Phoenix.LiveViewTest.LayoutView do
     ~L"""
     <html>
       <head>
-        <link rel="stylesheet" href="/custom/app.css"/>
+        <link rel="stylesheet" href="/css/custom.css"/>
+        <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>
         <link rel="stylesheet" href="//example.com/a.css"/>
         <link rel="stylesheet" href="https://example.com/b.css"/>
         <style>body { background-color: #eee; }</style>


### PR DESCRIPTION
Close #1295 - assume the default priv/static if static_url path is empty, otherwise resolve relative to priv dir, in other words:

`static_url: [path: "/static"]` will gerenate:

```
prefix: "/project/_build/test/lib/pulse/priv"
path: "/static/css/app.css"
```

And an empty `static_url` or empty static_url `path` will generate:

```
prefix: "/project/_build/test/lib/pulse/priv/static"
path: "/css/app.css"
```

/cc @mveytsman @mcrumm 