### PR TITLE
Ensure tracked file input is a LiveFileUpload

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -777,7 +777,7 @@ export default class View {
     let cid = isCid(forceCid) ? forceCid : this.targetComponentID(inputEl.form, targetCtx)
     let refGenerator = () => this.putRef([inputEl, inputEl.form], "change")
     let formData = serializeForm(inputEl.form, {_target: eventTarget.name})
-    if(inputEl.files && inputEl.files.length > 0 && inputEl.getAttribute(this.binding(PHX_HOOK)) === 'Phoenix.LiveFileUpload'){
+    if(DOM.isUploadInput(inputEl) && inputEl.files && inputEl.files.length > 0){
       LiveUploader.trackFiles(inputEl, Array.from(inputEl.files))
     }
     uploads = LiveUploader.serializeUploads(inputEl)

--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -777,7 +777,7 @@ export default class View {
     let cid = isCid(forceCid) ? forceCid : this.targetComponentID(inputEl.form, targetCtx)
     let refGenerator = () => this.putRef([inputEl, inputEl.form], "change")
     let formData = serializeForm(inputEl.form, {_target: eventTarget.name})
-    if(inputEl.files && inputEl.files.length > 0){
+    if(inputEl.files && inputEl.files.length > 0 && inputEl.getAttribute(this.binding(PHX_HOOK)) === 'Phoenix.LiveFileUpload'){
       LiveUploader.trackFiles(inputEl, Array.from(inputEl.files))
     }
     uploads = LiveUploader.serializeUploads(inputEl)


### PR DESCRIPTION
I had some troubles with "legacy" file uploading next to LiveUpload. 

If I had an `<input type="file" multiple>` in my form, its `files` property would be empty on first pop, but populated on second try. I also got a JS error in the console:

```es6
upload_entry.js:17 Uncaught TypeError: Cannot read properties of null (reading 'split')
    at Function.isActive (upload_entry.js:17)
    at live_uploader.js:83
    at Array.filter (<anonymous>)
    at Function.activeFiles (live_uploader.js:83)
    at Function.serializeUploads (live_uploader.js:42)
    at View.pushInput (view.js:783)
    at live_socket.js:676
    at View.withinTargets (view.js:204)
    at live_socket.js:354
    at LiveSocket.owner (live_socket.js:345)
```

so it seemed that Phoenix would track inputs that were not LiveUploads, and the file input's `files` would end up empty.
With this change, I can do "legacy" uploads next to LiveUploads fine.

I'm in no way sure that this is the preferred solution, by the way 😆 