### PR TITLE
Add Clarifying code comment to live upload guide

### DIFF
--- a/guides/server/uploads.md
+++ b/guides/server/uploads.md
@@ -171,6 +171,7 @@ def handle_event("save", _params, socket) do
   uploaded_files =
     consume_uploaded_entries(socket, :avatar, fn %{path: path}, _entry ->
       dest = Path.join([:code.priv_dir(:my_app), "static", "uploads", Path.basename(path)])
+      # The `static/uploads` directory must exist for `File.cp!/2` to work.
       File.cp!(path, dest)
       {:ok, Routes.static_path(socket, "/uploads/#{Path.basename(dest)}")}
     end)


### PR DESCRIPTION
This adds a note as a code comment to the live upload guide explaining that for `File.cp!` to work, the destination directory must exist.  While it does give a "no such file of directory" os error, I spent a good frustrated few minutes thinking it was the uploaded file that didn't exist.

This PR is just looking to save others the same potential small setback in what is otherwise a great experience of trying out example code that JustWorks.