### PR TITLE
Always fetch latest upload config from socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.15.5
 
 ### Bug fixes
+  - Fix `consume_upload_entry/3` with external uploads causing inconsistent entries state
   - Fix `push_event` losing events when a single diff produces multiple events from different components
 
 ## 0.15.4 (2021-01-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.15.5
 
 ### Bug fixes
-  - Fix `consume_upload_entry/3` with external uploads causing inconsistent entries state
+  - Fix `consume_uploaded_entry/3` with external uploads causing inconsistent entries state
   - Fix `push_event` losing events when a single diff produces multiple events from different components
 
 ## 0.15.4 (2021-01-26)

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -42,7 +42,8 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   def drop_upload_entries(%UploadConfig{} = conf, entry_refs) do
-    send(self(), {@prefix, :drop_upload_entries, conf, entry_refs})
+    info = %{ref: conf.ref, entry_refs: entry_refs, cid: conf.cid}
+    send(self(), {@prefix, :drop_upload_entries, info})
   end
 
   @impl true
@@ -205,7 +206,9 @@ defmodule Phoenix.LiveView.Channel do
     end
   end
 
-  def handle_info({@prefix, :drop_upload_entries, %{ref: ref, cid: cid}, entry_refs}, state) do
+  def handle_info({@prefix, :drop_upload_entries, info}, state) do
+    %{ref: ref, cid: cid, entry_refs: entry_refs} = info
+
     new_state =
       write_socket(state, cid, nil, fn socket, _ ->
         upload_config = Upload.get_upload_by_ref!(socket, ref)

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -205,9 +205,10 @@ defmodule Phoenix.LiveView.Channel do
     end
   end
 
-  def handle_info({@prefix, :drop_upload_entries, upload_config, entry_refs}, state) do
+  def handle_info({@prefix, :drop_upload_entries, %{ref: ref, cid: cid}, entry_refs}, state) do
     new_state =
-      write_socket(state, upload_config.cid, nil, fn socket, _ ->
+      write_socket(state, cid, nil, fn socket, _ ->
+        upload_config = Upload.get_upload_by_ref!(socket, ref)
         {Upload.drop_upload_entries(socket, upload_config, entry_refs), {:ok, nil, state}}
       end)
 
@@ -762,7 +763,7 @@ defmodule Phoenix.LiveView.Channel do
 
                 socket "/live", Phoenix.LiveView.Socket,
                   websocket: [connect_info: [session: @session_options]]
-                  
+
             4) Ensure the `protect_from_forgery` plug is in your router pipeline:
 
                 plug :protect_from_forgery

--- a/test/phoenix_live_view/upload_external_test.exs
+++ b/test/phoenix_live_view/upload_external_test.exs
@@ -178,7 +178,7 @@ defmodule Phoenix.LiveView.UploadExternalTest do
         Task.async(fn -> render_upload(input, file.name, 1) end)
       end
 
-    [_ | _] = Task.await_many(tasks)
+    [_ | _] = Task.yield_many(tasks, 5000)
 
     run(lv, fn socket ->
       entries = Phoenix.LiveView.uploaded_entries(socket, :avatar)


### PR DESCRIPTION
The `consume_uploaded_entry/3` function was re-using the upload config from the previous progress message for external uploads which, in turn, lead to inconsistent state for the uploaded entries list.

// @ssbb