### PR TITLE
Update send_update docs

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1297,11 +1297,6 @@ defmodule Phoenix.LiveView do
   own state, as well as messaging between components mounted in the same
   LiveView.
 
-  **Note:** `send_update/3` cannot update a LiveComponent that is mounted in a
-  different LiveView. To update a component in a different LiveView you must
-  send a message to the LiveView process that the LiveComponent is mounted
-  within (often via `Phoenix.PubSub`).
-
   ## Examples
 
       def handle_event("cancel-order", _, socket) do

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1277,12 +1277,14 @@ defmodule Phoenix.LiveView do
   @doc """
   Asynchronously updates a `Phoenix.LiveComponent` with new assigns.
 
-  The component that is updated must be stateful (the `:id` in the assigns must
-  match the `:id` associated with the component) and the component must be
-  mounted within the current LiveView.
+  The `:id` that identifies the component must be passed as part of the
+  assigns and it will be used to identify the live components to be updated.
 
-  If this call is executed from a process which is not a LiveView
-  nor a LiveComponent, the `pid` argument has to be specified.
+  The `pid` argument is optional and it defaults to the current process,
+  which means the update instruction will be sent to a component running
+  on the same LiveView. If the current process is not a LiveView or you
+  want to send updates to a live component running on another LiveView,
+  you should explicitly pass the LiveView's pid instead.
 
   When the component receives the update, first the optional
   [`preload/1`](`c:Phoenix.LiveComponent.preload/1`) then


### PR DESCRIPTION
Now that `LiveView.send_update/3` can send an update to a LiveComponent that is mounted in another LiveView the docs need to be updated to match.

I also experimented with some wording to clarify the related earlier paragraph:
>   If this call is executed from a process which is not a LiveView
  nor a LiveComponent, the `pid` argument has to be specified.

Attempt 1:
>  If this call is executed from a process which is not the LiveView that this
  LiveComponent is mounted within or a LiveComponent mounted within that
  LiveView, then the `pid` argument has to be specified.

Attempt 2:
>   When sending an update to a LiveComponent that is mounted in another LiveView,
  then the `pid` argument needs to be specified.

But I wasn't happy with those two proposed wordings. But I think the current text is a little confusing because if you are sending an update to a LiveComponent in another LiveView then you need to provide a pid. Maybe it would be more clear to explain what the `pid` means directly instead?