### PR TITLE
Add SourceMaps to minified JS

### DIFF
--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
     libraryTarget: 'umd',
     globalObject: 'this'
   },
+  devtool: 'source-map',
   module: {
     rules: [
       {


### PR DESCRIPTION
As discussed in https://groups.google.com/g/phoenix-core/c/Dk2AbXVnzeg

When running `npm run build`, this will:

* Add a comment to `priv/static/phoenix_live_view.js` pointing to the sourcemap
* Add a new file `priv/static/phoenix_live_view.js.map`

I have verified that when using webpack in your application, it will incorporate this sourcemap and therefore create better error stacktraces.