### PR TITLE
Ability to get uploaded entry metadata without consuming it

### DIFF
--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -108,6 +108,17 @@ defmodule Phoenix.LiveView.Upload do
   end
 
   @doc """
+  Returns the entry metadata.
+  Will raise if called on unfinished upload
+  """
+  def get_entry_meta(%Socket{} = socket, %UploadEntry{} = entry) do
+    socket.assigns.uploads
+    |> Map.fetch!(entry.upload_config)
+    |> UploadConfig.entry_pid(entry)
+    |> Phoenix.LiveView.UploadChannel.get_file_meta()
+  end
+
+  @doc """
   Updates the entry progress.
 
   Progress is either an integer percently between 0 and 100, or a map


### PR DESCRIPTION
Ability to get uploaded entry metadata without consuming it. Useful for any kind of back-end image processing divided in events that can not be done within consume callback. Or to save files with Ark/Waffle.


For example save handler for ecto with Ark can look as simple as this:

``` elixir
@impl true
def handle_event("save", %{"user" => params}, socket) do
  {[entry | _], []} = Upload.uploaded_entries(socket, name)

  %{path: path} = Upload.get_entry_meta(socket, entry)

  image = %Plug.Upload{
    content_type: entry.client_type,
    filename: entry.client_name,
    path: path
  }

  Users.create_user(%User{}, Map.put(params, "avatar", image))

  consume_uploaded_entries(socket, :avatar, &{:ok, &1})

  {:noreply, socket}
end
```