### PR TITLE
type of unsigned_params could be binary

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -372,7 +372,7 @@ defmodule Phoenix.LiveView do
 
   alias Phoenix.LiveView.Socket
 
-  @type unsigned_params :: map
+  @type unsigned_params :: map | binary
 
   @doc """
   The LiveView entry-point.


### PR DESCRIPTION
We can push a simple text from js with `pushEvent` method:

```js
this.pushEvent('event1', 'hello')
```

In the code of our live, the `handle_event` function will be like:

```ex
def handle_event("event1", "hello", socket) do
```

So the type of `unsigned_params` could be binary.