### PR TITLE
Support multiple phx target in tests

### DIFF
--- a/test/phoenix_live_view/integrations/components_test.exs
+++ b/test/phoenix_live_view/integrations/components_test.exs
@@ -183,6 +183,55 @@ defmodule Phoenix.LiveView.ComponentTest do
                "<div data-phx-component=\"3\" id=\"Jose-dup\" phx-target=\"#Jose-dup\" phx-click=\"transform\">\n  JOSE-DUP says hi\n  \n</div>"
     end
 
+    test "works with multiple phx-targets", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/multi-targets")
+
+      view |> element("#chris") |> render_click(%{"op" => "upcase"})
+
+      html = render(view)
+
+      assert [
+               {"div", _,
+                 [
+                   {"div", [{"id", "parent_id"} | _],
+                    ["\n  Parent was updated\n" <> _,
+                   {"div", [{"data-phx-component", "1"}, {"id", "chris"} | _],
+                    ["\n  CHRIS says hi\n" <> _]},
+                   {"div", [{"data-phx-component", "2"}, {"id", "jose"} | _],
+                     ["\n  jose says hi\n" <> _]}
+                    ]
+                   }
+                 ]
+               }
+             ] = DOM.parse(html)
+    end
+
+    test "phx-target works with non id selector", %{conn: conn} do
+      {:ok, view, _html} =
+        conn
+        |> Plug.Conn.put_session(:parent_selector, ".parent")
+        |> live("/multi-targets")
+
+      view |> element("#chris") |> render_click(%{"op" => "upcase"})
+
+      html = render(view)
+
+      assert [
+               {"div", _,
+                 [
+                   {"div", [{"id", "parent_id"} | _],
+                    ["\n  Parent was updated\n" <> _,
+                   {"div", [{"data-phx-component", "1"}, {"id", "chris"} | _],
+                    ["\n  CHRIS says hi\n" <> _]},
+                   {"div", [{"data-phx-component", "2"}, {"id", "jose"} | _],
+                     ["\n  jose says hi\n" <> _]}
+                    ]
+                   }
+                 ]
+               }
+             ] = DOM.parse(html)
+    end
+
     test "emits telemetry events when callback is successful", %{conn: conn} do
       attach_telemetry([:phoenix, :live_component, :handle_event])
       {:ok, view, _html} = live(conn, "/components")

--- a/test/phoenix_live_view/integrations/components_test.exs
+++ b/test/phoenix_live_view/integrations/components_test.exs
@@ -186,21 +186,16 @@ defmodule Phoenix.LiveView.ComponentTest do
     test "works with multiple phx-targets", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/multi-targets")
 
-      view |> element("#chris") |> render_click(%{"op" => "upcase"})
-
-      html = render(view)
+      html = view |> element("#chris") |> render_click(%{"op" => "upcase"})
 
       assert [
                {"div", _,
                  [
-                   {"div", [{"id", "parent_id"} | _],
-                    ["\n  Parent was updated\n" <> _,
+                   "\n  Parent was updated\n" <> _,
                    {"div", [{"data-phx-component", "1"}, {"id", "chris"} | _],
-                    ["\n  CHRIS says hi\n" <> _]},
+                     ["\n  CHRIS says hi\n" <> _]},
                    {"div", [{"data-phx-component", "2"}, {"id", "jose"} | _],
                      ["\n  jose says hi\n" <> _]}
-                    ]
-                   }
                  ]
                }
              ] = DOM.parse(html)
@@ -212,21 +207,16 @@ defmodule Phoenix.LiveView.ComponentTest do
         |> Plug.Conn.put_session(:parent_selector, ".parent")
         |> live("/multi-targets")
 
