### PR TITLE
fix issue with LiveView and LongPoll

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -457,7 +457,7 @@ export default class LiveSocket {
     this.boundTopLevelEvents = true
     // enter failsafe reload if server has gone away intentionally, such as "disconnect" broadcast
     this.socket.onClose(event => {
-      if(event.code === 1000 && this.main){
+      if(event && event.code === 1000 && this.main){
         this.reloadWithJitter(this.main)
       }
     })


### PR DESCRIPTION
LongPoll does not give an event argument to onClose. This is making it so you can't use LongPoll as a transport at all.

See: https://github.com/phoenixframework/phoenix/blob/master/assets/js/phoenix/longpoll.js#L116