### PR TITLE
Specify region for non us-east s3 buckets

### DIFF
--- a/guides/client/uploads-external.md
+++ b/guides/client/uploads-external.md
@@ -133,7 +133,7 @@ defp presign_upload(entry, socket) do
       expires_in: :timer.hours(1)
     )
 
-  meta = %{uploader: "S3", key: key, url: "http://#{bucket}.s3.amazonaws.com", fields: fields}
+  meta = %{uploader: "S3", key: key, url: "http://#{bucket}.s3-#{config.region}.amazonaws.com", fields: fields}
   {:ok, meta, socket}
 end
 ```


### PR DESCRIPTION
Heya,
I have followed the guide for [External File upload](https://hexdocs.pm/phoenix_live_view/uploads-external.html) and kept getting **500** from AWS on Preflight CORS request.  As result no files were uploaded from the browser due to CORS request not returning.
I copied request to CURL I noticed that it returns redirect instead of CORS headers directly. 
According to my understanding of [S3 documentation](https://docs.aws.amazon.com/general/latest/gr/s3.html) the endpoint `s3.amazonaws.com` can only be used for `us-east` region.

After adding the region prefix the issue is gone and files are uploading as expected. 