### PR TITLE
Fix for Dialyzer issue with HEEx and empty assigns

### DIFF
--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -534,7 +534,7 @@ defmodule Phoenix.LiveView.Engine do
   end
 
   defp to_conditional_var(keys, var, live_struct) when keys == %{} do
-    quote do
+    quote generated: true do
       unquote(var) =
         case changed do
           %{} -> nil


### PR DESCRIPTION
## Issue

When upgrading Phoenix.HTML, we needed to convert instances of `~E` in our codebase to `~H` as the former is now deprecated. Many of our existing `~E` invocations take the form:
```elixir
def welcome_message do
  ~E"""
  <h2>Welcome to <%= app_name() %>!</h2>
  """
end

defp app_name do
  Application.get_env(:my_app, :name)
end
```

Changing this to HEEx required introducing an `assigns` variable. The template requires no bindings, so I tried setting `assigns` to `%{}` or `nil`; e.g.
```elixir
def welcome_message do
  assigns = %{}

  ~H"""
  <h2>Welcome to <%= app_name() %>!</h2>
  """
end
```

However, this produced the following Dialyzer error message:
```
Warning: The pattern can never match the type.

Pattern:
%{}

Type:
nil
```

I have set up an [example LiveView app](https://github.com/J3RN/live_view-example) and [reproduced the issue](https://github.com/J3RN/live_view-example/runs/4213953270).

## Solution

To debug this, I expanded and stringified the `~H` macro invocation, which produces the following code (excerpted from the whole):
```elixir
changed = case(assigns) do
  %{__changed__: changed} when track_changes? ->
    changed
  _ ->
    nil
end
v0 = case(changed) do
  %{} ->
    nil
  _ ->
    Phoenix.LiveView.Engine.live_to_iodata(app_name())
end
```

My intuition is that Dialyzer can tell that, since `assigns` never has a `:__changed__` key, the variable `changed` will always have the value `nil`. Given that, the first case clause of the assignment to `v0` will never match, and is extraneous.

I went down the rabbit-hole of trying to optimize the generated code to not perform this extraneous check, but having limited time ultimately opted to mark the second case expression as generated so that Dialyzer doesn't complain.