### PR TITLE
Remove --live from guide

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -3,7 +3,7 @@
 ## New projects
 
 Phoenix v1.5+ comes with built-in support for LiveView apps. Just create
-your application with `mix phx.new my_app --live`.
+your application with `mix phx.new my_app`.
 
 Once you've created a LiveView project, refer to [LiveView documentation](`Phoenix.LiveView`)
 for further information on how to use it.


### PR DESCRIPTION
If I'm not mistaken, it is no longer necessary to append `--live` when generating a new Phoenix application with LiveView enabled.