### PR TITLE
Fix regression in render_upload/3 for channel uploads with progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
   - Fix live patch failing to update URL when live patch link is patched again from `handle_params`
+  - Fix regression in `LiveViewTest.render_upload/3` when using channel uploads and progress callback
 
 ## 0.15.5 (2021-04-20)
 

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1441,7 +1441,7 @@ defmodule Phoenix.LiveViewTest do
   end
 
   defp render_chunk(upload, entry_name, percent) do
-    _ = UploadClient.chunk(upload, entry_name, percent, proxy_pid(upload.view))
+    {:ok, _} = UploadClient.chunk(upload, entry_name, percent, proxy_pid(upload.view))
     render(upload.view)
   end
 end

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1441,7 +1441,7 @@ defmodule Phoenix.LiveViewTest do
   end
 
   defp render_chunk(upload, entry_name, percent) do
-    :ok = UploadClient.chunk(upload, entry_name, percent, proxy_pid(upload.view))
+    _ = UploadClient.chunk(upload, entry_name, percent, proxy_pid(upload.view))
     render(upload.view)
   end
 end

--- a/test/phoenix_live_view/upload_channel_test.exs
+++ b/test/phoenix_live_view/upload_channel_test.exs
@@ -62,12 +62,15 @@ defmodule Phoenix.LiveView.UploadChannelTest do
   end
 
   def consume(%LiveView.UploadEntry{} = entry, socket) do
-    socket = if entry.done? do
-      name = Phoenix.LiveView.consume_uploaded_entry(socket, entry, fn _ -> entry.client_name end)
-      LiveView.update(socket, :consumed, fn consumed -> [name] ++ consumed end)
-    else
-      socket
-    end
+    socket =
+      if entry.done? do
+        name =
+          Phoenix.LiveView.consume_uploaded_entry(socket, entry, fn _ -> entry.client_name end)
+
+        LiveView.update(socket, :consumed, fn consumed -> [name] ++ consumed end)
+      else
+        socket
+      end
 
     {:noreply, socket}
   end
@@ -111,15 +114,15 @@ defmodule Phoenix.LiveView.UploadChannelTest do
   end
 
   defp opts_for_allow_upload(opts) do
-      case Keyword.fetch(opts, :progress) do
-        {:ok, progress} ->
-          Keyword.put(opts, :progress, fn _, entry, socket ->
-            apply(__MODULE__, progress, [entry, socket])
-          end)
+    case Keyword.fetch(opts, :progress) do
+      {:ok, progress} ->
+        Keyword.put(opts, :progress, fn _, entry, socket ->
+          apply(__MODULE__, progress, [entry, socket])
+        end)
 
-        :error ->
-          opts
-      end
+      :error ->
+        opts
+    end
   end
 
   for context <- [:lv, :component] do
@@ -532,40 +535,62 @@ defmodule Phoenix.LiveView.UploadChannelTest do
       assert render_upload(avatar, "myfile1.jpeg", 1) =~ "component:myfile1.jpeg:1%"
 
       GenServer.call(lv.pid, {:setup, fn socket -> LiveView.assign(socket, uploads_count: 2) end})
-      GenServer.call(lv.pid, {:setup, fn socket ->
-        run = fn component_socket ->
-          new_socket = Phoenix.LiveView.allow_upload(component_socket, :avatar, accept: :any)
-          {:reply, :ok, new_socket}
-        end
-        LiveView.send_update(Phoenix.LiveViewTest.UploadComponent, id: "upload1", run: {run, nil})
-        socket
-      end})
+
+      GenServer.call(
+        lv.pid,
+        {:setup,
+         fn socket ->
+           run = fn component_socket ->
+             new_socket = Phoenix.LiveView.allow_upload(component_socket, :avatar, accept: :any)
+             {:reply, :ok, new_socket}
+           end
+
+           LiveView.send_update(Phoenix.LiveViewTest.UploadComponent,
+             id: "upload1",
+             run: {run, nil}
+           )
+
+           socket
+         end}
+      )
 
       dup_avatar = file_input(lv, "#upload1", :avatar, build_entries(1))
 
       assert UploadLive.exits_with(lv, dup_avatar, RuntimeError, fn ->
-        render_upload(dup_avatar, "myfile1.jpeg", 1)
-      end) =~ "existing upload for avatar already allowed in another component"
+               render_upload(dup_avatar, "myfile1.jpeg", 1)
+             end) =~ "existing upload for avatar already allowed in another component"
+
       refute Process.alive?(lv.pid)
     end
 
     @tag allow: [accept: :any]
     test "get allowed uploads from the form's target cid", %{lv: lv} do
       GenServer.call(lv.pid, {:setup, fn socket -> LiveView.assign(socket, uploads_count: 2) end})
