### PR TITLE
Updating example code for consistency

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -173,7 +173,7 @@ defmodule Phoenix.LiveComponent do
 
   LiveComponent can also receive slots, in the same way as a `Phoenix.Component`:
 
-      <.live_component module={MyComponent} >
+      <.live_component module={MyComponent} id={@data.id} >
         <div>Inner content here</div>
       </.live_component>
 


### PR DESCRIPTION
Added an id attribute to the live component in the Slots example to distinguish it from the regular Phoenix.Component and to avoid confusion for the reader.