### PR TITLE
fix: Update installation guides

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -165,7 +165,7 @@ and enable connecting to a LiveView socket in your `app.js` file.
 ```javascript
 // assets/js/app.js
 import {Socket} from "phoenix"
-import LiveSocket from "phoenix_live_view"
+import {LiveSocket} from "phoenix_live_view"
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}})


### PR DESCRIPTION
This will fix the issue of Webpack complaining about:

```
Uncaught TypeError: phoenix_live_view__WEBPACK_IMPORTED_MODULE_6___default() is not a constructor
```