### PR TITLE
Raises when invalid :max_entries for allow_upload is provided

### DIFF
--- a/test/phoenix_live_view/upload_config_test.exs
+++ b/test/phoenix_live_view/upload_config_test.exs
@@ -113,6 +113,20 @@ defmodule Phoenix.LiveView.UploadConfigTest do
       assert conf.acceptable_exts == MapSet.new([".gif"])
     end
 
+    test "raises when invalid :max_entries provided" do
+      assert_raise ArgumentError, ~r/invalid :max_entries value provided/, fn ->
+        LiveView.allow_upload(build_socket(), :avatar, accept: :any, max_entries: -1)
+      end
+
+      assert_raise ArgumentError, ~r/invalid :max_entries value provided/, fn ->
+        LiveView.allow_upload(build_socket(), :avatar, accept: :any, max_entries: 0)
+      end
+
+      assert_raise ArgumentError, ~r/invalid :max_entries value provided/, fn ->
+        LiveView.allow_upload(build_socket(), :avatar, accept: :any, max_entries: "bad")
+      end
+    end
+
     test "raises when invalid :max_file_size provided" do
       assert_raise ArgumentError, ~r/invalid :max_file_size value provided/, fn ->
         LiveView.allow_upload(build_socket(), :avatar, accept: :any, max_file_size: -1)


### PR DESCRIPTION
The type of the `:max_entries` option in the `allow_uploads` method is a `pos_integer()`.
https://github.com/phoenixframework/phoenix_live_view/blob/a109746493323fb5eabe2255bcfb8360d36c2674/lib/phoenix_live_view/upload_config.ex#L104

The current implementation does not check the given value of `max_entries` so the following codes do not raise errors:
```
allow_upload(socket, :avatar, accept: :any, max_entries: -1)
allow_upload(socket, :avatar, accept: :any, max_entries: 0)
allow_upload(socket, :avatar, accept: :any, max_entries: "bad")
```

This PR aims to ensure that the value pass through the `:max_entries` option is a positive integer.

