### PR TITLE
Add missing polyfill for URL() constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ import "classlist-polyfill"
 import "@webcomponents/template"
 import "shim-keyboard-event-key"
 import "core-js/features/set"
+import "core-js/features/url"
 
 import {Socket} from "phoenix"
 import LiveSocket from "phoenix_live_view"


### PR DESCRIPTION
Without a polyfill for `URL()` constructor, the IE11 raises an error here:

https://github.com/phoenixframework/phoenix_live_view/blob/cfed0cedacf365cd290e313c57d95088d4f67889/assets/js/phoenix_live_view.js#L1306