### PR TITLE
Clarify assign update logic in send_update/3 and update/2 docs

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -41,9 +41,9 @@ defmodule Phoenix.LiveComponent do
 
   First `c:mount/1` is called only with the socket. `c:mount/1` can be used
   to set any initial state. Then `c:update/2` is invoked with all of the
-  assigns given to [`live_component/3`](`Phoenix.LiveView.Helpers.live_component/3`). The default implementation of
-  `c:update/2` simply merges all assigns into the socket. Then, after the
-  component is updated, `c:render/1` is called with all assigns.
+  assigns given to [`live_component/3`](`Phoenix.LiveView.Helpers.live_component/3`).
+  If `c:update/2` is not defined all assigns are simply merged into the socket.
+  After the component is updated, `c:render/1` is called with all assigns.
 
   A stateless component is always mounted, updated, and rendered whenever
   the parent template changes. That's why they are stateless: no state

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1133,11 +1133,11 @@ defmodule Phoenix.LiveView do
   If this call is executed from a process which is not a LiveView
   nor a LiveComponent, the `pid` argument has to be specified.
 
-  When the component receives the update, the optional
-  [`preload/1`](`c:Phoenix.LiveComponent.preload/1`) callback is invoked, then
-  the updated values are merged with the component's assigns and
-  [`update/2`](`c:Phoenix.LiveComponent.update/2`) is called for the updated
-  component(s).
+  When the component receives the update, first the optional
+  [`preload/1`](`c:Phoenix.LiveComponent.preload/1`) then
+  [`update/2`](`c:Phoenix.LiveComponent.update/2`) is invoked with the new assigns.
+  If [`update/2`](`c:Phoenix.LiveComponent.update/2`) is not defined
+  all assigns are simply merged into the socket.
 
   While a component may always be updated from the parent by updating some
   parent assigns which will re-render the child, thus invoking


### PR DESCRIPTION
The docs stated in lib/phoenix_live_view.ex:
```
 the optional `preload/1  callback is invoked, then
 the updated values are merged with the component's assigns and
 `update/2` is called
```
so the flow it stated was:
preload(new_assigns) ->  ?updated_values_are_merged?  ->  update(socket, new_assigns)

I believe this wasn't reflecting the current logic and also I changed the "default implementation"
wording to "not defined" based on what I saw in `Utils.maybe_call_update!/3`.

Thank you for reviewing.