### PR TITLE
Live component assigns docs

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -82,6 +82,13 @@ defmodule Phoenix.LiveComponent do
   for stateful components. LiveView will emit warnings in future versions if
   this is not the case.
 
+  The assigns given to [`live_component/3`](`Phoenix.LiveView.Helpers.live_component/3`)
+  are handled as for a stateless component: either passed to
+  `c:update/2` if it is defined; or, merged to the socket assigns
+  otherwise.  The optional `c:preload/1` receives a list of the assigns
+  maps for all instances of the component in the parent LiveView, see
+  below for an example of how this may be helpful.
+
   In stateful components, `c:mount/1` is called only once, when the
   component is first rendered. For each rendering, the optional
   `c:preload/1` and `c:update/2` callbacks are called before `c:render/1`.

--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -42,8 +42,9 @@ defmodule Phoenix.LiveComponent do
   First `c:mount/1` is called only with the socket. `c:mount/1` can be used
   to set any initial state. Then `c:update/2` is invoked with all of the
   assigns given to [`live_component/3`](`Phoenix.LiveView.Helpers.live_component/3`).
-  If `c:update/2` is not defined all assigns are simply merged into the socket.
-  After the component is updated, `c:render/1` is called with all assigns.
+  If `c:update/2` is not defined, all assigns are simply merged into the socket
+  assigns after `c:mount/1`.  After the component is updated, `c:render/1` is
+  called with all assigns.
 
   A stateless component is always mounted, updated, and rendered whenever
   the parent template changes. That's why they are stateless: no state

--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -188,24 +188,31 @@ defmodule Phoenix.LiveView.Helpers do
   Renders a `Phoenix.LiveComponent` within a parent LiveView.
 
   While `LiveView`s can be nested, each LiveView starts its
-  own process. A LiveComponent provides similar functionality
-  to LiveView, except they run in the same process as the
-  `LiveView`, with its own encapsulated state.
+  own process. A LiveComponent provides functionality similar
+  to a LiveView, except it runs in the same process as the parent
+  `LiveView` and has its own encapsulated state.
 
-  LiveComponent comes in two shapes, stateful and stateless.
-  See `Phoenix.LiveComponent` for more information.
+  LiveComponent may be either stateful or stateless, see
+  `Phoenix.LiveComponent` for more information.
 
-  ## Examples
-
-  All of the `assigns` given are forwarded directly to the
-  `live_component`:
-
-      <%= live_component(MyApp.WeatherComponent, id: "thermostat", city: "Kraków") %>
+  The `assigns` are either received by the component's optional
+  `preload/2` if defined, or otherwise automatically merged to the
+  parent LiveView socket assigns after the component's `mount/1`
+  (therefore overriding existing assigns of the same name already in
+  the socket).
 
   Note the `:id` won't necessarily be used as the DOM ID.
   That's up to the component. However, note that the `:id` has
   a special meaning: whenever an `:id` is given, the component
   becomes stateful. Otherwise, `:id` is always set to `nil`.
+
+  ## Examples
+
+  The `%{city: "Kraków"}` assigns will be available in the component
+  via socket assigns after `mount/1`; or may be handled in `update/2`.
+
+      <%= live_component(MyApp.WeatherComponent, id: "thermostat", city: "Kraków") %>
+
   """
   defmacro live_component(component, assigns \\ [], do_block \\ []) do
     if match?({:@, _, [{:socket, _, _}]}, component) or match?({:socket, _, _}, component) do


### PR DESCRIPTION
Expand on LiveComponent assigns handling.  Ensure informal information in the guides is also in the docs for readers who look to it immediately.