### PR TITLE
Mention changes for testing functional components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
   - Relax `phoenix_html` dependency requirement
+  - Allow testing functional components by passing a function reference
+    to `Phoenix.LiveViewTest.render_component/3`.
 
 ## 0.16.0 (2021-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@
 ### Enhancements
   - Relax `phoenix_html` dependency requirement
   - Allow testing functional components by passing a function reference
-    to `Phoenix.LiveViewTest.render_component/3`.
+    to `Phoenix.LiveViewTest.render_component/3`
+
+### Bug fixes
+  - Do not generate CSRF tokens for non-POST forms
+  - Do not add compile-time dependencies on on_mount declarations
 
 ## 0.16.0 (2021-08-10)
 


### PR DESCRIPTION
As a fix for #1572 @josevalim (in 6c0d642a939de4bd84a8b8b13cdd842588ef660c) added the ability to render functional components in tests, this mentions this in the change log for `v0.16.1` 