### PR TITLE
Fix table in docs

### DIFF
--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -20,7 +20,7 @@ callback, for example:
 | [Form Events](form-bindings.md) | `phx-change`, `phx-submit`, `phx-feedback-for`, `phx-disable-with`, `phx-trigger-action`, `phx-auto-recover` |
 | [Focus/Blur Events](#focus-and-blur-events) | `phx-blur`, `phx-focus`, `phx-window-blur`, `phx-window-focus` |
 | [Key Events](#key-events) | `phx-keydown`, `phx-keyup`, `phx-window-keydown`, `phx-window-keyup`, `phx-key` |
-| [DOM Patching](dom-patching.md) | `phx-update` | `phx-remove`
+| [DOM Patching](dom-patching.md) | `phx-update`, `phx-remove` |
 | [JS Interop](js-interop.md#client-hooks) | `phx-hook` |
 | [Rate Limiting](#rate-limiting-events-with-debounce-and-throttle) | `phx-debounce`, `phx-throttle` |
 | [Static tracking](`Phoenix.LiveView.static_changed?/1) | `phx-track-static` |


### PR DESCRIPTION
The table with the key bindings had a little typo and wasn't displayed correctly.
