### PR TITLE
Allow dispatch without opts

### DIFF
--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -149,7 +149,11 @@ defmodule Phoenix.LiveView.JS do
 
       <button phx-click={JS.dispatch("click", to: ".nav")}>Click me!</button>
   """
-  def dispatch(cmd \\ %JS{}, event, opts) do
+  def dispatch(cmd \\ %JS{}, event)
+  def dispatch(%JS{} = cmd, event), do: dispatch(cmd, event, [])
+  def dispatch(event, opts), do: dispatch(%JS{}, event, opts)
+
+  def dispatch(%JS{} = cmd, event, opts) do
     opts = validate_keys(opts, :dispatch, [:to, :detail])
     args = %{event: event, to: opts[:to]}
 

--- a/test/phoenix_live_view/js_test.exs
+++ b/test/phoenix_live_view/js_test.exs
@@ -265,6 +265,10 @@ defmodule Phoenix.LiveView.JSTest do
       assert JS.dispatch("click", to: "#modal") == %JS{
                ops: [["dispatch", %{to: "#modal", event: "click"}]]
              }
+
+      assert JS.dispatch("click") == %JS{
+               ops: [["dispatch", %{to: nil, event: "click"}]]
+             }
     end
 
     test "raises with unknown options" do
@@ -274,12 +278,16 @@ defmodule Phoenix.LiveView.JSTest do
     end
 
     test "composability" do
-      js = JS.dispatch("click", to: "#modal") |> JS.dispatch("keydown", to: "#keyboard")
+      js =
+        JS.dispatch("click", to: "#modal")
+        |> JS.dispatch("keydown", to: "#keyboard")
+        |> JS.dispatch("keyup")
 
       assert js == %JS{
                ops: [
                  ["dispatch", %{to: "#modal", event: "click"}],
-                 ["dispatch", %{to: "#keyboard", event: "keydown"}]
+                 ["dispatch", %{to: "#keyboard", event: "keydown"}],
+                 ["dispatch", %{to: nil, event: "keyup"}]
                ]
              }
     end


### PR DESCRIPTION
This would allow calling `JS.dispatch/3` without the `opts` (since both of them are optional).

e.g.: `JS.dispatch("event")` instead of `JS.dispatch("event", [])`.

See: https://github.com/phoenixframework/phoenix_live_view/issues/1684#issuecomment-989512243