### PR TITLE
Add relative path to upload if webkitdirectory attribute used

### DIFF
--- a/assets/js/phoenix_live_view/live_uploader.js
+++ b/assets/js/phoenix_live_view/live_uploader.js
@@ -47,6 +47,7 @@ export default class LiveUploader {
       fileData[uploadRef] = fileData[uploadRef] || []
       entry.ref = this.genFileRef(file)
       entry.name = file.name || entry.ref
+      entry.path = file.webkitRelativePath || entry.name
       entry.type = file.type
       entry.size = file.size
       fileData[uploadRef].push(entry)

--- a/assets/js/phoenix_live_view/live_uploader.js
+++ b/assets/js/phoenix_live_view/live_uploader.js
@@ -47,7 +47,7 @@ export default class LiveUploader {
       fileData[uploadRef] = fileData[uploadRef] || []
       entry.ref = this.genFileRef(file)
       entry.name = file.name || entry.ref
-      entry.path = file.webkitRelativePath || entry.name
+      entry.relative_path = file.webkitRelativePath
       entry.type = file.type
       entry.size = file.size
       fileData[uploadRef].push(entry)

--- a/assets/js/phoenix_live_view/upload_entry.js
+++ b/assets/js/phoenix_live_view/upload_entry.js
@@ -91,6 +91,7 @@ export default class UploadEntry {
     return {
       last_modified: this.file.lastModified,
       name: this.file.name,
+      path: this.file.webkitRelativePath || this.file.name,
       size: this.file.size,
       type: this.file.type,
       ref: this.ref

--- a/assets/js/phoenix_live_view/upload_entry.js
+++ b/assets/js/phoenix_live_view/upload_entry.js
@@ -91,7 +91,7 @@ export default class UploadEntry {
     return {
       last_modified: this.file.lastModified,
       name: this.file.name,
-      path: this.file.webkitRelativePath || this.file.name,
+      relative_path: this.file.webkitRelativePath,
       size: this.file.size,
       type: this.file.type,
       ref: this.ref

--- a/lib/phoenix_live_view/upload_config.ex
+++ b/lib/phoenix_live_view/upload_config.ex
@@ -15,6 +15,7 @@ defmodule Phoenix.LiveView.UploadEntry do
             done?: false,
             cancelled?: false,
             client_name: nil,
+            client_path: nil,
             client_size: nil,
             client_type: nil,
             client_last_modified: nil
@@ -29,6 +30,7 @@ defmodule Phoenix.LiveView.UploadEntry do
           done?: boolean(),
           cancelled?: boolean(),
           client_name: String.t() | nil,
+          client_path: String.t() | nil,
           client_size: integer() | nil,
           client_type: String.t() | nil,
           client_last_modified: integer() | nil
@@ -519,6 +521,7 @@ defmodule Phoenix.LiveView.UploadConfig do
       upload_ref: conf.ref,
       upload_config: conf.name,
       client_name: Map.fetch!(client_entry, "name"),
+      client_path: client_entry["path"] || Map.fetch!(client_entry, "name"),
       client_size: Map.fetch!(client_entry, "size"),
       client_type: Map.fetch!(client_entry, "type"),
       client_last_modified: Map.get(client_entry, "last_modified")

--- a/lib/phoenix_live_view/upload_config.ex
+++ b/lib/phoenix_live_view/upload_config.ex
@@ -15,7 +15,7 @@ defmodule Phoenix.LiveView.UploadEntry do
             done?: false,
             cancelled?: false,
             client_name: nil,
-            client_path: nil,
+            client_relative_path: nil,
             client_size: nil,
             client_type: nil,
             client_last_modified: nil
@@ -30,7 +30,7 @@ defmodule Phoenix.LiveView.UploadEntry do
           done?: boolean(),
           cancelled?: boolean(),
           client_name: String.t() | nil,
-          client_path: String.t() | nil,
+          client_relative_path: String.t() | nil,
           client_size: integer() | nil,
           client_type: String.t() | nil,
           client_last_modified: integer() | nil
@@ -521,7 +521,7 @@ defmodule Phoenix.LiveView.UploadConfig do
       upload_ref: conf.ref,
       upload_config: conf.name,
       client_name: Map.fetch!(client_entry, "name"),
-      client_path: client_entry["path"] || Map.fetch!(client_entry, "name"),
+      client_relative_path: Map.get(client_entry, "relative_path"),
       client_size: Map.fetch!(client_entry, "size"),
       client_type: Map.fetch!(client_entry, "type"),
       client_last_modified: Map.get(client_entry, "last_modified")

--- a/test/phoenix_live_view/upload/channel_test.exs
+++ b/test/phoenix_live_view/upload/channel_test.exs
@@ -38,7 +38,7 @@ defmodule Phoenix.LiveView.UploadChannelTest do
       Enum.into(opts, %{
         last_modified: 1_594_171_879_000,
         name: "myfile#{i}.jpeg",
-        path: "myfile#{i}.jpeg",
+        relative_path: "./myfile#{i}.jpeg",
         content: String.duplicate("0", 100),
         size: 1_396_009,
         type: "image/jpeg"

--- a/test/phoenix_live_view/upload/channel_test.exs
+++ b/test/phoenix_live_view/upload/channel_test.exs
@@ -38,6 +38,7 @@ defmodule Phoenix.LiveView.UploadChannelTest do
       Enum.into(opts, %{
         last_modified: 1_594_171_879_000,
         name: "myfile#{i}.jpeg",
+        path: "myfile#{i}.jpeg",
         content: String.duplicate("0", 100),
         size: 1_396_009,
         type: "image/jpeg"

--- a/test/phoenix_live_view/upload/config_test.exs
+++ b/test/phoenix_live_view/upload/config_test.exs
@@ -183,7 +183,7 @@ defmodule Phoenix.LiveView.UploadConfigTest do
 
       %{
         "name" => name,
-        "path" => name,
+        "relative_path" => relative_path,
         "size" => size,
         "ref" => ref,
         "type" => type
@@ -195,7 +195,7 @@ defmodule Phoenix.LiveView.UploadConfigTest do
       assert [
                %Phoenix.LiveView.UploadEntry{
                  client_name: ^name,
-                 client_path: ^name,
+                 client_relative_path: ^relative_path,
                  client_size: ^size,
                  client_type: ^type,
                  ref: ^ref
@@ -212,7 +212,7 @@ defmodule Phoenix.LiveView.UploadConfigTest do
 
       %{
         "name" => name,
-        "path" => name,
+        "relative_path" => relative_path,
         "size" => size,
         "ref" => ref,
         "type" => type
@@ -224,7 +224,7 @@ defmodule Phoenix.LiveView.UploadConfigTest do
       assert [
                %Phoenix.LiveView.UploadEntry{
                  client_name: ^name,
-                 client_path: ^name,
+                 client_relative_path: ^relative_path,
                  client_size: ^size,
                  client_type: ^type,
                  ref: ^ref
@@ -395,7 +395,7 @@ defmodule Phoenix.LiveView.UploadConfigTest do
       "size" => 1024,
       "type" => "application/octet-stream"
     })
-    |> then(&Map.put_new(&1, "path", &1["name"]))
+    |> then(&Map.put_new(&1, "relative_path", "./#{&1["name"]}"))
     |> Map.put_new_lazy("ref", &Phoenix.LiveView.Utils.random_id/0)
   end
 end

--- a/test/phoenix_live_view/upload/config_test.exs
+++ b/test/phoenix_live_view/upload/config_test.exs
@@ -388,14 +388,16 @@ defmodule Phoenix.LiveView.UploadConfigTest do
   end
 
   defp build_client_entry(name, attrs \\ %{}) do
+    name = "#{name}_#{System.unique_integer([:positive, :monotonic])}"
+
     attrs
     |> Enum.into(%{
-      "name" => "#{name}_#{System.unique_integer([:positive, :monotonic])}",
+      "name" => name,
+      "relative_path" => "./#{name}",
       "last_modified" => DateTime.utc_now() |> DateTime.to_unix(),
       "size" => 1024,
       "type" => "application/octet-stream"
     })
-    |> then(&Map.put_new(&1, "relative_path", "./#{&1["name"]}"))
     |> Map.put_new_lazy("ref", &Phoenix.LiveView.Utils.random_id/0)
   end
 end

--- a/test/phoenix_live_view/upload/config_test.exs
+++ b/test/phoenix_live_view/upload/config_test.exs
@@ -183,6 +183,7 @@ defmodule Phoenix.LiveView.UploadConfigTest do
 
       %{
         "name" => name,
+        "path" => name,
         "size" => size,
         "ref" => ref,
         "type" => type
@@ -194,6 +195,7 @@ defmodule Phoenix.LiveView.UploadConfigTest do
       assert [
                %Phoenix.LiveView.UploadEntry{
                  client_name: ^name,
+                 client_path: ^name,
                  client_size: ^size,
                  client_type: ^type,
                  ref: ^ref
@@ -210,6 +212,7 @@ defmodule Phoenix.LiveView.UploadConfigTest do
 
       %{
         "name" => name,
+        "path" => name,
         "size" => size,
         "ref" => ref,
         "type" => type
@@ -221,6 +224,7 @@ defmodule Phoenix.LiveView.UploadConfigTest do
       assert [
                %Phoenix.LiveView.UploadEntry{
                  client_name: ^name,
+                 client_path: ^name,
                  client_size: ^size,
                  client_type: ^type,
                  ref: ^ref
@@ -391,6 +395,7 @@ defmodule Phoenix.LiveView.UploadConfigTest do
       "size" => 1024,
       "type" => "application/octet-stream"
     })
+    |> then(&Map.put_new(&1, "path", &1["name"]))
     |> Map.put_new_lazy("ref", &Phoenix.LiveView.Utils.random_id/0)
   end
 end


### PR DESCRIPTION
Now you can do this:
`<%= live_file_input @uploads.files, webkitdirectory: true %>`
and get `%UploadEntry{}` with a relative path.

One of the drawbacks of this implementation is that you cannot drag and drop folders, you than need some more javascript to make it work. (https://stackoverflow.com/questions/3590058/does-html5-allow-drag-drop-upload-of-folders-or-a-folder-tree)
But I think this is an important feature as is.

Another drawback is that this not supported on most mobile phones, but should not be a problem anyway.
(https://caniuse.com/?search=webkitdirectory)

There is a reported issue on this: #1482 