### PR TITLE
Update uploads-external guide to remove done()

### DIFF
--- a/guides/client/uploads-external.md
+++ b/guides/client/uploads-external.md
@@ -167,8 +167,8 @@ let liveSocket = new LiveSocket("/live", Socket, {
 ```
 
 We define an `Uploaders.S3` function, which receives our entries. It then
-performs an AJAX request for each entry, using the `entry.progress()`,
-`entry.error()`, and `entry.done()` functions to report upload events
-back to the LiveView. Lastly, we pass the `uploaders` namespace to the
-`LiveSocket` constructor to tell phoenix where to find the uploaders
-return within the external metadata.
+performs an AJAX request for each entry, using the `entry.progress()` and
+`entry.error()`. functions to report upload events back to the LiveView.
+Lastly, we pass the `uploaders` namespace to the `LiveSocket` constructor
+to tell phoenix where to find the uploaders return within the external
+metadata.


### PR DESCRIPTION
`done()` no longer exists on `entry`. It was removed in ccb2041ef30abae08c9be838932a8cc0f7e5ef8e.