### PR TITLE
Add exports and dependencies to top level package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,18 @@
   "description": "The Phoenix LiveView JavaScript client.",
   "license": "MIT",
   "main": "./priv/static/phoenix_live_view.js",
+  "module": "./assets/js/phoenix_live_view.js",
+  "exports": {
+    "import": "./assets/js/phoenix_live_view.js",
+    "require": "./priv/static/phoenix_live_view.js"
+  },
   "author": "Chris McCord <chris@chrismccord.com> (http://www.phoenixframework.org)",
   "repository": {
     "type": "git",
     "url": "git://github.com/phoenixframework/phoenix_live_view.git"
+  },
+  "dependencies": {
+    "morphdom": "2.6.1"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
Similar to https://github.com/phoenixframework/phoenix/pull/4191, allows for ESM bundler support, such as [vite](https://vitejs.dev/) or [snowpack](https://www.snowpack.dev/). Adds the following to the top level `package.json`:
* `module`: [Near standard](https://github.com/rollup/rollup/wiki/pkg.module) way to denote the ESM entry point of a given package.
* `exports`: [Node.js](https://nodejs.org/api/packages.html#packages_package_entry_points) standard for specifying the entry point for when the package is being `import`'ed or `require()`'d (specifying the same as `module`/`main` respectively.)
* `dependencies`: This is a copy of the [runtime deps](https://github.com/phoenixframework/phoenix_live_view/blob/master/assets/package.json#L14-L16) specified in the `assets/package.json`. Not sure there is a better way to expose these dependencies besides duplicating them.