### PR TITLE
feat: toggle_classes (updated 2021/01/08)

### DIFF
--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -54,6 +54,14 @@ let JS = {
     this.addOrRemoveClasses(el, [], names, transition, time, view)
   },
 
+  exec_toggle_class(eventType, phxEvent, view, sourceEl, {to, names, transition, time}){
+    if(to){
+      DOM.all(document, to, el => this.toggleClasses(el, names, transition, time, view))
+    } else {
+      this.toggleClasses(sourceEl, names, transition, view)
+    }
+  },
+
   exec_transition(eventType, phxEvent, view, sourceEl, el, {time, transition}){
     let [transition_start, running, transition_end] = transition
     let onStart = () => this.addOrRemoveClasses(el, transition_start.concat(running), [])
@@ -140,6 +148,15 @@ let JS = {
         el.dispatchEvent(new Event("phx:show-end"))
       }
     }
+  },
+
+  toggleClasses(el, classes, transition, time, view){
+    window.requestAnimationFrame(() => {
+      let [prevAdds, prevRemoves] = DOM.getSticky(el, "classes", [[], []])
+      let newAdds = classes.filter(name => prevAdds.indexOf(name) < 0 && !el.classList.contains(name))
+      let newRemoves = classes.filter(name => prevRemoves.indexOf(name) < 0 && el.classList.contains(name))
+      this.addOrRemoveClasses(el, newAdds, newRemoves, transition, time, view)
+    })
   },
 
   addOrRemoveClasses(el, adds, removes, transition, time, view){

--- a/assets/test/js_test.js
+++ b/assets/test/js_test.js
@@ -273,6 +273,59 @@ describe("JS", () => {
     })
   })
 
