### PR TITLE
Fix error message when phxSocket is not a Socket

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -123,7 +123,7 @@ export default class LiveSocket {
       a phoenix Socket must be provided as the second argument to the LiveSocket constructor. For example:
 
           import {Socket} from "phoenix"
-          import LiveSocket from "phoenix_live_view"
+          import {LiveSocket} from "phoenix_live_view"
           let liveSocket = new LiveSocket("/live", Socket, {...})
       `)
     }


### PR DESCRIPTION
`LiveSocket` is a named export not the default export of the module `"phoenix_live_view"`.