### PR TITLE
Added chunk_count: option to allow_upload() with default 2

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -695,6 +695,9 @@ defmodule Phoenix.LiveView do
     * `:max_file_size` - The maximum file size in bytes to allow to be uploaded.
       Defaults 8MB. For example, `12_000_000`.
 
+    * `:chunk_count` - The number of chunks to send in parallel when uploading.
+      Defaults `2`.
+
     * `:chunk_size` - The chunk size in bytes to send when uploading.
       Defaults `64_000`.
 

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -286,7 +286,8 @@ defmodule Phoenix.LiveView.Upload do
     client_meta = %{
       max_file_size: conf.max_file_size,
       max_entries: conf.max_entries,
-      chunk_size: conf.chunk_size
+      chunk_size: conf.chunk_size,
+      chunk_count: conf.chunk_count
     }
 
     {new_socket, new_conf, new_entries} = mark_preflighted(socket, conf)

--- a/lib/phoenix_live_view/upload_config.ex
+++ b/lib/phoenix_live_view/upload_config.ex
@@ -55,6 +55,7 @@ defmodule Phoenix.LiveView.UploadConfig do
   @default_max_entries 1
   @default_max_file_size 8_000_000
   @default_chunk_size 64_000
+  @default_chunk_count 2
   @default_chunk_timeout 10_000
 
   @unregistered :unregistered
@@ -83,6 +84,7 @@ defmodule Phoenix.LiveView.UploadConfig do
             max_entries: @default_max_entries,
             max_file_size: @default_max_file_size,
             chunk_size: @default_chunk_size,
+            chunk_count: @default_chunk_count,
             chunk_timeout: @default_chunk_timeout,
             entries: [],
             entry_refs_to_pids: %{},
@@ -234,6 +236,24 @@ defmodule Phoenix.LiveView.UploadConfig do
           @default_chunk_size
       end
 
+    chunk_count =
+      case Keyword.fetch(opts, :chunk_count) do
+        {:ok, pos_integer} when is_integer(pos_integer) and pos_integer > 0 ->
+          pos_integer
+
+        {:ok, other} ->
+          raise ArgumentError, """
+          invalid :chunk_count value provided to allow_upload.
+
+          Only a positive integer is supported (Defaults to #{@default_chunk_count} chunks). Got:
+
+          #{inspect(other)}
+          """
+
+        :error ->
+          @default_chunk_count
+      end
+
     chunk_timeout =
       case Keyword.fetch(opts, :chunk_timeout) do
         {:ok, pos_integer} when is_integer(pos_integer) and pos_integer > 0 ->
@@ -284,6 +304,7 @@ defmodule Phoenix.LiveView.UploadConfig do
       acceptable_exts: acceptable_exts,
       external: external,
       chunk_size: chunk_size,
+      chunk_count: chunk_count,
       chunk_timeout: chunk_timeout,
       progress_event: progress_event,
       auto_upload?: Keyword.get(opts, :auto_upload, false),


### PR DESCRIPTION
chunk_count improves upload speed on medium-high latency
connections without disrupting interactivity. When chunk_count
is 2 it means that a second chunk is being sent, while the
confirmation for the first is still outstanding. So instead of
dead waiting time from the latency we're using the latency to
transfer more in the mean time.

Not sure, do you want me to keep the generated priv/static/phoenix_live_view.js in the pull request?