+  describe("exec_toggle_class", () => {
+    test("with defaults", done => {
+      let view = setupView(`
+      <div id="modal" class="modal">modal</div>
+      <div id="toggle" phx-click='[["toggle_class", {"to": "#modal", "names": ["class1"]}]]'></div>
+      `)
+      let modal = simulateVisibility(document.querySelector("#modal"))
+      let toggle = document.querySelector("#toggle")
+
+      JS.exec("click", toggle.getAttribute("phx-click"), view, toggle)
+
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+          expect(Array.from(modal.classList)).toEqual(["modal", "class1"])
+          JS.exec("click", toggle.getAttribute("phx-click"), view, toggle)
+          window.requestAnimationFrame(() => {
+            window.requestAnimationFrame(() => {
+              expect(Array.from(modal.classList)).toEqual(["modal"])
+              done()
+            })
+          })
+        })
+      })
+    })
+    test("with multiple selector", done => {
+      let view = setupView(`
+      <div id="modal1" class="modal">modal</div>
+      <div id="modal2" class="modal">modal</div>
+      <div id="toggle" phx-click='[["toggle_class", {"to": "#modal1, #modal2", "names": ["class1"]}]]'></div>
+      `)
+      let modal1 = document.querySelector("#modal1")
+      let modal2 = document.querySelector("#modal2")
+      let toggle = document.querySelector("#toggle")
+
+      JS.exec("click", toggle.getAttribute("phx-click"), view, toggle)
+
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+          expect(Array.from(modal1.classList)).toEqual(["modal", "class1"])
+          expect(Array.from(modal2.classList)).toEqual(["modal", "class1"])
+          JS.exec("click", toggle.getAttribute("phx-click"), view, toggle)
+          window.requestAnimationFrame(() => {
+            window.requestAnimationFrame(() => {
+              expect(Array.from(modal1.classList)).toEqual(["modal"])
+              expect(Array.from(modal2.classList)).toEqual(["modal"])
+              done()
+            })
+          })
+        })
+      })
+    })
+  })
+
   describe("push", () => {
     test("regular event", done => {
       let view = setupView(`

--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -356,6 +356,28 @@ defmodule Phoenix.LiveView.JS do
     })
   end
 
+  def toggle_class(names) when is_binary(names), do: toggle_class(%JS{}, names, [])
+
+  def toggle_class(%JS{} = js, names) when is_binary(names) do
+    toggle_class(js, names, [])
+  end
+
+  def toggle_class(names, opts) when is_binary(names) and is_list(opts) do
+    toggle_class(%JS{}, names, opts)
+  end
+
+  def toggle_class(%JS{} = js, names, opts) when is_binary(names) and is_list(opts) do
+    opts = validate_keys(opts, :toggle_class, [:to, :transition, :time])
+    time = opts[:time] || @default_transition_time
+
+    put_op(js, "toggle_class", %{
+      to: opts[:to],
+      names: class_names(names),
+      transition: transition_class_names(opts[:transition]),
+      time: time
+    })
+  end
+
   @doc """
   Removes classes from elements.
 

--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -356,6 +356,29 @@ defmodule Phoenix.LiveView.JS do
     })
   end
 
+  @doc """
+  Toggles classes on an element.
+
+    * `names` - The string of classes to add.
+
+  ## Options
+
+    * `:to` - The optional DOM selector to toggle classes to.
+      Defaults to the interacted element.
+    * `:transition` - The string of classes to apply before adding classes or
+      a 3-tuple containing the transition class, the class to apply
+      to start the transition, and the ending transition class, such as:
+      `{"ease-out duration-300", "opacity-0", "opacity-100"}`
+    * `:time` - The time to apply the transition from `:transition`.
+      Defaults #{@default_transition_time}
+
+  ## Examples
+
+      <div id="item">My Item</div>
+      <button phx-click={JS.toggle_class("active", to: "#item")}>
+        toggle active!
+      </button>
+  """
   def toggle_class(names) when is_binary(names), do: toggle_class(%JS{}, names, [])
 
   def toggle_class(%JS{} = js, names) when is_binary(names) do

--- a/test/phoenix_live_view/js_test.exs
+++ b/test/phoenix_live_view/js_test.exs
@@ -260,6 +260,109 @@ defmodule Phoenix.LiveView.JSTest do
     end
   end
 
+  describe "toggle_class" do
+    test "with defaults" do
+      assert JS.toggle_class("show") == %JS{
+               ops: [
+                 [
+                   "toggle_class",
+                   %{names: ["show"], time: 200, to: nil, transition: [[], [], []]}
+                 ]
+               ]
+             }
+
+      assert JS.toggle_class("show", to: "#modal") == %JS{
+               ops: [
+                 [
+                   "toggle_class",
+                   %{names: ["show"], time: 200, to: "#modal", transition: [[], [], []]}
+                 ]
+               ]
+             }
+    end
+
+    test "multiple classes" do
+      assert JS.toggle_class("show hl") == %JS{
+               ops: [
+                 [
+                   "toggle_class",
+                   %{names: ["show", "hl"], time: 200, to: nil, transition: [[], [], []]}
+                 ]
+               ]
+             }
+    end
+
+    test "custom time" do
+      assert JS.toggle_class("show", time: 543) == %JS{
+               ops: [
+                 [
+                   "toggle_class",
+                   %{names: ["show"], time: 543, to: nil, transition: [[], [], []]}
+                 ]
+               ]
+             }
+    end
+
+    test "transition" do
+      assert JS.toggle_class("show", transition: "fade") == %JS{
+               ops: [
+                 [
+                   "toggle_class",
+                   %{names: ["show"], time: 200, to: nil, transition: [["fade"], [], []]}
+                 ]
+               ]
+             }
+
+      assert JS.toggle_class("c", transition: "a b") == %JS{
+               ops: [
+                 [
+                   "toggle_class",
+                   %{names: ["c"], time: 200, to: nil, transition: [["a", "b"], [], []]}
+                 ]
+               ]
+             }
+
+      assert JS.toggle_class("show", transition: {"fade", "opacity-0", "opacity-100"}) == %JS{
+               ops: [
+                 [
+                   "toggle_class",
+                   %{
+                     names: ["show"],
+                     time: 200,
+                     to: nil,
+                     transition: [["fade"], ["opacity-0"], ["opacity-100"]]
+                   }
+                 ]
+               ]
+             }
+    end
+
+    test "composability" do
+      js = JS.toggle_class("show", to: "#modal", time: 100) |> JS.toggle_class("hl")
+
+      assert js == %JS{
+               ops: [
+                 [
+                   "toggle_class",
+                   %{names: ["show"], time: 100, to: "#modal", transition: [[], [], []]}
+                 ],
+                 ["toggle_class", %{names: ["hl"], time: 200, to: nil, transition: [[], [], []]}]
+               ]
+             }
+    end
+
+    test "raises with unknown options" do
+      assert_raise ArgumentError, ~r/invalid option for toggle_class/, fn ->
+        JS.toggle_class("show", bad: :opt)
+      end
+    end
+
+    test "encoding" do
+      assert js_to_string(JS.toggle_class("show")) ==
+               "[[&quot;toggle_class&quot;,{&quot;names&quot;:[&quot;show&quot;],&quot;time&quot;:200,&quot;to&quot;:null,&quot;transition&quot;:[[],[],[]]}]]"
+    end
+  end
+
   describe "dispatch" do
     test "with defaults" do
       assert JS.dispatch("click", to: "#modal") == %JS{


### PR DESCRIPTION
I've been implementing a live view app and came across an instance where I wanted to toggle a class, not simply add or remove it. 

I _could_ simply store the state in a live view component or on the html tag itself (to decide if I want to remove or add), but it seemed like maybe a toggle would be nice to have.

~~**I haven't added any function @doc comments-- yet**. If `toggle_classes` isn't the direction the live view team wants to go with, then feel free to close this PR. Otherwise, if it looks good then I'll also add the documentation too (something similar to add_classes or remove_classes)~~ 👍 

## Example

Here's a simple use case where toggle adds or removes a class "dark" which could be used for darkmode:

https://user-images.githubusercontent.com/3220620/139871078-3f4f5f6c-a53b-4ef8-944c-a5a8b291af70.mov

In order to get it to work I had to build phoenix live view assets locally and do some shenanigans with my mix.exs to use a local dependency, so I won't be sharing the app code, but here's the live view:

```elixir
defmodule PhxTesterWeb.TestLive do
  use PhxTesterWeb, :live_view
  alias Phoenix.LiveView.JS

  def mount(_params, _, socket) do
    {:ok, socket}
  end

  def toggle_mode(js \\ %JS{}) do
    js
    |> JS.toggle_class("dark", to: "body")
  end

  def test_button(assigns) do
    ~H"""
    <div>
      <button class="modal-button" phx-click={toggle_mode()}>toggle</button>
    </div>
    """
  end
end
```

and .heex file
```html
The button below will toggle dark mode.
<%= test_button(%{}) %>
```

## Code

I had issues getting jest to pass and left a comment in the code: https://github.com/phoenixframework/phoenix_live_view/pull/1721#discussion_r741164658

### Unrelated

Running mix format changes the code decently. Perhaps it's worth running it once or setting up format rules in a config file. 
