### PR TITLE
[test] Update DiffTest to use ~H sigils.

### DIFF
--- a/test/phoenix_live_view/diff_test.exs
+++ b/test/phoenix_live_view/diff_test.exs
@@ -309,8 +309,8 @@ defmodule Phoenix.LiveView.DiffTest do
     def render(assigns) do
       send(self(), :render)
 
-      ~L"""
-      FROM <%= @from %> <%= @hello %>
+      ~H"""
+      <div>FROM <%= @from %> <%= @hello %></div>
       """
     end
   end
@@ -323,12 +323,14 @@ defmodule Phoenix.LiveView.DiffTest do
     end
 
     def render(assigns) do
-      ~L"""
-      <%= if @if do %>
-        IF <%= @from %>
-      <% else %>
-        ELSE <%= @from %>
-      <% end %>
+      ~H"""
+      <div>
+        <%= if @if do %>
+          IF <%= @from %>
+        <% else %>
+          ELSE <%= @from %>
+        <% end %>
+      </div>
       """
     end
   end
@@ -344,8 +346,8 @@ defmodule Phoenix.LiveView.DiffTest do
     def render(assigns) do
       send(self(), {:temporary_render, assigns})
 
-      ~L"""
-      FROM <%= if @first_time, do: "WELCOME!", else: @from %>
+      ~H"""
+      <div>FROM <%= if @first_time, do: "WELCOME!", else: @from %></div>
       """
     end
   end
@@ -354,8 +356,8 @@ defmodule Phoenix.LiveView.DiffTest do
     use Phoenix.LiveComponent
 
     def render(assigns) do
-      ~L"""
-      RENDER ONLY <%= @from %>
+      ~H"""
+      <div>RENDER ONLY <%= @from %></div>
       """
     end
   end
@@ -370,9 +372,11 @@ defmodule Phoenix.LiveView.DiffTest do
     def render(%{do: _}), do: raise("unexpected :do assign")
 
     def render(assigns) do
-      ~L"""
-      HELLO <%= @id %> <%= render_block(@inner_block, %{value: 1}) %>
-      HELLO <%= @id %> <%= render_block(@inner_block, %{value: 2}) %>
+      ~H"""
+      <div>
+        HELLO <%= @id %> <%= render_block(@inner_block, %{value: 1}) %>
+        HELLO <%= @id %> <%= render_block(@inner_block, %{value: 2}) %>
+      </div>
       """
     end
   end
@@ -387,36 +391,42 @@ defmodule Phoenix.LiveView.DiffTest do
     def render(%{do: _}), do: raise("unexpected :do assign")
 
     def render(assigns) do
-      ~L"""
-      HELLO <%= @id %> <%= render_block(@inner_block) %>
-      HELLO <%= @id %> <%= render_block(@inner_block) %>
+      ~H"""
+      <div>
+        HELLO <%= @id %> <%= render_block(@inner_block) %>
+        HELLO <%= @id %> <%= render_block(@inner_block) %>
+      </div>
       """
     end
   end
 
   defmodule FunctionComponent do
     def render_only(assigns) do
-      ~L"""
-      RENDER ONLY <%= @from %>
+      ~H"""
+      <div>RENDER ONLY <%= @from %></div>
       """
     end
 
     def render_with_block_no_args(assigns) do
-      ~L"""
-      HELLO <%= @id %> <%= render_block(@inner_block) %>
-      HELLO <%= @id %> <%= render_block(@inner_block) %>
+      ~H"""
+      <div>
+        HELLO <%= @id %> <%= render_block(@inner_block) %>
+        HELLO <%= @id %> <%= render_block(@inner_block) %>
+      </div>
       """
     end
 
     def render_with_block(assigns) do
-      ~L"""
-      HELLO <%= @id %> <%= render_block(@inner_block, 1) %>
-      HELLO <%= @id %> <%= render_block(@inner_block, 2) %>
+      ~H"""
+      <div>
+        HELLO <%= @id %> <%= render_block(@inner_block, 1) %>
+        HELLO <%= @id %> <%= render_block(@inner_block, 2) %>
+      </div>
       """
     end
 
     def render_with_live_component(assigns) do
-      ~L"""
+      ~H"""
       COMPONENT
       <%= live_component BlockComponent, id: "WORLD" do %>
         <% %{value: value } -> %>
@@ -440,11 +450,13 @@ defmodule Phoenix.LiveView.DiffTest do
     end
 
     def render(assigns) do
-      ~L"""
-      <%= @id %> - <%= @preloaded? %>
-      <%= for {component, index} <- Enum.with_index(@children, 0) do %>
-        <%= index %>: <%= component %>
-      <% end %>
+      ~H"""
+      <div>
+        <%= @id %> - <%= @preloaded? %>
+        <%= for {component, index} <- Enum.with_index(@children, 0) do %>
+          <%= index %>: <%= component %>
+        <% end %>
+      </div>
       """
     end
   end
