### PR TITLE
Fix issue with determining href for anchor tags inside an SVG

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -651,7 +651,7 @@ export default class LiveSocket {
       if(!type || !this.isConnected() || !this.main || wantsNewTab){ return }
       let href = target.href
       
-      if (href instanceof SvgAnimationObject) {href = href.baseVal}
+      if(href instanceof SvgAnimationObject){ href = href.baseVal }
       
       let linkState = target.getAttribute(PHX_LINK_STATE)
       e.preventDefault()

--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -650,6 +650,9 @@ export default class LiveSocket {
       let wantsNewTab = e.metaKey || e.ctrlKey || e.button === 1
       if(!type || !this.isConnected() || !this.main || wantsNewTab){ return }
       let href = target.href
+      
+      if (href instanceof SvgAnimationObject) {href = href.baseVal}
+      
       let linkState = target.getAttribute(PHX_LINK_STATE)
       e.preventDefault()
       if(this.pendingLink === href){ return }


### PR DESCRIPTION
When an anchor tag exists inside an SVG, the href is not a string but an [SvgAnimationObject](https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimatedString). This PR recognizes this and digs into the SvgAnimationObject to get the underlying href.