### PR TITLE
Fix typo in JS Interop docs concerning JS commands

### DIFF
--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -144,7 +144,7 @@ is triggered. First, update the element to embed the JS command into a data
 attribute:
 
 ```heex
-<div id={"item-#{item.id}"} class="item" data-highlight={JS.transition("highligh")}>
+<div id={"item-#{item.id}"} class="item" data-highlight={JS.transition("highlight")}>
   <%= item.title %>
 </div>
 ```


### PR DESCRIPTION
Was reading the JS Interoperability docs when I happened to notice that line 147 of `js-interop.md` contains a typo when referencing the name of the `JS.transition`, it reads `highligh` but should read `highlight`.