-      view |> element("#chris") |> render_click(%{"op" => "upcase"})
-
-      html = render(view)
+      html = view |> element("#chris") |> render_click(%{"op" => "upcase"})
 
       assert [
                {"div", _,
                  [
-                   {"div", [{"id", "parent_id"} | _],
-                    ["\n  Parent was updated\n" <> _,
+                   "\n  Parent was updated\n" <> _,
                    {"div", [{"data-phx-component", "1"}, {"id", "chris"} | _],
-                    ["\n  CHRIS says hi\n" <> _]},
+                     ["\n  CHRIS says hi\n" <> _]},
                    {"div", [{"data-phx-component", "2"}, {"id", "jose"} | _],
                      ["\n  jose says hi\n" <> _]}
-                    ]
-                   }
                  ]
                }
              ] = DOM.parse(html)

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -2,7 +2,7 @@ defmodule Phoenix.LiveViewTest.StatefulComponent do
   use Phoenix.LiveComponent
 
   def mount(socket) do
-    {:ok, assign(socket, name: "unknown", dup_name: nil)}
+    {:ok, assign(socket, name: "unknown", dup_name: nil, parent_id: nil)}
   end
 
   def update(assigns, socket) do
@@ -29,12 +29,15 @@ defmodule Phoenix.LiveViewTest.StatefulComponent do
 
   def render(%{socket: _} = assigns) do
     ~L"""
-    <div id="<%= @id %>" phx-target="#<%= @id %>" phx-click="transform">
+    <div id="<%= @id %>" phx-target="#<%= @id %><%= include_parent_id(@parent_id) %>" phx-click="transform">
       <%= @name %> says hi
       <%= if @dup_name, do: live_component @socket, __MODULE__, id: @dup_name, name: @dup_name %>
     </div>
     """
   end
+
+  defp include_parent_id(nil), do: ""
+  defp include_parent_id(parent_id), do: ",#{parent_id}"
 
   def handle_event("transform", %{"op" => op}, socket) do
     case op do
@@ -76,7 +79,7 @@ defmodule Phoenix.LiveViewTest.WithComponentLive do
     Redirect: <%= @redirect %>
     <%= for name <- @names do %>
       <%= live_component @socket, Phoenix.LiveViewTest.StatefulComponent,
-            id: name, name: name, from: @from, disabled: name in @disabled  %>
+            id: name, name: name, from: @from, disabled: name in @disabled, parent_id: nil %>
     <% end %>
     """
   end
@@ -106,5 +109,38 @@ defmodule Phoenix.LiveViewTest.WithComponentLive do
     names = socket.assigns.names
     new_socket = assign(socket, disabled: names, names: names ++ Enum.map(names, &(&1 <> "-new")))
     {:noreply, new_socket}
+  end
+end
+
+defmodule Phoenix.LiveViewTest.WithMultipleTargets do
+  use Phoenix.LiveView
+
+  def mount(_params, %{"names" => names, "from" => from} = session, socket) do
+    {
+      :ok,
+      assign(socket, [
+        names: names,
+        from: from,
+        disabled: [],
+        message: nil,
+        parent_selector: Map.get(session, "parent_selector", "#parent_id")
+      ])
+    }
+  end
+
+  def render(assigns) do
+    ~L"""
+    <div id="parent_id" class="parent">
+      <%= @message %>
+      <%= for name <- @names do %>
+        <%= live_component @socket, Phoenix.LiveViewTest.StatefulComponent,
+              id: name, name: name, from: @from, disabled: name in @disabled, parent_id: @parent_selector %>
+      <% end %>
+    </div>
+    """
+  end
+
+  def handle_event("transform", %{"op" => _op}, socket) do
+    {:noreply, assign(socket, :message, "Parent was updated")}
   end
 end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -40,6 +40,7 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/time-zones", AppendLive
     live "/shuffle", ShuffleLive
     live "/components", WithComponentLive
+    live "/multi-targets", WithMultipleTargets
     live "/assigns-not-in-socket", AssignsNotInSocketLive
     live "/errors", ErrorsLive
 


### PR DESCRIPTION
This PR addresses #1328 by introducing some changes to the `ClientProxy` used when testing. Namely, it extends the check that was being done for CIDs, where it would either take something that looked like a CID, or something that looked like a DOM id, and fail otherwise.

With these changes, multiple selectors should be supported, as well as selectors other than component or DOM ids.