### PR TITLE
Fallback to default lexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -626,7 +626,7 @@ as LiveView introduces a macro with that name and it is special cased by the und
   - No longer send event metadata by default. Metadata is now opt-in and user defined at the `LiveSocket` level.
   To maintain backwards compatibility with pre-0.13 behaviour, you can provide the following metadata option:
 
-  ```javascript
+  ```
   let liveSocket = new LiveSocket("/live", Socket, {
     params: {_csrf_token: csrfToken},
     metadata: {
@@ -949,7 +949,7 @@ The steps are:
 
   5) Then in your app.js:
 
-      ```javascript
+      ```
       let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
       let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}});
       ```
@@ -1030,7 +1030,7 @@ Also note that **the session from now on will have string keys**. LiveView will 
   - All `phx-update` containers now require a unique ID
   - `LiveSocket` JavaScript constructor now requires explicit dependency injection of Phoenix Socket constructor. For example:
 
-```javascript
+```
 import {Socket} from "phoenix"
 import LiveSocket from "phoenix_live_view"
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ $ npm install --save --prefix assets mdn-polyfills url-search-params-polyfill fo
 
 Note: The `shim-keyboard-event-key` polyfill is also required for [MS Edge 12-18](https://caniuse.com/#feat=keyboardevent-key).
 
-```javascript
+```
 // assets/js/app.js
 import "mdn-polyfills/Object.assign"
 import "mdn-polyfills/CustomEvent"

--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -2,7 +2,7 @@
 
 To enable LiveView client/server interaction, we instantiate a LiveSocket. For example:
 
-```javascript
+```
 import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
 
@@ -33,7 +33,7 @@ Calling `enableDebug()` turns on debug logging which includes LiveView life-cycl
 payload events as they come and go from client to server. In practice, you can expose
 your instance on `window` for quick access in the browser's web console, for example:
 
-```javascript
+```
 // app.js
 let liveSocket = new LiveSocket(...)
 liveSocket.connect()
@@ -57,7 +57,7 @@ the `LiveSocket` instance includes `enableLatencySim(milliseconds)` and `disable
 functions which apply throughout the current browser session. The `enableLatencySim` function
 accepts an integer in milliseconds for the round-trip-time to the server. For example:
 
-```javascript
+```
 // app.js
 let liveSocket = new LiveSocket(...)
 liveSocket.connect()
@@ -82,7 +82,7 @@ submits via `phx-submit`, the JavaScript events `"phx:page-loading-start"` and
 event may dispatch page loading events by annotating the DOM element with
 `phx-page-loading`. This is useful for showing main page loading status, for example:
 
-```javascript
+```
 // app.js
 import topbar from "topbar"
 window.addEventListener("phx:page-loading-start", info => topbar.show())
@@ -128,7 +128,7 @@ end
 Finally, a window event listener can listen for the event and conditionally
 execute the highlight command if the element matches:
 
-```javascript
+```
 let liveSocket = new LiveSocket(...)
 window.addEventListener(`phx:highlight`, (e) => {
   let el = document.getElementById(e.detail.id)
@@ -152,7 +152,7 @@ attribute:
 Now, in the event listener, use `LiveSocket.execJS` to trigger all JS
 commands in the new attribute:
 
-```javascript
+```
 let liveSocket = new LiveSocket(...)
 window.addEventListener(`phx:highlight`, (e) => {
   document.querySelectorAll(`[data-highlight]`).forEach(el => {
@@ -296,7 +296,7 @@ store the selected state.
 In these cases, the event functions on the DOM API can be used, for example
 to trigger a `phx-change` event:
 
-```javascript
+```
 document.getElementById("my-select").dispatchEvent(
   new Event("input", {bubbles: true})
 )
@@ -307,7 +307,7 @@ outlined in the "Client hooks" documentation.
 
 It is also possible to trigger a `phx-submit` using a "submit" event:
 
-```javascript
+```
 document.getElementById("my-form").dispatchEvent(
   new Event("submit", {bubbles: true, cancelable: true})
 )

--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -135,7 +135,7 @@ Finally, ensure you have placed a CSRF meta tag inside the `<head>` tag in your 
 
 and enable connecting to a LiveView socket in your `app.js` file.
 
-```javascript
+```
 // assets/js/app.js
 import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"


### PR DESCRIPTION
After `v0.17.5` some codeblocks specifying javascript as language were introduced in the markdown guides.

Current docs:
![Screenshot 2022-03-25 at 14 32 00](https://user-images.githubusercontent.com/6720169/160142192-a1dda1c9-63df-435a-afdc-d3dd9167e0b3.png)

After this diff:
![Screenshot 2022-03-25 at 14 32 15](https://user-images.githubusercontent.com/6720169/160142272-52cb7adc-80a4-428f-8713-313e4080b5d7.png)