@@ -453,27 +465,29 @@ defmodule Phoenix.LiveView.DiffTest do
     use Phoenix.LiveComponent
 
     def render(assigns) do
-      ~L"""
-      <%= render_itself(assigns) %>
+      ~H"""
+      <div>
+        <%= render_itself(assigns) %>
+      </div>
       """
     end
 
     def render_itself(assigns) do
       case assigns.key do
         :a ->
-          ~L"""
+          ~H"""
           <%= for key <- [:nothing] do %>
             <%= key %><%= key %>
           <% end %>
           """
 
         :b ->
-          ~L"""
+          ~H"""
           <%= %>
           """
 
         :c ->
-          ~L"""
+          ~H"""
           <%= live_component __MODULE__, id: make_ref(), key: :a %>
           """
       end
@@ -481,7 +495,7 @@ defmodule Phoenix.LiveView.DiffTest do
   end
 
   def component_template(assigns) do
-    ~L"""
+    ~H"""
     <div>
       <%= @component %>
     </div>
@@ -489,7 +503,7 @@ defmodule Phoenix.LiveView.DiffTest do
   end
 
   def another_component_template(assigns) do
-    ~L"""
+    ~H"""
     <span>
       <%= @component %>
     </span>
@@ -503,7 +517,7 @@ defmodule Phoenix.LiveView.DiffTest do
       {socket, full_render, components} = render(rendered)
 
       assert full_render == %{
-               0 => %{0 => "component", 1 => "world", :s => ["FROM ", " ", "\n"]},
+               0 => %{0 => "component", 1 => "world", :s => ["<div>FROM ", " ", "</div>\n"]},
                :s => ["<div>\n  ", "\n</div>\n"]
              }
 
@@ -556,7 +570,7 @@ defmodule Phoenix.LiveView.DiffTest do
       assert full_render == %{
                0 => %{
                  0 => "component",
-                 :s => ["RENDER ONLY ", "\n"]
+                 :s => ["<div>RENDER ONLY ", "</div>\n"]
                },
                :s => ["<div>\n  ", "\n</div>\n"]
              }
@@ -568,7 +582,7 @@ defmodule Phoenix.LiveView.DiffTest do
     test "block tracking" do
       assigns = %{socket: %Socket{}}
 
-      rendered = ~L"""
+      rendered = ~H"""
       <%= live_component BlockNoArgsComponent do %>
         INSIDE BLOCK
       <% end %>
@@ -582,7 +596,7 @@ defmodule Phoenix.LiveView.DiffTest do
                  1 => %{s: ["\n  INSIDE BLOCK\n"]},
                  2 => "",
                  3 => %{s: ["\n  INSIDE BLOCK\n"]},
-                 :s => ["HELLO ", " ", "\nHELLO ", " ", "\n"]
+                 :s => ["<div>\n  HELLO ", " ", "\n  HELLO ", " ", "\n</div>\n"]
                },
                :s => ["", "\n"]
              }
@@ -596,7 +610,7 @@ defmodule Phoenix.LiveView.DiffTest do
     test "render only" do
       assigns = %{socket: %Socket{}}
 
