### PR TITLE
Accept extra args for on_mount hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.17.0
+
+  - Rename the lifecycle default mount callback to `:on_mount`
+
 ## 0.16.3 (2021-09-03)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 0.17.0
 
-  - Allow `MFArgs` on the `on_mount/1` macro and as the `:on_mount` option in the `live_session` router macro.
-  - Rename the lifecycle default mount callback to `:on_mount`
+  - Allow a custom argument to `on_mount/1` e.g. `on_mount {MyHook, :admin}`
+  - Remove custom callback names for `on_mount/1` hooks (now it is always e.g. `MyHook.on_mount/4`)
 
 ## 0.16.3 (2021-09-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,38 @@
 
 ## 0.17.0
 
-  - Allow a custom argument to `on_mount/1` e.g. `on_mount {MyHook, :admin}`
-  - Remove custom callback names for `on_mount/1` hooks (now it is always e.g. `MyHook.on_mount/4`)
+### Breaking Changes
+
+LiveView 0.17 removes the custom callback function names for the
+`Phoenix.LiveView.on_mount/1` macro and the `:on_mount` option for
+`Phoenix.LiveView.Router.live_session/3` in favor of supporting a custom
+argument. The function to be invoked within a hook module will always be
+`on_mount/4`.
+
+For example, if you had invoked `on_mount/1` like so:
+
+```elixir
+on_mount {MyAppWeb.MyHook, :assign_current_user}
+```
+
+and defined your callback as:
+
+```elixir
+# my_hook.ex
+def assign_current_user(_params, _session, _socket) do
+end
+```
+
+Change it to:
+
+```elixir
+# my_hook.ex
+def on_mount(:assign_current_user, _params, _session, socket) do
+end
+```
+
+When given only a module name, the first argument to `on_mount/4` will be the
+atom `:default`.
 
 ## 0.16.3 (2021-09-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,27 @@
 
 ### Breaking Changes
 
-LiveView 0.17 removes the custom callback function names for the
+LiveView 0.17 removes the custom module-function callbacks for the
 `Phoenix.LiveView.on_mount/1` macro and the `:on_mount` option for
 `Phoenix.LiveView.Router.live_session/3` in favor of supporting a custom
-argument. The function to be invoked within a hook module will always be
-`on_mount/4`.
+argument. For clarity, the module function to be invoked during the mount
+lifecycle stage will always be named `on_mount/4`.
 
 For example, if you had invoked `on_mount/1` like so:
 
 ```elixir
+on_mount MyAppWeb.MyHook
 on_mount {MyAppWeb.MyHook, :assign_current_user}
 ```
 
-and defined your callback as:
+and defined your callbacks as:
 
 ```elixir
 # my_hook.ex
+
+def mount(_params, _session, _socket) do
+end
+
 def assign_current_user(_params, _session, _socket) do
 end
 ```
