### PR TITLE
Refactoring codes

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -269,8 +269,7 @@ defmodule Phoenix.LiveView.Channel do
     read_socket(state, cid, fn socket, _ ->
       result =
         with {:ok, uploads} <- Map.fetch(socket.assigns, :uploads),
-             {:ok, conf} <- Map.fetch(uploads, name),
-             do: {:ok, conf}
+             do: Map.fetch(uploads, name)
 
       {:reply, result, state}
     end)

--- a/test/phoenix_live_view/test/dom_test.exs
+++ b/test/phoenix_live_view/test/dom_test.exs
@@ -5,7 +5,7 @@ defmodule Phoenix.LiveViewTest.DOMTest do
 
   describe "find_live_views" do
     # >= 4432 characters
-    @too_big_session Enum.map(1..4432, fn _ -> "t" end) |> Enum.join()
+    @too_big_session Enum.map_join(1..4432, fn _ -> "t" end)
 
     test "finds views given html" do
       assert DOM.find_live_views(


### PR DESCRIPTION
- using `Enum.map_join` instead `Enum.map |> Enum.join`
- remove redundant last clause in `with`