### PR TITLE
set LiveView module as a `:log_module` metadata to show in the routes

### DIFF
--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -346,11 +346,16 @@ defmodule Phoenix.LiveView.Router do
 
     {as_helper, as_action} = inferred_as(live_view, opts[:as], action)
 
+    metadata =
+      metadata
+      |> Map.put(:phoenix_live_view, {live_view, action, opts, live_session})
+      |> Map.put_new(:log_module, live_view)
+
     {as_action,
      alias: false,
      as: as_helper,
      private: Map.put(private, :phoenix_live_view, {live_view, opts, live_session}),
-     metadata: Map.put(metadata, :phoenix_live_view, {live_view, action, opts, live_session})}
+     metadata: metadata}
   end
 
   defp validate_live_opts!(opts) do


### PR DESCRIPTION
Solves the issue described in [phoenix#4721](https://github.com/phoenixframework/phoenix/issues/4721)

Now since phoenix respects `:log_module` in metadata (see [phoenix#4723](https://github.com/phoenixframework/phoenix/pull/4723)) we can set it in here.
