### PR TITLE
Support function components via component/3

### DIFF
--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -902,6 +902,8 @@ defmodule Phoenix.LiveView.Engine do
 
   defp classify_taint(:live_component, [_, _, [do: _]]), do: :render
   defp classify_taint(:live_component, [_, _, _, [do: _]]), do: :render
+  defp classify_taint(:component, [_, [do: _]]), do: :render
+  defp classify_taint(:component, [_, _, [do: _]]), do: :render
   defp classify_taint(:render_layout, [_, _, _, [do: _]]), do: :render
 
   defp classify_taint(:alias, [_]), do: :always

--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -379,7 +379,7 @@ defmodule Phoenix.LiveView.Helpers do
 
   def __component__(func, assigns)
       when is_list(assigns) or is_map(assigns) do
-    raise "expected a function, got #{func}"
+    raise ArgumentError, "component/3 expected an anonymous function, got: #{inspect(func)}"
   end
 
   @doc """

--- a/test/phoenix_live_view/controller_test.exs
+++ b/test/phoenix_live_view/controller_test.exs
@@ -24,4 +24,19 @@ defmodule Phoenix.LiveView.ControllerTest do
     conn = get(conn, "/controller/live-render-4")
     assert html_response(conn, 200) =~ "title: Dashboard"
   end
+
+  test "renders function components from dead view", %{conn: conn} do
+    conn = get(conn, "/controller/render-with-function-component")
+    assert html_response(conn, 200) =~ "RENDER:COMPONENT:from component"
+  end
+
+  test "renders function components from dead layout", %{conn: conn} do
+    conn = get(conn, "/controller/render-layout-with-function-component")
+    assert html_response(conn, 200) =~ """
+    LAYOUT:COMPONENT:from layout
+
+    Hello
+
+    """
+  end
 end

--- a/test/phoenix_live_view/integrations/function_components_test.exs
+++ b/test/phoenix_live_view/integrations/function_components_test.exs
@@ -1,0 +1,130 @@
+defmodule Phoenix.LiveView.FunctionComponentsTest do
+  use ExUnit.Case, async: false
+
+  import Phoenix.LiveViewTest
+  alias Phoenix.LiveViewTest.Endpoint
+
+  @endpoint Endpoint
+
+  setup do
+    {:ok, conn: Phoenix.ConnTest.build_conn()}
+  end
+
+  defmodule RenderOnly do
+    use Phoenix.LiveComponent
+
+    def render(assigns) do
+      ~L"""
+      <%= component &hello/1, name: "WORLD" %>
+      """
+    end
+
+    defp hello(assigns) do
+      ~L"""
+      Hello <%= @name %>
+      """
+    end
+  end
+
+  defmodule RenderWithBlock do
+    use Phoenix.LiveComponent
+
+    def render(assigns) do
+      ~L"""
+      <%= component &hello/1, name: "WORLD" do %>
+      THE INNER BLOCK
+      <% end %>
+      """
+    end
+
+    def hello(assigns) do
+      ~L"""
+      Hello <%= @name %>
+      <%= render_block @inner_block %>
+      """
+    end
+  end
+
+  defmodule RenderWithBlockPassingArgs do
+    use Phoenix.LiveComponent
+
+    def render(assigns) do
+      ~L"""
+      <%= component &hello/1, name: "WORLD" do %>
+      <% [arg1: arg1, arg2: arg2] -> %>
+      THE INNER BLOCK
+      ARG1: <%= arg1 %>
+      ARG2: <%= arg2 %>
+      <% end %>
+      """
+    end
+
+    def hello(assigns) do
+      ~L"""
+      Hello <%= @name %>
+      <%= render_block @inner_block, arg1: 1, arg2: 2 %>
+      """
+    end
+  end
+
+  defmodule RenderWithLiveComponent do
+    use Phoenix.LiveComponent
+
+    def render(assigns) do
+      ~L"""
+      <%= component &render_with_live_component/1 %>
+      """
+    end
+
+    def render_with_live_component(assigns) do
+      ~L"""
+      COMPONENT
+      <%= live_component :fake_socket, RenderWithBlockPassingArgs %>
+      """
+    end
+  end
+
+  test "render component" do
+    assert render_component(RenderOnly, %{}) == """
+    Hello WORLD
+
+    """
+  end
+
+  test "render component with block" do
+    assert render_component(RenderWithBlock, %{}) == """
+    Hello WORLD
+
+    THE INNER BLOCK
+
+
+    """
+  end
+
+  test "render component with block passing args" do
+    assert render_component(RenderWithBlockPassingArgs, %{}) == """
+    Hello WORLD
+
+    THE INNER BLOCK
+    ARG1: 1
+    ARG2: 2
+
+
+    """
+  end
+
+  test "render component with live_component" do
+    assert render_component(RenderWithLiveComponent, %{}) == """
+    COMPONENT
+    Hello WORLD
+
+    THE INNER BLOCK
+    ARG1: 1
+    ARG2: 2
+
+
+
+
+    """
+  end
+end

--- a/test/support/controller.ex
+++ b/test/support/controller.ex
@@ -24,6 +24,19 @@ defmodule Phoenix.LiveViewTest.Controller do
     |> live_render(Phoenix.LiveViewTest.DashboardLive)
   end
 
+  def incoming(conn, %{"type" => "render-with-function-component"}) do
+    conn
+    |> put_view(Phoenix.LiveViewTest.LayoutView)
+    |> render("with-function-component.html")
+  end
+
+  def incoming(conn, %{"type" => "render-layout-with-function-component"}) do
+    conn
+    |> put_view(Phoenix.LiveViewTest.LayoutView)
+    |> put_root_layout({Phoenix.LiveViewTest.LayoutView, "layout-with-function-component.html"})
+    |> render("hello.html")
+  end
+
   def not_found(conn, _) do
     conn
     |> put_status(:not_found)

--- a/test/support/layout_view.ex
+++ b/test/support/layout_view.ex
@@ -29,6 +29,25 @@ defmodule Phoenix.LiveViewTest.LayoutView do
     """
   end
 
