### PR TITLE
Fix intentional line breaks after eex expressions

### DIFF
--- a/lib/phoenix_live_view/html_algebra.ex
+++ b/lib/phoenix_live_view/html_algebra.ex
@@ -308,7 +308,7 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
 
   # Final clause: multiple lines
   defp text_to_algebra([], _, acc),
-    do: acc |> Enum.reverse() |> tl() |> concat() |> force_unfit()
+    do: acc |> Enum.reverse() |> tl() |> concat()
 
   defp build_attrs([], on_break, _opts), do: on_break
 

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -395,28 +395,6 @@ if Version.match?(System.version(), ">= 1.13.0") do
       )
     end
 
-    test "keep tags with text and eex expressions inline" do
-      assert_formatter_output(
-        """
-          <p>
-            $
-            <%= @product.value %> in Dollars
-          </p>
-          <button>
-            Submit
-          </button>
-        """,
-        """
-        <p>
-          $ <%= @product.value %> in Dollars
-        </p>
-        <button>
-          Submit
-        </button>
-        """
-      )
-    end
-
     test "parse eex inside of html tags" do
       assert_formatter_output(
         """
@@ -764,7 +742,14 @@ if Version.match?(System.version(), ">= 1.13.0") do
     end
 
     test "keep intentional line breaks" do
-      input = """
+      assert_formatter_doesnt_change("""
+      <div>
+        Should not <%= "line break" %>.
+        But it does.
+      </div>
+      """)
+
+      assert_formatter_doesnt_change("""
       <section>
         <h1>
           <b>
@@ -778,9 +763,26 @@ if Version.match?(System.version(), ">= 1.13.0") do
 
         <h2>Subtitle</h2>
       </section>
-      """
+      """)
 
-      assert_formatter_doesnt_change(input)
+      assert_formatter_output(
+        """
+          <p>
+            $ <%= @product.value %> in Dollars
+          </p>
+          <button>
+            Submit
+          </button>
+        """,
+        """
+        <p>
+          $ <%= @product.value %> in Dollars
+        </p>
+        <button>
+          Submit
+        </button>
+        """
+      )
     end
 
     test "keep eex expressions in the next line" do


### PR DESCRIPTION
Related to https://github.com/phoenixframework/phoenix_live_view/issues/1950

Before this PR, the following input:

```
<div>
  Should not <%= "line break" %>.
  But it does.
</div>
```

wrongly, would out put this:

```
<div>
  Should not <%= "line break" %>
  .
  But it does.
</div>
```

This commit fixes that.