### PR TITLE
add more connection info to sockets

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -823,9 +823,12 @@ defmodule Phoenix.LiveView.Channel do
     connect_params = params["params"]
 
     # Optional verified parts
-    router = verified[:router]
     flash = verify_flash(endpoint, verified, params["flash"], connect_params)
+    remote_ip = get_in(connect_info, [:peer_data, :address])
+    router = verified[:router]
     socket_session = connect_info[:session] || %{}
+    user_agent = connect_info[:user_agent]
+    x_headers = connect_info[:x_headers] || []
 
     Process.monitor(transport_pid)
     load_csrf_token(endpoint, socket_session)
@@ -836,14 +839,17 @@ defmodule Phoenix.LiveView.Channel do
     end
 
     socket = %Socket{
-      endpoint: endpoint,
-      view: view,
-      root_view: root_view,
       connected?: true,
-      parent_pid: parent,
-      root_pid: root || self(),
+      endpoint: endpoint,
       id: id,
-      router: router
+      parent_pid: parent,
+      remote_ip: remote_ip,
+      root_pid: root || self(),
+      root_view: root_view,
+      router: router,
+      user_agent: user_agent,
+      view: view,
+      x_headers: x_headers
     }
 
     {params, host_uri, action} =

--- a/lib/phoenix_live_view/socket.ex
+++ b/lib/phoenix_live_view/socket.ex
@@ -26,7 +26,19 @@ defmodule Phoenix.LiveView.Socket do
 
   if Version.match?(System.version(), ">= 1.8.0") do
     @derive {Inspect,
-             only: [:id, :endpoint, :router, :view, :parent_pid, :root_pid, :assigns, :changed]}
+             only: [
+               :assigns,
+               :changed,
+               :endpoint,
+               :id,
+               :parent_pid,
+               :remote_ip,
+               :root_pid,
+               :router,
+               :user_agent,
+               :view,
+               :x_headers
+             ]}
   end
 
   defstruct id: nil,
@@ -42,6 +54,9 @@ defmodule Phoenix.LiveView.Socket do
             fingerprints: Phoenix.LiveView.Diff.new_fingerprints(),
             redirected: nil,
             host_uri: nil,
+            remote_ip: nil,
+            user_agent: nil,
+            x_headers: [],
             connected?: false
 
   @type assigns :: map | Phoenix.LiveView.Socket.AssignsNotInSocket.t()
@@ -61,6 +76,9 @@ defmodule Phoenix.LiveView.Socket do
           fingerprints: fingerprints,
           redirected: nil | tuple(),
           host_uri: URI.t(),
+          remote_ip: tuple(),
+          user_agent: String.t(),
+          x_headers: keyword(),
           connected?: boolean()
         }
 


### PR DESCRIPTION
For some tasks, I would like to store a user's IP address and user agent as part of the audit trail. In Channels that I control, I can already do this. This PR adds the same capability to LiveView to get those values if they are specified in the `connect_info` when establishing the `socket` in the Endpoint.

Specifically it adds three fields to the socket: `remote_ip`, `user_agent`, and `x_headers`. I also considered adding those to the socket as a map under a `transport` key, but I decided to ship this as is and get feedback first.

I'm happy to make any necessary changes to get this across the line. Thanks again for LiveView! I've really enjoyed working with it.