### PR TITLE
Handle tag_close inside named slots

### DIFF
--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -418,7 +418,7 @@ defmodule Phoenix.LiveView.HTMLEngine do
     validate_phx_attrs!(attrs, tag_meta, state)
 
     state
-    |> set_root_on_tag()
+    |> maybe_set_root_on_tag()
     |> handle_tag_and_attrs(name, attrs, suffix, to_location(tag_meta))
   end
 
@@ -428,7 +428,7 @@ defmodule Phoenix.LiveView.HTMLEngine do
     validate_phx_attrs!(attrs, tag_meta, state)
 
     state
-    |> set_root_on_tag()
+    |> maybe_set_root_on_tag()
     |> push_tag(token)
     |> handle_tag_and_attrs(name, attrs, ">", to_location(tag_meta))
   end
@@ -448,11 +448,20 @@ defmodule Phoenix.LiveView.HTMLEngine do
     end
   end
 
-  defp set_root_on_tag(state) do
+  defp maybe_set_root_on_tag(state) do
     case state do
-      %{root: nil, tags: []} -> %{state | root: true}
-      %{root: true, tags: []} -> %{state | root: false}
-      %{root: bool} when is_boolean(bool) -> state
+      %{root: nil, tags: []} ->
+        %{state | root: true}
+
+      %{root: true, tags: []} ->
+        %{state | root: false}
+
+      %{root: bool} when is_boolean(bool) ->
+        state
+
+      %{root: nil, slots: [], tags: [{_, <<first, _::binary>>, _, _} | _]}
+        when first == ?: ->
+        state
     end
   end
 

--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -82,13 +82,14 @@ defmodule Phoenix.LiveView.HTMLEngine do
   @doc false
   def handle_end(state) do
     state
+    |> Map.put(:root, false)
     |> token_state()
     |> handle_tokens(Enum.reverse(state.tokens))
     |> validate_unclosed_tags!("do-block")
     |> invoke_subengine(:handle_end, [])
   end
 
-  defp token_state(%{subengine: subengine, substate: substate, file: file}) do
+  defp token_state(%{subengine: subengine, substate: substate, file: file} = state) do
     %{
       subengine: subengine,
       substate: substate,
@@ -96,7 +97,7 @@ defmodule Phoenix.LiveView.HTMLEngine do
       stack: [],
       tags: [],
       slots: [],
-      root: nil
+      root: state[:root]
     }
   end
 
@@ -457,10 +458,6 @@ defmodule Phoenix.LiveView.HTMLEngine do
         %{state | root: false}
 
       %{root: bool} when is_boolean(bool) ->
-        state
-
-      %{root: nil, slots: [], tags: [{_, <<first, _::binary>>, _, _} | _]}
-        when first == ?: ->
         state
     end
   end

--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -49,7 +49,7 @@ defmodule Phoenix.LiveView.HTMLEngine do
 
     token_state =
       state
-      |> token_state()
+      |> token_state(nil)
       |> handle_tokens(tokens)
       |> validate_unclosed_tags!("template")
 
@@ -82,14 +82,13 @@ defmodule Phoenix.LiveView.HTMLEngine do
   @doc false
   def handle_end(state) do
     state
-    |> Map.put(:root, false)
-    |> token_state()
+    |> token_state(false)
     |> handle_tokens(Enum.reverse(state.tokens))
     |> validate_unclosed_tags!("do-block")
     |> invoke_subengine(:handle_end, [])
   end
 
-  defp token_state(%{subengine: subengine, substate: substate, file: file} = state) do
+  defp token_state(%{subengine: subengine, substate: substate, file: file}, root) do
     %{
       subengine: subengine,
       substate: substate,
@@ -97,7 +96,7 @@ defmodule Phoenix.LiveView.HTMLEngine do
       stack: [],
       tags: [],
       slots: [],
-      root: state[:root]
+      root: root
     }
   end
 

--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -419,7 +419,7 @@ defmodule Phoenix.LiveView.HTMLEngine do
     validate_phx_attrs!(attrs, tag_meta, state)
 
     state
-    |> maybe_set_root_on_tag()
+    |> set_root_on_tag()
     |> handle_tag_and_attrs(name, attrs, suffix, to_location(tag_meta))
   end
 
@@ -429,7 +429,7 @@ defmodule Phoenix.LiveView.HTMLEngine do
     validate_phx_attrs!(attrs, tag_meta, state)
 
     state
-    |> maybe_set_root_on_tag()
+    |> set_root_on_tag()
     |> push_tag(token)
     |> handle_tag_and_attrs(name, attrs, ">", to_location(tag_meta))
   end
@@ -449,16 +449,11 @@ defmodule Phoenix.LiveView.HTMLEngine do
     end
   end
 
-  defp maybe_set_root_on_tag(state) do
+  defp set_root_on_tag(state) do
     case state do
-      %{root: nil, tags: []} ->
-        %{state | root: true}
-
-      %{root: true, tags: []} ->
-        %{state | root: false}
-
-      %{root: bool} when is_boolean(bool) ->
-        state
+      %{root: nil, tags: []} -> %{state | root: true}
+      %{root: true, tags: []} -> %{state | root: false}
+      %{root: bool} when is_boolean(bool) -> state
     end
   end
 

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -1001,7 +1001,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
         """)
       end)
 
-      message = ~r".exs:3:(3:)? invalid slot entry <:sample>. A slot entry must be a direct child of a component"
+      message = ~r".exs:(2|3):(3:)? invalid slot entry <:sample>. A slot entry must be a direct child of a component"
 
       assert_raise(ParseError, message, fn ->
         eval("""
@@ -1011,7 +1011,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
             <p>Content</p>
           </:sample>
         <% end %>
-        </div>
+        </Phoenix.LiveView.HTMLEngineTest.function_component_with_single_slot>
         """)
       end)
 

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -1001,6 +1001,20 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
         """)
       end)
 
+      message = ~r".exs:3:(3:)? invalid slot entry <:sample>. A slot entry must be a direct child of a component"
+
+      assert_raise(ParseError, message, fn ->
+        eval("""
+        <Phoenix.LiveView.HTMLEngineTest.function_component_with_single_slot>
+        <%= if true do %>
+          <:sample>
+            <p>Content</p>
+          </:sample>
+        <% end %>
+        </div>
+        """)
+      end)
+
       message = ~r".exs:3:(5:)? invalid slot entry <:footer>. A slot entry must be a direct child of a component"
 
       assert_raise(ParseError, message, fn ->


### PR DESCRIPTION
Fix #1892

A template like

```elixir
<.function_component_with_single_slot>
<%= if true do %>
 <:sample>
   <p>inner</p>
 </:sample>
<% end %>
</.function_component_with_single_slot>
```

is tokenized as

```elixir
tokens: [
  {:tag_open, ":sample", [], %{column: 2, line: 3}},
  {:text, "\n   ", %{column_end: 4, line_end: 4}},
  {:tag_open, "p", [], %{column: 4, line: 4}},
  {:text, "inner", %{column_end: 16, line_end: 4}},
  {:tag_close, "p", %{column: 16, line: 4}},
  {:text, "\n ", %{column_end: 2, line_end: 5}},
  {:tag_close, ":sample", %{column: 2, line: 5}}
]
```

The `no case clause matching` happens due to the parsing of `{:tag_close, "p", %{column: 16, line: 4}}` which tries to set an unexpected root. So seems like the fix is to check if that tag is inside a named slot and no slots have been parsed yet (because slots are added only on `{:tag_close, ":sample", %{column: 2, line: 5}}`) if so then just skip (return current state) and keep evaluating the tokens, which eventually will raise the expected `ParserError`