### PR TITLE
Update mount/handle_params lifecycle calls

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -370,12 +370,13 @@ defmodule Phoenix.LiveView.Channel do
 
   defp maybe_call_mount_handle_params(%{socket: socket} = state, router, url, params) do
     %{view: view, redirected: mount_redirect} = socket
+    lifecycle = Utils.lifecycle(socket, view, :handle_params, 3)
 
     cond do
       mount_redirect ->
         mount_handle_params_result({:noreply, socket}, state, :mount)
 
-      not function_exported?(view, :handle_params, 3) ->
+      not lifecycle.any? ->
         {:diff, diff, new_state} = render_diff(state, socket, true)
         {:ok, diff, :mount, new_state}
 
@@ -389,7 +390,7 @@ defmodule Phoenix.LiveView.Channel do
 
       true ->
         socket
-        |> Utils.call_handle_params!(view, params, url)
+        |> Utils.maybe_call_handle_params(lifecycle, params, url)
         |> mount_handle_params_result(state, :mount)
     end
   end

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -390,7 +390,7 @@ defmodule Phoenix.LiveView.Channel do
 
       true ->
         socket
-        |> Utils.maybe_call_handle_params(lifecycle, params, url)
+        |> Utils.call_handle_params!(view, lifecycle.exported?, params, url)
         |> mount_handle_params_result(state, :mount)
     end
   end

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -370,7 +370,7 @@ defmodule Phoenix.LiveView.Channel do
 
   defp maybe_call_mount_handle_params(%{socket: socket} = state, router, url, params) do
     %{view: view, redirected: mount_redirect} = socket
-    lifecycle = Utils.lifecycle(socket, view, :handle_params, 3)
+    lifecycle = Lifecycle.stage_info(socket, view, :handle_params, 3)
 
     cond do
       mount_redirect ->

--- a/lib/phoenix_live_view/lifecycle.ex
+++ b/lib/phoenix_live_view/lifecycle.ex
@@ -15,6 +15,11 @@ defmodule Phoenix.LiveView.Lifecycle do
 
   defstruct handle_event: [], handle_info: [], handle_params: [], mount: []
 
+  def attach_hook(%Socket{router: nil}, id, :handle_params, _fun) do
+    raise "cannot attach hook with id #{inspect(id)} on :handle_params because" <>
+            " the view was not mounted at the router with the live/3 macro"
+  end
+
   def attach_hook(%Socket{} = socket, id, stage, fun)
       when stage in [:handle_event, :handle_info, :handle_params] do
     lifecycle = lifecycle(socket)

--- a/lib/phoenix_live_view/lifecycle.ex
+++ b/lib/phoenix_live_view/lifecycle.ex
@@ -110,6 +110,14 @@ defmodule Phoenix.LiveView.Lifecycle do
     %{id: id, stage: stage, function: fun}
   end
 
+  @doc """
+  Returns whether any hooks have been attached to the given `stage`.
+  """
+  def callbacks?(%Socket{private: %{@lifecycle => lifecycle}}, stage)
+      when stage in [:handle_event, :handle_info, :handle_params, :mount] do
+    lifecycle |> Map.fetch!(stage) |> Enum.any?()
+  end
+
   # Lifecycle Event API
 
   @doc false

--- a/lib/phoenix_live_view/lifecycle.ex
+++ b/lib/phoenix_live_view/lifecycle.ex
@@ -15,6 +15,20 @@ defmodule Phoenix.LiveView.Lifecycle do
 
   defstruct handle_event: [], handle_info: [], handle_params: [], mount: []
 
+  @doc """
+  Returns a map of infos about the lifecycle stage for the given `view`.
+  """
+  def stage_info(%Socket{} = socket, view, stage, arity) do
+    callbacks? = callbacks?(socket, stage)
+    exported? = function_exported?(view, stage, arity)
+
+    %{
+      any?: callbacks? or exported?,
+      callbacks?: callbacks?,
+      exported?: exported?
+    }
+  end
+
   def attach_hook(%Socket{router: nil}, id, :handle_params, _fun) do
     raise "cannot attach hook with id #{inspect(id)} on :handle_params because" <>
             " the view was not mounted at the router with the live/3 macro"

--- a/lib/phoenix_live_view/lifecycle.ex
+++ b/lib/phoenix_live_view/lifecycle.ex
@@ -29,6 +29,11 @@ defmodule Phoenix.LiveView.Lifecycle do
     }
   end
 
