### PR TITLE
Add :log_function info to router metadata

### DIFF
--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -350,6 +350,7 @@ defmodule Phoenix.LiveView.Router do
       metadata
       |> Map.put(:phoenix_live_view, {live_view, action, opts, live_session})
       |> Map.put_new(:log_module, live_view)
+      |> Map.put_new(:log_function, action)
 
     {as_action,
      alias: false,

--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -350,7 +350,7 @@ defmodule Phoenix.LiveView.Router do
       metadata
       |> Map.put(:phoenix_live_view, {live_view, action, opts, live_session})
       |> Map.put_new(:log_module, live_view)
-      |> Map.put_new(:log_function, action)
+      |> Map.put_new(:log_function, :mount)
 
     {as_action,
      alias: false,


### PR DESCRIPTION
As [suggested](https://github.com/phoenixframework/phoenix/pull/4748#issuecomment-1093135759) by @chrismccord in https://github.com/phoenixframework/phoenix/pull/4748, add `log_function` in addition to `:log_module` to liveview metadata informations.