### PR TITLE
Erase child flash on redirect

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -521,9 +521,16 @@ defmodule Phoenix.LiveView.Channel do
 
     result =
       Diff.write_component(socket, cid, components, fn component_socket, component ->
-        component_socket
-        |> maybe_update_uploads(payload)
-        |> inner_component_handle_event(component, event, val)
+        {component_socket, {redirected, flash}} = inner_component =
+          component_socket
+          |> maybe_update_uploads(payload)
+          |> inner_component_handle_event(component, event, val)
+
+        if redirected do
+          {Utils.clear_flash(component_socket), {redirected, flash}}
+        else
+          inner_component
+        end
       end)
 
     # Due to race conditions, the browser can send a request for a

--- a/test/phoenix_live_view/integrations/flash_test.exs
+++ b/test/phoenix_live_view/integrations/flash_test.exs
@@ -304,6 +304,22 @@ defmodule Phoenix.LiveView.FlashIntegrationTest do
       assert result =~ "uri[http://www.example.com/flash-root?patch]"
       assert result =~ "root[ok!]"
     end
+
+    test "erase child flash", %{conn: conn} do
+      {:ok, flash_live, _} = live(conn, "/flash-root")
+
+      flash_live
+      |> element("#flash-component")
+      |> render_click(%{
+        "type" => "push_patch",
+        "to" => "/flash-root?patch",
+        "info" => "ok!"
+      })
+
+      result = render(flash_live)
+      assert result =~ "root[ok!]"
+      assert has_element?(flash_live, "#flash-component span[phx-value-key=info]", "component[]:info")
+    end
   end
 
   describe "LiveView <=> DeadView" do


### PR DESCRIPTION
An attempt to fix #1842 

By @josevalim: "The only thing is that I would expect the child flash to be erased when we copy the flash to the parent"

So this PR does clear component's flash when it's set to redirect, which is when the flash is copied to the parent.