### PR TITLE
Add more details to the uploads guide

### DIFF
--- a/guides/server/uploads.md
+++ b/guides/server/uploads.md
@@ -1,24 +1,27 @@
 # Uploads
 
 LiveView supports interactive file uploads with progress for
-both direct to server uploads as well as external
-direct-to-cloud [external uploads](uploads-external.html) on the client.
+both direct to server uploads as well as direct-to-cloud
+[external uploads](uploads-external.html) on the client.
 
-Uploads are enabled by using `Phoenix.LiveView.allow_upload/3`
-and specifying the constraints, such as accepted file types,
-max file size, number of maximum selected entries, etc.
-When the client selects file(s), the file metadata is
-automatically validated against the `allow_upload`
-specification. Uploads are populated in an `@uploads` assign
-in the socket, granting reactive based templates that
-automatically update with progress, error information, etc.
+### Built-in Features
 
-The complete upload flow is as follows:
+  * Accept specification - Define accepted file types, max
+    number of entries, max file size, etc. When the client
+    selects file(s), the file metadata is automatically
+    validated against the specification. See
+    `Phoenix.LiveView.allow_upload/3`.
+
+  * Reactive entries - Uploads are populated in an
+    `@uploads` assign in the socket. Entries automatically
+    respond to progress, errors, cancelation, etc.
+
+  * Drag and drop - Use the `phx-drop-target` attribute to
+    enable. See `Phoenix.LiveView.Helpers.live_file_input/2`.
 
 ## Allow uploads
 
-You enable an upload, typically on mount, via
-[`allow_upload/3`](`Phoenix.LiveView.allow_upload/3`):
+You enable an upload, typically on mount, via [`allow_upload/3`]:
 
 ```elixir
 @impl Phoenix.LiveView
@@ -30,49 +33,130 @@ def mount(_params, _session, socket) do
 end
 ```
 
+That's it for now! We will come back to the LiveView to
+implement some form- and upload-related callbacks later, but
+most of the functionality around uploads takes place in the
+template.
+
 ## Render reactive elements
 
 Use the `Phoenix.LiveView.Helpers.live_file_input/2` file
-input generator to render a file input for the upload.
-The generator has full support for `multiple=true`, and the
-attribute will automatically be set if `:max_entries` is
-greater than 1 in the [`allow_upload/3`](`Phoenix.LiveView.allow_upload/3`) spec.
-
-Within the template, you render each upload entry. The entry
-struct contains all the information about the upload,
-including progress, name, errors, etc.
-
-For example:
+input generator to render a file input for the upload:
 
 ```elixir
-<%= for entry <- @uploads.avatar.entries do %>
-<%= entry.client_name %> - <%= entry.progress %>%
-<% end %>
+# lib/my_app_web/live/upload_live.html.leex
 
-<form phx-submit="save" phx-change="validate">
+<form id="upload-form" phx-submit="save" phx-change="validate">
   <%= live_file_input @uploads.avatar %>
   <button type="submit">Upload</button>
 </form>
 ```
 
-You must bind `phx-submit` and `phx-change` on the form.
+> **Important:** You must bind `phx-submit` and `phx-change` on the form.
+
+Note that while [`live_file_input/2`]
+allows you to set additional attributes on the file input,
+many attributes such as `id`, `accept`, and `multiple` will
+be set automatically based on the [`allow_upload/3`] spec.
 
 Reactive updates to the template will occur as the end-user
-interacts with the file input. Validation will occur based on
-any conditions you have specified in
-[`allow_upload/3`](`Phoenix.LiveView.allow_upload/3`) but you
-must implement at least a minimal callback:
+interacts with the file input.
+
+### Upload entries
+
+Uploads are populated in an `@uploads` assign in the socket.
+Each allowed upload contains a _list_ of entries,
+irrespective of the `:max_entries` value in the
+[`allow_upload/3`] spec. These entry structs contain all the
+information about an upload, including progress, client file
+info, errors, etc.
+
+Let's look at an annotated example:
 
 ```elixir
+# lib/my_app_web/live/upload_live.html.leex
+
+<%# use phx-drop-target with the upload ref to enable file drag and drop %>
+<section phx-drop-target="<%= @uploads.avatar.ref %>">
+
+<%# render each avatar entry %>
+<%= for entry <- @uploads.avatar.entries do %>
+  <article class="upload-entry">
+
+    <figure>
+      <%# Phoenix.LiveView.Helpers.live_img_preview/2 renders a client-side preview %>
+      <%= live_img_preview entry %>
+      <figcaption><%= entry.client_name %></figcaption>
+    </figure>
+
+    <%# entry.progress will update automatically for in-flight entries %>
+    <progress value="<%= entry.progress %>" max="100"> <%= entry.progress %>% </progress>
+
+    <%# a regular click event whose handler will invoke Phoenix.LiveView.cancel_upload/3 %>
+    <button phx-click="cancel-upload" phx-value-ref="<%= entry.ref %>" aria-label="cancel">&times;</button>
+
+    <%# Phoenix.LiveView.Helpers.upload_errors/2 returns a list of error atoms %>
+    <%= for err <- upload_errors(@uploads.avatar, entry) do %>
+      <p class="alert alert-danger"><%= error_to_string(err) %></p>
+    <% end %>
+
+  </article>
+<% end %>
+
+</section>
+```
+
+The `section` element in the example acts as the
+`phx-drop-target` for the `:avatar` upload. Users can interact
+with the file input or they can drop files over the element
+to add new entries.
+
+Upload entries are created when a file is added to the form
+input and each will exist until it has been consumed,
+following a successfully completed upload.
+
+### Entry validation
+
+Validation occurs automatically based on any conditions
+that were specified in [`allow_upload/3`] however, as
+mentioned previously you are required to bind `phx-change`
+on the form in order for the validation to be performed.
+Therefore you must implement at least a minimal callback:
+
+```elixir
+@impl Phoenix.LiveView
 def handle_event("validate", _params, socket) do
   {:noreply, socket}
 end
 ```
 
