### PR TITLE
Fix wrong reference and typo in `js.js`

### DIFF
--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -118,7 +118,7 @@ let JS = {
       } else {
         if(eventType === "remove"){ return }
         this.addOrRemoveClasses(el, in_classes, out_classes)
-        DOM.putSticky(el, "toggle", currentEl => currentEl.style.display = (display ||"block"))
+        DOM.putSticky(el, "toggle", currentEl => currentEl.style.display = (display || "block"))
         view.transition(time, () => {
           this.addOrRemoveClasses(el, [], in_classes)
         })


### PR DESCRIPTION
There was a typo in `exec_hide`.
Also the element reference in the `exec_show` and `exec_hide` was wrong for the case that no `to` was set (e.g. `to: nil`).