### PR TITLE
Fix unused variable compilation warning in live_component/4

### DIFF
--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -208,7 +208,7 @@ defmodule Phoenix.LiveView.Helpers do
   becomes stateful. Otherwise, `:id` is always set to `nil`.
   """
   # TODO: Deprecate the socket as argument
-  defmacro live_component(_socket, component, assigns \\ [], do_block \\ []) do
+  defmacro live_component(socket, component, assigns \\ [], do_block \\ []) do
     {do_block, assigns} =
       case {do_block, assigns} do
         {[do: do_block], _} -> {do_block, assigns}
@@ -219,6 +219,9 @@ defmodule Phoenix.LiveView.Helpers do
     {assigns, inner_block} = rewrite_do(do_block, assigns, __CALLER__)
 
     quote do
+      # Fixes unused variable compilation warning
+      _ = unquote(socket)
+
       Phoenix.LiveView.Helpers.__live_component__(
         unquote(component).__live__(),
         unquote(assigns),


### PR DESCRIPTION
When upgrading the dependencies in the phoenix integration tests, I ran into the same compilation warning that was mentioned in #1330.

```
warning: variable "socket" is unused (if the variable is not meant to be used, prefix it with an underscore)                                                                                 
  lib/default_app_web/live/live_helpers.ex:18: DefaultAppWeb.LiveHelpers.live_modal/3                                                                                                        
                                                                                                                                                                                             
Compilation failed due to warnings while using the --warnings-as-errors option
```

This updates the macro to assign the unused `socket` param to `_` and fixes the compilation warning.

Fixes #1330.