### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ component named `form`:
 
 ```elixir
 ~H"""
-<.form let={f} for={@changeset} action="#">
+<.form let={f} for={@changeset}>
   <%= input f, :foo %>
 </.form>
 """

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ component named `form`:
 
 ```elixir
 ~H"""
-<.form let={f} for={@changeset} url="#">
+<.form let={f} for={@changeset} action="#">
   <%= input f, :foo %>
 </.form>
 """


### PR DESCRIPTION
The url property on a form does not exist, I believe this was meant to be action. However, the default value for action is "#", so maybe it's best to omit it?