### PR TITLE
Use correct reference for the button tag

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -550,7 +550,7 @@ defmodule Phoenix.LiveViewTest do
       {:ok, view, html} = live(conn, "/thermo")
 
       assert view
-             |> element("buttons", "Increment")
+             |> element("button", "Increment")
              |> render_click() =~ "The temperature is: 30℉"
   """
   def render_click(element, value \\ %{})


### PR DESCRIPTION
I think it meant to be `button` as correct tag reference