### PR TITLE
`component/3` should warn about wrong func arity?

### DIFF
--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -250,7 +250,9 @@ defmodule Phoenix.LiveView.Helpers do
       <%= component(&MyApp.Weather.component/1, city: "Kraków") %>
 
   """
-  defmacro component(func, assigns \\ [], do_block \\ []) do
+  defmacro component(func, assigns \\ [], do_block \\ [])
+
+  defmacro component({:&, _, [{:/, _, [{_, _, _}, 1]}]} = func, assigns, do_block) do
     {do_block, assigns} =
       case {do_block, assigns} do
         {[do: do_block], _} -> {do_block, assigns}
@@ -267,6 +269,22 @@ defmodule Phoenix.LiveView.Helpers do
         unquote(inner_block)
       )
     end
+  end
+
+  defmacro component(_func, _assigns, _do_block) do
+    raise ArgumentError, """
+      component/3 expected an anonymous function with 1-arity
+
+      Please call component with a 1-arity function, for example:
+
+          <%= component &func/1 %>
+
+          def func(assigns) do
+            ~L\"""
+            Hello
+            \"""
+          end
+    """
   end
 
   defp rewrite_do(nil, opts, _caller), do: {opts, nil}

--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -241,7 +241,7 @@ defmodule Phoenix.LiveView.Helpers do
 
   ## Examples
 
-  The function can either local:
+  The function can be either local:
 
       <%= component(&weather_component/1, city: "Kraków") %>
 

--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -377,8 +377,7 @@ defmodule Phoenix.LiveView.Helpers do
     func.(assigns)
   end
 
-  def __component__(func, assigns, _)
-      when is_function(func) and is_list(assigns) or is_map(assigns) do
+  def __component__(func, assigns, _) when is_list(assigns) or is_map(assigns) do
     raise ArgumentError, """
     component/3 expected an anonymous function with 1-arity, got: #{inspect(func)}
 
@@ -392,11 +391,6 @@ defmodule Phoenix.LiveView.Helpers do
           \"""
         end
     """
-  end
-
-  def __component__(func, assigns, _)
-      when is_list(assigns) or is_map(assigns) do
-    raise ArgumentError, "component/3 expected an anonymous function, got: #{inspect(func)}"
   end
 
   @doc """

--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -231,13 +231,14 @@ defmodule Phoenix.LiveView.Helpers do
   end
 
   @doc """
-  Renders a stateless component defined by a function.
+  Renders a component defined by the given function.
 
-  Takes two optional arguments, assigns and a do block that will be used as
-  the @inner_block.
+  It takes two optional arguments, the assigns to pass to the given function
+  and a do-block - which will be converted into a `@inner_block`  assign (see
+  `render_block/3` for more information).
 
-  All of the `assigns` given are forwarded directly to the function as
-  the first only argument.
+  The given function must expect one argument, which are the `assigns` as a
+  map.
 
   ## Examples
 

--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -380,17 +380,17 @@ defmodule Phoenix.LiveView.Helpers do
   def __component__(func, assigns, _)
       when is_function(func) and is_list(assigns) or is_map(assigns) do
     raise ArgumentError, """
-      component/3 expected an anonymous function with 1-arity, got: #{inspect(func)}
+    component/3 expected an anonymous function with 1-arity, got: #{inspect(func)}
 
-      Please call component with a 1-arity function, for example:
+    Please call component with a 1-arity function, for example:
 
-          <%= component &func/1 %>
+        <%= component &func/1 %>
 
-          def func(assigns) do
-            ~L\"""
-            Hello
-            \"""
-          end
+        def func(assigns) do
+          ~L\"""
+          Hello
+          \"""
+        end
     """
   end
 

--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -250,9 +250,7 @@ defmodule Phoenix.LiveView.Helpers do
       <%= component(&MyApp.Weather.component/1, city: "Kraków") %>
 
   """
-  defmacro component(func, assigns \\ [], do_block \\ [])
-
-  defmacro component({:&, _, [{:/, _, [{_, _, _}, 1]}]} = func, assigns, do_block) do
+  defmacro component(func, assigns \\ [], do_block \\ []) do
     {do_block, assigns} =
       case {do_block, assigns} do
         {[do: do_block], _} -> {do_block, assigns}
@@ -269,22 +267,6 @@ defmodule Phoenix.LiveView.Helpers do
         unquote(inner_block)
       )
     end
-  end
-
-  defmacro component(_func, _assigns, _do_block) do
-    raise ArgumentError, """
-      component/3 expected an anonymous function with 1-arity
-
-      Please call component with a 1-arity function, for example:
-
-          <%= component &func/1 %>
-
-          def func(assigns) do
-            ~L\"""
-            Hello
-            \"""
-          end
-    """
   end
 
   defp rewrite_do(nil, opts, _caller), do: {opts, nil}
@@ -388,14 +370,31 @@ defmodule Phoenix.LiveView.Helpers do
 
   @doc false
   def __component__(func, assigns, inner)
-      when is_function(func) and is_list(assigns) or is_map(assigns) do
+      when is_function(func, 1) and is_list(assigns) or is_map(assigns) do
     assigns = Map.new(assigns)
     assigns = if inner, do: Map.put(assigns, :inner_block, inner), else: assigns
 
     func.(assigns)
   end
 
-  def __component__(func, assigns)
+  def __component__(func, assigns, _)
+      when is_function(func) and is_list(assigns) or is_map(assigns) do
+    raise ArgumentError, """
+      component/3 expected an anonymous function with 1-arity, got: #{inspect(func)}
+
+      Please call component with a 1-arity function, for example:
+
+          <%= component &func/1 %>
+
+          def func(assigns) do
+            ~L\"""
+            Hello
+            \"""
+          end
+    """
+  end
+
+  def __component__(func, assigns, _)
       when is_list(assigns) or is_map(assigns) do
     raise ArgumentError, "component/3 expected an anonymous function, got: #{inspect(func)}"
   end


### PR DESCRIPTION
Calling `<%= component &hello/0 %>` returns:

```
** (CompileError) [...] expected "assigns" to expand to an existing variable or be part of a match
```

And calling with `&hello/2` or more args returns:

```
** (BadArityError) #Function<... hello/2-"> with arity 2 called with 1 argument (%{name: "WORLD"})
```

Considering that a `var!(assigns)` is always expected, is it safe to assume that `component/3` should enforce arity 1? If so, can we improve the error message?

_With this patch:_

```
** (ArgumentError)   component/3 expected an anonymous function with 1-arity

  Please call component with a 1-arity function, for example:

      <%= component &func/1 %>

      def func(assigns) do
        ~L"""
        Hello
        """
      end
```

Makes sense?

/cc @msaraiva 