+  defp callbacks?(%Socket{private: %{@lifecycle => lifecycle}}, stage)
+       when stage in [:handle_event, :handle_info, :handle_params, :mount] do
+    lifecycle |> Map.fetch!(stage) |> Kernel.!=([])
+  end
+
   def attach_hook(%Socket{router: nil}, id, :handle_params, _fun) do
     raise "cannot attach hook with id #{inspect(id)} on :handle_params because" <>
             " the view was not mounted at the router with the live/3 macro"
@@ -127,14 +132,6 @@ defmodule Phoenix.LiveView.Lifecycle do
 
   defp hook!(id, stage, fun) when is_atom(stage) and is_function(fun) do
     %{id: id, stage: stage, function: fun}
-  end
-
-  @doc """
-  Returns whether any hooks have been attached to the given `stage`.
-  """
-  def callbacks?(%Socket{private: %{@lifecycle => lifecycle}}, stage)
-      when stage in [:handle_event, :handle_info, :handle_params, :mount] do
-    lifecycle |> Map.fetch!(stage) |> Kernel.!=([])
   end
 
   # Lifecycle Event API

--- a/lib/phoenix_live_view/lifecycle.ex
+++ b/lib/phoenix_live_view/lifecycle.ex
@@ -120,7 +120,7 @@ defmodule Phoenix.LiveView.Lifecycle do
   """
   def callbacks?(%Socket{private: %{@lifecycle => lifecycle}}, stage)
       when stage in [:handle_event, :handle_info, :handle_params, :mount] do
-    lifecycle |> Map.fetch!(stage) |> Enum.any?()
+    lifecycle |> Map.fetch!(stage) |> Kernel.!=([])
   end
 
   # Lifecycle Event API

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -2,7 +2,7 @@ defmodule Phoenix.LiveView.Static do
   # Holds the logic for static rendering.
   @moduledoc false
 
-  alias Phoenix.LiveView.{Socket, Utils, Diff, Route}
+  alias Phoenix.LiveView.{Socket, Utils, Diff, Route, Lifecycle}
 
   # Token version. Should be changed whenever new data is stored.
   @token_vsn 5
@@ -199,7 +199,7 @@ defmodule Phoenix.LiveView.Static do
       throw({:phoenix, :child_redirect, redir, Utils.get_flash(socket)})
     end
 
-    if Utils.lifecycle(socket, view, :handle_params, 3).any? do
+    if Lifecycle.stage_info(socket, view, :handle_params, 3).any? do
       raise ArgumentError, "handle_params/3 is not allowed on child LiveViews, only at the root"
     end
 
@@ -272,7 +272,7 @@ defmodule Phoenix.LiveView.Static do
   end
 
   defp mount_handle_params(%Socket{redirected: mount_redir} = socket, view, params, uri) do
-    lifecycle = Utils.lifecycle(socket, view, :handle_params, 3)
+    lifecycle = Lifecycle.stage_info(socket, view, :handle_params, 3)
 
     cond do
       mount_redir ->

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -286,7 +286,7 @@ defmodule Phoenix.LiveView.Static do
         Route.live_link_info!(socket, view, uri)
 
       true ->
-        Utils.maybe_call_handle_params(socket, lifecycle, params, uri)
+        Utils.call_handle_params!(socket, view, lifecycle.exported?, params, uri)
     end
   end
 

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -2,7 +2,7 @@ defmodule Phoenix.LiveView.Static do
   # Holds the logic for static rendering.
   @moduledoc false
 
-  alias Phoenix.LiveView.{Socket, Utils, Diff, Route, Lifecycle}
+  alias Phoenix.LiveView.{Socket, Utils, Diff, Route}
 
   # Token version. Should be changed whenever new data is stored.
   @token_vsn 5

--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -285,24 +285,10 @@ defmodule Phoenix.LiveView.Utils do
   end
 
   @doc """
-  Returns a map of infos about the lifecycle stage for the given `view`.
-  """
-  def lifecycle(%Socket{} = socket, view, stage, arity) do
-    callbacks? = Lifecycle.callbacks?(socket, stage)
-    exported? = function_exported?(view, stage, arity)
-
-    %{
-      any?: callbacks? or exported?,
-      callbacks?: callbacks?,
-      exported?: exported?
-    }
-  end
-
-  @doc """
   Calls the `c:Phoenix.LiveView.mount/3` callback, otherwise returns the socket as is.
   """
   def maybe_call_live_view_mount!(%Socket{} = socket, view, params, session) do
-    lifecycle = lifecycle(socket, view, :mount, 3)
+    lifecycle = Lifecycle.stage_info(socket, view, :mount, 3)
 
     if lifecycle.any? do
       :telemetry.span(

--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -288,13 +288,15 @@ defmodule Phoenix.LiveView.Utils do
   Returns a map of infos about the lifecycle stage for the given `view`.
   """
   def lifecycle(%Socket{} = socket, view, stage, arity) do
