### PR TITLE
Fix - form helper generating CSRF token for non-POST forms

### DIFF
--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -942,7 +942,7 @@ defmodule Phoenix.LiveView.Helpers do
 
     {csrf_token, opts} =
       Keyword.pop_lazy(opts, :csrf_token, fn ->
-        method == "post" && Phoenix.HTML.Tag.csrf_token_value(action)
+        if method == "post", do: Phoenix.HTML.Tag.csrf_token_value(action)
       end)
 
     opts =

--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -936,18 +936,20 @@ defmodule Phoenix.LiveView.Helpers do
         | action: action
       }
 
-    # And then process csrf_token, multipart, and method as in form_tag
+    # And then process method, csrf_token, and multipart as in form_tag
+    {method, opts} = Keyword.pop(opts, :method, "post")
+    {method, hidden_method} = form_method(method)
+
     {csrf_token, opts} =
-      Keyword.pop_lazy(opts, :csrf_token, fn -> Phoenix.HTML.Tag.csrf_token_value(action) end)
+      Keyword.pop_lazy(opts, :csrf_token, fn ->
+        method == "post" && Phoenix.HTML.Tag.csrf_token_value(action)
+      end)
 
     opts =
       case Keyword.pop(opts, :multipart, false) do
         {false, opts} -> opts
         {true, opts} -> Keyword.put(opts, :enctype, "multipart/form-data")
       end
-
-    {method, opts} = Keyword.pop(opts, :method, "post")
-    {method, hidden_method} = form_method(method)
 
     # Finally we can render the form
     assigns =

--- a/test/phoenix_live_view/helpers_test.exs
+++ b/test/phoenix_live_view/helpers_test.exs
@@ -156,6 +156,24 @@ defmodule Phoenix.LiveView.HelpersTest do
              ] = html
     end
 
+    test "does not generate csrf_token if method is not post" do
+      assigns = %{}
+
+      html =
+        parse(~H"""
+          <.form let={f} for={:myform} method="get">
+            <%= text_input f, :foo %>
+          </.form>
+        """)
+
+      assert [
+               {"form", [{"action", "#"}, {"method", "get"}],
+                [
+                  {"input", [{"id", "myform_foo"}, {"name", "myform[foo]"}, {"type", "text"}], []}
+                ]}
+             ] = html
+    end
+
     test "geneates form with available options and custom attributes" do
       assigns = %{}
 


### PR DESCRIPTION
The current documentation for `Phoenix.LiveView.Helpers.form/1` states: 

> for "post" requests, the form tag will automatically include an input tag with name _csrf_token. When set to false, this is disabled

Currently, even if the method is not set to "post", a CSRF token is generated, unless `csrf_token={false}` is explicitly set. This PR adds a check of the method before generating the token.