-      rendered = ~L"""
+      rendered = ~H"""
       <%= component &FunctionComponent.render_only/1, from: :component %>
       """
 
@@ -605,7 +619,7 @@ defmodule Phoenix.LiveView.DiffTest do
       assert full_render == %{
                0 => %{
                  0 => "component",
-                 :s => ["RENDER ONLY ", "\n"]
+                 :s => ["<div>RENDER ONLY ", "</div>\n"]
                },
                :s => ["", "\n"]
              }
@@ -617,7 +631,7 @@ defmodule Phoenix.LiveView.DiffTest do
     test "block tracking without args" do
       assigns = %{socket: %Socket{}}
 
-      rendered = ~L"""
+      rendered = ~H"""
       <%= component &FunctionComponent.render_with_block_no_args/1, id: "DEFAULT" do %>
         INSIDE BLOCK
       <% end %>
@@ -631,7 +645,7 @@ defmodule Phoenix.LiveView.DiffTest do
                  1 => %{s: ["\n  INSIDE BLOCK\n"]},
                  2 => "DEFAULT",
                  3 => %{s: ["\n  INSIDE BLOCK\n"]},
-                 :s => ["HELLO ", " ", "\nHELLO ", " ", "\n"]
+                 :s => ["<div>\n  HELLO ", " ", "\n  HELLO ", " ", "\n</div>\n"]
                },
                :s => ["", "\n"]
              }
@@ -641,7 +655,7 @@ defmodule Phoenix.LiveView.DiffTest do
     end
 
     defp function_tracking(assigns) do
-      ~L"""
+      ~H"""
       <%= component &FunctionComponent.render_with_block/1, id: @id do %>
         <% value -> %>
           WITH VALUE <%= value %> - <%= @value %>
@@ -660,7 +674,7 @@ defmodule Phoenix.LiveView.DiffTest do
                  1 => %{0 => "1", :s => ["\n    WITH VALUE ", " - ", "\n"], 1 => "123"},
                  2 => "DEFAULT",
                  3 => %{0 => "2", :s => ["\n    WITH VALUE ", " - ", "\n"], 1 => "123"},
-                 :s => ["HELLO ", " ", "\nHELLO ", " ", "\n"]
+                 :s => ["<div>\n  HELLO ", " ", "\n  HELLO ", " ", "\n</div>\n"]
                },
                :s => ["", "\n"]
              }
@@ -714,7 +728,7 @@ defmodule Phoenix.LiveView.DiffTest do
     test "with live_component" do
       assigns = %{socket: %Socket{}}
 
-      rendered = ~L"""
+      rendered = ~H"""
       <%= component &FunctionComponent.render_with_live_component/1 %>
       """
 
@@ -728,7 +742,7 @@ defmodule Phoenix.LiveView.DiffTest do
                    1 => %{0 => "1", :s => ["\n  WITH VALUE ", "\n"]},
                    2 => "WORLD",
                    3 => %{0 => "2", :s => ["\n  WITH VALUE ", "\n"]},
-                   :s => ["HELLO ", " ", "\nHELLO ", " ", "\n"]
+                   :s => ["<div>\n  HELLO ", " ", "\n  HELLO ", " ", "\n</div>\n"]
                  }
                },
                :s => ["", "\n"]
@@ -747,7 +761,7 @@ defmodule Phoenix.LiveView.DiffTest do
 
       assert full_render == %{
                0 => 1,
-               :c => %{1 => %{0 => "component", 1 => "world", :s => ["FROM ", " ", "\n"]}},
+               :c => %{1 => %{0 => "component", 1 => "world", :s => ["<div>FROM ", " ", "</div>\n"]}},
                :s => ["<div>\n  ", "\n</div>\n"]
              }
 
@@ -772,7 +786,7 @@ defmodule Phoenix.LiveView.DiffTest do
 
       assert full_render == %{
                0 => 1,
-               :c => %{1 => %{0 => "component", 1 => "world", :s => ["FROM ", " ", "\n"]}},
+               :c => %{1 => %{0 => "component", 1 => "world", :s => ["<div>FROM ", " ", "</div>\n"]}},
                :s => ["<div>\n  ", "\n</div>\n"]
              }
 
@@ -791,7 +805,7 @@ defmodule Phoenix.LiveView.DiffTest do
 
       assert another_full_render == %{
                0 => 2,
-               :c => %{2 => %{0 => "component", 1 => "world", :s => ["FROM ", " ", "\n"]}},
+               :c => %{2 => %{0 => "component", 1 => "world", :s => ["<div>FROM ", " ", "</div>\n"]}},
                :s => ["<span>\n  ", "\n</span>\n"]
              }
 
@@ -808,7 +822,7 @@ defmodule Phoenix.LiveView.DiffTest do
     test "raises on duplicate component IDs" do
       assigns = %{socket: %Socket{}}
 
