### PR TITLE
Fix default behaviour for `dispatch/3`/`show/3`/`hide/3`

### DIFF
--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -19,7 +19,11 @@ let JS = {
   // commands
 
   exec_dispatch(eventType, phxEvent, view, sourceEl, {to, event, detail}){
-    DOM.all(document, to, el => DOM.dispatchEvent(el, event, detail))
+    if(to){
+      DOM.all(document, to, el => DOM.dispatchEvent(el, event, detail))
+    } else {
+      DOM.dispatchEvent(sourceEl, event, detail)
+    }
   },
 
   exec_push(eventType, phxEvent, view, sourceEl, args){

--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -144,7 +144,7 @@ defmodule Phoenix.LiveView.JS do
   """
   def dispatch(cmd \\ %JS{}, event, opts) do
     opts = validate_keys(opts, :dispatch, [:to, :detail])
-    args = %{event: event, to: Keyword.fetch!(opts, :to)}
+    args = %{event: event, to: opts[:to]}
 
     args =
       case Keyword.fetch(opts, :detail) do
@@ -225,7 +225,7 @@ defmodule Phoenix.LiveView.JS do
     time = opts[:time] || @default_transition_time
 
     put_op(cmd, "show", %{
-      to: Keyword.fetch!(opts, :to),
+      to: opts[:to],
       display: opts[:display],
       transition: names,
       time: time
@@ -261,7 +261,7 @@ defmodule Phoenix.LiveView.JS do
     time = opts[:time] || @default_transition_time
 
     put_op(cmd, "hide", %{
-      to: Keyword.fetch!(opts, :to),
+      to: opts[:to],
       transition: names,
       time: time
     })


### PR DESCRIPTION
This add a check to `dispatch` (in `js.js`) if `:to` is set and if not, defaults to the current element.

It also replaces `Keyword.fetch!/2` with `Access` syntax to default to `nil` when `:to` is missing in the keyword list for `dispatch/3`, `show/3` and `hide/3`.

This fixes #1684.