### PR TITLE
Relax html tag validation

### DIFF
--- a/lib/phoenix_live_view/html_tokenizer.ex
+++ b/lib/phoenix_live_view/html_tokenizer.ex
@@ -185,20 +185,7 @@ defmodule Phoenix.LiveView.HTMLTokenizer do
   end
 
   defp done_tag_name(text, column, buffer) do
-    tag_name = buffer_to_string(buffer)
-
-    case tag_name do
-      <<first::utf8, rest::binary>> when first in ?a..?z ->
-        if downcase?(rest) do
-          {:ok, tag_name, column, text}
-        else
-          message = "expected tag name containing only lowercase chars, got: #{tag_name}"
-          {:warn, tag_name, column, text, message}
-        end
-
-      _ ->
-        {:ok, tag_name, column, text}
-    end
+    {:ok, buffer_to_string(buffer), column, text}
   end
 
   ## handle_maybe_tag_open_end
@@ -486,10 +473,6 @@ defmodule Phoenix.LiveView.HTMLTokenizer do
   defp pop_brace(%{braces: [pos | braces]} = state) do
     {pos, %{state | braces: braces}}
   end
-
-  defp downcase?(<<c, _::binary>>) when c in ?A..?Z, do: false
-  defp downcase?(<<_, rest::binary>>), do: downcase?(rest)
-  defp downcase?(<<>>), do: true
 
   defp warn(message, file, line) do
     stacktrace = Macro.Env.stacktrace(%{__ENV__ | file: file, line: line, module: nil})

--- a/test/phoenix_live_view/html_tokenizer_test.exs
+++ b/test/phoenix_live_view/html_tokenizer_test.exs
@@ -129,22 +129,6 @@ defmodule Phoenix.LiveView.HTMLTokenizerTest do
         tokenize("<foo")
       end
     end
-
-    test "warn if a tag starting with a lowercase char is not all lowercase" do
-      output =
-        ExUnit.CaptureIO.capture_io(:standard_error, fn ->
-          tokenize("""
-          <div>
-            <sPan>
-              <div></div>
-            </span>
-          <diV>\
-          """)
-        end)
-
-      assert output =~ ~r"expected tag name containing only lowercase chars, got: sPan\n\s*+nofile:2:"
-      assert output =~ ~r"expected tag name containing only lowercase chars, got: diV\n\s*nofile:5:"
-    end
   end
 
   describe "attributes" do


### PR DESCRIPTION
Otherwise the tokenizer emits a warning for things like:

```html
<svg>
  ...
    <linearGradient ...>
      ...
    </linearGradient>
  ...
</svg>
```