-      rendered = ~L"""
+      rendered = ~H"""
       <%= live_component RenderOnlyComponent, id: "SAME", from: "SAME" %>
       <%= live_component RenderOnlyComponent, id: "SAME", from: "SAME" %>
       """
@@ -878,7 +892,7 @@ defmodule Phoenix.LiveView.DiffTest do
 
       assert full_render == %{
                0 => 1,
-               :c => %{1 => %{0 => "WELCOME!", :s => ["FROM ", "\n"]}},
+               :c => %{1 => %{0 => "WELCOME!", :s => ["<div>FROM ", "</div>\n"]}},
                :s => ["<div>\n  ", "\n</div>\n"]
              }
 
@@ -904,7 +918,7 @@ defmodule Phoenix.LiveView.DiffTest do
       {socket, diff, components} = render(rendered)
 
       assert diff == %{
-               0 => %{0 => "component", 1 => "world", :s => ["FROM ", " ", "\n"]},
+               0 => %{0 => "component", 1 => "world", :s => ["<div>FROM ", " ", "</div>\n"]},
                :s => ["<div>\n  ", "\n</div>\n"]
              }
 
@@ -918,7 +932,7 @@ defmodule Phoenix.LiveView.DiffTest do
 
       assert diff == %{
                0 => 1,
-               :c => %{1 => %{0 => "rerender", 1 => "world", :s => ["FROM ", " ", "\n"]}}
+               :c => %{1 => %{0 => "rerender", 1 => "world", :s => ["<div>FROM ", " ", "</div>\n"]}}
              }
 
       assert socket.fingerprints == {root_prints, %{}}
@@ -1027,7 +1041,7 @@ defmodule Phoenix.LiveView.DiffTest do
 
       assert full_render == %{
                0 => 2,
-               :c => %{2 => %{0 => "replaced", 1 => "world", :s => ["FROM ", " ", "\n"]}}
+               :c => %{2 => %{0 => "replaced", 1 => "world", :s => ["<div>FROM ", " ", "</div>\n"]}}
              }
 
       assert socket.fingerprints == previous_socket.fingerprints
@@ -1050,7 +1064,7 @@ defmodule Phoenix.LiveView.DiffTest do
       assigns = %{components: components}
 
       %{fingerprint: fingerprint} =
-        rendered = ~L"""
+        rendered = ~H"""
         <div>
           <%= for {component, index} <- Enum.with_index(@components, 0) do %>
             <%= index %>: <%= component %>
@@ -1063,7 +1077,7 @@ defmodule Phoenix.LiveView.DiffTest do
       assert full_render == %{
                0 => %{d: [["0", 1], ["1", 2]], s: ["\n    ", ": ", "\n  "]},
                :c => %{
-                 1 => %{0 => "index_1", 1 => "world", :s => ["FROM ", " ", "\n"]},
+                 1 => %{0 => "index_1", 1 => "world", :s => ["<div>FROM ", " ", "</div>\n"]},
                  2 => %{0 => "index_2", 1 => "world", :s => 1}
                },
                :s => ["<div>\n  ", "\n</div>\n"]
@@ -1087,7 +1101,7 @@ defmodule Phoenix.LiveView.DiffTest do
       template = fn components ->
         assigns = %{components: components}
 
-        ~L"""
+        ~H"""
         <div>
           <%= for {component, index} <- Enum.with_index(@components, 0) do %>
             <%= index %>: <%= component %>
@@ -1107,7 +1121,7 @@ defmodule Phoenix.LiveView.DiffTest do
       assert full_render == %{
                0 => %{d: [["0", 1], ["1", 2]], s: ["\n    ", ": ", "\n  "]},
                :c => %{
-                 1 => %{0 => %{0 => "index_1", :s => ["\n  IF ", "\n"]}, :s => ["", "\n"]},
+                 1 => %{0 => %{0 => "index_1", :s => ["\n    IF ", "\n  "]}, :s => ["<div>\n  ", "\n</div>\n"]},
                  2 => %{0 => %{0 => "index_2"}, :s => 1}
                },
                :s => ["<div>\n  ", "\n</div>\n"]
@@ -1143,7 +1157,7 @@ defmodule Phoenix.LiveView.DiffTest do
 
       assert diff == %{
                0 => %{d: [["0", 4]]},
-               :c => %{4 => %{0 => %{0 => "index_4", :s => ["\n  ELSE ", "\n"]}, :s => -1}}
+               :c => %{4 => %{0 => %{0 => "index_4", :s => ["\n    ELSE ", "\n  "]}, :s => -1}}
              }
 
       {cid_to_component, _, 5} = diff_components
@@ -1162,7 +1176,7 @@ defmodule Phoenix.LiveView.DiffTest do
       assert diff == %{
                0 => %{d: [["0", 1], ["1", 5]]},
                :c => %{
-                 1 => %{0 => %{0 => "index_1", :s => ["\n  ELSE ", "\n"]}},
+                 1 => %{0 => %{0 => "index_1", :s => ["\n    ELSE ", "\n  "]}},
                  5 => %{0 => %{0 => "index_5"}, :s => -1}
                }
              }
@@ -1180,7 +1194,7 @@ defmodule Phoenix.LiveView.DiffTest do
       assigns = %{components: components, ids: ["foo", "bar"]}
 
       %{fingerprint: fingerprint} =
-        rendered = ~L"""
+        rendered = ~H"""
         <div>
           <%= for prefix_id <- @ids do %>
             <%= prefix_id %>
@@ -1202,7 +1216,7 @@ defmodule Phoenix.LiveView.DiffTest do
                  s: ["\n    ", "\n    ", "\n  "]
                },
                :c => %{
-                 1 => %{0 => "index_1", 1 => "world", :s => ["FROM ", " ", "\n"]},
+                 1 => %{0 => "index_1", 1 => "world", :s => ["<div>FROM ", " ", "</div>\n"]},
                  2 => %{0 => "index_2", 1 => "world", :s => 1},
                  3 => %{0 => "index_1", 1 => "world", :s => 1},
                  4 => %{0 => "index_2", 1 => "world", :s => 3}
@@ -1234,7 +1248,7 @@ defmodule Phoenix.LiveView.DiffTest do
       assigns = %{components: components}
 
       %{fingerprint: fingerprint} =
-        rendered = ~L"""
+        rendered = ~H"""
         <div>
           <%= for {component, index} <- Enum.with_index(@components, 1) do %>
             <%= index %>: <%= component_template(%{component: component}) %>
@@ -1253,7 +1267,7 @@ defmodule Phoenix.LiveView.DiffTest do
                  s: ["\n    ", ": ", "\n  "]
                },
                :c => %{
-                 1 => %{0 => "index_1", 1 => "world", :s => ["FROM ", " ", "\n"]},
+                 1 => %{0 => "index_1", 1 => "world", :s => ["<div>FROM ", " ", "</div>\n"]},
                  2 => %{0 => "index_2", 1 => "world", :s => 1}
                },
                :s => ["<div>\n  ", "\n</div>\n"]
@@ -1282,7 +1296,7 @@ defmodule Phoenix.LiveView.DiffTest do
       assigns = %{components: components}
 
       %{fingerprint: fingerprint} =
-        rendered = ~L"""
+        rendered = ~H"""
         <div>
           <%= for {component, index} <- Enum.with_index(@components, 1) do %>
             <%= if index > 1 do %><%= index %>: <%= component %><% end %>
@@ -1297,7 +1311,7 @@ defmodule Phoenix.LiveView.DiffTest do
                  d: [[""], [%{0 => "2", 1 => 1, :s => ["", ": ", ""]}]],
                  s: ["\n    ", "\n  "]
                },
-               :c => %{1 => %{0 => "index_2", 1 => "world", :s => ["FROM ", " ", "\n"]}},
+               :c => %{1 => %{0 => "index_2", 1 => "world", :s => ["<div>FROM ", " ", "</div>\n"]}},
                :s => ["<div>\n  ", "\n</div>\n"]
              }
 
@@ -1316,7 +1330,7 @@ defmodule Phoenix.LiveView.DiffTest do
       assigns = %{socket: %Socket{}}
 
       %{fingerprint: _fingerprint} =
-        rendered = ~L"""
+        rendered = ~H"""
         <%= for key <- [:b, :c, :a] do %>
           <%= live_component(NestedDynamicComponent, id: key, key: key) %>
         <% end %>
@@ -1327,7 +1341,7 @@ defmodule Phoenix.LiveView.DiffTest do
       assert full_render == %{
                0 => %{d: [[1], [2], [3]], s: ["\n  ", "\n"]},
                :c => %{
-                 1 => %{0 => %{0 => "", :s => ["", "\n"]}, :s => ["", "\n"]},
+                 1 => %{0 => %{0 => "", :s => ["", "\n"]}, :s => ["<div>\n  ", "\n</div>\n"]},
                  2 => %{0 => %{0 => 4, :s => ["", "\n"]}, :s => 1},
                  3 => %{
                    0 => %{
@@ -1345,7 +1359,7 @@ defmodule Phoenix.LiveView.DiffTest do
     end
 
     defp tracking(assigns) do
-      ~L"""
+      ~H"""
       <%= live_component BlockComponent, %{id: "TRACKING"} do %>
         <% %{value: value} -> %>
           WITH PARENT VALUE <%= @parent_value %>
@@ -1374,7 +1388,7 @@ defmodule Phoenix.LiveView.DiffTest do
                      1 => "2",
                      :s => ["\n    WITH PARENT VALUE ", "\n    WITH VALUE ", "\n"]
                    },
-                   :s => ["HELLO ", " ", "\nHELLO ", " ", "\n"]
+                   :s => ["<div>\n  HELLO ", " ", "\n  HELLO ", " ", "\n</div>\n"]
                  }
                },
                :s => ["", "\n"]


### PR DESCRIPTION
Followup to my previous PRs to attempt to change the tests to use `~H`/heex.