### PR TITLE
Add render_heex/1 to publicly turn heex into an assertable string

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -112,8 +112,8 @@ defmodule Phoenix.LiveViewTest do
 
   ## Testing components
 
-  There are two main mechanisms for testing components. To test stateless
-  components or just a regular rendering of a component, one can use
+  There are three main mechanisms for testing components. To test leex
+  stateless components or just a regular rendering of a component, one can use
   `render_component/2`:
 
       assert render_component(MyComponent, id: 123, user: %User{}) =~
@@ -133,6 +133,13 @@ defmodule Phoenix.LiveViewTest do
   ID=user-13 and retrieve its `phx-target`. If `phx-target` points
   to a component, that will be the component used, otherwise it will
   fallback to the view.
+
+  If you want to test heex functional components, you can pass the
+  result of your function call to `render_heex/1` which will turn
+  the resulting struct into some HTML for you to introspect:
+
+    html = render_heex(MyComponent.call(assigns))
+
   """
 
   @flash_cookie "__phoenix_flash__"
@@ -435,6 +442,17 @@ defmodule Phoenix.LiveViewTest do
     {_, diff, _} = Diff.render(socket, rendered, Diff.new_components())
     diff |> Diff.to_iodata() |> IO.iodata_to_binary()
   end
+
+  @doc """
+  Turns the output of a functional component into a HTML string that can be
+  introspected.
+
+  ## Examples
+
+      assert render_heex(MyComponent.display_user(%{user: %User{name: "Chris"}})) =~ "<h3>Chris</h3>"
+
+  """
+  def render_heex(rendered_struct), do: rendered_struct |> Phoenix.HTML.Safe.to_iodata() |> IO.iodata_to_binary()
 
   @doc """
   Sends a click event given by `element` and returns the rendered result.

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -3,11 +3,7 @@ defmodule Phoenix.ComponentTest do
 
   use Phoenix.Component
 
-  defp h2s(template) do
-    template
-    |> Phoenix.HTML.Safe.to_iodata()
-    |> IO.iodata_to_binary()
-  end
+  import Phoenix.LiveViewTest, only: [render_heex: 1]
 
   describe "rendering" do
     defp hello(assigns) do
@@ -19,7 +15,7 @@ defmodule Phoenix.ComponentTest do
     test "renders component" do
       assigns = %{}
 
-      assert h2s(~H"""
+      assert render_heex(~H"""
              <%= component &hello/1, name: "WORLD" %>
              """) == """
              Hello WORLD
@@ -37,7 +33,7 @@ defmodule Phoenix.ComponentTest do
     test "renders component with block" do
       assigns = %{}
 
-      assert h2s(~H"""
+      assert render_heex(~H"""
              <%= component &hello_with_block/1, name: "WORLD" do %>
              THE INNER BLOCK
              <% end %>
@@ -53,7 +49,7 @@ defmodule Phoenix.ComponentTest do
     test "renders component with block from content_tag" do
       assigns = %{}
 
-      assert h2s(~H"""
+      assert render_heex(~H"""
              <%= Phoenix.HTML.Tag.content_tag :div do %>
              <%= component &hello_with_block/1, name: "WORLD" do %>
              THE INNER BLOCK
@@ -80,7 +76,7 @@ defmodule Phoenix.ComponentTest do
     test "render component with block passing args" do
       assigns = %{}
 
-      assert h2s(~H"""
+      assert render_heex(~H"""
              <%= component &hello_with_block_args/1, name: "WORLD" do %>
              <% [arg1: arg1, arg2: arg2] -> %>
              THE INNER BLOCK


### PR DESCRIPTION
With the addtion of heex "functional components" in 0.16, we now lack a way of directly rendering components into strings (`render_component` does not work with such components, and the components return the result of the `~H` sigil which a struct and not html template). This PR adds a test helper to deal with this situation, which is simply the test helper used internally moved and renamed, thanks to @LostKobrakai for the inspiration.