### PR TITLE
Fix assertion in test example

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -207,7 +207,7 @@ defmodule Phoenix.LiveViewTest do
   ## Examples
 
       {:ok, view, html} = live(conn, "/path")
-      assert view.module = MyLive
+      assert view.module == MyLive
       assert html =~ "the count is 3"
 
       assert {:error, {:redirect, %{to: "/somewhere"}}} = live(conn, "/path")


### PR DESCRIPTION
I was going through the docs for testing liveviews, and I came across this example, which is matching in a way it won't even compile. Changing it to an equality check sounds like the right thing here.