### PR TITLE
provide options to adjust reload settings

### DIFF
--- a/assets/js/phoenix_live_view/constants.js
+++ b/assets/js/phoenix_live_view/constants.js
@@ -1,7 +1,8 @@
 
 export const CONSECUTIVE_RELOADS = "consecutive-reloads"
 export const MAX_RELOADS = 10
-export const RELOAD_JITTER = [1000, 3000]
+export const RELOAD_JITTER_MIN = 1000
+export const RELOAD_JITTER_MAX = 3000
 export const FAILSAFE_JITTER = 30000
 export const PHX_EVENT_CLASSES = [
   "phx-click-loading", "phx-change-loading", "phx-submit-loading",


### PR DESCRIPTION
When a heavily loaded service restarts or crashes, clients need to retry.  This
can create problems where a "thundering herd" of clients can hammer a site into
oblivion.  Similarly, crashes also can create a tight-loop of reconnections if
preventative measures are not put in place.

Phoenix Live View implements a backoff mechanism that provides an initial
series of retries, spread out randomly.  Should these initial retries not
re-establish the connection, it "backs off" for a much longer period.

To date, these settings have been constants.  This can be limiting in
situations where developers have unique requirements.  This patch allows
overriding of four constants for use in such situations.

This is done through new options to the LiveSocket constructor, as follows:

* `maxReloads`: number of reload attempts before "failsafe mode"
* `reloadJitterMin`: minimum delay between normal reload attempts
* `reloadJitterMax`: maximum delay between normal reload attempts
* `failsafeJitter`:  delay between failsafe reload attempts