### PR TITLE
Fix missing do in for in render_upload documentation

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1382,7 +1382,7 @@ defmodule Phoenix.LiveViewTest do
   Given the following LiveView template:
 
       <%= for entry <- @uploads.avatar.entries do %>
-          <%=entry.name %>: <%= entry.progress %>%
+          <%= entry.name %>: <%= entry.progress %>%
       <% end %>
 
   Your test case can assert the uploaded content:

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1381,7 +1381,7 @@ defmodule Phoenix.LiveViewTest do
 
   Given the following LiveView template:
 
-      <%= for entry <- @uploads.avatar.entries %>
+      <%= for entry <- @uploads.avatar.entries do %>
           <%=entry.name %>: <%= entry.progress %>%
       <% end %>
 


### PR DESCRIPTION
![missingdo](https://user-images.githubusercontent.com/8680198/120799285-71052300-c536-11eb-9145-704073bdd65a.png)

The for block above is missing a do.