### PR TITLE
re-enable production source maps

### DIFF
--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -1,8 +1,6 @@
 const path = require('path')
 
 module.exports = (env, options) => {
-  const devMode = options.mode !== 'production';
-
   return {
     entry: './js/phoenix_live_view/index.js',
     output: {
@@ -14,7 +12,7 @@ module.exports = (env, options) => {
       },
       globalObject: 'this'
     },
-    devtool: devMode ? 'source-map' : undefined,
+    devtool: 'source-map',
     module: {
       rules: [
         {


### PR DESCRIPTION
* introduced in #1385
* removed again in #1474
* mailing list https://groups.google.com/g/phoenix-core/c/Dk2AbXVnzeg
* `phoenix` counter-part https://github.com/phoenixframework/phoenix/pull/4276