### PR TITLE
Fix render_upload/3 doc

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1324,13 +1324,15 @@ defmodule Phoenix.LiveViewTest do
 
   Your test case can assert the uploaded content:
 
-      avatar = file_input(lv, "my-form-id", :avatar, %{
-        last_modified: 1_594_171_879_000,
-        name: "myfile.jpeg",
-        content: File.read!("myfile.jpg"),
-        size: 1_396_009,
-        type: "image/jpeg"
-      })
+      avatar = file_input(lv, "#my-form-id", :avatar, [
+        %{
+          last_modified: 1_594_171_879_000,
+          name: "myfile.jpeg",
+          content: File.read!("myfile.jpg"),
+          size: 1_396_009,
+          type: "image/jpeg"
+        }
+      ])
 
       assert render_upload(avatar, "foo.jpeg") =~ "100%"
 


### PR DESCRIPTION
I was happily trying to write integration tests for the first time for the awesome file uploads when I encountered this error:
```
     ** (FunctionClauseError) no function clause matching in Phoenix.LiveViewTest.Upload.populate_entry/1

     The following arguments were given to Phoenix.LiveViewTest.Upload.populate_entry/1:

         # 1
         {:content, "dummy content"}

     Attempted function clauses (showing 1 out of 1):

         defp populate_entry(%{} = entry)

     code: file_input(show_live, "#script-inputs", :main, %{
```

It was a bit sneaky but compare the [doc of file_input/4](https://github.com/phoenixframework/phoenix_live_view/blob/a4d5353260b14c9c7850570dc83d41b72ff643fe/lib/phoenix_live_view/test/live_view_test.ex#L952-L958) with [the doc of render_upload/3](https://github.com/phoenixframework/phoenix_live_view/blob/a4d5353260b14c9c7850570dc83d41b72ff643fe/lib/phoenix_live_view/test/live_view_test.ex#L1327-L1333) 👀 

1. `render_upload/3` is missing a `#` in the `form_selector` - tiny gotcha
2. bigger gotcha in the same func doc - the third argument of `file_input()` is a **list of maps**, not just a map

Pretty sure I'm right! (my test code does work now at least :) )