### PR TITLE
Add on_mount option to live_session

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -855,15 +855,13 @@ defmodule Phoenix.LiveView.Channel do
       router: router
     } = verified
 
-    %Route{live_session_extra: extra} = route
-
     # Make sure the view is loaded. Otherwise if the first request
     # ever is a LiveView connection, the view won't be loaded and
     # the mount/handle_params callbacks won't be invoked as they
     # are optional, leading to errors.
     config = view.__live__()
 
-    live_session_on_mount = load_live_session_on_mount(extra)
+    live_session_on_mount = load_live_session_on_mount(route)
     lifecycle = lifecycle(config, live_session_on_mount)
 
     %Phoenix.Socket{
@@ -931,7 +929,7 @@ defmodule Phoenix.LiveView.Channel do
     end
   end
 
-  defp load_live_session_on_mount(%{on_mount: hooks}), do: hooks
+  defp load_live_session_on_mount(%Route{live_session_extra: %{on_mount: hooks}}), do: hooks
   defp load_live_session_on_mount(_), do: []
 
   defp lifecycle(%{lifecycle: lifecycle}, []), do: lifecycle

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -929,7 +929,7 @@ defmodule Phoenix.LiveView.Channel do
     end
   end
 
-  defp load_live_session_on_mount(%Route{live_session_extra: %{on_mount: hooks}}), do: hooks
+  defp load_live_session_on_mount(%Route{live_session: %{extra: %{on_mount: hooks}}}), do: hooks
   defp load_live_session_on_mount(_), do: []
 
   defp lifecycle(%{lifecycle: lifecycle}, []), do: lifecycle

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -863,7 +863,7 @@ defmodule Phoenix.LiveView.Channel do
     config = view.__live__()
 
     live_session_on_mount = load_live_session_on_mount(router, live_session_name)
-    lifecycle = lifecycle(config, live_session_on_mount) |> IO.inspect(label: :lifecycle)
+    lifecycle = lifecycle(config, live_session_on_mount)
 
     %Phoenix.Socket{
       endpoint: endpoint,

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -852,9 +852,10 @@ defmodule Phoenix.LiveView.Channel do
       root_pid: root_pid,
       session: verified_user_session,
       assign_new: assign_new,
-      router: router,
-      live_session_name: live_session_name
+      router: router
     } = verified
+
+    %Route{live_session_extra: extra} = route
 
     # Make sure the view is loaded. Otherwise if the first request
     # ever is a LiveView connection, the view won't be loaded and
@@ -862,7 +863,7 @@ defmodule Phoenix.LiveView.Channel do
     # are optional, leading to errors.
     config = view.__live__()
 
-    live_session_on_mount = load_live_session_on_mount(router, live_session_name)
+    live_session_on_mount = load_live_session_on_mount(extra)
     lifecycle = lifecycle(config, live_session_on_mount)
 
     %Phoenix.Socket{
@@ -930,18 +931,8 @@ defmodule Phoenix.LiveView.Channel do
     end
   end
 
-  defp load_live_session_on_mount(nil, _), do: []
-
-  defp load_live_session_on_mount(router, live_session_name) do
-    if function_exported?(router, :__phoenix_live_session_on_mount__, 1) do
-      case router.__phoenix_live_session_on_mount__(live_session_name) do
-        {:ok, hooks} -> hooks
-        _ -> []
-      end
-    else
-      []
-    end
-  end
+  defp load_live_session_on_mount(%{on_mount: hooks}), do: hooks
+  defp load_live_session_on_mount(_), do: []
 
   defp lifecycle(%{lifecycle: lifecycle}, []), do: lifecycle
 

--- a/lib/phoenix_live_view/plug.ex
+++ b/lib/phoenix_live_view/plug.ex
@@ -8,7 +8,7 @@ defmodule Phoenix.LiveView.Plug do
 
   @impl Plug
   def call(%Plug.Conn{private: %{phoenix_live_view: {view, opts, live_session}}} = conn, _) do
-    {_name, live_session_extra, _vsn} = live_session
+    %{extra: live_session_extra} = live_session
 
     session = live_session(live_session_extra, conn)
 

--- a/lib/phoenix_live_view/route.ex
+++ b/lib/phoenix_live_view/route.ex
@@ -9,6 +9,7 @@ defmodule Phoenix.LiveView.Route do
             opts: [],
             live_session_name: nil,
             live_session_vsn: nil,
+            live_session_extra: %{},
             params: %{},
             uri: nil
 
@@ -68,7 +69,7 @@ defmodule Phoenix.LiveView.Route do
 
     case Phoenix.Router.route_info(router, "GET", route_path, host) do
       %{plug: Phoenix.LiveView.Plug, phoenix_live_view: lv, path_params: path_params} ->
-        {view, action, opts, {live_session_name, _live_session_opts, vsn}} = lv
+        {view, action, opts, {live_session_name, live_session_extra, vsn}} = lv
 
         route = %Route{
           view: view,
@@ -78,6 +79,7 @@ defmodule Phoenix.LiveView.Route do
           opts: opts,
           live_session_name: live_session_name,
           live_session_vsn: vsn,
+          live_session_extra: live_session_extra,
           params: Map.merge(query_params, path_params)
         }
 

--- a/lib/phoenix_live_view/route.ex
+++ b/lib/phoenix_live_view/route.ex
@@ -7,9 +7,7 @@ defmodule Phoenix.LiveView.Route do
             view: nil,
             action: nil,
             opts: [],
-            live_session_name: nil,
-            live_session_vsn: nil,
-            live_session_extra: %{},
+            live_session: %{},
             params: %{},
             uri: nil
 
@@ -69,7 +67,7 @@ defmodule Phoenix.LiveView.Route do
 
     case Phoenix.Router.route_info(router, "GET", route_path, host) do
       %{plug: Phoenix.LiveView.Plug, phoenix_live_view: lv, path_params: path_params} ->
-        {view, action, opts, {live_session_name, live_session_extra, vsn}} = lv
+        {view, action, opts, live_session} = lv
 
         route = %Route{
           view: view,
@@ -77,9 +75,7 @@ defmodule Phoenix.LiveView.Route do
           action: action,
           uri: parsed_uri,
           opts: opts,
-          live_session_name: live_session_name,
-          live_session_vsn: vsn,
-          live_session_extra: live_session_extra,
+          live_session: live_session,
           params: Map.merge(query_params, path_params)
         }
 

--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -226,13 +226,13 @@ defmodule Phoenix.LiveView.Router do
 
     if nested = Module.get_attribute(module, :phoenix_live_session_current) do
       raise """
-      attempting to define live_session #{inspect(name)} inside #{inspect(elem(nested, 0))}.
+      attempting to define live_session #{inspect(name)} inside #{inspect(nested.name)}.
       live_session definitions cannot be nested.
       """
     end
 
     live_sessions = Module.get_attribute(module, :phoenix_live_sessions)
-    existing = Enum.find(live_sessions, fn {existing_name, _, _} -> name == existing_name end)
+    existing = Enum.find(live_sessions, fn %{name: existing_name} -> name == existing_name end)
 
     if existing do
       raise """
@@ -241,8 +241,8 @@ defmodule Phoenix.LiveView.Router do
       """
     end
 
-    Module.put_attribute(module, :phoenix_live_session_current, {name, extra, vsn})
-    Module.put_attribute(module, :phoenix_live_sessions, {name, extra, vsn})
+    Module.put_attribute(module, :phoenix_live_session_current, %{name: name, extra: extra, vsn: vsn})
+    Module.put_attribute(module, :phoenix_live_sessions, %{name: name, extra: extra, vsn: vsn})
   end
 
   @live_session_opts [:on_mount, :root_layout, :session]
@@ -337,7 +337,7 @@ defmodule Phoenix.LiveView.Router do
       when is_atom(action) and is_list(opts) do
     live_session =
       Module.get_attribute(router, :phoenix_live_session_current) ||
-        {:default, %{session: %{}}, session_vsn(router)}
+        %{name: :default, extra: %{session: %{}}, vsn: session_vsn(router)}
 
     live_view = Phoenix.Router.scoped_alias(router, live_view)
     {private, metadata, opts} = validate_live_opts!(opts)

--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -141,9 +141,6 @@ defmodule Phoenix.LiveView.Router do
 
   * `:on_mount` - The optional list of hooks to attach to the mount lifecycle _of
     each LiveView in the session_. Passing a single value is also accepted.
-    _Note:_ using this option requires adding `use Phoenix.LiveView.Router`
-    to your router module, otherwise the hooks will not be registered and _no
-    warning will be emitted_.
 
   ## Examples
 
@@ -458,28 +455,6 @@ defmodule Phoenix.LiveView.Router do
       vsn = System.system_time()
       Module.put_attribute(module, :phoenix_session_vsn, vsn)
       vsn
-    end
-  end
-
-  defmacro __before_compile__(env) do
-    on_mount =
-      for {name, %{on_mount: on_mount}, _vsn} <-
-            Module.get_attribute(env.module, :phoenix_live_sessions),
-          into: %{},
-          do: {name, on_mount}
-
-    quote do
-      @phoenix_live_session_on_mount unquote(Macro.escape(on_mount))
-      def __phoenix_live_session_on_mount__(name) do
-        Map.fetch(@phoenix_live_session_on_mount, name)
-      end
-    end
-  end
-
-  defmacro __using__(_opts) do
-    quote do
-      import Phoenix.LiveView.Router
-      @before_compile Phoenix.LiveView.Router
     end
   end
 end

--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -276,22 +276,9 @@ defmodule Phoenix.LiveView.Router do
         expected a tuple with the view module and template string or atom name, got #{inspect(bad_layout)}
         """
 
-      {:on_mount, mod}, acc when is_atom(mod) ->
-        Map.put(acc, :on_mount, [Phoenix.LiveView.Lifecycle.on_mount(module, mod)])
-
-      {:on_mount, {mod, fun} = id}, acc when is_atom(mod) and is_atom(fun) ->
-        Map.put(acc, :on_mount, [Phoenix.LiveView.Lifecycle.on_mount(module, id)])
-
-      {:on_mount, on_mount}, acc when is_list(on_mount) ->
-        hooks = Enum.map(on_mount, &Phoenix.LiveView.Lifecycle.on_mount(module, &1))
+      {:on_mount, on_mount}, acc  ->
+        hooks = Enum.map(List.wrap(on_mount), &Phoenix.LiveView.Lifecycle.on_mount(module, &1))
         Map.put(acc, :on_mount, hooks)
-
-      {:on_mount, bad_on_mount}, _acc ->
-        raise ArgumentError, """
-        invalid live_session :on_mount
-
-        expected a list (or single value) of Module or {Module, Function}, got #{inspect(bad_on_mount)}
-        """
 
       {key, _val}, _acc ->
         raise ArgumentError, """

--- a/lib/phoenix_live_view/session.ex
+++ b/lib/phoenix_live_view/session.ex
@@ -21,7 +21,7 @@ defmodule Phoenix.LiveView.Session do
     %Session{live_session_name: session_name, live_session_vsn: session_vsn} = session
 
     cond do
-      route.live_session_name == session_name and route.live_session_vsn == session_vsn ->
+      route.live_session.name == session_name and route.live_session.vsn == session_vsn ->
         {:ok, replace_root(session, route.view, self())}
 
       true ->

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -81,6 +81,7 @@ defmodule Phoenix.LiveView.Static do
     {to_sign_session, mount_session} = load_session(conn_session, opts)
     live_session = live_session(conn)
     config = load_live!(view, :view)
+    lifecycle = lifecycle(config, live_session)
     {tag, extended_attrs} = container(config, opts)
     router = Keyword.get(opts, :router)
     action = Keyword.get(opts, :action)
@@ -97,7 +98,7 @@ defmodule Phoenix.LiveView.Static do
           connect_params: %{},
           connect_info: %{},
           conn_session: conn_session,
-          lifecycle: config.lifecycle,
+          lifecycle: lifecycle,
           root_view: view,
           __changed__: %{}
         },
@@ -242,6 +243,14 @@ defmodule Phoenix.LiveView.Static do
       %{kind: other} ->
         raise "expected #{inspect(view_or_component)} to be a #{kind}, but it is a #{other}"
     end
+  end
+
+  defp lifecycle(%{lifecycle: lifecycle}, {_, %{on_mount: on_mount}, _}) do
+    %{lifecycle | mount: on_mount ++ lifecycle.mount}
+  end
+
+  defp lifecycle(%{lifecycle: lifecycle}, _) do
+    lifecycle
   end
 
   defp call_mount_and_handle_params!(socket, view, session, params, uri) do

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -36,7 +36,7 @@ defmodule Phoenix.LiveView.Static do
 
   defp live_session(%Plug.Conn{} = conn) do
     case conn.private[:phoenix_live_view] do
-      {_view, _opts, {_name, _live_session_extra, _vsn} = lv_session} -> lv_session
+      {_view, _opts, %{name: _name, extra: _extra, vsn: _vsn} = lv_session} -> lv_session
       nil -> nil
     end
   end
@@ -245,7 +245,7 @@ defmodule Phoenix.LiveView.Static do
     end
   end
 
-  defp lifecycle(%{lifecycle: lifecycle}, {_, %{on_mount: on_mount}, _}) do
+  defp lifecycle(%{lifecycle: lifecycle}, %{extra: %{on_mount: on_mount}}) do
     %{lifecycle | mount: on_mount ++ lifecycle.mount}
   end
 
@@ -295,7 +295,7 @@ defmodule Phoenix.LiveView.Static do
     # IMPORTANT: If you change the third argument, @token_vsn has to be bumped.
     live_session_pair =
       case live_session do
-        {name, _extra, vsn} -> {name, vsn}
+        %{name: name, vsn: vsn} -> {name, vsn}
         nil -> nil
       end
 

--- a/test/phoenix_live_view/integrations/lifecycle_test.exs
+++ b/test/phoenix_live_view/integrations/lifecycle_test.exs
@@ -28,7 +28,7 @@ defmodule Phoenix.LiveView.LifecycleTest do
 
     assert assigns.init_assigns_mount
     assert assigns.init_assigns_other_mount
-    assert assigns.last_at_mount == :init_assigns_other_mount
+    assert assigns.last_on_mount == :init_assigns_other_mount
   end
 
   test "on_mount hook raises when :halt is returned without a redirected socket", %{conn: conn} do

--- a/test/phoenix_live_view/plug_test.exs
+++ b/test/phoenix_live_view/plug_test.exs
@@ -12,7 +12,7 @@ defmodule Phoenix.LiveView.PlugTest do
     conn
     |> Plug.Test.init_test_session(%{})
     |> Phoenix.LiveView.Router.fetch_live_flash([])
-    |> put_private(:phoenix_live_view, {view, opts, {:default, %{}, 0}})
+    |> put_private(:phoenix_live_view, {view, opts, %{name: :default, extra: %{}, vsn: 0}})
     |> LiveViewPlug.call(view)
   end
 

--- a/test/phoenix_live_view/router_test.exs
+++ b/test/phoenix_live_view/router_test.exs
@@ -77,8 +77,8 @@ defmodule Phoenix.LiveView.RouterTest do
     test "with defaults", %{conn: conn} do
       path = "/thermo-live-session"
       assert {:internal, route} = Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
-      assert route.live_session_name == :test
-      assert route.live_session_vsn
+      assert route.live_session.name == :test
+      assert route.live_session.vsn
 
       assert conn |> get(path) |> html_response(200) |> verified_session() == %{}
     end
@@ -86,8 +86,8 @@ defmodule Phoenix.LiveView.RouterTest do
     test "with extra session metadata", %{conn: conn} do
       path = "/thermo-live-session-admin"
       assert {:internal, route} = Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
-      assert route.live_session_name == :admin
-      assert route.live_session_vsn
+      assert route.live_session.name == :admin
+      assert route.live_session.vsn
 
       assert conn |> get(path) |> html_response(200) |> verified_session() ==
                %{"admin" => true}
@@ -96,8 +96,8 @@ defmodule Phoenix.LiveView.RouterTest do
     test "with session MFA metadata", %{conn: conn} do
       path = "/thermo-live-session-mfa"
       assert {:internal, route} = Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
-      assert route.live_session_name == :mfa
-      assert route.live_session_vsn
+      assert route.live_session.name == :mfa
+      assert route.live_session.vsn
 
       assert conn |> get(path) |> html_response(200) |> verified_session() ==
                %{"inlined" => true, "called" => true}
@@ -109,13 +109,16 @@ defmodule Phoenix.LiveView.RouterTest do
       assert {:internal, route} =
                Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
 
-      hook_map = %{
-        id: Phoenix.LiveViewTest.HaltConnectedMount,
-        stage: :mount,
-        function: Function.capture(Phoenix.LiveViewTest.HaltConnectedMount, :mount, 3)
+      assert route.live_session.extra == %{
+        on_mount: [
+          %{
+            id: Phoenix.LiveViewTest.HaltConnectedMount,
+            stage: :mount,
+            function: Function.capture(Phoenix.LiveViewTest.HaltConnectedMount, :mount, 3)
+          }
+        ],
+        session: %{}
       }
-
-      assert %{on_mount: [^hook_map]} = route.live_session_extra
 
       assert conn |> get(path) |> html_response(200) =~
                "last_on_mount:Phoenix.LiveViewTest.HaltConnectedMount"

--- a/test/support/live_views/lifecycle.ex
+++ b/test/support/live_views/lifecycle.ex
@@ -137,7 +137,6 @@ end
 defmodule Phoenix.LiveViewTest.HooksLive.Noop do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
 
-  @spec render(any) :: Phoenix.LiveView.Rendered.t()
   def render(assigns) do
     ~L"""
     <h1>Noop</h1>

--- a/test/support/live_views/lifecycle.ex
+++ b/test/support/live_views/lifecycle.ex
@@ -133,3 +133,27 @@ defmodule Phoenix.LiveViewTest.HooksLive.RedirectMount do
 
   def render(assigns), do: ~L""
 end
+
+defmodule Phoenix.LiveViewTest.HooksLive.Noop do
+  use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
+
+  @spec render(any) :: Phoenix.LiveView.Rendered.t()
+  def render(assigns) do
+    ~L"""
+    <h1>Noop</h1>
+    last_on_mount:<%= inspect(assigns[:last_on_mount]) %>
+    """
+  end
+end
+
+defmodule Phoenix.LiveViewTest.HaltConnectedMount do
+  alias Phoenix.LiveView
+
+  def mount(_params, _session, socket) do
+    if LiveView.connected?(socket) do
+      {:halt, LiveView.push_redirect(socket, to: "/lifecycle")}
+    else
+      {:cont, LiveView.assign(socket, :last_on_mount, __MODULE__)}
+    end
+  end
+end

--- a/test/support/live_views/lifecycle.ex
+++ b/test/support/live_views/lifecycle.ex
@@ -5,14 +5,14 @@ defmodule Phoenix.LiveViewTest.InitAssigns do
     {:cont,
      socket
      |> LiveView.assign(:init_assigns_mount, true)
-     |> LiveView.assign(:last_at_mount, :init_assigns_mount)}
+     |> LiveView.assign(:last_on_mount, :init_assigns_mount)}
   end
 
   def other_mount(_params, _session, socket) do
     {:cont,
      socket
      |> LiveView.assign(:init_assigns_other_mount, true)
-     |> LiveView.assign(:last_at_mount, :init_assigns_other_mount)}
+     |> LiveView.assign(:last_on_mount, :init_assigns_other_mount)}
   end
 end
 
@@ -25,7 +25,7 @@ defmodule Phoenix.LiveViewTest.HooksLive do
 
   def render(assigns) do
     ~L"""
-    last_at_mount:<%= inspect(assigns[:last_at_mount]) %>
+    last_on_mount:<%= inspect(assigns[:last_on_mount]) %>
     params_hook:<%= assigns[:params_hook_ref] %>
     count:<%= @count %>
     <button id="dec" phx-click="dec">-</button>

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -125,6 +125,10 @@ defmodule Phoenix.LiveViewTest.Router do
     live_session :merged, session: %{"top-level" => true} do
       live "/thermo-live-session-merged", ThermostatLive
     end
+
+    live_session :lifecycle, on_mount: Phoenix.LiveViewTest.HaltConnectedMount do
+      live "/lifecycle/halt-connected-mount", HooksLive.Noop
+    end
   end
 
   scope "/", as: :user_defined_metadata, alias: Phoenix.LiveViewTest do


### PR DESCRIPTION
Follows #1490 and #1511 to allow `on_mount` at the router via `live_session`.  