### PR TITLE
Push patch route verification deeper down to the root view

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -322,7 +322,7 @@ defmodule Phoenix.LiveView do
     * [Uploads (External)](uploads-external.md)
   '''
 
-  alias Phoenix.LiveView.{Socket, Route}
+  alias Phoenix.LiveView.Socket
 
   @type unsigned_params :: map
 
@@ -1047,17 +1047,8 @@ defmodule Phoenix.LiveView do
 
   """
   def push_patch(%Socket{} = socket, opts) do
-    %{to: to} = opts = push_opts!(opts, "push_patch/2")
-
-    case Route.live_link_info!(socket, socket.private.root_view, to) do
-      {:internal, %Route{params: params, action: action}} ->
-        put_redirect(socket, {:live, {params, action}, opts})
-
-      {:external, _uri} ->
-        raise ArgumentError,
-              "cannot push_patch/2 to #{inspect(to)} because the given path " <>
-                "does not point to the current root view #{inspect(socket.private.root_view)}"
-    end
+    opts = push_opts!(opts, "push_patch/2")
+    put_redirect(socket, {:live, :patch, opts})
   end
 
   @doc """

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -688,7 +688,7 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   defp patch_params_and_action!(socket, %{to: to}) do
-    to = URI.to_string(%{socket.host_uri | path: to})
+    to = %{socket.host_uri | path: to}
 
     case Route.live_link_info!(socket, socket.private.root_view, to) do
       {:internal, %Route{params: params, action: action}} ->

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -416,7 +416,9 @@ defmodule Phoenix.LiveView.Channel do
       {:live, :redirect, %{to: _to} = opts} ->
         {:live_redirect, copy_flash(new_state, Utils.get_flash(new_socket), opts), new_state}
 
-      {:live, {params, action}, %{to: to} = opts} ->
+      {:live, :patch, %{to: to} = opts} ->
+        {params, action} = patch_params_and_action!(new_socket, opts)
+
         %{socket: new_socket} = new_state = drop_redirect(new_state)
         uri = build_uri(new_state, to)
 
@@ -664,14 +666,16 @@ defmodule Phoenix.LiveView.Channel do
         |> push_live_redirect(opts, ref, pending_diff_ack)
         |> stop_shutdown_redirect(:live_redirect, opts)
 
-      {:live, {params, action}, %{to: _to, kind: _kind} = opts} when root_pid == self() ->
+      {:live, :patch, %{to: _to, kind: _kind} = opts} when root_pid == self() ->
+        {params, action} = patch_params_and_action!(new_socket, opts)
+
         new_state
         |> drop_redirect()
         |> maybe_push_pending_diff_ack(pending_diff_ack)
         |> Map.update!(:socket, &Utils.replace_flash(&1, flash))
         |> sync_handle_params_with_live_redirect(params, action, opts, ref)
 
-      {:live, {_params, _action}, %{to: _to, kind: _kind}} = patch ->
+      {:live, :patch, %{to: _to, kind: _kind}} = patch ->
         send(new_socket.root_pid, {@prefix, :redirect, patch, flash})
         {:diff, diff, new_state} = render_diff(new_state, new_socket, false)
 
@@ -680,6 +684,20 @@ defmodule Phoenix.LiveView.Channel do
          |> drop_redirect()
          |> maybe_push_pending_diff_ack(pending_diff_ack)
          |> push_diff(diff, ref)}
+    end
+  end
+
+  defp patch_params_and_action!(socket, %{to: to}) do
+    to = URI.to_string(%{socket.host_uri | path: to})
+
+    case Route.live_link_info!(socket, socket.private.root_view, to) do
+      {:internal, %Route{params: params, action: action}} ->
+        {params, action}
+
+      {:external, _uri} ->
+        raise ArgumentError,
+              "cannot push_patch/2 to #{inspect(to)} because the given path " <>
+                "does not point to the current root view #{inspect(socket.private.root_view)}"
     end
   end
 
@@ -767,7 +785,13 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   defp push(state, event, payload) do
-    message = %Message{topic: state.topic, event: event, payload: payload, join_ref: state.join_ref}
+    message = %Message{
+      topic: state.topic,
+      event: event,
+      payload: payload,
+      join_ref: state.join_ref
+    }
+
     send(state.socket.transport_pid, state.serializer.encode!(message))
     state
   end

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -688,7 +688,8 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   defp patch_params_and_action!(socket, %{to: to}) do
-    to = %{socket.host_uri | path: to}
+    destructure [path, query], :binary.split(to, "?")
+    to = %{socket.host_uri | path: path, query: query}
 
     case Route.live_link_info!(socket, socket.private.root_view, to) do
       {:internal, %Route{params: params, action: action}} ->

--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -347,7 +347,7 @@ defmodule Phoenix.LiveView.Utils do
     """
   end
 
-  defp validate_mount_redirect!({:live, {_, _}, _}), do: raise_bad_mount_and_live_patch!()
+  defp validate_mount_redirect!({:live, :patch, _}), do: raise_bad_mount_and_live_patch!()
   defp validate_mount_redirect!(_), do: :ok
 
   @doc """

--- a/test/phoenix_live_view_test.exs
+++ b/test/phoenix_live_view_test.exs
@@ -364,16 +364,10 @@ defmodule Phoenix.LiveViewUnitTest do
         push_patch(@socket, to: "//foo.com")
       end
 
-      assert_raise ArgumentError,
-                   ~r"cannot push_patch/2 to \"/counter/123\" because the given path does not point to the current root view",
-                   fn ->
-                     push_patch(put_in(@socket.private.root_view, __MODULE__), to: "/counter/123")
-                   end
-
       socket = %{@socket | view: Phoenix.LiveViewTest.ParamCounterLive}
 
       assert push_patch(socket, to: "/counter/123").redirected ==
-               {:live, {%{"id" => "123"}, nil}, %{kind: :push, to: "/counter/123"}}
+               {:live, :patch, %{kind: :push, to: "/counter/123"}}
     end
   end
 end


### PR DESCRIPTION
This closes #1665 as it uses the full uri for searching the router instead of just the path passed to push_patch.