### PR TITLE
Update simple LiveComponent function example

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -409,7 +409,7 @@ defmodule Phoenix.LiveComponent do
         assigns = %{text: text, click: click}
 
         ~H"\""
-        <button class="css-framework-class" phx-click="<%= @click %>">
+        <button class="css-framework-class" phx-click={@click}>
             <%= @text %>
         </button>
         "\""


### PR DESCRIPTION
The use of `phx-click="<%= @click %>"` in markup of a `~H` sigil or a HEEX template results in an invalid syntax.