### PR TITLE
Fix a few small typos in (mostly) documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ will emit warnings in future releases. We recommend using the `~H` sigil and the
 extension for all future templates in your application. You should also plan to migrate
 the old templates accordingly using the recommendations below.
 
-Migrating from `LEEx` to `HEEx` is relatively straighforward. There are two main differences.
+Migrating from `LEEx` to `HEEx` is relatively straightforward. There are two main differences.
 First of all, HEEx does not allow interpolation inside tags. So instead of:
 
 ```elixir
@@ -309,7 +309,7 @@ import { LiveSocket } from "phoenix_live_view"
 ## 0.14.8 (2020-10-30)
 
 ### Bug fixes
-  - Fix compatiblity with latest Plug
+  - Fix compatibility with latest Plug
 
 ## 0.14.7 (2020-09-25)
 
@@ -433,7 +433,7 @@ import { LiveSocket } from "phoenix_live_view"
 
 ### Backwards incompatible changes
   - No longer send event metadata by default. Metadata is now opt-in and user defined at the `LiveSocket` level.
-  To maintain backwards compatiblity with pre-0.13 behaviour, you can provide the following metadata option:
+  To maintain backwards compatibility with pre-0.13 behaviour, you can provide the following metadata option:
 
   ```javascript
   let liveSocket = new LiveSocket("/live", Socket, {
@@ -520,7 +520,7 @@ The new implementation will check there is a button at `#term .buttons a`, with 
   - Add `phx-trigger-action` form annotation to trigger an HTTP form submit on next DOM patch
 
 ### Bug fixes
-  - Fix `phx-target` `@myself` targetting a sibling LiveView component with the same component ID
+  - Fix `phx-target` `@myself` targeting a sibling LiveView component with the same component ID
   - Fix `phx:page-loading-stop` firing before the DOM patch has been performed
   - Fix `phx-update="prepend"` failing to properly patch the DOM when the same ID is updated back to back
   - Fix redirects on mount failing to copy flash
@@ -626,7 +626,7 @@ The new implementation will check there is a button at `#term .buttons a`, with 
   - Allow the router to be accessed as `socket.router`
   - Allow `MFArgs` as the `:session` option in the `live` router macro
   - Trigger page loading event when main LV errors
-  - Automatially clear the flash on live navigation examples - only the newly assigned flash is persisted
+  - Automatically clear the flash on live navigation examples - only the newly assigned flash is persisted
 
 ## 0.8.1 (2020-02-27)
 
@@ -653,7 +653,7 @@ The new implementation will check there is a button at `#term .buttons a`, with 
   - Add `put_live_layout` plug to put the root layout used for live routes
   - Allow `redirect` and `push_redirect` from mount
   - Use acknowledgement tracking to avoid patching inputs until the server has processed the form event
-  - Add css loading states to all phx bound elements with event specfic css classes
+  - Add css loading states to all phx bound elements with event specific css classes
   - Dispatch `phx:page-loading-start` and `phx:page-loading-stop` on window for live navigation, initial page loads, and form submits, for user controlled page loading integration
   - Allow any phx bound element to specify `phx-page-loading` to dispatch loading events above when the event is pushed
   - Add client side latency simulator with new `enableLatencySim(milliseconds)` and `disableLatencySim()`
@@ -779,7 +779,7 @@ Also note that **the session from now on will have string keys**. LiveView will 
   - Allow `live_link` and `live_redirect` to exist anywhere in the page and it will always target the main LiveView (the one defined at the router)
 
 ### Backwards incompatible changes
-  - `phx-target="window"` has been removed in favor of `phx-window-keydown`, `phx-window-focus`, etc, and the `phx-target` binding has been repurposed for targetting LiveView and LiveComponent events from the client
+  - `phx-target="window"` has been removed in favor of `phx-window-keydown`, `phx-window-focus`, etc, and the `phx-target` binding has been repurposed for targeting LiveView and LiveComponent events from the client
   - `Phoenix.LiveView` no longer defined `live_render` and `live_link`. These functions have been moved to `Phoenix.LiveView.Helpers` which can now be fully imported in your views. In other words, replace `import Phoenix.LiveView, only: [live_render: ..., live_link: ...]` by `import Phoenix.LiveView.Helpers`
 
 ## 0.4.1 (2019-11-07)

--- a/guides/server/uploads.md
+++ b/guides/server/uploads.md
@@ -14,7 +14,7 @@ both direct to server uploads as well as direct-to-cloud
 
   * Reactive entries - Uploads are populated in an
     `@uploads` assign in the socket. Entries automatically
-    respond to progress, errors, cancelation, etc.
+    respond to progress, errors, cancellation, etc.
 
   * Drag and drop - Use the `phx-drop-target` attribute to
     enable. See `Phoenix.LiveView.Helpers.live_file_input/2`.

--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -136,7 +136,7 @@ defmodule Phoenix.LiveView.Router do
       For MFA, the function is invoked, passing the `Plug.Conn` struct is prepended
       to the arguments list.
 
-    * `:root_layout` - The optional root layout tuple for the intial HTTP render to
+    * `:root_layout` - The optional root layout tuple for the initial HTTP render to
       override any existing root layout set in the router.
 
     * `:on_mount` - The optional list of hooks to attach to the mount lifecycle _of
@@ -273,7 +273,7 @@ defmodule Phoenix.LiveView.Router do
         expected a tuple with the view module and template string or atom name, got #{inspect(bad_layout)}
         """
 
-      {:on_mount, on_mount}, acc  ->
+      {:on_mount, on_mount}, acc ->
         hooks = Enum.map(List.wrap(on_mount), &Phoenix.LiveView.Lifecycle.on_mount(module, &1))
         Map.put(acc, :on_mount, hooks)
 

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1503,7 +1503,7 @@ defmodule Phoenix.LiveViewTest do
 
   When redirecting between two LiveViews of the same `live_session`,
   mounts the new LiveView and shutsdown the previous one, which
-  mimicks general browser live navigation behaviour.
+  mimics general browser live navigation behaviour.
 
   When attempting to navigate from a LiveView of a different
   `live_session`, an error redirect condition is returned indicating

--- a/test/phoenix_live_view/helpers_test.exs
+++ b/test/phoenix_live_view/helpers_test.exs
@@ -181,7 +181,7 @@ defmodule Phoenix.LiveView.HelpersTest do
              ] = html
     end
 
-    test "geneates form with available options and custom attributes" do
+    test "generates form with available options and custom attributes" do
       assigns = %{}
 
       html =

--- a/test/phoenix_live_view/html_tokenizer_test.exs
+++ b/test/phoenix_live_view/html_tokenizer_test.exs
@@ -213,7 +213,7 @@ defmodule Phoenix.LiveView.HTMLTokenizerTest do
       end
     end
 
-    test "raise on missing attribure name" do
+    test "raise on missing attribute name" do
       assert_raise ParseError, "nofile:2:8: expected attribute name", fn ->
         tokenize("""
         <div>


### PR DESCRIPTION
_Mostly_ documentation, because of the little double space in `router.ex`.