### PR TITLE
Update title to avoid render error in docs

### DIFF
--- a/guides/client/dom-patching.md
+++ b/guides/client/dom-patching.md
@@ -1,4 +1,4 @@
-# DOM patching & temporary assigns
+# DOM patching and temporary assigns
 
 A container can be marked with `phx-update`, allowing the DOM patch
 operations to avoid updating or removing portions of the LiveView, or to append


### PR DESCRIPTION
Fix for "&" in title
<img width="248" alt="Screen Shot 2021-10-26 at 14 53 30" src="https://user-images.githubusercontent.com/510233/138873241-e87395ae-ddf2-4601-93e0-de0359b106b9.png">

Not sure why the HTML entity is rendered instead, need to check if it is a bug in ex docs. In the meantime this fixes it and makes it consistent with other titles in docs

