### PR TITLE
Allow overriding of existing attribute via `JS.set_attribute`

### DIFF
--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -170,7 +170,7 @@ let JS = {
 
   setOrRemoveAttrs(el, sets, removes){
     let [prevSets, prevRemoves] = DOM.getSticky(el, "attrs", [[], []])
-    let keepSets = sets.filter(([attr, _val]) => !this.hasSet(prevSets, attr) && !el.attributes.getNamedItem(attr))
+    let keepSets = sets.filter(([attr, _val]) => !this.hasSet(prevSets, attr))
     let keepRemoves = removes.filter(attr => prevRemoves.indexOf(attr) < 0 && el.attributes.getNamedItem(attr))
     let newSets = prevSets.filter(([attr, _val]) => removes.indexOf(attr) < 0).concat(keepSets)
     let newRemoves = prevRemoves.filter(attr => !this.hasSet(sets, attr)).concat(keepRemoves)

--- a/assets/test/js_test.js
+++ b/assets/test/js_test.js
@@ -398,13 +398,15 @@ describe("JS", () => {
   describe("exec_set_attr and exec_remove_attr", () => {
     test("with defaults", () => {
       let view = setupView(`
-      <div id="modal" class="modal">modal</div>
+      <div id="modal" class="modal" aria-label="Some Modal">modal</div>
       <div id="set" phx-click='[["set_attr", {"to": "#modal", "attr": ["aria-expanded", "true"]}]]'></div>
       <div id="remove" phx-click='[["remove_attr", {"to": "#modal", "attr": "aria-expanded"}]]'></div>
+      <div id="replace" phx-click='[["set_attr", {"to": "#modal", "attr": ["aria-label", "Some other Modal"]}]]'></div>
       `)
       let modal = document.querySelector("#modal")
       let set = document.querySelector("#set")
       let remove = document.querySelector("#remove")
+      let replace = document.querySelector("#replace")
 
       expect(modal.getAttribute("aria-expanded")).toEqual(null)
       JS.exec("click", set.getAttribute("phx-click"), view, set)
@@ -412,6 +414,10 @@ describe("JS", () => {
 
       JS.exec("click", remove.getAttribute("phx-click"), view, remove)
       expect(modal.getAttribute("aria-expanded")).toEqual(null)
+      
+      expect(modal.getAttribute("aria-label")).toEqual("Some Modal")
+      JS.exec("click", replace.getAttribute("phx-click"), view, replace)
+      expect(modal.getAttribute("aria-label")).toEqual("Some other Modal")
     })
 
     test("with no selector", () => {


### PR DESCRIPTION
Currently an existing attribute cannot be changed via `JS.set_attribute`.
This PR allows overriding it with a new value.

This fixes #1868 .