### PR TITLE
A maximum of concurrent uploads using Channels can be set and enforced

### DIFF
--- a/assets/js/phoenix_live_view/entry_uploader.js
+++ b/assets/js/phoenix_live_view/entry_uploader.js
@@ -9,16 +9,22 @@ export default class EntryUploader {
     this.offset = 0
     this.chunkSize = chunkSize
     this.chunkTimer = null
-    this.uploadChannel = liveSocket.channel(`lvu:${entry.ref}`, {token: entry.metadata()})
+    this._started = false
+    this._onDone = undefined
   }
 
   error(reason){
+    this._started = false
     clearTimeout(this.chunkTimer)
     this.uploadChannel.leave()
     this.entry.error(reason)
+    this.onDone()
   }
 
-  upload(){
+  upload(onDone){
+    this._onDone = onDone
+    this.uploadChannel = this.liveSocket.channel(`lvu:${this.entry.ref}`, {token: this.entry.metadata()})
+    this._started = true
     this.uploadChannel.onError(reason => this.error(reason))
     this.uploadChannel.join()
       .receive("ok", _data => this.readNextChunk())
@@ -26,6 +32,8 @@ export default class EntryUploader {
   }
 
   isDone(){ return this.offset >= this.entry.file.size }
+  onDone() { typeof this._onDone === "function" && this._onDone() }
+  hasStarted() { return this._started }
 
   readNextChunk(){
     let reader = new window.FileReader()
@@ -48,6 +56,8 @@ export default class EntryUploader {
         this.entry.progress((this.offset / this.entry.file.size) * 100)
         if(!this.isDone()){
           this.chunkTimer = setTimeout(() => this.readNextChunk(), this.liveSocket.getLatencySim() || 0)
+        } else {
+          this.onDone()
         }
       })
   }

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -921,6 +921,8 @@ defmodule Phoenix.LiveView do
     * `:chunk_timeout` - The time in milliseconds to wait before closing the
       upload channel when a new chunk has not been received. Defaults `10_000`.
 
+    * `:max_concurrency` - The amount of entries to upload at the same time. Defaults to 10.
+
     * `:external` - The 2-arity function for generating metadata for external
       client uploaders. See the Uploads section for example usage.
 

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -1059,16 +1059,21 @@ defmodule Phoenix.LiveView.Channel do
     write_socket(state, cid, nil, fn socket, _ ->
       conf = Upload.get_upload_by_ref!(socket, ref)
 
-      case Upload.register_entry_upload(socket, conf, pid, entry_ref) do
-        {:ok, new_socket, entry} ->
-          reply = %{max_file_size: entry.client_size, chunk_timeout: conf.chunk_timeout}
-          GenServer.reply(from, {:ok, reply})
-          new_state = put_upload_pid(state, pid, ref, entry_ref, cid)
-          {new_socket, {:ok, nil, new_state}}
+      if length(Map.keys(state.upload_pids)) < conf.max_concurrency do
+        case Upload.register_entry_upload(socket, conf, pid, entry_ref) do
+          {:ok, new_socket, entry} ->
+            reply = %{max_file_size: entry.client_size, chunk_timeout: conf.chunk_timeout}
+            GenServer.reply(from, {:ok, reply})
+            new_state = put_upload_pid(state, pid, ref, entry_ref, cid)
+            {new_socket, {:ok, nil, new_state}}
 
-        {:error, reason} ->
-          GenServer.reply(from, {:error, reason})
-          {socket, :error}
+          {:error, reason} ->
+            GenServer.reply(from, {:error, reason})
+            {socket, :error}
+        end
+      else
+        GenServer.reply(from, {:error, :max_concurrency_reached})
+        {socket, :error}
       end
     end)
   end

--- a/lib/phoenix_live_view/upload_channel.ex
+++ b/lib/phoenix_live_view/upload_channel.ex
@@ -56,7 +56,7 @@ defmodule Phoenix.LiveView.UploadChannel do
       {:error, reason} when reason in [:expired, :invalid] ->
         {:error, %{reason: :invalid_token}}
 
-      {:error, reason} when reason in [:already_registered, :disallowed] ->
+      {:error, reason} when reason in [:already_registered, :disallowed, :max_concurrency_reached] ->
         {:error, %{reason: reason}}
     end
   end


### PR DESCRIPTION
A cleaner version of my previous pull request. Could someone please look at this and tell me what I still need to do to get this merged?

For my application, it is vital that 50 or more files can be uploaded simultaneously. With the current uploading strategy, the uploads will time-out because they will all upload at the same time. To fix this, I propose that a max_concurrency can be enforced by the server.

Currently this is implemented as follows:
If the amount of uploads is less or equal to the max_concurrency, all uploads will be sent at the same time.
Otherwise, a selection of uploads that have not started or are cancelled will start uploading on their respective channel.
Whenever an upload finishes, it triggers a provided callback (onDone/0) which will reschedule uploads that can be started.
In the case that starting an upload exceeds the limit set by max_concurrency, the channel is closed with an error, thus also reducing the attack surface for a possible DDOS.

Notable changes in existing code:
assets/js/phoenix_live_view/entry_uploader.js:
I moved the instantiation of the Channel from the constructor to the upload function because the channel cannot be re-used if the upload exceeds the concurrency limit. Due to concurrency complexities I do not fully understand (my Javascript knowledge is limited) it could occur that an upload is scheduled by the client when it should not have been.

lib/phoenix_live_view/test/upload_client.ex:
The client did not support channel errors yet, so I had to implement this.