### PR TITLE
Apply pending updates to root views on livesocket navigations

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -77,8 +77,6 @@ let DOM = {
     return el.getAttribute && updateTypes.indexOf(el.getAttribute(phxUpdate)) >= 0
   },
 
-  findPhxSticky(el){ return this.all(el, `[${PHX_STICKY}]`) },
-
   findPhxChildren(el, parentId){
     return this.all(el, `${PHX_VIEW_SELECTOR}[${PHX_PARENT_ID}="${parentId}"]`)
   },

--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -120,6 +120,8 @@ export default class View {
   }
 
   isMain(){ return this.el.getAttribute(PHX_MAIN) !== null }
+  
+  isSticky() { return DOM.isPhxSticky(this.el) }
 
   connectParams(){
     let params = this.liveSocket.params(this.el)
@@ -1022,7 +1024,6 @@ export default class View {
           if(this.liveSocket.commitPendingLink(linkRef)){
             this.href = href
           }
-          this.applyPendingUpdates()
           callback && callback(linkRef)
         }
       })


### PR DESCRIPTION
Fixes https://github.com/phoenixframework/phoenix_live_view/issues/1866, https://github.com/phoenixframework/phoenix_live_view/issues/1867

In LiveView v`0.17.6` sticky option was introduced, which enabled to keep the liveview state between `live_redirect`. But neither  `live_redirect` nor `live_patch` isn't updating sticky views with pending diffs, which were come in the background, while the main view had a pending link.

This PR intends to solve a problem by applying pending updates for each root view after livesocket finished navigation. 

Aside from bug fixing, PR changes also:
* the responsibility of applying pending updates on navigation is moved from view to livesocket ( excluding `view.applyJoinPatch`, where the view is still responsible for applying own pending updates ).
* Use `livesocket.roots` + checking `PHX_STICKY` attribute instead of DOM query for finding sticky views  (sticky views are placed to `livesocket.roots` (see [sticky view implementation](https://github.com/phoenixframework/phoenix_live_view/commit/a038f3b9d5fbb2b4623f8a3d68dae6082c8c06bd#diff-d6e0926af881a2fd38a6f7992ed706c597be93ae542f4149e71f9442887be1ecR166) ) along with the main view. )

There is another PR from https://github.com/phoenixframework/phoenix_live_view/pull/1871 from @rktjmp, who I wanted to appreciate a lot for posting bugs and doing research on a problem. I'm not sure how we can consolidate efforts, but am ready to do so.
