### PR TITLE
Fix typo in render_slot docs

### DIFF
--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -658,7 +658,7 @@ defmodule Phoenix.LiveView.Helpers do
           <tr>
             <%= for col <- @col do %>
               <th><%= col.label %></th>
-            <% end >
+            <% end %>
           </tr>
           <%= for row <- @rows do %>
             <tr>


### PR DESCRIPTION
Small typo correction. 