### PR TITLE
Improve `LiveViewTest.render_component`'s handling of assigns

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -454,7 +454,7 @@ defmodule Phoenix.LiveViewTest do
                "some markup in component"
 
   """
-  defmacro render_component(component, assigns, opts \\ []) do
+  defmacro render_component(component, assigns \\ Macro.escape(%{}), opts \\ []) do
     endpoint = Module.get_attribute(__CALLER__.module, :endpoint)
 
     quote do
@@ -472,7 +472,10 @@ defmodule Phoenix.LiveViewTest do
   @doc false
   def __render_component__(endpoint, %{module: component}, assigns, opts) do
     socket = %Socket{endpoint: endpoint, router: opts[:router]}
-    assigns = Map.new(assigns)
+
+    assigns =
+      Map.new(assigns)
+      |> Map.put_new(:__changed__, %{})
 
     # TODO: Make the ID required once we support only stateful module components as live_component
     mount_assigns = if assigns[:id], do: %{myself: %Phoenix.LiveComponent.CID{cid: -1}}, else: %{}
@@ -487,6 +490,7 @@ defmodule Phoenix.LiveViewTest do
 
     assigns
     |> Map.new()
+    |> Map.put_new(:__changed__, %{})
     |> function.()
     |> rendered_to_diff_string(socket)
   end

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -11,6 +11,7 @@ defmodule Phoenix.ComponentTest do
 
   describe "rendering" do
     defp hello(assigns) do
+      assigns = assign_new(assigns, :name, fn -> "World" end)
       ~H"""
       Hello <%= @name %>
       """
@@ -249,7 +250,8 @@ defmodule Phoenix.ComponentTest do
     import Phoenix.LiveViewTest
 
     test "render_component/1" do
-      assert render_component(&hello/1, name: "World!") == "Hello World!"
+      assert render_component(&hello/1) == "Hello World"
+      assert render_component(&hello/1, name: "WORLD!") == "Hello WORLD!"
     end
   end
 end


### PR DESCRIPTION
This PR adds two conveniences to `render_component` in testing.

1) Allows you to test a component without assigns 
```elixir
assert render_component(&hello/1) == "Hello World"
```
2) Adds the `:__changed__` key to assigns if not present. Both `assign` and `assign_new` require that key to be present, so before this change to test a component that used `assign`, you would have to do:

```elixir
assert render_component(&hello/1, name: "World!", __changed__: %{}) == "Hello World!"
```
now it's just
```elixir
assert render_component(&hello/1, name: "World!") == "Hello World!"
```