### PR TITLE
Fix doc typo [skip ci]

### DIFF
--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -297,7 +297,7 @@ defmodule Phoenix.LiveView.Helpers do
   map.
 
   All of the `assigns` given are forwarded directly to the function as
-  the first only argument.
+  a single argument.
 
   ## Examples
 


### PR DESCRIPTION
Considered "first and only" but this seems better to me.