### PR TITLE
Don't call `mount/3` of LiveView when the instruction of returns of hooks on mount is `:halt`

### DIFF
--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -288,7 +288,7 @@ defmodule Phoenix.LiveView.Utils do
   Calls the `c:Phoenix.LiveView.mount/3` callback, otherwise returns the socket as is.
   """
   def maybe_call_live_view_mount!(%Socket{} = socket, view, params, session) do
-    {_, %Socket{} = socket} = Lifecycle.mount(params, session, socket)
+    {cont_or_halt, %Socket{} = socket} = Lifecycle.mount(params, session, socket)
 
     if function_exported?(view, :mount, 3) do
       :telemetry.span(
@@ -296,8 +296,10 @@ defmodule Phoenix.LiveView.Utils do
         %{socket: socket, params: params, session: session},
         fn ->
           socket =
-            params
-            |> view.mount(session, socket)
+            case cont_or_halt do
+              :cont -> view.mount(params, session, socket)
+              :halt -> socket
+            end
             |> handle_mount_result!({:mount, 3, view})
 
           {socket, %{socket: socket, params: params, session: session}}


### PR DESCRIPTION
It fixes #1598.

If you agree with this approach, I will keep work on it.

TODO
- [ ] Add tests