### PR TITLE
[test] Update LiveViewTest.StatefulComponent to use ~H sigil.

### DIFF
--- a/test/phoenix_live_view/integrations/live_components_test.exs
+++ b/test/phoenix_live_view/integrations/live_components_test.exs
@@ -24,7 +24,7 @@ defmodule Phoenix.LiveView.LiveComponentsTest do
     conn = get(conn, "/components")
 
     assert html_response(conn, 200) =~
-             "<div id=\"chris\" phx-target=\"#chris\" phx-click=\"transform\">"
+             "<div phx-click=\"transform\" id=\"chris\" phx-target=\"#chris\">"
   end
 
   test "renders successfully when connected", %{conn: conn} do
@@ -34,9 +34,9 @@ defmodule Phoenix.LiveView.LiveComponentsTest do
              {"div", _,
               [
                 _,
-                {"div", [{"data-phx-component", "1"}, {"id", "chris"} | _],
+                {"div", [{"data-phx-component", "1"}, {"phx-click", "transform"}, {"id", "chris"} | _],
                  ["\n  chris says hi\n  \n"]},
-                {"div", [{"data-phx-component", "2"}, {"id", "jose"} | _],
+                {"div", [{"data-phx-component", "2"}, {"phx-click", "transform"}, {"id", "jose"} | _],
                  ["\n  jose says hi\n  \n"]}
               ]}
            ] = DOM.parse(render(view))
@@ -47,20 +47,22 @@ defmodule Phoenix.LiveView.LiveComponentsTest do
     html = render_click(view, "dup-and-disable", %{})
 
     assert [
-             "Redirect: none\n\n  DISABLED\n\n\n  DISABLED\n\n\n  ",
+             "Redirect: none\n\n  ",
+             {"div", [{"data-phx-component", "1"}], ["\n  DISABLED\n"]},
+             {"div", [{"data-phx-component", "2"}], ["\n  DISABLED\n"]},
              {"div",
               [
                 {"data-phx-component", "3"},
+                {"phx-click", "transform"},
                 {"id", "chris-new"},
-                {"phx-target", "#chris-new"},
-                {"phx-click", "transform"}
+                {"phx-target", "#chris-new"}
               ], ["\n  chris-new says hi\n  \n"]},
              {"div",
               [
                 {"data-phx-component", "4"},
+                {"phx-click", "transform"},
                 {"id", "jose-new"},
-                {"phx-target", "#jose-new"},
-                {"phx-click", "transform"}
+                {"phx-target", "#jose-new"}
               ], ["\n  jose-new says hi\n  \n"]}
            ] = DOM.parse(html)
   end
@@ -69,14 +71,14 @@ defmodule Phoenix.LiveView.LiveComponentsTest do
     {:ok, view, html} = live(conn, "/components")
 
     assert [
-             {"div", [{"data-phx-component", "1"}, {"id", "chris"} | _], ["\n  chris says" <> _]},
-             {"div", [{"data-phx-component", "2"}, {"id", "jose"} | _], ["\n  jose says" <> _]}
+             {"div", [{"data-phx-component", "1"}, {"phx-click", "transform"}, {"id", "chris"} | _], ["\n  chris says" <> _]},
+             {"div", [{"data-phx-component", "2"}, {"phx-click", "transform"}, {"id", "jose"} | _], ["\n  jose says" <> _]}
            ] = html |> DOM.parse() |> DOM.all("#chris, #jose")
 
     html = render_click(view, "delete-name", %{"name" => "chris"})
 
     assert [
-             {"div", [{"data-phx-component", "2"}, {"id", "jose"} | _], ["\n  jose says" <> _]}
+             {"div", [{"data-phx-component", "2"}, {"phx-click", "transform"}, {"id", "jose"} | _], ["\n  jose says" <> _]}
            ] = html |> DOM.parse() |> DOM.all("#chris, #jose")
 
     refute view |> element("#chris") |> has_element?()
@@ -135,9 +137,9 @@ defmodule Phoenix.LiveView.LiveComponentsTest do
 
       assert [
                _,
-               {"div", [{"data-phx-component", "1"}, {"id", "chris"} | _],
+               {"div", [{"data-phx-component", "1"}, {"phx-click", "transform"}, {"id", "chris"} | _],
                 ["\n  CHRIS says hi\n" <> _]},
-               {"div", [{"data-phx-component", "2"}, {"id", "jose"} | _],
+               {"div", [{"data-phx-component", "2"}, {"phx-click", "transform"}, {"id", "jose"} | _],
                 ["\n  jose says hi\n" <> _]}
              ] = DOM.parse(html)
 
@@ -145,9 +147,9 @@ defmodule Phoenix.LiveView.LiveComponentsTest do
 
       assert [
                _,
-               {"div", [{"data-phx-component", "1"}, {"id", "chris"} | _],
+               {"div", [{"data-phx-component", "1"}, {"phx-click", "transform"}, {"id", "chris"} | _],
                 ["\n  CHRIS says hi\n" <> _]},
-               {"div", [{"data-phx-component", "2"}, {"id", "jose"} | _],
+               {"div", [{"data-phx-component", "2"}, {"phx-click", "transform"}, {"id", "jose"} | _],
                 ["\n  Jose says hi\n" <> _]}
              ] = DOM.parse(html)
 
@@ -155,12 +157,12 @@ defmodule Phoenix.LiveView.LiveComponentsTest do
 
       assert [
                _,
-               {"div", [{"data-phx-component", "1"}, {"id", "chris"} | _],
+               {"div", [{"data-phx-component", "1"}, {"phx-click", "transform"}, {"id", "chris"} | _],
                 ["\n  CHRIS says hi\n" <> _]},
-               {"div", [{"data-phx-component", "2"}, {"id", "jose"} | _],
+               {"div", [{"data-phx-component", "2"}, {"phx-click", "transform"}, {"id", "jose"} | _],
                 [
                   "\n  Jose says hi\n  ",
-                  {"div", [{"data-phx-component", "3"}, {"id", "Jose-dup"} | _],
+                  {"div", [{"data-phx-component", "3"}, {"phx-click", "transform"}, {"id", "Jose-dup"} | _],
                    ["\n  Jose-dup says hi\n" <> _]}
                 ]}
              ] = DOM.parse(html)
@@ -169,18 +171,18 @@ defmodule Phoenix.LiveView.LiveComponentsTest do
 
       assert [
                _,
-               {"div", [{"data-phx-component", "1"}, {"id", "chris"} | _],
+               {"div", [{"data-phx-component", "1"}, {"phx-click", "transform"}, {"id", "chris"} | _],
                 ["\n  CHRIS says hi\n" <> _]},
-               {"div", [{"data-phx-component", "2"}, {"id", "jose"} | _],
+               {"div", [{"data-phx-component", "2"}, {"phx-click", "transform"}, {"id", "jose"} | _],
                 [
                   "\n  Jose says hi\n  ",
-                  {"div", [{"data-phx-component", "3"}, {"id", "Jose-dup"} | _],
+                  {"div", [{"data-phx-component", "3"}, {"phx-click", "transform"}, {"id", "Jose-dup"} | _],
                    ["\n  JOSE-DUP says hi\n" <> _]}
                 ]}
              ] = DOM.parse(html)
 
       assert view |> element("#jose #Jose-dup") |> render() ==
-               "<div data-phx-component=\"3\" id=\"Jose-dup\" phx-target=\"#Jose-dup\" phx-click=\"transform\">\n  JOSE-DUP says hi\n  \n</div>"
+               "<div data-phx-component=\"3\" phx-click=\"transform\" id=\"Jose-dup\" phx-target=\"#Jose-dup\">\n  JOSE-DUP says hi\n  \n</div>"
     end
 
     test "emits telemetry events when callback is successful", %{conn: conn} do
@@ -255,12 +257,12 @@ defmodule Phoenix.LiveView.LiveComponentsTest do
       refute_receive {:preload, _}
 
       assert [
-               {"div", [{"data-phx-component", "1"}, {"id", "chris"} | _],
+               {"div", [{"data-phx-component", "1"}, {"phx-click", "transform"}, {"id", "chris"} | _],
                 ["\n  NEW-chris says hi\n  \n"]}
              ] = view |> element("#chris") |> render() |> DOM.parse()
 
       assert [
-               {"div", [{"data-phx-component", "2"}, {"id", "jose"} | _],
+               {"div", [{"data-phx-component", "2"}, {"phx-click", "transform"}, {"id", "jose"} | _],
                 ["\n  NEW-jose says hi\n  \n"]}
              ] = view |> element("#jose") |> render() |> DOM.parse()
     end

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -38,14 +38,16 @@ defmodule Phoenix.LiveViewTest.StatefulComponent do
   end
 
   def render(%{disabled: true} = assigns) do
-    ~L"""
-    DISABLED
+    ~H"""
+    <div>
+      DISABLED
+    </div>
     """
   end
 
   def render(%{socket: _} = assigns) do
-    ~L"""
-    <div id="<%= @id %>" phx-target="#<%= @id %>" phx-click="transform">
+    ~H"""
+    <div id={@id} phx-target={"#" <> @id} phx-click="transform">
       <%= @name %> says hi
       <%= if @dup_name, do: live_component __MODULE__, id: @dup_name, name: @dup_name %>
     </div>


### PR DESCRIPTION
This is a followup to https://github.com/phoenixframework/phoenix_live_view/pull/1534 that fixes some more tests to use the new ~H sigil.