### PR TITLE
Add execJS and execJSTo methods to phx-hook

### DIFF
--- a/assets/js/phoenix_live_view/view_hook.js
+++ b/assets/js/phoenix_live_view/view_hook.js
@@ -60,6 +60,14 @@ export default class ViewHook {
     return this.__view.withinTargets(phxTarget, view => view.dispatchUploads(name, files))
   }
 
+  execJS(encodedJS, eventType = null){
+    return this.__liveSocket.execJS(this.el, encodedJS, eventType)
+  }
+
+  execJSTo(targetEl, encodedJS, eventType = null){
+    return this.__liveSocket.execJS(targetEl, encodedJS, eventType)
+  }
+
   __cleanup__(){
     this.__listeners.forEach(callbackRef => this.removeHandleEvent(callbackRef))
   }

--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -196,6 +196,8 @@ The above life-cycle callbacks have in-scope access to the following attributes:
     on the server-side. Dispatching new uploads triggers an input change event which will be sent to the
     LiveComponent or LiveView the `selectorOrTarget` is defined in, where it's value can be either a query selector or an
     actual DOM element. If the query selector returns more than one live file input, an error will be logged.
+  * `execJS(encodedJS, eventType = null)` - method to execute [`JS`](`Phoenix.LiveView.JS`) commands on the bound DOM node. See also `LiveSocket.execJS`.
+  * `execJSTo(targetEl, encodedJS, eventType = null)` - method to execute [`JS`](`Phoenix.LiveView.JS`) commands on the given target element. See also `LiveSocket.execJS`.
 
 For example, the markup for a controlled input for phone-number formatting could be written
 like this:


### PR DESCRIPTION
`liveSocket` has `execJS` which can run `Phoenix.LiveView.JS` commands. This isn't exposed to hooks however.

This PR adds two functions, `execJS(js, eventType|null)` which runs the JS commands on the "hook element", and `execJSTo(el, js, eventType|null)` which runs the JS command on any given element.

The `execJS[To]` names were chosen to be inline with `pushEvent[To]` and `upload[To]`, as well as `JS(to: ...)`'s format.

I couldn't see any existing tests for hooks to add to.