### PR TITLE
Fixes typo 'classing'

### DIFF
--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -3,7 +3,7 @@ defmodule Phoenix.LiveView.JS do
   Provides commands for executing JavaScript utility operations on the client.
 
   JS commands support a variety of utility operations for common client-side
-  needs, such as adding classing, showing or hiding content, and transitioning
+  needs, such as adding or removing css classes, showing or hiding content, and transitioning
   in and out with animations. While these operations can be accomplished via
   client-side hooks, JS commands are DOM patch aware, so operations applied
   by the JS APIs will stick to elements across patches from the server.


### PR DESCRIPTION
I think `classing` was typo. Have updated it to a more explicit use case.   