### PR TITLE
Name parameter in callback for docs rendering

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -353,7 +353,7 @@ defmodule Phoenix.LiveView do
 
   """
   @callback mount(
-              unsigned_params() | :not_mounted_at_router,
+              params :: unsigned_params() | :not_mounted_at_router,
               session :: map,
               socket :: Socket.t()
             ) ::


### PR DESCRIPTION
Simple fix so it doesn't just render as `arg1` in the docs