### PR TITLE
Update state on phx_leave live_view event in Phoenix.LiveViewTest.ClientProxy

### DIFF
--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -550,7 +550,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
 
   defp drop_view_by_id(state, id, reason) do
     {:ok, view} = fetch_view_by_id(state, id)
-    push(state, view, "phx_leave", %{})
+    state = push(state, view, "phx_leave", %{})
 
     state =
       Enum.reduce(view.children, state, fn {child_id, _child_session}, acc ->
@@ -768,17 +768,18 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
   end
 
   defp push(state, view, event, payload) do
-    ref = to_string(state.ref + 1)
-
-    send(view.pid, %Phoenix.Socket.Message{
+    ref = state.ref + 1
+    message = %Phoenix.Socket.Message{
       join_ref: state.join_ref,
       topic: view.topic,
       event: event,
       payload: payload,
-      ref: ref
-    })
+      ref: to_string(ref)
+    }
 
-    %{state | ref: state.ref + 1}
+    send(view.pid, message)
+
+    %{state | ref: ref}
   end
 
   defp push_with_reply(state, from, view, event, payload) do

--- a/test/phoenix_live_view/integrations/live_components_test.exs
+++ b/test/phoenix_live_view/integrations/live_components_test.exs
@@ -98,6 +98,18 @@ defmodule Phoenix.LiveView.LiveComponentsTest do
     refute render(view) =~ "Hello World"
   end
 
+  test "tracks removals of a nested LiveView alongside with a LiveComponent in the root view", %{conn: conn} do
+    {:ok, view, _} = live(conn, "/component_and_nested_in_live")
+    html = render(view)
+    assert html =~ "hello"
+    assert html =~ "world"
+    render_click(view, "disable", %{})
+
+    html = render(view)
+    refute html =~ "hello"
+    refute html =~ "world"
+  end
+
   test "tracks removals when there is a race between server and client", %{conn: conn} do
     {:ok, view, _} = live(conn, "/cids_destroyed")
 

--- a/test/support/live_views/component_and_nested_in_live.ex
+++ b/test/support/live_views/component_and_nested_in_live.ex
@@ -1,0 +1,50 @@
+defmodule Phoenix.LiveViewTest.ComponentAndNestedInLive do
+  use Phoenix.LiveView
+
+  defmodule NestedLive do
+    use Phoenix.LiveView
+
+    def mount(_params, _session, socket) do
+      {:ok, assign(socket, :hello, "hello")}
+    end
+
+    def render(assigns) do
+      ~H"<div><%= @hello %></div>"
+    end
+
+    def handle_event("disable", _params, socket) do
+      send(socket.parent_pid, :disable)
+      {:noreply, socket}
+    end
+  end
+
+  defmodule NestedComponent do
+    use Phoenix.LiveComponent
+
+    def mount(socket) do
+      {:ok, assign(socket, :world, "world")}
+    end
+
+    def render(assigns) do
+      ~H"<div><%= @world %></div>"
+    end
+  end
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :enabled, true)}
+  end
+
+  def render(assigns) do
+    ~H"""
+      <%= if @enabled do %>
+        <%= live_render @socket, NestedLive, id: :nested_live %>
+        <%= live_component NestedComponent, id: :_component %>
+      <% end %>
+    """
+  end
+
+  def handle_event("disable", _, socket) do
+    {:noreply, assign(socket, :enabled, false)}
+  end
+end
+

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -101,6 +101,7 @@ defmodule Phoenix.LiveViewTest.Router do
     # integration components
     live "/component_in_live", ComponentInLive.Root
     live "/cids_destroyed", CidsDestroyedLive
+    live "/component_and_nested_in_live", ComponentAndNestedInLive
 
     # integration lifecycle
     live "/lifecycle", HooksLive


### PR DESCRIPTION
This bug was found in the current project I'm working. There is a LiveView which initially has 2 live components and 1 child liveview. There is a button that doesn't re-render these chilren so components are destroyed as well as the child liveview. The problem was while testing this LiveView: I always got this error:
```
     ** (EXIT from #PID<0.5100.0>) an exception was raised:
         ** (KeyError) key :cids not found in: %{}
             (phoenix_live_view 0.17.5) lib/phoenix_live_view/test/client_proxy.ex:641: anonymous fn/3 in Phoenix.LiveViewTest.ClientProxy.patch_view/3
             ...
```
While debugging this problem I got the following messages on re-render (inspecting a message in `ClientProxy.push/4` private function):

```
push message: %Phoenix.Socket.Message{
  event: "cids_will_destroy",
  join_ref: 0,
  payload: %{"cids" => [3, 2]},
  ref: "2",
  topic: "lv:phx-FsoL0-4ahwCDvY1i"
}
push message: %Phoenix.Socket.Message{
  event: "phx_leave",
  join_ref: 0,
  payload: %{},
  ref: "3",
  topic: "lv:child-liveview-860ff497-916c-4d70-9677-ae73ffc2fc31"
}
push message: %Phoenix.Socket.Message{
  event: "cids_destroyed",
  join_ref: 0,
  payload: %{"cids" => [3, 2]},
  ref: "3", # next event after "phx_leave" has the SAME ref value !!!
  topic: "lv:phx-FsoL0-4ahwCDvY1i"
}
```

It looked like the ref value wasn't incremented on `phx_leave` event.

The PR fixes this problem

