### PR TITLE
Fix docs for assert_redirect

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1175,7 +1175,7 @@ defmodule Phoenix.LiveViewTest do
     assert_patch(view, to, 0)
   end
 
-  @doc """
+  @doc ~S"""
   Asserts a redirect will happen within `timeout` milliseconds.
   The default `timeout` is 100.
 
@@ -1185,7 +1185,7 @@ defmodule Phoenix.LiveViewTest do
   ## Examples
 
       render_click(view, :event_that_triggers_redirect)
-      {_path, flash} = assert_redirect view
+      {path, flash} = assert_redirect view
       assert flash["info"] == "Welcome"
       assert path =~ ~r/path\/\d+/
 


### PR DESCRIPTION
Fixes a typo with a variable name and adds the `~S` sigil to properly
render the regex in ExDoc.

Closes #1648