-    info = %{
-      callbacks?: Lifecycle.callbacks?(socket, stage),
-      exported?: function_exported?(view, stage, arity),
+    callbacks? = Lifecycle.callbacks?(socket, stage)
+    exported? = function_exported?(view, stage, arity)
+
+    %{
+      any?: callbacks? or exported?,
+      callbacks?: callbacks?,
+      exported?: exported?,
       view: view
     }
-
-    Map.put(info, :any?, info.callbacks? or info.exported?)
   end
 
   @doc """

--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -288,19 +288,19 @@ defmodule Phoenix.LiveView.Utils do
   Calls the `c:Phoenix.LiveView.mount/3` callback, otherwise returns the socket as is.
   """
   def maybe_call_live_view_mount!(%Socket{} = socket, view, params, session) do
-    lifecycle = Lifecycle.stage_info(socket, view, :mount, 3)
+    %{any?: any?, exported?: exported?} = Lifecycle.stage_info(socket, view, :mount, 3)
 
-    if lifecycle.any? do
+    if any? do
       :telemetry.span(
         [:phoenix, :live_view, :mount],
         %{socket: socket, params: params, session: session},
         fn ->
           socket =
-            case {Lifecycle.mount(params, session, socket), lifecycle} do
-              {{:cont, %Socket{} = socket}, %{exported?: true}} ->
+            case Lifecycle.mount(params, session, socket) do
+              {:cont, %Socket{} = socket} when exported? ->
                 view.mount(params, session, socket)
 
-              {{_, %Socket{} = socket}, _} ->
+              {_, %Socket{} = socket} ->
                 {:ok, socket}
             end
             |> handle_mount_result!({:mount, 3, view})

--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -291,7 +291,6 @@ defmodule Phoenix.LiveView.Utils do
     info = %{
       callbacks?: Lifecycle.callbacks?(socket, stage),
       exported?: function_exported?(view, stage, arity),
-      ref: {stage, arity, view},
       view: view
     }
 
@@ -317,7 +316,7 @@ defmodule Phoenix.LiveView.Utils do
               {{_, %Socket{} = socket}, _} ->
                 {:ok, socket}
             end
-            |> handle_mount_result!(lifecycle.ref)
+            |> handle_mount_result!({:mount, 3, view})
 
           {socket, %{socket: socket, params: params, session: session}}
         end

--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -364,8 +364,8 @@ defmodule Phoenix.LiveView.Utils do
       [:phoenix, :live_view, :handle_params],
       %{socket: socket, params: params, uri: uri},
       fn ->
-        case {Lifecycle.handle_params(params, uri, socket), exported?} do
-          {{:cont, %Socket{} = socket}, _exported? = true} ->
+        case Lifecycle.handle_params(params, uri, socket) do
+          {:cont, %Socket{} = socket} when exported? ->
             case view.handle_params(params, uri, socket) do
               {:noreply, %Socket{} = socket} ->
                 {{:noreply, socket}, %{socket: socket, params: params, uri: uri}}
@@ -378,7 +378,7 @@ defmodule Phoenix.LiveView.Utils do
                 """
             end
 
-          {{_, %Socket{} = socket}, _exported?} ->
+          {_, %Socket{} = socket} ->
             {{:noreply, socket}, %{socket: socket, params: params, uri: uri}}
         end
       end

--- a/test/phoenix_live_view/hook_test.exs
+++ b/test/phoenix_live_view/hook_test.exs
@@ -137,33 +137,6 @@ defmodule Phoenix.LiveView.HookTest do
     end
   end
 
-  test "callbacks?/2" do
-    socket = build_socket()
-    refute Lifecycle.callbacks?(socket, :mount)
-    refute Lifecycle.callbacks?(socket, :handle_event)
-    refute Lifecycle.callbacks?(socket, :handle_info)
-    refute Lifecycle.callbacks?(socket, :handle_params)
-
-    # In lieu of calling the on_mount macro, we can do a gnarly
-    # update to get a mount hook inside the Lifecycle (:
-    socket =
-      update_in(socket.private.lifecycle, fn lifecycle ->
-        hook = Lifecycle.on_mount(Phoenix.LiveViewTest.HooksLive, {__MODULE__, :noop})
-        %{lifecycle | mount: [hook]}
-      end)
-
-    assert Lifecycle.callbacks?(socket, :mount)
-
-    socket = LiveView.attach_hook(socket, :foo, :handle_event, &noop/3)
-    assert Lifecycle.callbacks?(socket, :handle_event)
-
-    socket = LiveView.attach_hook(socket, :foo, :handle_info, &noop/2)
-    assert Lifecycle.callbacks?(socket, :handle_info)
-
-    socket = LiveView.attach_hook(socket, :foo, :handle_params, &noop/3)
-    assert Lifecycle.callbacks?(socket, :handle_params)
-  end
-
   defp lifecycle(%LiveView.Socket{private: %{lifecycle: struct}}), do: struct
   defp lifecycle(%LiveView.Socket{}), do: nil
 

--- a/test/phoenix_live_view/hook_test.exs
+++ b/test/phoenix_live_view/hook_test.exs
@@ -4,8 +4,11 @@ defmodule Phoenix.LiveView.HookTest do
   alias Phoenix.LiveView
   alias Phoenix.LiveView.Lifecycle
 
-  defp build_socket() do
-    %LiveView.Socket{private: %{lifecycle: %Lifecycle{}}}
+  defp build_socket(router \\ Phoenix.LiveViewTest.Router) do
+    %LiveView.Socket{
+      private: %{lifecycle: %Lifecycle{}},
+      router: router
+    }
   end
 
   describe "attach_hook/3" do
@@ -68,6 +71,12 @@ defmodule Phoenix.LiveView.HookTest do
                handle_event: [%{id: :noop, stage: :handle_event}],
                handle_params: [%{id: :noop, stage: :handle_params}]
              } = lifecycle(socket)
+    end
+
+    test "raises on stage :handle_params when socket is not mounted at the router" do
+      assert_raise RuntimeError, ~r/not mounted at the router/, fn ->
+        LiveView.attach_hook(build_socket(nil), :boom, :handle_params, &noop/3)
+      end
     end
   end
 
@@ -137,10 +146,11 @@ defmodule Phoenix.LiveView.HookTest do
 
     # In lieu of calling the on_mount macro, we can do a gnarly
     # update to get a mount hook inside the Lifecycle (:
-    socket = update_in(socket.private.lifecycle, fn lifecycle ->
-      hook = Lifecycle.on_mount(Phoenix.LiveViewTest.HooksLive, {__MODULE__, :noop})
-      %{lifecycle | mount: [hook]}
-    end)
+    socket =
+      update_in(socket.private.lifecycle, fn lifecycle ->
+        hook = Lifecycle.on_mount(Phoenix.LiveViewTest.HooksLive, {__MODULE__, :noop})
+        %{lifecycle | mount: [hook]}
+      end)
 
     assert Lifecycle.callbacks?(socket, :mount)
 

--- a/test/phoenix_live_view/integrations/lifecycle_test.exs
+++ b/test/phoenix_live_view/integrations/lifecycle_test.exs
@@ -118,6 +118,11 @@ defmodule Phoenix.LiveView.LifecycleTest do
     assert render(lv) =~ "params_hook:1"
   end
 
+  test "handle_params/3 without module callback", %{conn: conn} do
+    {:ok, lv, _html} = live(conn, "/lifecycle/handle-params-not-defined")
+    assert render(lv) =~ "url=http://www.example.com/lifecycle/handle-params-not-defined"
+  end
+
   test "handle_params/3 when callback is not exported raises without halt", %{conn: conn} do
     {:ok, lv, html} = live(conn, "/lifecycle")
     assert html =~ "params_hook:\n"

--- a/test/support/live_views/lifecycle.ex
+++ b/test/support/live_views/lifecycle.ex
@@ -223,3 +223,15 @@ defmodule Phoenix.LiveViewTest.HooksLive.WithComponent do
     """
   end
 end
+
+defmodule Phoenix.LiveViewTest.HooksLive.HandleParamsNotDefined do
+  use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
+
+  def mount(_, _, socket) do
+    {:ok, attach_hook(socket, :assign_url, :handle_params, fn _, url, socket ->
+      {:cont, assign(socket, :url, url)}
+    end)}
+  end
+
+  def render(assigns), do: ~H"url=<%= assigns[:url] %>"
+end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -108,6 +108,7 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/lifecycle/redirect-cont-mount", HooksLive.RedirectMount, :cont
     live "/lifecycle/redirect-halt-mount", HooksLive.RedirectMount, :halt
     live "/lifecycle/components", HooksLive.WithComponent
+    live "/lifecycle/handle-params-not-defined", HooksLive.HandleParamsNotDefined
 
     # live_session
     live_session :test do


### PR DESCRIPTION
This PR provides the following updates to the lifecycle flow:

* Lifecycle hooks for mount/handle_params will be called whether or not the LiveView module defines the callback.
* Lifecycle hooks for mount/handle_params are always invoked within their respective calls to `:telemetry span/3`.
* `attach_hook/4` will raise when attaching a `:handle_params` hook on a LiveView not mounted at the router.

Fixes #1563, Closes #1601