### PR TITLE
make the upload file extension check case insensitive

### DIFF
--- a/lib/phoenix_live_view/upload_config.ex
+++ b/lib/phoenix_live_view/upload_config.ex
@@ -597,7 +597,7 @@ defmodule Phoenix.LiveView.UploadConfig do
       String.starts_with?(client_type, "video/") and "video/*" in acceptable_types -> true
       # strict
       client_type in acceptable_types -> true
-      Path.extname(entry.client_name) in conf.acceptable_exts -> true
+      String.downcase(Path.extname(entry.client_name)) in conf.acceptable_exts -> true
       true -> false
     end
   end

--- a/lib/phoenix_live_view/upload_config.ex
+++ b/lib/phoenix_live_view/upload_config.ex
@@ -597,7 +597,7 @@ defmodule Phoenix.LiveView.UploadConfig do
       String.starts_with?(client_type, "video/") and "video/*" in acceptable_types -> true
       # strict
       client_type in acceptable_types -> true
-      String.downcase(Path.extname(entry.client_name)) in conf.acceptable_exts -> true
+      String.downcase(Path.extname(entry.client_name), :ascii) in conf.acceptable_exts -> true
       true -> false
     end
   end

--- a/test/phoenix_live_view/upload_config_test.exs
+++ b/test/phoenix_live_view/upload_config_test.exs
@@ -276,6 +276,7 @@ defmodule Phoenix.LiveView.UploadConfigTest do
         build_socket()
         |> LiveView.allow_upload(:avatar, accept: ~w(.jpg .jpeg), max_entries: 5)
         |> LiveView.allow_upload(:hero, accept: ~w(.jpg .jpeg), max_entries: 5)
+        |> LiveView.allow_upload(:audio, accept: ~w(.wav), max_entries: 2)
 
       assert {:ok, config} =
                UploadConfig.put_entries(socket.assigns.uploads.avatar, [
@@ -291,6 +292,18 @@ defmodule Phoenix.LiveView.UploadConfigTest do
                %UploadEntry{client_name: "photo.jpeg"},
                %UploadEntry{client_name: "photo.JPEG"}
              ] = config.entries
+
+
+    assert {:ok, config} =
+    UploadConfig.put_entries(socket.assigns.uploads.audio, [
+      build_client_entry(:audio, %{"name" => "audio.wav", "type" => "audio/wav"}),
+      build_client_entry(:audio, %{"name" => "audio.WAV", "type" => "audio/wav"})
+    ])
+
+    assert [
+              %UploadEntry{client_name: "audio.wav"},
+              %UploadEntry{client_name: "audio.WAV"}
+            ] = config.entries
 
       hero_config = socket.assigns.uploads.hero
       entry = build_client_entry(:avatar, %{"name" => "file.gif"})


### PR DESCRIPTION
According to the [mozilla docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept), an accept-input may be:

> A valid **case-insensitive** filename extension, starting with a period (".") character. For example: .jpg, .pdf, or .doc.

This PR simply downcases the incoming file extension before it compares it to the allowed file extensions.