### PR TITLE
feature: add beforeReload hook support #1921

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -304,7 +304,10 @@ export default class LiveSocket {
       if(this.hasPendingLink()){
         window.location = this.pendingLink
       } else {
-        window.location.reload()
+        var shouldStopReload = view.triggerBeforeReload();
+        if (!shouldStopReload){
+          window.location.reload()
+        }
       }
     }, afterMs)
   }

--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -90,6 +90,7 @@ export default class View {
     this.stopCallback = function(){ }
     this.pendingJoinOps = this.parent ? null : []
     this.viewHooks = {}
+    this.viewAfterDestoryHooks = {}
     this.uploaders = {}
     this.formSubmits = []
     this.children = this.parent ? null : {}
@@ -147,7 +148,10 @@ export default class View {
     let onFinished = () => {
       callback()
       for(let id in this.viewHooks){
-        this.destroyHook(this.viewHooks[id])
+        if (this.viewHooks[id].beforeReload){
+          this.viewAfterDestoryHooks[id] = this.viewHooks[id];
+        }
+        this.destroyHook(this.viewHooks[id]);
       }
     }
 
@@ -186,6 +190,17 @@ export default class View {
 
   triggerReconnected(){
     for(let id in this.viewHooks){ this.viewHooks[id].__reconnected() }
+  }
+
+  triggerBeforeReload(){
+    var result = false;
+    for(let id in this.viewAfterDestoryHooks){
+      var probbed_return = this.viewAfterDestoryHooks[id].__beforeReload()
+      if (probbed_return){
+        result = true;
+      }
+    }
+    return result;
   }
 
   log(kind, msgCallback){

--- a/assets/js/phoenix_live_view/view_hook.js
+++ b/assets/js/phoenix_live_view/view_hook.js
@@ -29,6 +29,8 @@ export default class ViewHook {
     this.disconnected && this.disconnected()
   }
 
+  __beforeReload(){ return this.beforeReload && this.beforeReload() }
+
   pushEvent(event, payload = {}, onReply = function (){ }){
     return this.__view.pushHookEvent(null, event, payload, onReply)
   }

--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -179,6 +179,7 @@ or removed by the server, a hook object may be provided via `phx-hook`.
     by a parent update, or by the parent being removed entirely
   * `disconnected` - the element's parent LiveView has disconnected from the server
   * `reconnected` - the element's parent LiveView has reconnected to the server
+  * `beforeReload` - the element's parent LiveView is trying to conduct a full reload. If this lifecycle callback returns a truthy value, LiveView assumes that the logic related to reloading is delegated to the hook and will not execute the reload.
 
 The above life-cycle callbacks have in-scope access to the following attributes:
 


### PR DESCRIPTION
This PR introduces a lifecycle callback named "beforeReload" which allows developers to detect the reloading event before it is happening. 

This lifecycle callback can be used by developers for custom reloading logic or trigger custom UI responses towards their users.

```
beforeReload(){
  return true;
}
```
As shown above, if you return a truthy value to the lifecycle callback, LiveView will not execute the reload logic due to disconnection.

This PR changed 3 major area
1. Code for the feature
2. One test case for the feature
3. One manual bullet in js-interop.md for the feature

Thank you