### PR TITLE
Apply fixes for LiveViewTest with uploads

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1368,7 +1368,7 @@ defmodule Phoenix.LiveViewTest do
 
   ## Examples
 
-      avatar = file_input(lv, "form", :avatar, %{name: ..., ...})
+      avatar = file_input(lv, "#my-form-id", :avatar, [%{name: ..., ...}, ...])
       assert {:ok, %{ref: _ref, config: %{chunk_size: _}}} = preflight_upload(avatar)
   """
   def preflight_upload(%Upload{} = upload) do

--- a/lib/phoenix_live_view/test/upload_client.ex
+++ b/lib/phoenix_live_view/test/upload_client.ex
@@ -181,4 +181,8 @@ defmodule Phoenix.LiveViewTest.UploadClient do
       :error ->  raise "no file input with name \"#{name}\" found in #{inspect(state.entries)}"
     end
   end
+
+  def handle_info(:garbage_collect, state) do
+    {:noreply, state}
+  end
 end


### PR DESCRIPTION
Three small updates related to file uploads and LiveViewTest:

1. Fix the example for `preflight_upload/1` (Related to #1346)
2. Handle `:garbage_collect` messages in `UploadClient` - these show up from time to time as unhandled messages in user-land test output
3. Handle the `ClientProxy` reply for the progress update after a `:chunk` call. This _should_ fix the MatchErrors that continue to plague the CI runs 🙏 even though I still can't reproduce it locally