### PR TITLE
Get the upload component id from the form's phx-target

### DIFF
--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -259,7 +259,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
                :ok <- maybe_enabled(type, node, element),
                {:ok, event} <- maybe_event(type, node, element),
                {:ok, extra} <- maybe_values(type, node, element),
-               {:ok, cid} <- maybe_cid(root, node) do
+               {:ok, cid} <- __maybe_cid__(root, node) do
             {values, uploads} =
               case value do
                 %Upload{} = upload -> {extra, upload}
@@ -778,11 +778,11 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
     {:ok, root}
   end
 
-  defp maybe_cid(_tree, nil) do
+  def __maybe_cid__(_tree, nil) do
     {:ok, nil}
   end
 
-  defp maybe_cid(tree, node) do
+  def __maybe_cid__(tree, node) do
     case DOM.all_attributes(node, "phx-target") do
       [] ->
         {:ok, nil}

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -979,8 +979,10 @@ defmodule Phoenix.LiveViewTest do
 
   def __find_cid__!(view, selector) do
     html_tree = view |> render() |> DOM.parse()
-    case DOM.maybe_one(html_tree, selector) do
-      {:ok, form} -> if str = DOM.component_id(form), do: String.to_integer(str)
+    with {:ok, form} <- DOM.maybe_one(html_tree, selector),
+         {:ok, cid} <- ClientProxy.__maybe_cid__(html_tree, form) do
+      cid
+    else
       {:error, _reason, msg} -> raise ArgumentError, msg
     end
   end


### PR DESCRIPTION
Updates the component selector in [`file_input/4`](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveViewTest.html#file_input/4) to use the `phx-target` from the form input.

This could use a more robust set of tests around targeting.
Unless someone else beats me to it I will write them eventually :)

Closes #1357