### PR TITLE
Fix bug when form event listener is added from an element that no longer exists on the page.

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1504,10 +1504,12 @@ export let DOM = {
           setTimeout(() => this.triggerCycle(el, DEBOUNCE_TRIGGER, currentCycle), timeout)
         }
 
-        if(el.form && this.once(el.form, "bind-debounce")){
-          el.form.addEventListener("submit", (e) => {
-            Array.from((new FormData(el.form)).entries(), ([name, val]) => {
-              let input = el.form.querySelector(`[name="${name}"]`)
+
+        let form = el.form
+        if(form && this.once(form, "bind-debounce")){
+          form.addEventListener("submit", (e) => {
+            Array.from((new FormData(form)).entries(), ([name, val]) => {
+              let input = form.querySelector(`[name="${name}"]`)
               this.incCycle(input, DEBOUNCE_TRIGGER)
               this.deletePrivate(input, THROTTLED)
             })


### PR DESCRIPTION
We add the bind-debounce listener to the form from the first element that has debounce binding. If that particular element no longer exists when the form is submitted, the `el.form` will be nil, and we get an exception when calling `new FormData(el.form))`.

Instead, we save the form as it's own variable in the closure, so we can refer to it in the callback even if the element has been removed.
