### PR TITLE
Fix timout typo introduced in assert_redirect docs.

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1110,7 +1110,7 @@ defmodule Phoenix.LiveViewTest do
 
   @doc """
   Asserts a redirect will happen within `timeout` milliseconds.
-  The default `timout` is 100.
+  The default `timeout` is 100.
 
   It returns a tuple containing the new path and the flash messages from said
   redirect, if any. Note the flash will contain string keys.
@@ -1135,7 +1135,7 @@ defmodule Phoenix.LiveViewTest do
 
   @doc """
   Asserts a redirect will happen to a given path within `timeout` milliseconds.
-  The default `timout` is 100.
+  The default `timeout` is 100.
 
   It returns the flash messages from said redirect, if any.
   Note the flash will contain string keys.


### PR DESCRIPTION
Why are typos invisible until the PR merges?

(cc @mveytsman)