### PR TITLE
Use "action" attribute to set URL of form in docs

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -414,7 +414,7 @@ defmodule Phoenix.LiveComponent do
 
   They also work inside any function component, such as `form`:
 
-      <.form let={f} for={@changeset} url="#">
+      <.form let={f} for={@changeset} action="#">
         <%= live_component FormComponent, id: :form %>
       </.form>
 


### PR DESCRIPTION
I believe that is what was meant there.
Thank you for reviewing.