### PR TITLE
Instructions for protect_from_forgery to be included

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -750,12 +750,16 @@ defmodule Phoenix.LiveView.Channel do
 
                 socket "/live", Phoenix.LiveView.Socket,
                   websocket: [connect_info: [session: @session_options]]
+                  
+            4) Ensure the `protect_from_forgery` plug is in your router pipeline:
+            
+                plug :protect_from_forgery
 
-            4) Define the CSRF meta tag inside the `<head>` tag in your layout:
+            5) Define the CSRF meta tag inside the `<head>` tag in your layout:
 
                 <%= csrf_meta_tag() %>
 
-            5) Pass it forward in your app.js:
+            6) Pass it forward in your app.js:
 
                 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
                 let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}});


### PR DESCRIPTION
If this plug is not included, the session cannot be verified and will error out. You must include this plug somewhere in your pipeline in order to use Channel sessions.