@@ -28,7 +33,11 @@ Change it to:
 
 ```elixir
 # my_hook.ex
-def on_mount(:assign_current_user, _params, _session, socket) do
+
+def on_mount(:default, _params, _session, _socket) do
+end
+
+def on_mount(:assign_current_user, _params, _session, _socket) do
 end
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.17.0
 
+  - Allow `MFArgs` on the `on_mount/1` macro and as the `:on_mount` option in the `live_session` router macro.
   - Rename the lifecycle default mount callback to `:on_mount`
 
 ## 0.16.3 (2021-09-03)

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -531,9 +531,8 @@ defmodule Phoenix.LiveView do
   LiveView, you **must** halt, otherwise an error will be raised.
 
   You may pass additional data to the callback by using a
-  module-function-args triple. For convenience, Keywords and singular
-  arguments will be wrapped in a list and treated as the 4th argument
-  to the callback, lists will be treated as a list of arguments.
+  module-function-args triple. The list of args will be prepended to the
+  default `c:mount/3` arguments.
 
   Registering `on_mount` hooks can be useful to perform authentication
   as well as add custom behaviour to other callbacks via `attach_hook/4`.
@@ -549,18 +548,8 @@ defmodule Phoenix.LiveView do
           {:cont, assign(socket, :page_title, "DemoWeb")}
         end
 
-        # The following are all examples of passing additional
-        # arguments into a on_mount callback.
-
-        def on_mount_too(_, _, socket, :extra) do
-          {:cont, socket}
-        end
-
-        def on_mount_three(_, _, socket, role: :admin) do
-          {:cont, socket}
-        end
-
-        def on_mount_args(_, _, socket, :foo, :bar, :etc) do
+        # An example receiving additional arguments from `on_mount/1`.
+        def on_mount_args(:extra, :args, _params, _session, socket) do
           {:cont, socket}
         end
       end
@@ -569,10 +558,11 @@ defmodule Phoenix.LiveView do
         use Phoenix.LiveView
 
         on_mount {DemoWeb.LiveAuth, :ensure_mounted_current_user}
-        on_mount DemoWeb.InitAssigns
-        on_mount {DemoWeb.InitAssigns, :on_mount_too, :extra}
-        on_mount {DemoWeb.InitAssigns, :on_mount_three, role: :admin}
-        on_mount {DemoWeb.InitAssigns, :on_mount_args, [:foo, :bar, :etc]}
+
+        on_mount DemoWeb.InitAssigns # expands to {DemoWeb.InitAssigns, :on_mount}
+
+        # An example passing additional arguments to DemoWeb.InitAssigns.on_mount_args/5.
+        on_mount {DemoWeb.InitAssigns, :on_mount_args, [:extra, :args]}
       end
   """
   defmacro on_mount(mod_or_mod_fun_or_mfa) do

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -531,7 +531,7 @@ defmodule Phoenix.LiveView do
   LiveView, you **must** halt, otherwise an error will be raised.
 
   You may pass additional data to the callback by using a
-  module-function-arg triple. For convenience, Keywords and singular
+  module-function-args triple. For convenience, Keywords and singular
   arguments will be wrapped in a list and treated as the 4th argument
   to the callback, lists will be treated as a list of arguments.
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -565,25 +565,25 @@ defmodule Phoenix.LiveView do
         on_mount {DemoWeb.InitAssigns, :on_mount_args, [:extra, :args]}
       end
   """
-  defmacro on_mount(mod_or_mod_fun_or_mfa) do
-    mod_or_mod_fun_or_mfa =
-      if Macro.quoted_literal?(mod_or_mod_fun_or_mfa) do
-        Macro.prewalk(mod_or_mod_fun_or_mfa, &expand_alias(&1, __CALLER__))
+  defmacro on_mount(mod_or_mod_arg) do
+    mod_or_mod_arg =
+      if Macro.quoted_literal?(mod_or_mod_arg) do
+        Macro.prewalk(mod_or_mod_arg, &expand_alias(&1, __CALLER__))
       else
-        mod_or_mod_fun_or_mfa
+        mod_or_mod_arg
       end
 
     quote do
       Module.put_attribute(
         __MODULE__,
         :phoenix_live_mount,
-        Phoenix.LiveView.Lifecycle.on_mount(__MODULE__, unquote(mod_or_mod_fun_or_mfa))
+        Phoenix.LiveView.Lifecycle.on_mount(__MODULE__, unquote(mod_or_mod_arg))
       )
     end
   end
 
   defp expand_alias({:__aliases__, _, _} = alias, env),
-    do: Macro.expand(alias, %{env | function: {:on_mount, 3}})
+    do: Macro.expand(alias, %{env | function: {:on_mount, 4}})
 
   defp expand_alias(other, _env), do: other
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -570,7 +570,7 @@ defmodule Phoenix.LiveView do
   end
 
   defp expand_alias({:__aliases__, _, _} = alias, env),
-    do: Macro.expand(alias, %{env | function: {:mount, 3}})
+    do: Macro.expand(alias, %{env | function: {:on_mount, 3}})
 
   defp expand_alias(other, _env), do: other
 

--- a/lib/phoenix_live_view/lifecycle.ex
+++ b/lib/phoenix_live_view/lifecycle.ex
@@ -106,9 +106,6 @@ defmodule Phoenix.LiveView.Lifecycle do
   end
 
   @doc false
-  def on_mount(view, view), do: raise_own_mount_hook!(view, view)
-  def on_mount(view, {view, :mount} = id), do: raise_own_mount_hook!(view, id)
-
   def on_mount(_view, {module, arg}) when is_atom(module) do
     mount_hook!({module, arg})
   end
@@ -213,21 +210,5 @@ defmodule Phoenix.LiveView.Lifecycle do
   defp raise_continue_with_redirect!(hook) do
     raise ArgumentError,
           "the hook #{inspect(hook.id)} for lifecycle event :mount attempted to redirect without halting."
-  end
-
-  defp raise_own_mount_hook!(view, result) do
-    raise ArgumentError, """
-    cannot attach the mount/3 callback to its own lifecycle.
-
-    The LiveView module #{inspect(view)}
-    attempted to attach its own mount/3 function via the
-    on_mount macro. Doing so will lead to the mount function
-    being invoked multiple times per disconnected and connected
-    render of the LiveView and is therefore prohibited.
-
-    To silence this error, please remove the following declaration:
-
-        on_mount #{inspect(result)}
-    """
   end
 end

--- a/lib/phoenix_live_view/lifecycle.ex
+++ b/lib/phoenix_live_view/lifecycle.ex
@@ -114,7 +114,7 @@ defmodule Phoenix.LiveView.Lifecycle do
   end
 
   def on_mount(_view, module) when is_atom(module) do
-    hook!(module, :mount, Function.capture(module, :mount, 3))
+    hook!(module, :mount, Function.capture(module, :on_mount, 3))
   end
 
   def on_mount(view, result) do

--- a/lib/phoenix_live_view/lifecycle.ex
+++ b/lib/phoenix_live_view/lifecycle.ex
@@ -137,15 +137,7 @@ defmodule Phoenix.LiveView.Lifecycle do
     """
   end
 
-  defp mount_hook!({mod, fun} = id, arg) do
-    args =
-      cond do
-        [] == arg -> arg
-        Keyword.keyword?(arg) -> [arg]
-        is_list(arg) -> arg
-        true -> List.wrap(arg)
-      end
-
+  defp mount_hook!({mod, fun} = id, args) when is_list(args) do
     captured_fun = Function.capture(mod, fun, 3 + length(args))
 
     id |> hook!(:mount, captured_fun) |> Map.put(:args, args)
@@ -165,7 +157,7 @@ defmodule Phoenix.LiveView.Lifecycle do
   @doc false
   def mount(params, session, %Socket{private: %{@lifecycle => lifecycle}} = socket) do
     reduce_socket(lifecycle.mount, socket, fn hook, acc ->
-      case apply(hook.function, [params, session, acc] ++ hook.args) do
+      case apply(hook.function, hook.args ++ [params, session, acc]) do
         {:halt, %Socket{redirected: nil}} ->
           raise_halt_without_redirect!(hook)
 

--- a/lib/phoenix_live_view/lifecycle.ex
+++ b/lib/phoenix_live_view/lifecycle.ex
@@ -130,8 +130,8 @@ defmodule Phoenix.LiveView.Lifecycle do
     Expected one of:
 
         Module
-        {Module, Function}
-        {Module, Function, Arg}
+        {Module, :function}
+        {Module, :function, [arg1, arg2, ...]}
 
     Got: #{inspect(result)}
     """

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Phoenix.LiveView.MixProject do
   use Mix.Project
 
-  @version "0.16.3"
+  @version "0.17.0-dev"
 
   def project do
     [

--- a/test/phoenix_live_view/integrations/lifecycle_test.exs
+++ b/test/phoenix_live_view/integrations/lifecycle_test.exs
@@ -15,7 +15,7 @@ defmodule Phoenix.LiveView.LifecycleTest do
 
   test "on_mount hook raises when hook result is invalid", %{conn: conn} do
     assert_raise Plug.Conn.WrapperError,
-                 ~r(invalid return from hook {Phoenix.LiveViewTest.HooksLive.BadMount, :bad_mount}),
+                 ~r(invalid return from hook {Phoenix.LiveViewTest.HooksLive.BadMount, :default}),
                  fn ->
                    live(conn, "/lifecycle/bad-mount")
                  end
@@ -41,7 +41,7 @@ defmodule Phoenix.LiveView.LifecycleTest do
 
   test "on_mount hook raises when :cont is returned with a redirected socket", %{conn: conn} do
     assert_raise Plug.Conn.WrapperError,
-                 ~r(the hook {Phoenix.LiveViewTest.HooksLive.RedirectMount, :hook} for lifecycle event :mount attempted to redirect without halting.),
+                 ~r(the hook {Phoenix.LiveViewTest.HooksLive.RedirectMount, :default} for lifecycle event :mount attempted to redirect without halting.),
                  fn ->
                    live(conn, "/lifecycle/redirect-cont-mount")
                  end

--- a/test/phoenix_live_view/router_test.exs
+++ b/test/phoenix_live_view/router_test.exs
@@ -112,9 +112,10 @@ defmodule Phoenix.LiveView.RouterTest do
       assert route.live_session.extra == %{
         on_mount: [
           %{
-            id: Phoenix.LiveViewTest.HaltConnectedMount,
+            id: {Phoenix.LiveViewTest.HaltConnectedMount, :on_mount},
             stage: :mount,
-            function: Function.capture(Phoenix.LiveViewTest.HaltConnectedMount, :on_mount, 3)
+            function: Function.capture(Phoenix.LiveViewTest.HaltConnectedMount, :on_mount, 3),
+            args: []
           }
         ],
         session: %{}
@@ -124,6 +125,27 @@ defmodule Phoenix.LiveView.RouterTest do
                "last_on_mount:Phoenix.LiveViewTest.HaltConnectedMount"
 
       assert {:error, {:live_redirect, %{to: "/lifecycle"}}} = live(conn, path)
+    end
+
+    test "with on_mount hook+args", %{conn: conn} do
+      path = "/lifecycle/mount-args"
+
+      assert {:internal, route} =
+               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
+
+      assert route.live_session.extra == %{
+        on_mount: [
+          %{
+            id: {Phoenix.LiveViewTest.MountArgs, :on_mount},
+            stage: :mount,
+            function: Function.capture(Phoenix.LiveViewTest.MountArgs, :on_mount, 4),
+            args: [[{:q, "search"}]]
+          }
+        ],
+        session: %{}
+      }
+
+      assert {:error, {:live_redirect, %{to: "/lifecycle?q=search"}}} = live(conn, path)
     end
 
     test "raises when nesting" do

--- a/test/phoenix_live_view/router_test.exs
+++ b/test/phoenix_live_view/router_test.exs
@@ -114,7 +114,7 @@ defmodule Phoenix.LiveView.RouterTest do
           %{
             id: Phoenix.LiveViewTest.HaltConnectedMount,
             stage: :mount,
-            function: Function.capture(Phoenix.LiveViewTest.HaltConnectedMount, :mount, 3)
+            function: Function.capture(Phoenix.LiveViewTest.HaltConnectedMount, :on_mount, 3)
           }
         ],
         session: %{}

--- a/test/phoenix_live_view/router_test.exs
+++ b/test/phoenix_live_view/router_test.exs
@@ -139,13 +139,13 @@ defmodule Phoenix.LiveView.RouterTest do
             id: {Phoenix.LiveViewTest.MountArgs, :on_mount},
             stage: :mount,
             function: Function.capture(Phoenix.LiveViewTest.MountArgs, :on_mount, 4),
-            args: [[{:q, "search"}]]
+            args: [%{inlined: true}]
           }
         ],
         session: %{}
       }
 
-      assert {:error, {:live_redirect, %{to: "/lifecycle?q=search"}}} = live(conn, path)
+      assert {:error, {:live_redirect, %{to: "/lifecycle?called=true&inlined=true"}}} = live(conn, path)
     end
 
     test "raises when nesting" do

--- a/test/phoenix_live_view/router_test.exs
+++ b/test/phoenix_live_view/router_test.exs
@@ -112,10 +112,9 @@ defmodule Phoenix.LiveView.RouterTest do
       assert route.live_session.extra == %{
         on_mount: [
           %{
-            id: {Phoenix.LiveViewTest.HaltConnectedMount, :on_mount},
+            id: {Phoenix.LiveViewTest.HaltConnectedMount, :default},
             stage: :mount,
-            function: Function.capture(Phoenix.LiveViewTest.HaltConnectedMount, :on_mount, 3),
-            args: []
+            function: Function.capture(Phoenix.LiveViewTest.HaltConnectedMount, :on_mount, 4)
           }
         ],
         session: %{}
@@ -127,7 +126,7 @@ defmodule Phoenix.LiveView.RouterTest do
       assert {:error, {:live_redirect, %{to: "/lifecycle"}}} = live(conn, path)
     end
 
-    test "with on_mount hook+args", %{conn: conn} do
+    test "with on_mount {Module, arg}", %{conn: conn} do
       path = "/lifecycle/mount-args"
 
       assert {:internal, route} =
@@ -136,10 +135,9 @@ defmodule Phoenix.LiveView.RouterTest do
       assert route.live_session.extra == %{
         on_mount: [
           %{
-            id: {Phoenix.LiveViewTest.MountArgs, :on_mount},
+            id: {Phoenix.LiveViewTest.MountArgs, :inlined},
             stage: :mount,
             function: Function.capture(Phoenix.LiveViewTest.MountArgs, :on_mount, 4),
-            args: [%{inlined: true}]
           }
         ],
         session: %{}

--- a/test/support/live_views/lifecycle.ex
+++ b/test/support/live_views/lifecycle.ex
@@ -1,7 +1,7 @@
 defmodule Phoenix.LiveViewTest.InitAssigns do
   alias Phoenix.LiveView
 
-  def mount(_params, _session, socket) do
+  def on_mount(_params, _session, socket) do
     {:cont,
      socket
      |> LiveView.assign(:init_assigns_mount, true)
@@ -155,7 +155,7 @@ end
 defmodule Phoenix.LiveViewTest.HaltConnectedMount do
   alias Phoenix.LiveView
 
-  def mount(_params, _session, socket) do
+  def on_mount(_params, _session, socket) do
     if LiveView.connected?(socket) do
       {:halt, LiveView.push_redirect(socket, to: "/lifecycle")}
     else

--- a/test/support/live_views/lifecycle.ex
+++ b/test/support/live_views/lifecycle.ex
@@ -16,6 +16,15 @@ defmodule Phoenix.LiveViewTest.InitAssigns do
   end
 end
 
+defmodule Phoenix.LiveViewTest.MountArgs do
+  use Phoenix.Component
+
+  def on_mount(_params, _session, socket, redirect_params) do
+    qs = URI.encode_query(redirect_params)
+    {:halt, push_redirect(socket, to: "/lifecycle?#{qs}")}
+  end
+end
+
 defmodule Phoenix.LiveViewTest.HooksLive do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
   alias Phoenix.LiveViewTest.InitAssigns

--- a/test/support/live_views/lifecycle.ex
+++ b/test/support/live_views/lifecycle.ex
@@ -19,8 +19,8 @@ end
 defmodule Phoenix.LiveViewTest.MountArgs do
   use Phoenix.Component
 
-  def on_mount(_params, _session, socket, redirect_params) do
-    qs = URI.encode_query(redirect_params)
+  def on_mount(%{inlined: true}, _params, _session, socket) do
+    qs = URI.encode_query(%{called: true, inlined: true})
     {:halt, push_redirect(socket, to: "/lifecycle?#{qs}")}
   end
 end

--- a/test/support/live_views/lifecycle.ex
+++ b/test/support/live_views/lifecycle.ex
@@ -111,9 +111,9 @@ end
 defmodule Phoenix.LiveViewTest.HooksLive.BadMount do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
 
-  on_mount {__MODULE__, :bad_mount}
+  on_mount __MODULE__
 
-  def on_mount(:bad_mount, _params, _session, _socket), do: :boom
+  def on_mount(:default, _params, _session, _socket), do: :boom
 
   def mount(_params, _session, _socket) do
     raise "expected to exit before #{__MODULE__}.mount/3"
@@ -141,9 +141,9 @@ defmodule Phoenix.LiveViewTest.HooksLive.RedirectMount do
     end
   end
 
-  on_mount {__MODULE__, :hook}
+  on_mount __MODULE__
 
-  def on_mount(:hook, _, _, %{assigns: %{live_action: action}} = socket) do
+  def on_mount(:default, _, _, %{assigns: %{live_action: action}} = socket) do
     {action, push_redirect(socket, to: "/lifecycle")}
   end
 

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -135,7 +135,7 @@ defmodule Phoenix.LiveViewTest.Router do
       live "/lifecycle/halt-connected-mount", HooksLive.Noop
     end
 
-    live_session :mount_args, on_mount: {Phoenix.LiveViewTest.MountArgs, :on_mount, q: "search"} do
+    live_session :mount_mfa, on_mount: {Phoenix.LiveViewTest.MountArgs, :on_mount, [%{inlined: true}]} do
       live "/lifecycle/mount-args", HooksLive.Noop
     end
   end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -67,6 +67,7 @@ defmodule Phoenix.LiveViewTest.Router do
     live_session :styled_layout, root_layout: {Phoenix.LiveViewTest.LayoutView, "styled.html"} do
       live "/styled-elements", ElementsLive
     end
+
     live_session :app_layout, root_layout: {Phoenix.LiveViewTest.LayoutView, :app} do
       live "/layout", LayoutLive
     end
@@ -76,6 +77,7 @@ defmodule Phoenix.LiveViewTest.Router do
 
       # The layout option needs to have higher precedence than bad layout
       live "/bad_layout", LayoutLive
+
       live_session :parent_layout, root_layout: false do
         live "/parent_layout", ParentLayoutLive
       end
@@ -131,6 +133,10 @@ defmodule Phoenix.LiveViewTest.Router do
 
     live_session :lifecycle, on_mount: Phoenix.LiveViewTest.HaltConnectedMount do
       live "/lifecycle/halt-connected-mount", HooksLive.Noop
+    end
+
+    live_session :mount_args, on_mount: {Phoenix.LiveViewTest.MountArgs, :on_mount, q: "search"} do
+      live "/lifecycle/mount-args", HooksLive.Noop
     end
   end
 

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -135,7 +135,7 @@ defmodule Phoenix.LiveViewTest.Router do
       live "/lifecycle/halt-connected-mount", HooksLive.Noop
     end
 
-    live_session :mount_mfa, on_mount: {Phoenix.LiveViewTest.MountArgs, :on_mount, [%{inlined: true}]} do
+    live_session :mount_mfa, on_mount: {Phoenix.LiveViewTest.MountArgs, :inlined} do
       live "/lifecycle/mount-args", HooksLive.Noop
     end
   end


### PR DESCRIPTION
Closes #1630

Also if the argument checks are too much we can pare them down and move the brackets `[[]]` back to userland :)

Draft PR as it's based on #1633

