### PR TITLE
Track all views with pending updates

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -165,6 +165,27 @@ export default class LiveSocket {
         window.location.reload()
       }
     })
+
+    // hack
+    this.__viewsWithPendingUpdates = []
+  }
+
+  // hack
+  addViewWithPendingUpdates(view) {
+    this.__viewsWithPendingUpdates.push(view)
+  }
+
+  removeViewWithPendingUpdates(view) {
+    this.__viewsWithPendingUpdates =
+      this.__viewsWithPendingUpdates.filter((v) => v != view)
+  }
+
+  // hack
+  applyPendingUpdatesToViewsWithPendingUpdates() {
+    this.__viewsWithPendingUpdates.forEach((view) => {
+      view.applyPendingUpdates()
+    })
+    this.__viewsWithPendingUpdates = []
   }
 
   // public

--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -166,26 +166,20 @@ export default class LiveSocket {
       }
     })
 
-    // hack
-    this.__viewsWithPendingUpdates = []
+    this.viewsWithPendingUpdates = []
   }
 
-  // hack
   addViewWithPendingUpdates(view) {
-    this.__viewsWithPendingUpdates.push(view)
+    this.viewsWithPendingUpdates.push(view)
   }
 
   removeViewWithPendingUpdates(view) {
-    this.__viewsWithPendingUpdates =
-      this.__viewsWithPendingUpdates.filter((v) => v != view)
+    this.viewsWithPendingUpdates = this.viewsWithPendingUpdates.filter((v) => v != view)
   }
 
-  // hack
   applyPendingUpdatesToViewsWithPendingUpdates() {
-    this.__viewsWithPendingUpdates.forEach((view) => {
-      view.applyPendingUpdates()
-    })
-    this.__viewsWithPendingUpdates = []
+    this.viewsWithPendingUpdates.forEach((view) => view.applyPendingUpdates())
+    this.viewsWithPendingUpdates = []
   }
 
   // public


### PR DESCRIPTION
Fixes #1867 #1866 

If a live view receives WS messages in the order `live_patch, diff, reply`, the `diff` message will have its updates deferred until the live patch event is complete (awaits a reply). Once the `reply` is received, `view.js` will call `applyPendingUpdates` and the `diff` messages changes will be applied.

If the `diff` message was intended for a non-root, non-nested view (one that is rendered in the layout via `live_render`), then it will never have its pending updates applied as the `reply` callback only runs `applyPendingUpdates` against it *own* view.

This patch, mostly as an example fix for now, just lets the live socket track any views with pending updates and the `live_patch` reply call back also tells the live socket to apply any pending updates it knows about.