### PR TITLE
Remove unnecessary error string

### DIFF
--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -510,7 +510,6 @@ defmodule Phoenix.LiveView.Helpers do
   ## Examples
 
       def error_to_string(:too_large), do: "Too large"
-      def error_to_string(:too_many_files), do: "You have selected too many files"
       def error_to_string(:not_accepted), do: "You have selected an unacceptable file type"
 
       <%= for entry <- @uploads.avatar.entries do %>


### PR DESCRIPTION
Since the introduction of `upload_errors/1` the error string `:too_many_files` is not a valid example for `upload_errors/2`.