### PR TITLE
add uri to mount telemetry metadata

### DIFF
--- a/guides/server/telemetry.md
+++ b/guides/server/telemetry.md
@@ -14,7 +14,8 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
           %{
             socket: Phoenix.LiveView.Socket.t,
             params: unsigned_params | :not_mounted_at_router,
-            session: map
+            session: map,
+            uri: String.t() | nil
           }
 
 
@@ -30,7 +31,8 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
           %{
             socket: Phoenix.LiveView.Socket.t,
             params: unsigned_params | :not_mounted_at_router,
-            session: map
+            session: map,
+            uri: String.t() | nil
           }
 
 
@@ -46,7 +48,8 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
             kind: atom,
             reason: term,
             params: unsigned_params | :not_mounted_at_router,
-            session: map
+            session: map,
+            uri: String.t() | nil
           }
 
   * `[:phoenix, :live_view, :handle_params, :start]` - Dispatched by a `Phoenix.LiveView`

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -922,7 +922,7 @@ defmodule Phoenix.LiveView.Channel do
         socket = Utils.configure_socket(socket, mount_priv, action, flash, host_uri)
 
         socket
-        |> Utils.maybe_call_live_view_mount!(view, params, merged_session)
+        |> Utils.maybe_call_live_view_mount!(view, params, merged_session, url)
         |> build_state(phx_socket)
         |> maybe_call_mount_handle_params(router, url, params)
         |> reply_mount(from, verified, route)

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -257,7 +257,7 @@ defmodule Phoenix.LiveView.Static do
     mount_params = if socket.router, do: params, else: :not_mounted_at_router
 
     socket
-    |> Utils.maybe_call_live_view_mount!(view, mount_params, session)
+    |> Utils.maybe_call_live_view_mount!(view, mount_params, session, uri)
     |> mount_handle_params(view, params, uri)
     |> case do
       {:noreply, %Socket{redirected: {:live, _, _}} = socket} ->

--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -287,13 +287,13 @@ defmodule Phoenix.LiveView.Utils do
   @doc """
   Calls the `c:Phoenix.LiveView.mount/3` callback, otherwise returns the socket as is.
   """
-  def maybe_call_live_view_mount!(%Socket{} = socket, view, params, session) do
+  def maybe_call_live_view_mount!(%Socket{} = socket, view, params, session, uri \\ nil) do
     %{any?: any?, exported?: exported?} = Lifecycle.stage_info(socket, view, :mount, 3)
 
     if any? do
       :telemetry.span(
         [:phoenix, :live_view, :mount],
-        %{socket: socket, params: params, session: session},
+        %{socket: socket, params: params, session: session, uri: uri},
         fn ->
           socket =
             case Lifecycle.mount(params, session, socket) do
@@ -305,7 +305,7 @@ defmodule Phoenix.LiveView.Utils do
             end
             |> handle_mount_result!({:mount, 3, view})
 
-          {socket, %{socket: socket, params: params, session: session}}
+          {socket, %{socket: socket, params: params, session: session, uri: uri}}
         end
       )
     else

--- a/test/phoenix_live_view/integrations/live_view_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test.exs
@@ -65,12 +65,14 @@ defmodule Phoenix.LiveView.LiveViewTest do
 
       assert metadata.params == %{"foo" => "bar"}
       assert metadata.session == %{"current_user_id" => "1"}
+      assert metadata.uri == "http://www.example.com/thermo?foo=bar"
 
       assert_receive {:event, [:phoenix, :live_view, :mount, :stop], %{duration: _},
                       %{socket: %Socket{transport_pid: nil}} = metadata}
 
       assert metadata.params == %{"foo" => "bar"}
       assert metadata.session == %{"current_user_id" => "1"}
+      assert metadata.uri == "http://www.example.com/thermo?foo=bar"
     end
 
     @tag session: %{current_user_id: "1"}
@@ -86,6 +88,7 @@ defmodule Phoenix.LiveView.LiveViewTest do
 
       assert metadata.params == %{"crash_on" => "disconnected_mount"}
       assert metadata.session == %{"current_user_id" => "1"}
+      assert metadata.uri == "http://www.example.com/errors?crash_on=disconnected_mount"
 
       assert_receive {:event, [:phoenix, :live_view, :mount, :exception], %{duration: _},
                       %{socket: %Socket{transport_pid: nil}} = metadata}
@@ -94,6 +97,7 @@ defmodule Phoenix.LiveView.LiveViewTest do
       assert %RuntimeError{} = metadata.reason
       assert metadata.params == %{"crash_on" => "disconnected_mount"}
       assert metadata.session == %{"current_user_id" => "1"}
+      assert metadata.uri == "http://www.example.com/errors?crash_on=disconnected_mount"
     end
 
     test "live mount in single call", %{conn: conn} do
@@ -134,6 +138,7 @@ defmodule Phoenix.LiveView.LiveViewTest do
       assert metadata.socket.transport_pid
       assert metadata.params == %{"foo" => "bar"}
       assert metadata.session == %{"current_user_id" => "1"}
+      assert metadata.uri == "http://www.example.com/thermo?foo=bar"
 
       assert_receive {:event, [:phoenix, :live_view, :mount, :stop], %{duration: _},
                       %{socket: %{transport_pid: pid}} = metadata}
@@ -142,6 +147,7 @@ defmodule Phoenix.LiveView.LiveViewTest do
       assert metadata.socket.transport_pid
       assert metadata.params == %{"foo" => "bar"}
       assert metadata.session == %{"current_user_id" => "1"}
+      assert metadata.uri == "http://www.example.com/thermo?foo=bar"
     end
 
     @tag session: %{current_user_id: "1"}
@@ -157,6 +163,7 @@ defmodule Phoenix.LiveView.LiveViewTest do
       assert metadata.socket.transport_pid
       assert metadata.params == %{"crash_on" => "connected_mount"}
       assert metadata.session == %{"current_user_id" => "1"}
+      assert metadata.uri == "http://www.example.com/errors?crash_on=connected_mount"
 
       assert_receive {:event, [:phoenix, :live_view, :mount, :exception], %{duration: _},
                       %{socket: %{transport_pid: pid}} = metadata}
@@ -167,6 +174,7 @@ defmodule Phoenix.LiveView.LiveViewTest do
       assert %RuntimeError{} = metadata.reason
       assert metadata.params == %{"crash_on" => "connected_mount"}
       assert metadata.session == %{"current_user_id" => "1"}
+      assert metadata.uri == "http://www.example.com/errors?crash_on=connected_mount"
     end
 
     test "push_redirect when disconnected", %{conn: conn} do


### PR DESCRIPTION
Include the URI in the `[:phoenix, :live_view, :mount, *]` telemetry (when applicable). This allows logging the URI as a client navigates between liveviews alongside the session metadata.