### PR TITLE
Add regression tests for live_session on_mount

### DIFF
--- a/test/phoenix_live_view/router_test.exs
+++ b/test/phoenix_live_view/router_test.exs
@@ -137,7 +137,7 @@ defmodule Phoenix.LiveView.RouterTest do
     end
 
     test "with on_mount {Module, arg}", %{conn: conn} do
-      path = "/lifecycle/mount-args"
+      path = "/lifecycle/mount-mod-arg"
 
       assert {:internal, route} =
                Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
@@ -155,6 +155,56 @@ defmodule Phoenix.LiveView.RouterTest do
 
       assert {:error, {:live_redirect, %{to: "/lifecycle?called=true&inlined=true"}}} =
                live(conn, path)
+    end
+
+    test "with on_mount [Module, ...]", %{conn: conn} do
+      path = "/lifecycle/mount-mods"
+
+      assert {:internal, route} =
+               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
+
+      assert route.live_session.extra == %{
+               on_mount: [
+                 %{
+                   id: {Phoenix.LiveViewTest.OnMount, :default},
+                   stage: :mount,
+                   function: Function.capture(Phoenix.LiveViewTest.OnMount, :on_mount, 4)
+                 },
+                 %{
+                   id: {Phoenix.LiveViewTest.OtherOnMount, :default},
+                   stage: :mount,
+                   function: Function.capture(Phoenix.LiveViewTest.OtherOnMount, :on_mount, 4)
+                 }
+               ],
+               session: %{}
+             }
+
+      assert {:ok, _, _} = live(conn, path)
+    end
+
+    test "with on_mount [{Module, arg}, ...]", %{conn: conn} do
+      path = "/lifecycle/mount-mods-args"
+
+      assert {:internal, route} =
+               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
+
+      assert route.live_session.extra == %{
+               on_mount: [
+                 %{
+                   id: {Phoenix.LiveViewTest.OnMount, :other},
+                   stage: :mount,
+                   function: Function.capture(Phoenix.LiveViewTest.OnMount, :on_mount, 4)
+                 },
+                 %{
+                   id: {Phoenix.LiveViewTest.OtherOnMount, :other},
+                   stage: :mount,
+                   function: Function.capture(Phoenix.LiveViewTest.OtherOnMount, :on_mount, 4)
+                 }
+               ],
+               session: %{}
+             }
+
+      assert {:ok, _, _} = live(conn, path)
     end
 
     test "raises when nesting" do

--- a/test/support/live_views/lifecycle.ex
+++ b/test/support/live_views/lifecycle.ex
@@ -25,6 +25,30 @@ defmodule Phoenix.LiveViewTest.MountArgs do
   end
 end
 
+defmodule Phoenix.LiveViewTest.OnMount do
+  use Phoenix.Component
+
+  def on_mount(:default, _params, _session, socket) do
+    {:cont, socket}
+  end
+
+  def on_mount(:other, _params, _session, socket) do
+    {:cont, socket}
+  end
+end
+
+defmodule Phoenix.LiveViewTest.OtherOnMount do
+  use Phoenix.Component
+
+  def on_mount(:default, _params, _session, socket) do
+    {:cont, socket}
+  end
+
+  def on_mount(:other, _params, _session, socket) do
+    {:cont, socket}
+  end
+end
+
 defmodule Phoenix.LiveViewTest.HooksLive do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
   alias Phoenix.LiveViewTest.InitAssigns

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -141,8 +141,21 @@ defmodule Phoenix.LiveViewTest.Router do
       live "/lifecycle/halt-connected-mount", HooksLive.Noop
     end
 
-    live_session :mount_mfa, on_mount: {Phoenix.LiveViewTest.MountArgs, :inlined} do
-      live "/lifecycle/mount-args", HooksLive.Noop
+    live_session :mount_mod_arg, on_mount: {Phoenix.LiveViewTest.MountArgs, :inlined} do
+      live "/lifecycle/mount-mod-arg", HooksLive.Noop
+    end
+
+    live_session :mount_mods,
+      on_mount: [Phoenix.LiveViewTest.OnMount, Phoenix.LiveViewTest.OtherOnMount] do
+      live "/lifecycle/mount-mods", HooksLive.Noop
+    end
+
+    live_session :mount_mod_args,
+      on_mount: [
+        {Phoenix.LiveViewTest.OnMount, :other},
+        {Phoenix.LiveViewTest.OtherOnMount, :other}
+      ] do
+      live "/lifecycle/mount-mods-args", HooksLive.Noop
     end
   end
 


### PR DESCRIPTION
Ensuring live_session with the `:on_mount` option supports lists of Module and/or {Module, arg}.