### PR TITLE
Add missing changelog for 0.15.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,11 @@ your application.
 ### Deprecations
   - Implicit assigns when passing a `do-end` block to `live_component` is deprecated
 
+## 0.15.7 (2021-05-24)
+
+### Bug fixes
+  - Fix broken webpack build throwing missing morphdom dependency
+
 ## 0.15.6 (2021-05-24)
 
 ### Bug fixes


### PR DESCRIPTION
Reading up through the change log to upgrade my local live view it was a bit confusing to not find any mention of `0.15.7` and I started reading the changes for 0.16 until I realised it was missing, this just pulls in the short change log from `0.15.7`