-      GenServer.call(lv.pid, {:setup, fn socket ->
-        run = fn component_socket ->
-          new_socket =
-            component_socket
-            |> Phoenix.LiveView.allow_upload(:avatar, accept: :any)
-            |> Phoenix.LiveView.allow_upload(:background, accept: :any)
 
-          {:reply, :ok, new_socket}
-        end
-        LiveView.send_update(Phoenix.LiveViewTest.UploadComponent, id: "upload1", run: {run, nil})
-        socket
-      end})
+      GenServer.call(
+        lv.pid,
+        {:setup,
+         fn socket ->
+           run = fn component_socket ->
+             new_socket =
+               component_socket
+               |> Phoenix.LiveView.allow_upload(:avatar, accept: :any)
+               |> Phoenix.LiveView.allow_upload(:background, accept: :any)
 
-      assert %Phoenix.LiveViewTest.Upload{} = file_input(lv, "#upload1", :background, build_entries(1))
+             {:reply, :ok, new_socket}
+           end
+
+           LiveView.send_update(Phoenix.LiveViewTest.UploadComponent,
+             id: "upload1",
+             run: {run, nil}
+           )
+
+           socket
+         end}
+      )
+
+      assert %Phoenix.LiveViewTest.Upload{} =
+               file_input(lv, "#upload1", :background, build_entries(1))
 
       assert_raise RuntimeError, "no uploads allowed for background", fn ->
         file_input(lv, "#upload0", :background, build_entries(1))

--- a/test/phoenix_live_view/upload_channel_test.exs
+++ b/test/phoenix_live_view/upload_channel_test.exs
@@ -62,8 +62,11 @@ defmodule Phoenix.LiveView.UploadChannelTest do
   end
 
   def consume(%LiveView.UploadEntry{} = entry, socket) do
-    if entry.done? do
-      Phoenix.LiveView.consume_uploaded_entry(socket, entry, fn _ -> :ok end)
+    socket = if entry.done? do
+      name = Phoenix.LiveView.consume_uploaded_entry(socket, entry, fn _ -> entry.client_name end)
+      LiveView.update(socket, :consumed, fn consumed -> [name] ++ consumed end)
+    else
+      socket
     end
 
     {:noreply, socket}
@@ -279,7 +282,7 @@ defmodule Phoenix.LiveView.UploadChannelTest do
             %{name: "foo.jpeg", content: String.duplicate("0", 100)}
           ])
 
-          assert render_upload(avatar, "foo.jpeg") =~ "100%"
+        assert render_upload(avatar, "foo.jpeg") =~ "consumed:foo.jpeg"
       end
 
       @tag allow: [max_entries: 3, chunk_size: 20, accept: :any]

--- a/test/support/live_views/upload_live.ex
+++ b/test/support/live_views/upload_live.ex
@@ -6,6 +6,9 @@ defmodule Phoenix.LiveViewTest.UploadLive do
     <%= for preflight <- @preflights do %>
       preflight:<%= inspect(preflight) %>
     <% end %>
+    <%= for name <- @consumed do %>
+      consumed:<%= name %>
+    <% end %>
     <form phx-change="validate" phx-submit="save">
       <%= for entry <- @uploads.avatar.entries do %>
         lv:<%= entry.client_name %>:<%= entry.progress %>%
@@ -27,7 +30,7 @@ defmodule Phoenix.LiveViewTest.UploadLive do
   end
 
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, :preflights, [])}
+    {:ok, assign(socket, preflights: [], consumed: [])}
   end
 
   def handle_call({:setup, setup_func}, _from, socket) do
@@ -77,6 +80,9 @@ defmodule Phoenix.LiveViewTest.UploadComponent do
     <%= for preflight <- @preflights do %>
       preflight:<%= inspect(preflight) %>
     <% end %>
+    <%= for name <- @consumed do %>
+      consumed:<%= name %>
+    <% end %>
     <form phx-change="validate" id="<%= @id %>" phx-submit="save" phx-target="<%= @myself %>">
       <%= for entry <- @uploads.avatar.entries do %>
         component:<%= entry.client_name %>:<%= entry.progress %>%
@@ -114,6 +120,7 @@ defmodule Phoenix.LiveViewTest.UploadComponent do
     {:ok,
      new_socket
      |> assign(preflights: [])
+     |> assign(consumed: [])
      |> assign(assigns)}
   end
 


### PR DESCRIPTION
~Fixes a regression created from fixing the latent errors around chunk replies for uploads in tests (#1409). Essentially I just moved the `receive` block into the chunk function that handles external uploads. This was done to avoid accidentally receiving unexpected messages, such as `:garbage_collect`, from the UploadChannel.~

Provides a proper fix for the sync render replies racing the chunk reply. When consuming uploads in the progress callback, the channel for the uploaded entry is being shut down at the same time we are receiving the reply– this is the expected behaviour, but we need to account for it by catching the shutdown message from the upload channel.

Closes #1432