### PR TITLE
fixing compile-time deprecation warning

### DIFF
--- a/lib/phoenix_live_view/upload_config.ex
+++ b/lib/phoenix_live_view/upload_config.ex
@@ -407,7 +407,7 @@ defmodule Phoenix.LiveView.UploadConfig do
   end
 
   defp accept_option!(filter) when is_binary(filter) do
-    if MIME.valid?(filter) do
+    if MIME.extensions(filter) != [] do
       {filter, []}
     else
       raise ArgumentError, """


### PR DESCRIPTION
This PR addresses the compile time warning around the deprecation of `Mime.valid?/1`. The replacement function has been part of `:mime` since before the current version in Live View's lock file so this should be a safe substitution for all supported versions of Live View that follow this change.