### PR TITLE
Fix lv:clear-flash tests on components

### DIFF
--- a/test/phoenix_live_view/integrations/flash_test.exs
+++ b/test/phoenix_live_view/integrations/flash_test.exs
@@ -356,25 +356,34 @@ defmodule Phoenix.LiveView.FlashIntegrationTest do
   test "lv:clear-flash component", %{conn: conn} do
     {:ok, flash_live, _} = live(conn, "/flash-root")
 
-    result =
-      flash_live
-      |> element("#flash-component")
-      |> render_click(%{"type" => "put_flash", "info" => "ok!"})
+    flash_live
+    |> element("#flash-component")
+    |> render_click(%{"type" => "put_flash", "info" => "ok!"})
 
-    assert result =~ "component[ok!]:info"
+    flash_live
+    |> element("#flash-component")
+    |> render_click(%{"type" => "put_flash", "error" => "oops!"})
 
-    result = flash_live |> element("#flash-component span", "Clear all") |> render_click()
-    assert result =~ "component[]:info"
+    assert has_element?(flash_live, "span[phx-value-key=info]", "component[ok!]:info")
+    assert has_element?(flash_live, "span[phx-value-key=error]", "component[oops!]:error")
 
-    result =
-      flash_live
-      |> element("#flash-component")
-      |> render_click(%{"type" => "put_flash", "error" => "oops!"})
+    flash_live |> element("#flash-component span", "Clear all") |> render_click()
 
-    assert result =~ "component[oops!]:error"
+    assert has_element?(flash_live, "#flash-component span[phx-value-key=info]", "component[]:info")
+    assert has_element?(flash_live, "#flash-component span[phx-value-key=error]", "component[]:error")
+  end
 
-    result = flash_live |> element("#flash-component span", ":error") |> render_click()
-    assert result =~ "component[]:error"
+  test "lv:clear-flash component with phx-value-key", %{conn: conn} do
+    {:ok, flash_live, _} = live(conn, "/flash-root")
+
+    flash_live
+    |> element("#flash-component")
+    |> render_click(%{"type" => "put_flash", "error" => "oops!"})
+
+    assert has_element?(flash_live, "#flash-component span[phx-value-key=error]", "component[oops!]:error")
+
+    flash_live |> element("#flash-component span", ":error") |> render_click()
+    assert has_element?(flash_live, "#flash-component span[phx-value-key=error]", "component[]:error")
   end
 
   test "works without session and flash", %{conn: conn} do

--- a/test/phoenix_live_view/integrations/flash_test.exs
+++ b/test/phoenix_live_view/integrations/flash_test.exs
@@ -364,8 +364,8 @@ defmodule Phoenix.LiveView.FlashIntegrationTest do
     |> element("#flash-component")
     |> render_click(%{"type" => "put_flash", "error" => "oops!"})
 
-    assert has_element?(flash_live, "span[phx-value-key=info]", "component[ok!]:info")
-    assert has_element?(flash_live, "span[phx-value-key=error]", "component[oops!]:error")
+    assert has_element?(flash_live, "#flash-component span[phx-value-key=info]", "component[ok!]:info")
+    assert has_element?(flash_live, "#flash-component span[phx-value-key=error]", "component[oops!]:error")
 
     flash_live |> element("#flash-component span", "Clear all") |> render_click()
 
@@ -383,6 +383,7 @@ defmodule Phoenix.LiveView.FlashIntegrationTest do
     assert has_element?(flash_live, "#flash-component span[phx-value-key=error]", "component[oops!]:error")
 
     flash_live |> element("#flash-component span", ":error") |> render_click()
+
     assert has_element?(flash_live, "#flash-component span[phx-value-key=error]", "component[]:error")
   end
 

--- a/test/support/live_views/flash.ex
+++ b/test/support/live_views/flash.ex
@@ -49,9 +49,9 @@ defmodule Phoenix.LiveViewTest.FlashComponent do
   def render(assigns) do
     ~H"""
     <div id={@id} phx-target={@myself} phx-click="click">
-    <span phx-click="lv:clear-flash">Clear all</span>
-    <span phx-click="lv:clear-flash" phx-value-key="info">component[<%= live_flash(@flash, :info) %>]:info</span>
-    <span phx-click="lv:clear-flash" phx-value-key="error">component[<%= live_flash(@flash, :error) %>]:error</span>
+    <span phx-target={@myself} phx-click="lv:clear-flash">Clear all</span>
+    <span phx-target={@myself} phx-click="lv:clear-flash" phx-value-key="info">component[<%= live_flash(@flash, :info) %>]:info</span>
+    <span phx-target={@myself} phx-click="lv:clear-flash" phx-value-key="error">component[<%= live_flash(@flash, :error) %>]:error</span>
     </div>
     """
   end


### PR DESCRIPTION
The current `Phoenix.LiveViewTest.FlashComponent` does not target the `lv:clear-flash` actions to itself and the test is passing due to a false positive. More info at https://github.com/phoenixframework/phoenix_live_view/issues/1842#issuecomment-1099729676

It does not address the case explained at https://github.com/phoenixframework/phoenix_live_view/issues/1842#issuecomment-1018569574 but AFAIK this test is supposed to be about clearing the flash of the component itself so the changes here are just to fix this specific scenario.