### PR TITLE
Add refute_redirect test utilities

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1238,43 +1238,20 @@ defmodule Phoenix.LiveViewTest do
   end
 
   @doc """
-  Refutes a redirect will happen within `timeout` milliseconds.
-  The default `timeout` is 100.
+  Refutes a redirect to a given path was performed.
 
-  It returns :ok if there was no redirect.
-
-  ## Examples
-
-      render_click(view, :event_that_does_not_triggers_redirect)
-      :ok = refute_redirect view
-  """
-  def refute_redirect(view, timeout \\ 100)
-
-  def refute_redirect(view, timeout) when is_integer(timeout) do
-    refute_navigation(view, :redirect, nil, timeout)
-  end
-
-  def refute_redirect(view, to) when is_binary(to), do: refute_redirect(view, to, 100)
-
-  @doc """
-  Refutes a redirect will happen to a given path within `timeout` milliseconds.
-  The default `timeout` is 100.
-
-  It returns :ok if the specified redirect didn't happen before timeout.
+  It returns :ok if the specified redirect isn't already in the mailbox.
 
   ## Examples
 
       render_click(view, :event_that_triggers_redirect_to_path)
       :ok = refute_redirect view, "/wrong_path"
   """
-  def refute_redirect(view, to, timeout)
-      when is_binary(to) and is_integer(timeout) do
-    refute_navigation(view, :redirect, to, timeout)
+  def refute_redirected(view, to) when is_binary(to) do
+    refute_navigation(view, :redirect, to)
   end
 
-  defp refute_navigation(view, kind, to, timeout) do
-    %{proxy: {ref, topic, _}} = view
-
+  defp refute_navigation(view = %{proxy: {ref, topic, _}}, kind, to) do
     receive do
       {^ref, {^kind, ^topic, %{to: new_to}}} when new_to == to or to == nil ->
         message =
@@ -1286,8 +1263,7 @@ defmodule Phoenix.LiveViewTest do
 
         raise ArgumentError, message <> "but got a #{kind} to #{inspect(to)}"
     after
-      timeout ->
-        :ok
+      0 -> :ok
     end
   end
 

--- a/test/phoenix_live_view/integrations/live_view_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test.exs
@@ -748,6 +748,41 @@ defmodule Phoenix.LiveView.LiveViewTest do
     end
 
     @tag session: %{nest: []}
+    test "refute_redirect", %{conn: conn} do
+      {:ok, thermo_view, _html} = live(conn, "/thermo")
+
+      clock_view = find_live_child(thermo_view, "clock")
+
+      refute_redirect(thermo_view)
+
+      send(
+        clock_view.pid,
+        {:run,
+         fn socket ->
+           {:noreply, LiveView.push_redirect(socket, to: "/some_url")}
+         end}
+      )
+
+      refute_redirect(thermo_view, "/not_going_here")
+
+      send(
+        clock_view.pid,
+        {:run,
+         fn socket ->
+           {:noreply, LiveView.push_redirect(socket, to: "/another_url")}
+         end}
+      )
+
+      try do
+        refute_redirect(thermo_view, "/another_url")
+      rescue
+        e ->
+          assert %ArgumentError{message: message} = e
+          assert message =~ "not to redirect to"
+      end
+    end
+
+    @tag session: %{nest: []}
     test "push_redirect with destination that can vary", %{conn: conn} do
       {:ok, thermo_view, html} = live(conn, "/thermo")
       assert html =~ "Redirect: none"

--- a/test/phoenix_live_view/integrations/live_view_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test.exs
@@ -753,8 +753,6 @@ defmodule Phoenix.LiveView.LiveViewTest do
 
       clock_view = find_live_child(thermo_view, "clock")
 
-      refute_redirect(thermo_view)
-
       send(
         clock_view.pid,
         {:run,
@@ -763,7 +761,7 @@ defmodule Phoenix.LiveView.LiveViewTest do
          end}
       )
 
-      refute_redirect(thermo_view, "/not_going_here")
+      refute_redirected(thermo_view, "/not_going_here")
 
       send(
         clock_view.pid,
@@ -774,7 +772,7 @@ defmodule Phoenix.LiveView.LiveViewTest do
       )
 
       try do
-        refute_redirect(thermo_view, "/another_url")
+        refute_redirected(thermo_view, "/another_url")
       rescue
         e ->
           assert %ArgumentError{message: message} = e


### PR DESCRIPTION
Adds test utilities that refute whether a redirect happened (optionally, to a given path; also optionally, within a given timeout). 

PR also includes a test that uses the test utility, which I guess is how you would write a test for a test utility? ¯\\\_(ツ)_/¯

Issue: https://github.com/phoenixframework/phoenix_live_view/issues/1539

If it looks good, I can do the other `refute_*`s too.