### PR TITLE
Fix assign(s) typo in PhoenixLiveView docs

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -202,7 +202,7 @@ defmodule Phoenix.LiveView do
         end
       end
 
-  In all cases, each assign in the template will be accessible as `@assign`.
+  In all cases, each assign in the template will be accessible as `@assigns`.
   You can learn more about [assigns and HEEx templates in their own guide](assigns-eex.md).
 
   ## Bindings


### PR DESCRIPTION
Small typo I've noticed while reading the excellent documentation. :heart: 