### PR TITLE
Update js-interop.md

### DIFF
--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -244,4 +244,4 @@ And then on the client:
 *Note*: events pushed from the server via `push_event` are global and will be dispatched
 to all active hooks on the client who are handling that event.
 
-*Note*: In case a LiveView pushes events and renders content, `handleEvent` callbacks are invoked after the page is updated. Therefore, if the LiveView redirects at the same time it pushes events, callbacks won't be invoked on the old page's elements. Callbacks would be invoked on the new page's elements.
+*Note*: In case a LiveView pushes events and renders content, `handleEvent` callbacks are invoked after the page is updated. Therefore, if the LiveView redirects at the same time it pushes events, callbacks won't be invoked on the old page's elements. Callbacks would be invoked on the redirected page's newly mounted hook elements.

--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -244,4 +244,4 @@ And then on the client:
 *Note*: events pushed from the server via `push_event` are global and will be dispatched
 to all active hooks on the client who are handling that event.
 
-*Note*: In case a LiveView pushes events and renders content, `handleEvent` callbacks are invoked after the page is updated. Therefore, if the LiveView redirects at the same time it pushes events, callbacks won't be invoked.
+*Note*: In case a LiveView pushes events and renders content, `handleEvent` callbacks are invoked after the page is updated. Therefore, if the LiveView redirects at the same time it pushes events, callbacks won't be invoked on the old page's elements. Callbacks would be invoked on the new page's elements.


### PR DESCRIPTION
Clarify when pushed events will be called in the case of page transitions.

This might be incorrect, but I had the question and figured that a clarifying PR would be better than a Slack message. It seems to work such that the new page's hooks are invoked when mount uses `push_event`, although the wording is that callbacks won't be invoked.