### PR TITLE
Update dom-patching.md

### DIFF
--- a/guides/client/dom-patching.md
+++ b/guides/client/dom-patching.md
@@ -72,7 +72,7 @@ to the container as well as to each child:
 
     <div id="chat-messages" phx-update="append">
       <%= for message <- @messages do %>
-        <p id="<%= message.id %>">
+        <p id={message.id}>
           <span><%= message.username %>:</span> <%= message.text %>
         </p>
       <% end %>


### PR DESCRIPTION
Just a tiny update for DOM patching & temporary assigns Guides.
Replace `<p id="<%= message.id %>">` by `<p id={message.id}>`.

Follow the [commit ](d1a5a4024e3dec4a1aabb4319defb7e048c855c6).