### PR TITLE
fix the target element for click-away

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -594,7 +594,7 @@ export default class LiveSocket {
           if(JS.isVisible(el)){
             let target = e.target.closest(`[${phxClick}]`) || e.target
             DOM.putPrivate(target, "click-ref", clickRefWas)
-            JS.exec("click", phxEvent, view, target, ["push", {data: this.eventMeta("click", e, e.target)}])
+            JS.exec("click", phxEvent, view, el, ["push", {data: this.eventMeta("click", e, e.target)}])
           }
         })
       }


### PR DESCRIPTION
This looks like it resolves the issue mentioned here: https://github.com/phoenixframework/phoenix_live_view/issues/1808#L590

By forwarding `el` it `JS.exec` will use the element that has `phx-target` attribute. Right now, in master, it is sending the closest `phx-click` element or the element that has been clicked. 

I am not 100% sure convinced that this is the correct fix for it, but it did solve it in my test scenario. I was also not sure if `this.eventMeta` should then also be updated to use the correct target element or not.

~However, as I commented in the issue as well, I noticed a new behaviour in `master` where the private `click-ref` tracking can get in the way when you have more than 1 element with `click-away`. It ends up blocking regular clicks (not `click-away`'s). Maybe this is just a by design thing and there shouldn't be more than 1 rendered at the same time though?~
> This click issue looked similar to https://github.com/phoenixframework/phoenix_live_view/issues/1809 and applying a new isVisible check fixes the issue I encountered with this as well. 