### PR TITLE
Allow uploads to be sent in batches to avoid congestion

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -404,7 +404,7 @@ class EntryUploader {
     this.offset = 0
     this.chunkSize = chunkSize
     this.chunkTimer = null
-    this.uploadChannel = liveSocket.channel(`lvu:${entry.ref}`, {token: entry.metadata()})
+    this.uploadChannel = liveSocket.channel(`lvu:${entry.ref}`, {token: this.entry.metadata()})
     this._started = false
   }
 
@@ -417,9 +417,14 @@ class EntryUploader {
   upload(){
     this.uploadChannel.onError(reason => this.error(reason))
     this.uploadChannel.join()
-      .receive("ok", data => this.readNextChunk())
-      .receive("error", reason => this.error(reason))
-    this._started = true
+      .receive("ok", data => {
+        this._started = true
+        this.readNextChunk()
+      })
+      .receive("error", reason => {
+          console.log("error",reason)
+          this.error(reason)
+      })
   }
 
   hasStarted() { return this._started }

--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -391,7 +391,10 @@ let uploadInBatches = function(uploaders, onError, resp, liveSocket) {
   if (entriesToProcess.length === 0) return
 
   for (let i = 0; i < resp.config.max_concurrency - inProgress; i++) {
-    entriesToProcess[i].upload()
+    let entry = entriesToProcess[i]
+    if (entry) {
+        entry.upload()
+    }
   }
 
   setTimeout(uploadInBatches, 700, uploaders, onError, resp, liveSocket)

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -701,7 +701,7 @@ defmodule Phoenix.LiveView do
     * `:chunk_timeout` - The time in milliseconds to wait before closing the
       upload channel when a new chunk has not been received. Defaults `10_000`.
 
-    * `:batch_size` - The amount of entries in to upload at the same time. Defaults to 10.
+    * `:max_concurrency` - The amount of entries in to upload at the same time. Defaults to 10.
 
     * `:external` - The 2-arity function for generating metadata for external
       client uploaders. See the Uploads section for example usage.

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -701,6 +701,8 @@ defmodule Phoenix.LiveView do
     * `:chunk_timeout` - The time in milliseconds to wait before closing the
       upload channel when a new chunk has not been received. Defaults `10_000`.
 
+    * `:batch_size` - The amount of entries in to upload at the same time. Defaults to 10.
+
     * `:external` - The 2-arity function for generating metadata for external
       client uploaders. See the Uploads section for example usage.
 

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -991,16 +991,21 @@ defmodule Phoenix.LiveView.Channel do
     write_socket(state, cid, nil, fn socket, _ ->
       conf = Upload.get_upload_by_ref!(socket, ref)
 
-      case Upload.register_entry_upload(socket, conf, pid, entry_ref) do
-        {:ok, new_socket, entry} ->
-          reply = %{max_file_size: entry.client_size, chunk_timeout: conf.chunk_timeout}
-          GenServer.reply(from, {:ok, reply})
-          new_state = put_upload_pid(state, pid, ref, entry_ref, cid)
-          {new_socket, {:ok, nil, new_state}}
+      if length(Map.keys(state.upload_pids)) <= conf.max_concurrency do
+        case Upload.register_entry_upload(socket, conf, pid, entry_ref) do
+          {:ok, new_socket, entry} ->
+            reply = %{max_file_size: entry.client_size, chunk_timeout: conf.chunk_timeout}
+            GenServer.reply(from, {:ok, reply})
+            new_state = put_upload_pid(state, pid, ref, entry_ref, cid)
+            {new_socket, {:ok, nil, new_state}}
 
-        {:error, reason} ->
-          GenServer.reply(from, {:error, reason})
-          {socket, :error}
+          {:error, reason} ->
+            GenServer.reply(from, {:error, reason})
+            {socket, :error}
+        end
+      else
+        GenServer.reply(from, {:error, :max_concurrency_reached})
+        {socket, :error}
       end
     end)
   end

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -122,7 +122,9 @@ defmodule Phoenix.LiveView.Upload do
     |> update_uploads(socket)
   end
 
-  def update_progress(%Socket{} = socket, config_ref, entry_ref, %{"error" => reason})
+  def update_progress(%Socket{} = socket, config_ref, entry_ref, %{
+        "error" => %{"reason" => reason}
+      })
       when is_binary(reason) do
     conf = get_upload_by_ref!(socket, config_ref)
 

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -306,7 +306,8 @@ defmodule Phoenix.LiveView.Upload do
     client_meta = %{
       max_file_size: conf.max_file_size,
       max_entries: conf.max_entries,
-      chunk_size: conf.chunk_size
+      chunk_size: conf.chunk_size,
+      batch_size: conf.batch_size
     }
 
     {new_socket, new_conf, new_entries} = mark_preflighted(socket, conf)

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -307,7 +307,7 @@ defmodule Phoenix.LiveView.Upload do
       max_file_size: conf.max_file_size,
       max_entries: conf.max_entries,
       chunk_size: conf.chunk_size,
-      batch_size: conf.batch_size
+      max_concurrency: conf.max_concurrency
     }
 
     {new_socket, new_conf, new_entries} = mark_preflighted(socket, conf)

--- a/lib/phoenix_live_view/upload_channel.ex
+++ b/lib/phoenix_live_view/upload_channel.ex
@@ -56,7 +56,8 @@ defmodule Phoenix.LiveView.UploadChannel do
       {:error, reason} when reason in [:expired, :invalid] ->
         {:error, %{reason: :invalid_token}}
 
-      {:error, reason} when reason in [:already_registered, :disallowed] ->
+      {:error, reason}
+      when reason in [:already_registered, :disallowed, :max_concurrency_reached] ->
         {:error, %{reason: reason}}
     end
   end

--- a/lib/phoenix_live_view/upload_config.ex
+++ b/lib/phoenix_live_view/upload_config.ex
@@ -56,7 +56,7 @@ defmodule Phoenix.LiveView.UploadConfig do
   @default_max_file_size 8_000_000
   @default_chunk_size 64_000
   @default_chunk_timeout 10_000
-  @default_batch_size 10
+  @default_max_concurrency 10
 
   @unregistered :unregistered
   @invalid :invalid
@@ -85,7 +85,7 @@ defmodule Phoenix.LiveView.UploadConfig do
             max_file_size: @default_max_file_size,
             chunk_size: @default_chunk_size,
             chunk_timeout: @default_chunk_timeout,
-            batch_size: @default_batch_size,
+            max_concurrency: @default_max_concurrency,
             entries: [],
             entry_refs_to_pids: %{},
             entry_refs_to_metas: %{},
@@ -256,22 +256,22 @@ defmodule Phoenix.LiveView.UploadConfig do
           @default_chunk_timeout
       end
 
-    batch_size =
-      case Keyword.fetch(opts, :batch_size) do
+    max_concurrency =
+      case Keyword.fetch(opts, :max_concurrency) do
         {:ok, pos_integer} when is_integer(pos_integer) and pos_integer > 0 ->
           pos_integer
 
         {:ok, other} ->
           raise ArgumentError, """
-          invalid :batch_size value provided to allow_upload.
+          invalid :max_concurrency value provided to allow_upload.
 
-          Only a positive integer is supported (Defaults to #{@default_batch_size} ). Got:
+          Only a positive integer is supported (Defaults to #{@default_max_concurrency} ). Got:
 
           #{inspect(other)}
           """
 
         :error ->
-          @default_batch_size
+          @default_max_concurrency
       end
 
     progress_event =
@@ -305,7 +305,7 @@ defmodule Phoenix.LiveView.UploadConfig do
       external: external,
       chunk_size: chunk_size,
       chunk_timeout: chunk_timeout,
-      batch_size: batch_size,
+      max_concurrency: max_concurrency,
       progress_event: progress_event,
       auto_upload?: Keyword.get(opts, :auto_upload, false),
       allowed?: true

--- a/lib/phoenix_live_view/upload_config.ex
+++ b/lib/phoenix_live_view/upload_config.ex
@@ -56,6 +56,7 @@ defmodule Phoenix.LiveView.UploadConfig do
   @default_max_file_size 8_000_000
   @default_chunk_size 64_000
   @default_chunk_timeout 10_000
+  @default_batch_size 10
 
   @unregistered :unregistered
   @invalid :invalid
@@ -84,6 +85,7 @@ defmodule Phoenix.LiveView.UploadConfig do
             max_file_size: @default_max_file_size,
             chunk_size: @default_chunk_size,
             chunk_timeout: @default_chunk_timeout,
+            batch_size: @default_batch_size,
             entries: [],
             entry_refs_to_pids: %{},
             entry_refs_to_metas: %{},
@@ -254,6 +256,24 @@ defmodule Phoenix.LiveView.UploadConfig do
           @default_chunk_timeout
       end
 
+    batch_size =
+      case Keyword.fetch(opts, :batch_size) do
+        {:ok, pos_integer} when is_integer(pos_integer) and pos_integer > 0 ->
+          pos_integer
+
+        {:ok, other} ->
+          raise ArgumentError, """
+          invalid :batch_size value provided to allow_upload.
+
+          Only a positive integer is supported (Defaults to #{@default_batch_size} ). Got:
+
+          #{inspect(other)}
+          """
+
+        :error ->
+          @default_batch_size
+      end
+
     progress_event =
       case Keyword.fetch(opts, :progress) do
         {:ok, func} when is_function(func, 3) ->
@@ -285,6 +305,7 @@ defmodule Phoenix.LiveView.UploadConfig do
       external: external,
       chunk_size: chunk_size,
       chunk_timeout: chunk_timeout,
+      batch_size: batch_size,
       progress_event: progress_event,
       auto_upload?: Keyword.get(opts, :auto_upload, false),
       allowed?: true


### PR DESCRIPTION
Should solve #1464 . 

I have tested this with a custom `handle_progress/3` function and it works as expected. 
Uploading over 50 files is no problem as new ones are scheduled when uploads in progress are done.