### PR TITLE
fix malformed URI object creation

### DIFF
--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -98,13 +98,13 @@ defmodule Phoenix.LiveView.Utils do
   defp prune_uri(:not_mounted_at_router), do: :not_mounted_at_router
 
   defp prune_uri(url) do
-    %URI{host: host, port: port, scheme: scheme} = url
+    uri = URI.parse(url)
 
-    if host == nil do
+    if uri.host == nil do
       raise "client did not send full URL, missing host in #{url}"
     end
 
-    %URI{host: host, port: port, scheme: scheme}
+    uri
   end
 
   @doc """

--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -104,7 +104,7 @@ defmodule Phoenix.LiveView.Utils do
       raise "client did not send full URL, missing host in #{url}"
     end
 
-    uri
+    %{uri | path: nil}
   end
 
   @doc """


### PR DESCRIPTION
The current socket host_uri object is being created malformed as it lacks the authority keyword. This prevents manipulation with URI operations like `URI.merge/2`. It was creating very *odd* error messages.

Example malformed URI struct:

```
%URI{
  authority: nil,
  fragment: nil,
  host: "api.dev.rogersworld.tv",
  path: nil,
  port: 443,
  query: nil,
  scheme: "https",
  userinfo: nil
}
```

When I try to use `URI.merge/2` on it, I get nonsense: ```** (ArgumentError) you must merge onto an absolute URI```

It turns out that the URI object created by the prune_uri function creates a malformed URI object as the authority field is a required one, and URI is simply being dumb about it.

(Technically I suppose this is also a bug with the URI parser if it thinks this is not an absolute URI....)

This change should resolve that issue since it has the appropriate authority field now.