+  def render("with-function-component.html", assigns) do
+    ~L"""
+    RENDER:<%= component(&Phoenix.LiveViewTest.FunctionComponent.render/1, value: "from component") %>
+    """
+  end
+
+  def render("layout-with-function-component.html", assigns) do
+    ~L"""
+    LAYOUT:<%= component(&Phoenix.LiveViewTest.FunctionComponent.render/1, value: "from layout") %>
+    <%= @inner_content %>
+    """
+  end
+
+  def render("hello.html", assigns) do
+    ~L"""
+    Hello
+    """
+  end
+
   def render("styled.html", assigns) do
     ~L"""
     <html>

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -1,3 +1,13 @@
+defmodule Phoenix.LiveViewTest.FunctionComponent do
+  import Phoenix.LiveView.Helpers
+
+  def render(assigns) do
+    ~L"""
+    COMPONENT:<%= @value %>
+    """
+  end
+end
+
 defmodule Phoenix.LiveViewTest.StatefulComponent do
   use Phoenix.LiveComponent
 


### PR DESCRIPTION
This is the first of a set of PRs intended to improve support for components in Phoenix. 

This first PR introduces a `component/3` macro that should be used to define stateless components based on pure functions. The goal is to be able to create stateless components that can:

1. Be used in controller-based dead views, including layouts
2. Include live components in their inner block
3. Be diff-tracking-aware

The `component/3` macro along with the changes in https://github.com/phoenixframework/phoenix_html/pull/331 are requirements for the next PR which will introduce an HTML tokenizer and engine that will be able to parse an extended version of `EEX` called `HEEX`. This new format will allow injecting components in an HTML-like style (similar to React, Vue, Surface, ...). In addition, it will statically validate the structure of the template, raising errors on common mistakes like unclosed/unmatched tags.

The first version of the HTML tokenizer and engine is already done and will be submitted for review as soon as we have this one merged.

Cheers.
