### PR TITLE
Fix code example for push_event

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -991,7 +991,7 @@ defmodule Phoenix.LiveView do
 
   A hook declared via `phx-hook` can handle it via `handleEvent`:
 
-      this.handleEvent("points", data => ...)
+      this.handleEvent("scores", data => ...)
 
   ## `window` example
 


### PR DESCRIPTION
In the example, the server was sending "scores" event, but frontend was handling "points" event.