### PR TITLE
restore button disabled state correctly

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -2535,7 +2535,7 @@ export class View {
         el.removeAttribute(PHX_READONLY)
       }
       if(el.getAttribute(PHX_DISABLED) !== null){
-        el.disabled = false
+        el.disabled = el.getAttribute(PHX_DISABLED)
         el.removeAttribute(PHX_DISABLED)
       }
       // remove classes

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -1070,7 +1070,7 @@ describe("View + Component", function() {
           <input type="text" name="q" value="ddsdsd" placeholder="Live dependency search" list="results" autocomplete="off">
           <datalist id="results">
           </datalist>
-          <button type="submit" phx-disable-with="Searching...">Searching...</button>
+          <button type="submit" phx-disable-with="Searching..." disabled="">Searching...</button>
         </form>
       `.trim())
     })


### PR DESCRIPTION
I noticed in a project I am working on that the disabled state is not correctly restored on buttons, I spent a long time looking through my own code before realising that Phoenix LiveView also changes the disabled state. Then looking at the code I noticed it always returns it to `false` even though it does keep track of the previous value in a dataset property. So this patch should resolve it. 

There was a test for it already which I think was invalid? The original started out disabled and ended without disabled, but I believe it should have been disabled at the end as well so I updated that test in my patch too.

- Fixes https://github.com/phoenixframework/phoenix_live_view/issues/1372