### PR TITLE
Add a null check to DOM.all

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -33,6 +33,7 @@ let DOM = {
   },
 
   all(node, query, callback){
+    if (!node) { return []; }
     let array = Array.from(node.querySelectorAll(query))
     return callback ? array.forEach(callback) : array
   },

--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -33,7 +33,7 @@ let DOM = {
   },
 
   all(node, query, callback){
-    if (!node) { return []; }
+    if(!node){ return [] }
     let array = Array.from(node.querySelectorAll(query))
     return callback ? array.forEach(callback) : array
   },


### PR DESCRIPTION
We may sometimes call `DOM.all()` on elements that have already been destroyed.

This closes #1532
