### PR TITLE
Add flash function component.

### DIFF
--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -1080,6 +1080,18 @@ defmodule Phoenix.LiveView.Helpers do
     """
   end
 
+  def flash(assigns) do
+    type = assigns[:type] || raise ArgumentError, "missing :type assign for flash"
+    message = assigns[:message] || raise ArgumentError, "missing :message assign for flash"
+    class = assigns[:class] || "alert alert-#{type}"
+
+    ~H"""
+    <%= if is_binary(message) and byte_size(String.trim(message)) > 0 do %>
+      <p class={class} role="alert"><%= @message %></p>
+    <% end %>
+    """
+  end
+
   defp form_method(method) when method in ~w(get post), do: {method, nil}
   defp form_method(method) when is_binary(method), do: {"post", method}
 

--- a/test/phoenix_live_view/helpers_test.exs
+++ b/test/phoenix_live_view/helpers_test.exs
@@ -125,10 +125,52 @@ defmodule Phoenix.LiveView.HelpersTest do
     |> Phoenix.LiveViewTest.DOM.parse()
   end
 
+  describe "flash" do
+    test "raises when missing required assigns" do
+      assert_raise ArgumentError, ~r/missing :type assign/, fn ->
+        assigns = %{}
+
+        parse(~H"""
+        <.flash />
+        """)
+      end
+    end
+
+    test "generates flash if message is present" do
+      assigns = %{}
+
+      html =
+        parse(~H"""
+        <.flash type="alert" message="User created successfully." />
+        """)
+
+      assert [
+               {"p", [{"class", "alert alert-alert"}, {"role", "alert"}],
+                ["User created successfully."]}
+             ] == html
+    end
+
+    test "does not generate flash if message is empty" do
+      assigns = %{}
+
+      empty_messages = [nil, "", " "]
+
+      for empty_message <- empty_messages do
+        html =
+          parse(~H"""
+          <.flash type="alert" message={empty_message} />
+          """)
+
+        assert [] == html
+      end
+    end
+  end
+
   describe "form" do
     test "raises when missing required assigns" do
       assert_raise ArgumentError, ~r/missing :for assign/, fn ->
         assigns = %{}
+
         parse(~H"""
         <.form let={f}>
           <%= text_input f, :foo %>


### PR DESCRIPTION
The idea is to have a function component to `flash` messages, so when no messages are present, we avoid printing an empty `<p>` tag.

```heex
<!-- input -->
<.flash type="info" message="User created." />

<!-- output -->
<p class="alert alert-info" role="alert">User created.</p>

<!-- input -->
<.flash type="info" class="custom-class" message="User created." />

<!-- output -->
<p class="custom-class" role="alert">User created.</p>
```