### PR TITLE
Implement Phoenix.LiveView.Helpers.upload_errors/1

### DIFF
--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -379,8 +379,18 @@ defmodule Phoenix.LiveView.Helpers do
 
   The following errors may be returned:
 
-    * `:too_large` - The entry exceeds the `:max_file_size` constraint
     * `:too_many_files` - The number of selected files exceeds the `:max_entries` constraint
+  """
+  def upload_errors(%Phoenix.LiveView.UploadConfig{} = conf) do
+    for {ref, error} <- conf.errors, ref == conf.ref, do: error
+  end
+
+  @doc """
+  Returns the entry errors for an upload.
+
+  The following errors may be returned:
+
+    * `:too_large` - The entry exceeds the `:max_file_size` constraint
     * `:not_accepted` - The entry does not match the `:accept` MIME types
 
   ## Examples

--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -380,6 +380,16 @@ defmodule Phoenix.LiveView.Helpers do
   The following errors may be returned:
 
     * `:too_many_files` - The number of selected files exceeds the `:max_entries` constraint
+
+  ## Examples
+
+      def error_to_string(:too_many_files), do: "You have selected too many files"
+
+      <%= for err <- upload_errors(@uploads.avatar) do %>
+        <div class="alert alert-danger">
+          <%= error_to_string(err) %>
+        </div>
+      <% end %>
   """
   def upload_errors(%Phoenix.LiveView.UploadConfig{} = conf) do
     for {ref, error} <- conf.errors, ref == conf.ref, do: error


### PR DESCRIPTION
I'm not 100% how to test this, as I did not found any `upload_errors/2` related tests. The idea is, that calling this function will return the errors for the whole upload conf instead of a particular file, this is especially helpful when dealing with the `:too_many_files` error.