### PR TITLE
Support let to bind args sent from render_block/2

### DIFF
--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -501,14 +501,7 @@ defmodule Phoenix.LiveView.HTMLEngine do
         ++
         quote line: line, generated: true do
           other ->
-            message = """
-            cannot match arguments sent from `render_block/2` against the pattern in `let`.
-
-            Expected a value matching `#{unquote(Macro.to_string(pattern))}`, got: `#{inspect(other)}`.
-            """
-            raise RuntimeError, message
-
-            # Phoenix.LiveView.HTMLEngine.__unmatched_let__!(unquote(Macro.to_string(pattern)), other)
+            Phoenix.LiveView.HTMLEngine.__unmatched_let__!(unquote(Macro.to_string(pattern)), other)
         end
 
       _ ->

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -317,6 +317,30 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
       end)
     end
 
+    test "raise on duplicated `let`" do
+      message = ~r".exs:4:(8:)? cannot define multiple `let` attributes. Another `let` has already been defined at line 3"
+
+      assert_raise(SyntaxError, message, fn ->
+        eval("""
+        <br>
+        <Phoenix.LiveView.HTMLEngineTest.remote_function_component value='1'
+          let={var1}
+          let={var2}
+        />
+        """)
+      end)
+
+      assert_raise(SyntaxError, message, fn ->
+        eval("""
+        <br>
+        <.local_function_component value='1'
+          let={var1}
+          let={var2}
+        />
+        """)
+      end)
+    end
+
     test "empty attributes" do
       assigns = %{}
       assert compile("<.assigns_component />") == "%{}"


### PR DESCRIPTION
There's still one thing missing in this PR. 

Currently, if the user provides a non-matching pattern in `let` (due to a typo or something similar), like:

```
<.func
  value="aBcD"
  let={%{ittem: item}}>
  ...
</.func>
```

this would be raised, pointing to the initial line where the component was injected:

```
** (CaseClauseError) no case clause matching: {%{ittem: "the item"}}
```

Ideally, it should provide a more assertive message pointing to the line of the `let`, something like:

```
cannot match arguments sent from `render_block/2` against the pattern in `let`. 

Expected a value matching `%{ittem: item}`, got: `%{item: "the item"}`.
```