### PR TITLE
adding a missing comma on the documentation

### DIFF
--- a/guides/server/using-gettext.md
+++ b/guides/server/using-gettext.md
@@ -18,5 +18,5 @@ Then in your LiveView `mount/3`, you can restore the locale:
 
     def mount(_params, %{"locale" => locale}, socket) do
       Gettext.put_locale(MyApp.Gettext, locale)
-      {:ok socket}
+      {:ok, socket}
     end


### PR DESCRIPTION
Hey, thanks a lot for the hard work, I found a small missing comma in the documentation :)