### PR TITLE
Allowing browsers to open links in a new window

### DIFF
--- a/priv/static/phoenix_live_view.js
+++ b/priv/static/phoenix_live_view.js
@@ -3303,7 +3303,8 @@ within:
         let target = closestPhxBinding(e.target, PHX_LIVE_LINK);
         let type = target && target.getAttribute(PHX_LIVE_LINK);
         let wantsNewTab = e.metaKey || e.ctrlKey || e.button === 1;
-        if (!type || !this.isConnected() || !this.main || wantsNewTab) {
+        let wantsNewWindow = e.shiftKey;
+        if (!type || !this.isConnected() || !this.main || wantsNewTab || wantsNewWindow) {
           return;
         }
         let href = target.href;


### PR DESCRIPTION
Enables Shift+Clicking a live view link to open it in a new window, similar to Ctrl+Click opening in a new tab.

Browser Support:
https://support.mozilla.org/en-US/kb/mouse-shortcuts-perform-common-tasks
https://support.google.com/chrome/answer/157179?hl=en&co=GENIE.Platform%3DDesktop#zippy=%2Cmouse-shortcuts