### PR TITLE
Add follow_trigger_action test utility

### DIFF
--- a/test/support/live_views/elements.ex
+++ b/test/support/live_views/elements.ex
@@ -104,15 +104,27 @@ defmodule Phoenix.LiveViewTest.ElementsLive do
       <input name="hello[utc_text]" type="text">
       <%= Phoenix.HTML.Form.datetime_select :hello, :utc_select, second: [] %>
     </form>
+
+    <form id="trigger-form" phx-submit="form-submit-trigger" phx-value-key="value" phx-trigger-action=<%= @trigger_action %>>
+    </form>
     """
   end
 
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, :event, nil)}
+    socket =
+      socket
+      |> assign(:event, nil)
+      |> assign(:trigger_action, false)
+
+    {:ok, socket}
   end
 
   def handle_params(params, _uri, socket) do
     {:noreply, assign(socket, :event, "handle_params: #{inspect(params)}")}
+  end
+
+  def handle_event("form-submit-trigger", _value, socket) do
+    {:noreply, assign(socket, :trigger_action, true)}
   end
 
   def handle_event(event, value, socket) do


### PR DESCRIPTION
Adds a `follow_trigger_action` macro that triggers an event, submits a form, and returns a conn.

Context: https://github.com/phoenixframework/phoenix_live_view/issues/1436