### PR TITLE
Add missing polyfill for Event() constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ All current Chrome, Safari, Firefox, and MS Edge are supported.
 IE11 support is available with the following polyfills:
 
 ```console
-$ npm install --save --prefix assets mdn-polyfills url-search-params-polyfill formdata-polyfill child-replace-with-polyfill classlist-polyfill @webcomponents/template shim-keyboard-event-key core-js
+$ npm install --save --prefix assets mdn-polyfills url-search-params-polyfill formdata-polyfill child-replace-with-polyfill classlist-polyfill new-event-polyfill @webcomponents/template shim-keyboard-event-key core-js
 ```
 
 Note: The `shim-keyboard-event-key` polyfill is also required for [MS Edge 12-18](https://caniuse.com/#feat=keyboardevent-key).
@@ -141,6 +141,7 @@ import "child-replace-with-polyfill"
 import "url-search-params-polyfill"
 import "formdata-polyfill"
 import "classlist-polyfill"
+import "new-event-polyfill"
 import "@webcomponents/template"
 import "shim-keyboard-event-key"
 import "core-js/features/set"


### PR DESCRIPTION
Without a polyfill for `new Event()` constructor, the IE11 raises an error here:

https://github.com/phoenixframework/phoenix_live_view/blob/756ea696cc46f88e03f5c076fe9217cb0a2951a5/assets/js/phoenix_live_view.js#L1058
