### PR TITLE
Update Live layouts guide re: root layout change

### DIFF
--- a/guides/server/live-layouts.md
+++ b/guides/server/live-layouts.md
@@ -14,7 +14,7 @@ considered:
     a root layout. The root layout is typically declared on the
     router with `put_root_layout` and defined as "root.html.heex"
     in your `MyAppWeb.LayoutView`. It may also be given via the
-    `:layout` option to the router's `live` macro.
+    `:root_layout` option to a `live_session` macro in the router.
 
   * the app layout - this is the default application layout which
     is not included or used by LiveViews. It defaults to "app.html.heex"


### PR DESCRIPTION
While the `:layout` option to the `live` macro was partially removed
from the Live layouts guide in #1566, the sentence that is the subject
of this PR was overlooked.

If the preference would be to simplify the guide by removing any reference
to overriding the layout, then I can update this PR accordingly. However
as a newcomer to Phoenix who was just poking around to see how to set a
different root layout for a `live` route, this guide seems like a reasonable
place to discover that information.

If the PR reviewer agrees, then I will follow up with a second PR suggesting
changes to the paragraph that starts:

> "The "root" layout is shared by both "app" and "live" layouts.