### PR TITLE
Allow testing with assert_patch where the path isn't known in advance.

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1035,7 +1035,6 @@ defmodule Phoenix.LiveViewTest do
     call(view, :page_title)
   end
 
-
   @doc """
   Asserts a live patch will happen within `timeout` milliseconds. The default
   `timeout` is 100.
@@ -1137,7 +1136,6 @@ defmodule Phoenix.LiveViewTest do
   @doc """
   Asserts a redirect will happen to a given path within `timeout` milliseconds.
   The default `timout` is 100.
-
 
   It returns the flash messages from said redirect, if any.
   Note the flash will contain string keys.

--- a/test/phoenix_live_view/integrations/flash_test.exs
+++ b/test/phoenix_live_view/integrations/flash_test.exs
@@ -136,7 +136,7 @@ defmodule Phoenix.LiveView.FlashIntegrationTest do
       assert result =~ "uri[http://www.example.com/flash-root?foo]"
       assert result =~ "root[ok!]:info"
 
-      assert assert_patch(flash_live, "/flash-root?foo") == :ok
+      assert_patch(flash_live, "/flash-root?foo")
     end
 
     test "push_patch with flash does not include previous event flash", %{conn: conn} do
@@ -151,7 +151,7 @@ defmodule Phoenix.LiveView.FlashIntegrationTest do
       assert result =~ "root[ok!]:info"
       assert result =~ "root[]:error"
 
-      assert assert_patch(flash_live, "/flash-root?foo") == :ok
+      assert_patch(flash_live, "/flash-root?foo")
     end
 
     test "clears flash on client-side patches", %{conn: conn} do


### PR DESCRIPTION
Make the path argument to assert_patch optional.
Add a path call to get the current liveview path.

This is useful when you're testing a create form which is going to patch you to a path for the created resource
and you don't know in advance what the id is going to be.

For example:

```elixir
   render_click(view, "save")
   assert_patch view
   assert path(view) =~ r/\/compose\/\d+/
```

Co-authored with @mveytsman 