### PR TITLE
Document LiveView controller example requiring Phoenix controller

### DIFF
--- a/lib/phoenix_live_view/controller.ex
+++ b/lib/phoenix_live_view/controller.ex
@@ -19,7 +19,7 @@ defmodule Phoenix.LiveView.Controller do
   ## Examples
 
       defmodule ThermostatController do
-        ...
+        use AppWeb, :controller
         import Phoenix.LiveView.Controller
 
         def show(conn, %{"id" => thermostat_id}) do


### PR DESCRIPTION
It was not apparent to me that the `Phoenix.LiveView.Controller` required the `Phoenix.Controller`. If you find this minor edit acceptable, it could help someone else.

Thank you for sharing this incredible project.