### PR TITLE
Fix typo in assert_patch/3 documentation

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1191,8 +1191,8 @@ defmodule Phoenix.LiveViewTest do
   def assert_patch(view, to) when is_binary(to), do: assert_patch(view, to, 100)
 
   @doc """
-  Asserts a live patch will to a given path within `timeout` milliseconds. The
-  default `timeout` is 100.
+  Asserts a live patch will happen to a given path within `timeout`
+  milliseconds. The default `timeout` is 100.
 
   It always returns `:ok`.
 


### PR DESCRIPTION
Hello,
I noticed what I suppose is a typo in the doc for `Phoenix.LiveViewTest.assert_patch/3`, fixed by this PR.

Hope this may be useful :)