### PR TITLE
Fix HTML rendering of doc for `live_component`

### DIFF
--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -472,19 +472,19 @@ defmodule Phoenix.LiveView.Helpers do
 
     2. Then instead of:
 
-          ```
-          <%= live_component MyModule, id: "hello" do %>
-            ...
-          <% end %>
-          ```
+       ```
+       <%= live_component MyModule, id: "hello" do %>
+       ...
+       <% end %>
+       ```
 
        You should do:
 
-          ```
-          <.live_component module={MyModule} id="hello">
-            ...
-          </.live_component>
-          ```
+       ```
+       <.live_component module={MyModule} id="hello">
+       ...
+       </.live_component>
+       ```
 
     3. If your component is using `render_block/2`, replace
        it by `render_slot/2`

--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -472,15 +472,19 @@ defmodule Phoenix.LiveView.Helpers do
 
     2. Then instead of:
 
+          ```
           <%= live_component MyModule, id: "hello" do %>
             ...
           <% end %>
+          ```
 
        You should do:
 
+          ```
           <.live_component module={MyModule} id="hello">
             ...
           </.live_component>
+          ```
 
     3. If your component is using `render_block/2`, replace
        it by `render_slot/2`


### PR DESCRIPTION
The code fragment in the `live_component` doc isn't rendering correctly when output as HTML.

Before:

https://hexdocs.pm/phoenix_live_view/0.17.5/Phoenix.LiveView.Helpers.html#live_component/2

<img width="832" alt="before" src="https://user-images.githubusercontent.com/126417/144030288-ad833d75-efa8-4ac7-bfdc-dd53edbea859.png">

After:

<img width="835" alt="after" src="https://user-images.githubusercontent.com/126417/144031176-171fb35a-e3cb-4e76-94f0-3a02b12e7b56.png">

