### PR TITLE
Removes brackets from string values

### DIFF
--- a/lib/phoenix_live_view/html_algebra.ex
+++ b/lib/phoenix_live_view/html_algebra.ex
@@ -328,7 +328,7 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
       {:ok, string} when is_binary(string) ->
         ~s(#{attr}="#{string}")
 
-      {:ok, _ast} ->
+      _ ->
         expr =
           break("")
           |> concat(expr_to_code_algebra(value, meta, opts))

--- a/lib/phoenix_live_view/html_algebra.ex
+++ b/lib/phoenix_live_view/html_algebra.ex
@@ -324,13 +324,18 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
   defp render_attribute({attr, {:string, value, _meta}}, _opts), do: ~s(#{attr}="#{value}")
 
   defp render_attribute({attr, {:expr, value, meta}}, opts) do
-    expr =
-      break("")
-      |> concat(expr_to_code_algebra(value, meta, opts))
-      |> nest(2)
+    case Code.string_to_quoted(value) do
+      {:ok, string} when is_binary(string) ->
+        ~s(#{attr}="#{string}")
 
-    concat(["#{attr}={", expr, concat(break(""), "}")])
-    |> group()
+      {:ok, _ast} ->
+        expr =
+          break("")
+          |> concat(expr_to_code_algebra(value, meta, opts))
+          |> nest(2)
+
+        group(concat(["#{attr}={", expr, concat(break(""), "}")]))
+    end
   end
 
   defp render_attribute({attr, {_, value, _meta}}, _opts), do: ~s(#{attr}=#{value})

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -585,6 +585,29 @@ if Version.match?(System.version(), ">= 1.13.0") do
       """)
     end
 
+    test "changes expr to literal when it is an string" do
+      assert_formatter_doesnt_change("""
+      <div class={@id} />
+      """)
+
+      assert_formatter_doesnt_change("""
+      <div class={some_function(:foo, :bar)} />
+      """)
+
+      assert_formatter_output(
+        """
+        <div class={"mx-auto flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-full bg-purple-100 sm:mx-0"}>
+          Content
+        </div>
+        """,
+        """
+        <div class="mx-auto flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-full bg-purple-100 sm:mx-0">
+          Content
+        </div>
+        """
+      )
+    end
+
     test "does not break lines when tag doesn't contain content" do
       input = """
       <thead>


### PR DESCRIPTION
This commit changes `attrs={"value"}` to `attrs="value"` when the value is just a string