### PR TITLE
Allow Storage Overrides

### DIFF
--- a/assets/test/live_socket_test.js
+++ b/assets/test/live_socket_test.js
@@ -227,4 +227,16 @@ describe('LiveSocket', () => {
     // this fails.  Is this correct?
     // expect(liveSocket.getActiveElement()).not.toEqual(input)
   })
+
+  test('storage can be overridden', async () => {
+    let getItemCalls = 0
+    let override = {
+      getItem: function(keyName) { getItemCalls = getItemCalls + 1 }
+    }
+
+    let liveSocket = new LiveSocket('/live', Socket, {sessionStorage: override})
+    liveSocket.getLatencySim()
+
+    expect(getItemCalls).toEqual(1)
+  })
 })


### PR DESCRIPTION
resolves #1460 

This makes it possible to provide replacements for `sessionStorage` and `localStorage` in deployments where you cannot count on access to those APIs.  

Thank you Phoenix team for considering this addition.