### PR TITLE
add a progress_status_timeout option for allow_upload

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -707,6 +707,9 @@ defmodule Phoenix.LiveView do
     * `:chunk_timeout` - The time in milliseconds to wait before closing the
       upload channel when a new chunk has not been received. Defaults `10_000`.
 
+    * `:progress_status_timeout` - The time in milliseconds to wait before receving
+      a response to the `progess` event. If set to `nil`, there is no timeout Defaults to `30_000`.
+
     * `:external` - The 2-arity function for generating metadata for external
       client uploaders. See the Uploads section for example usage.
 

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -286,7 +286,8 @@ defmodule Phoenix.LiveView.Upload do
     client_meta = %{
       max_file_size: conf.max_file_size,
       max_entries: conf.max_entries,
-      chunk_size: conf.chunk_size
+      chunk_size: conf.chunk_size,
+      progress_status_timeout: conf.progress_status_timeout
     }
 
     {new_socket, new_conf, new_entries} = mark_preflighted(socket, conf)

--- a/lib/phoenix_live_view/upload_config.ex
+++ b/lib/phoenix_live_view/upload_config.ex
@@ -55,6 +55,7 @@ defmodule Phoenix.LiveView.UploadConfig do
   @default_max_file_size 8_000_000
   @default_chunk_size 64_000
   @default_chunk_timeout 10_000
+  @default_progress_status_timeout 30_000
 
   @unregistered :unregistered
   @invalid :invalid
@@ -83,6 +84,7 @@ defmodule Phoenix.LiveView.UploadConfig do
             max_file_size: @default_max_file_size,
             chunk_size: @default_chunk_size,
             chunk_timeout: @default_chunk_timeout,
+            progress_status_timeout: @default_progress_status_timeout,
             entries: [],
             entry_refs_to_pids: %{},
             entry_refs_to_metas: %{},
@@ -253,6 +255,29 @@ defmodule Phoenix.LiveView.UploadConfig do
           nil
       end
 
+      progress_status_timeout =
+      case Keyword.fetch(opts, :progress_status_timeout) do
+        {:ok, nil} ->
+          nil
+
+        {:ok, pos_integer} when is_integer(pos_integer) and pos_integer > 0 ->
+          pos_integer
+
+        {:ok, other} ->
+          raise ArgumentError, """
+          invalid :progress_status_timeout value provided to allow_upload.
+
+          Only a positive integer in milliseconds is supported (Defaults to #{
+            @default_progress_status_timeout
+          } ms). Got:
+
+          #{inspect(other)}
+          """
+
+        :error ->
+          @default_progress_status_timeout
+      end
+
     %UploadConfig{
       ref: random_ref,
       name: name,
@@ -266,6 +291,7 @@ defmodule Phoenix.LiveView.UploadConfig do
       external: external,
       chunk_size: chunk_size,
       chunk_timeout: chunk_timeout,
+      progress_status_timeout: progress_status_timeout,
       progress_event: progress_event,
       auto_upload?: Keyword.get(opts, :auto_upload, false),
       allowed?: true


### PR DESCRIPTION
This adds an option to `allow_upload` which will let you change the timeout wait (or eliminate the timeout completely) for progress messages to be acknowledged by the LiveView. 

I am running this code because of an [issue](https://github.com/phoenixframework/phoenix_live_view/issues/1394) I was experiencing in production where a slow response to progress messages would cause the JS to completely reload the page and lose the file that was already uploaded.

_(I understand that my situation may be an outlier or that there may be a better solution to this problem but I wanted to offer this potential contribution up anyway.)_

