### PR TITLE
docs: Fix UpChunk example

### DIFF
--- a/guides/client/uploads-external.md
+++ b/guides/client/uploads-external.md
@@ -75,7 +75,7 @@ Uploaders.UpChunk = function(entries, onViewError){
   entries.forEach(entry => {
     // create the upload session with UpChunk
     let { file, meta: { entrypoint } } = entry
-    let upload = UpChunk.createUpload({ entrypoint, file })
+    let upload = UpChunk.createUpload({ endpoint: entrypoint, file })
 
     // stop uploading in the event of a view error
     onViewError(() => upload.pause())


### PR DESCRIPTION
UpChunk requires a property called `endpoint`, not `entrypoint` for its `createUpload` method. (https://github.com/muxinc/upchunk#then-in-the-browser)