### PR TITLE
Fix non-appearance of deprecation warning for live_component(@socket, ...)

### DIFF
--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -446,7 +446,7 @@ defmodule Phoenix.LiveView.Helpers do
   """
   @doc deprecated: "Use .live_component as a function component instead"
   defmacro live_component(component, assigns, do_block \\ []) do
-    if match?({:@, _, [{:socket, _, _}]}, component) or match?({:socket, _, _}, component) do
+    if is_assign?(:socket, component) do
       IO.warn(
         "passing the @socket to live_component is no longer necessary, " <>
           "please remove the socket argument",
@@ -946,4 +946,10 @@ defmodule Phoenix.LiveView.Helpers do
 
   defp form_method(method) when method in ~w(get post), do: {method, nil}
   defp form_method(method) when is_binary(method), do: {"post", method}
+
+  defp is_assign?(assign_name, expression) do
+    match?({:@, _, [{^assign_name, _, _}]}, expression) or
+    match?({^assign_name, _, _}, expression) or
+    match?({{:., _, [Phoenix.LiveView.Engine, :fetch_assign!]}, _, [{:assigns, _, _}, ^assign_name]}, expression)
+  end
 end

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -151,7 +151,7 @@ defmodule Phoenix.LiveViewTest.WithMultipleTargets do
     <div id="parent_id" class="parent">
       <%= @message %>
       <%= for name <- @names do %>
-        <%= live_component @socket, Phoenix.LiveViewTest.StatefulComponent,
+        <%= live_component Phoenix.LiveViewTest.StatefulComponent,
               id: name, name: name, from: @from, disabled: name in @disabled, parent_id: @parent_selector %>
       <% end %>
     </div>


### PR DESCRIPTION
Once upgrading to phoenix_live_view 0.16 we were expecting to get the warning based on the changelog but we weren't getting any.

It appeared that the warning was not appearing because of the patterns not matching. Are template assigns represented with a different tuple now?

I added a new pattern based on the tuple pattern I saw when debugging the issue.

Not sure this is the best course of action, or even if the original pattern must continue to be there or not.

Thanks!