### PR TITLE
Warn about changes to the `LiveSocket` JS export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,10 @@ live_session :session_name, root_layout: {MyAppWeb.LayoutView, "custom_layout.ht
 end
 ```
 
+Additionally, if you were relying on the default export for the `LiveSocket` JavaScript class,
+e.g. `import LiveSocket from "phoenix_live_view";` this has been removed and you must import it
+explicitly e.g. `import { LiveSocket } from "phoenix_live_view";`.
+
 ### Enhancements
   - Introduce HEEx templates
   - Introduce `Phoenix.Component`


### PR DESCRIPTION
:wave: Prior to `0.16` the default export (in javascript terms) of `phoenix_live_view` was `LiveSocket`. This meant that this:
```
import LiveSocket from "phoenix_live_view";
```

Worked fine, and that `0.16` broke this, leading to WebPack complaining about a missing default but compiling anyway, and the browser console mildly complaining. Standard LiveView tests did not catch this because they don't actually run any JS.

Fixing this is as simple as doing:

```
import { LiveSocket } from "phoenix_live_view";
```

But there was no documentation about this in the changelog, so, this PR warns about this for the future people caught out by this 😂 