### PR TITLE
Preserve single quote delimiter on attrs

### DIFF
--- a/lib/phoenix_live_view/html_algebra.ex
+++ b/lib/phoenix_live_view/html_algebra.ex
@@ -337,6 +337,7 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
   end
 
   defp render_attribute({:root, {:expr, expr, _}}, _opts), do: ~s({#{expr}})
+  defp render_attribute({attr, {:string, value, %{delimiter: ?'}}}, _opts), do: ~s(#{attr}='#{value}')
   defp render_attribute({attr, {:string, value, _meta}}, _opts), do: ~s(#{attr}="#{value}")
 
   defp render_attribute({attr, {:expr, value, meta}}, opts) do

--- a/lib/phoenix_live_view/html_algebra.ex
+++ b/lib/phoenix_live_view/html_algebra.ex
@@ -337,7 +337,15 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
   end
 
   defp render_attribute({:root, {:expr, expr, _}}, _opts), do: ~s({#{expr}})
-  defp render_attribute({attr, {:string, value, %{delimiter: ?'}}}, _opts), do: ~s(#{attr}='#{value}')
+
+  defp render_attribute({attr, {:string, value, %{delimiter: ?'}}}, _opts) do
+    if String.contains?(value, ["\"", "'"]) do
+      ~s(#{attr}='#{value}')
+    else
+      ~s(#{attr}="#{value}")
+    end
+  end
+
   defp render_attribute({attr, {:string, value, _meta}}, _opts), do: ~s(#{attr}="#{value}")
 
   defp render_attribute({attr, {:expr, value, meta}}, opts) do

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -1235,10 +1235,22 @@ if Version.match?(System.version(), ">= 1.13.0") do
       )
     end
 
-    test "keep single quote delimiter" do
+    test "keep single quote delimiter when value has quotes" do
       assert_formatter_doesnt_change("""
       <div title='Say "hi!"'></div>
       """)
+    end
+
+    test "transform single quotes to double when value has no quotes" do
+      input = """
+      <div title='Say hi!'></div>
+      """
+
+      expected = """
+      <div title="Say hi!"></div>
+      """
+
+      assert_formatter_output(input, expected)
     end
 
     # TODO: Remove this `if` after Elixir versions before than 1.14 are no

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -1235,6 +1235,12 @@ if Version.match?(System.version(), ">= 1.13.0") do
       )
     end
 
+    test "keep single quote delimiter" do
+      assert_formatter_doesnt_change("""
+      <div title='Say "hi!"'></div>
+      """)
+    end
+
     # TODO: Remove this `if` after Elixir versions before than 1.14 are no
     # longer supported.
     if function_exported?(EEx, :tokenize, 2) do


### PR DESCRIPTION
Trying out the new HEEx formatter I found a case where it isn't keeping single quotes delimiters on the final rendered template, eg:

It's changing `data-labels='["1", "2"]'` to `data-labels="["1", "2"]"` causing a compilation failure.

The tokenizer can handle it so I suppose the formatter should follow, right? https://github.com/phoenixframework/phoenix_live_view/blob/917b90e68577165aabc73eee030969bf3e490742/test/phoenix_live_view/html_tokenizer_test.exs#L412-L416