+Entries for files that do not match the [`allow_upload/3`]
+spec will contain errors. Use
+`Phoenix.LiveView.Helpers.upload_errors/2` and your own
+helper function to render a friendly error message:
+
+```elixir
+def error_to_string(:too_large), do: "Too large"
+def error_to_string(:too_many_files), do: "You have selected too many files"
+def error_to_string(:not_accepted), do: "You have selected an unacceptable file type"
+```
+
+### Cancel an entry
+
+Upload entries may also be canceled, either programmatically
+or as a result of a user action. For instance, to handle the
+click event in the template above, you could do the following:
+
+```elixir
+@impl Phoenix.LiveView
+def handle_event("cancel-upload", %{"ref" => ref}, socket) do
+  {:noreply, cancel_upload(socket, :avatar, ref)}
+end
+```
+
 ## Consume uploaded entries
 
-When the end-user submits a form containing a
-[`live_file_input/2`](`Phoenix.LiveView.Helpers.live_file_input/2`),
+When the end-user submits a form containing a [`live_file_input/2`],
 the JavaScript client first uploads the file(s) before
 invoking the callback for the form's `phx-submit` event.
 
@@ -82,13 +166,15 @@ to process the completed uploads, persisting the relevant
 upload data alongside the form data:
 
 ```elixir
+@impl Phoenix.LiveView
 def handle_event("save", _params, socket) do
   uploaded_files =
     consume_uploaded_entries(socket, :avatar, fn %{path: path}, _entry ->
-      dest = Path.join("priv/static/uploads", Path.basename(path))
+      dest = Path.join([:code.priv_dir(:my_app), "static", "uploads", Path.basename(path)])
       File.cp!(path, dest)
       Routes.static_path(socket, "/uploads/#{Path.basename(dest)}")
     end)
+
   {:noreply, update(socket, :uploaded_files, &(&1 ++ uploaded_files))}
 end
 ```
@@ -99,3 +185,51 @@ end
 
 For more information on implementing client-side,
 direct-to-cloud uploads, see the [External Uploads guide](uploads-external.md).
+
+## Appendix A: UploadLive
+
+A complete example of the LiveView from this guide:
+
+```elixir
+# lib/my_app_web/live/upload_live.ex
+defmodule MyAppWeb.UploadLive do
+  use MyAppWeb, :live_view
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    {:ok,
+    socket
+    |> assign(:uploaded_files, [])
+    |> allow_upload(:avatar, accept: ~w(.jpg .jpeg), max_entries: 2)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("validate", _params, socket) do
+    {:noreply, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("cancel-upload", %{"ref" => ref}, socket) do
+    {:noreply, cancel_upload(socket, :avatar, ref)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("save", _params, socket) do
+    uploaded_files =
+      consume_uploaded_entries(socket, :avatar, fn %{path: path}, _entry ->
+        dest = Path.join([:code.priv_dir(:my_app), "static", "uploads", Path.basename(path)])
+        File.cp!(path, dest)
+        Routes.static_path(socket, "/uploads/#{Path.basename(dest)}")
+      end)
+
+    {:noreply, update(socket, :uploaded_files, &(&1 ++ uploaded_files))}
+  end
+
+  defp error_to_string(:too_large), do: "Too large"
+  defp error_to_string(:too_many_files), do: "You have selected too many files"
+  defp error_to_string(:not_accepted), do: "You have selected an unacceptable file type"
+end
+```
+
+[`allow_upload/3`]: `Phoenix.LiveView.allow_upload/3`
+[`live_file_input/2`]: `Phoenix.LiveView.Helpers.live_file_input/2`


### PR DESCRIPTION
Updates the uploads guide to capture some additional information:

* Drag and drop support via `phx-drop-target`
* Automatic attributes for `live_file_input/2`
* Entry validation feedback via `upload_errors/2`
* Entry cancelation with `cancel_upload/3`
* Use `:code.priv_dir/1` in the `consume_uploaded_entries/3` callback example
* A complete annotated example of the LiveView module and leex template