### PR TITLE
Stabilize patching focused select elements

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -295,6 +295,15 @@ let DOM = {
     }
   },
 
+  syncPropsToAttrs(el){
+    if(el instanceof HTMLSelectElement){
+      let selectedItem = el.options.item(el.selectedIndex)
+      if(selectedItem && selectedItem.getAttribute("selected") === null){
+        selectedItem.setAttribute("selected", "")
+      }
+    }
+  },
+
   isTextualInput(el){ return FOCUSABLE_INPUTS.indexOf(el.type) >= 0 },
 
   isNowTriggerFormExternal(el, phxTriggerExternal){

--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -198,7 +198,7 @@ export default class DOMPatch {
 
   forceFocusedSelectUpdate(fromEl, toEl){
     let isSelect = ["select", "select-one", "select-multiple"].find((t) => t === fromEl.type)
-    return fromEl.multiple === true || (isSelect && fromEl.innerHTML != toEl.innerHTML)
+    return fromEl.multiple === true || (isSelect && fromEl.selectedIndex != toEl.selectedIndex)
   }
 
   isCIDPatch(){ return this.cidPatch }

--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -156,6 +156,7 @@ export default class DOMPatch {
           // input handling
           DOM.copyPrivates(toEl, fromEl)
           DOM.discardError(targetContainer, toEl, phxFeedbackFor)
+          DOM.syncPropsToAttrs(toEl)
 
           let isFocusedFormEl = focused && fromEl.isSameNode(focused) && DOM.isFormInput(fromEl)
           if(isFocusedFormEl && !this.forceFocusedSelectUpdate(fromEl, toEl)){
@@ -198,7 +199,7 @@ export default class DOMPatch {
 
   forceFocusedSelectUpdate(fromEl, toEl){
     let isSelect = ["select", "select-one", "select-multiple"].find((t) => t === fromEl.type)
-    return fromEl.multiple === true || (isSelect && fromEl.selectedIndex != toEl.selectedIndex)
+    return fromEl.multiple === true || (isSelect && fromEl.innerHTML != toEl.innerHTML)
   }
 
   isCIDPatch(){ return this.cidPatch }


### PR DESCRIPTION
When a `<select>` input has focus during a DOM patch, we only force an update if the innerHTML has changed. However due to the internal state of the form control, the innerHTML may already differ from what the server sent and therefore we may always patch. For instance, given then following HTML:

```html
<select>
  <option>A</option>
  <option>B</option>
  <option>C</option>
</select>
```

The `innerHTML` will evaluate as follows:

```
fromHtml=
    <option selected="">A</option>
    <option>B</option>
    <option>C</option>
  
toHtml=
    <option>A</option>
    <option>B</option>
    <option>C</option>
```
> Chrome is the only browser to exhibit a "flash" when the DOM is patched, but all browsers tested produced the same innerHTML fragments in this example.

~This PR will instead use the [`selectedIndex`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/selectedIndex) of the element(s) to determine whether or not to force a patch of the focused element.~

This PR adds a check onBeforeElUpdated to synchronize the selected option of the new element when no selected attribute exists. This is to accommodate for the `selected=""` attribute added by browsers to implicitly select the first option.

Note: This change does **not** affect the behaviour of the select control. Users still need to maintain the selected value in their own state and set it accordingly on the selected option. The effect of this change is to stabilize the behaviour of the control when the default selected value is in play.

Closes #1525 