### PR TITLE
fix typo static tracking link

### DIFF
--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -23,7 +23,7 @@ callback, for example:
 | [DOM Patching](dom-patching.md) | `phx-update`, `phx-remove` |
 | [JS Interop](js-interop.md#client-hooks) | `phx-hook` |
 | [Rate Limiting](#rate-limiting-events-with-debounce-and-throttle) | `phx-debounce`, `phx-throttle` |
-| [Static tracking](`Phoenix.LiveView.static_changed?/1) | `phx-track-static` |
+| [Static tracking](Phoenix.LiveView.html#static_changed?/1) | `phx-track-static` |
 
 ## Click Events
 

--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -23,7 +23,7 @@ callback, for example:
 | [DOM Patching](dom-patching.md) | `phx-update`, `phx-remove` |
 | [JS Interop](js-interop.md#client-hooks) | `phx-hook` |
 | [Rate Limiting](#rate-limiting-events-with-debounce-and-throttle) | `phx-debounce`, `phx-throttle` |
-| [Static tracking](Phoenix.LiveView.html#static_changed?/1) | `phx-track-static` |
+| [Static tracking](`Phoenix.LiveView.static_changed?/1`) | `phx-track-static` |
 
 ## Click Events
 


### PR DESCRIPTION
On https://hexdocs.pm/phoenix_live_view/bindings.html, when I click `Static tracking` link I was redirected to: https://hexdocs.pm/phoenix_live_view/%60Phoenix.LiveView.static_changed?/1

Before:
<img width="1087" alt="Screen Shot 2022-01-24 at 12 01 56" src="https://user-images.githubusercontent.com/1036970/150807528-3eea5ae8-1a24-4e5c-a4e9-9c6cd508605d.png">

After fixed locally, when I put my mouse on top of the `Static tracking` link:

<img width="1088" alt="Screen Shot 2022-01-24 at 12 02 43" src="https://user-images.githubusercontent.com/1036970/150807692-abdaba7f-56d0-490a-bdb8-723a3aa918c3.png">

When I clicked I was redirected to [file:///.../phoenix_live_view/doc/Phoenix.LiveView.html#static_changed?/1]()

<img width="831" alt="Screen Shot 2022-01-24 at 12 10 04" src="https://user-images.githubusercontent.com/1036970/150809173-699e0400-5f62-4e26-9cb7-a273fbb04e84.png">