### PR TITLE
Replace LiveEEx with HEEx in link

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -251,7 +251,7 @@ defmodule Phoenix.LiveView do
       end
 
   In all cases, each assign in the template will be accessible as `@assign`.
-  You can learn more about [assigns and LiveEEx templates in their own guide](assigns-eex.md).
+  You can learn more about [assigns and HEEx templates in their own guide](assigns-eex.md).
 
   ## Bindings
 


### PR DESCRIPTION
The title of the linked page was already changed to `Assigns and HEEx templates`, but it seems the link was missed.