### PR TITLE
HTMLFormatter - Preserve inline element on the same line when followed by a eex expression without whitespace

### DIFF
--- a/lib/phoenix_live_view/html_formatter.ex
+++ b/lib/phoenix_live_view/html_formatter.ex
@@ -445,6 +445,9 @@ defmodule Phoenix.LiveView.HTMLFormatter do
         name in @inline_elements and head_is_text_ending_with_whitespace?(upper_buffer) ->
           :preserve
 
+        name in @inline_elements and head_is_eex_expresion?(upper_buffer) ->
+          :preserve
+
         contains_special_attrs?(attrs) ->
           :preserve
 
@@ -453,15 +456,6 @@ defmodule Phoenix.LiveView.HTMLFormatter do
 
         true ->
           :block
-      end
-
-    buffer =
-      cond do
-        name in @inline_elements and head_is_eex_expresion?(upper_buffer) ->
-          Enum.map(buffer, &maybe_force_text_on_newline/1)
-
-        true ->
-          buffer
       end
 
     tag_block = {:tag_block, name, attrs, Enum.reverse(buffer), %{mode: mode}}

--- a/lib/phoenix_live_view/html_formatter.ex
+++ b/lib/phoenix_live_view/html_formatter.ex
@@ -541,12 +541,6 @@ defmodule Phoenix.LiveView.HTMLFormatter do
   defp head_is_eex_expresion?([{:eex, _, _} | _]), do: true
   defp head_is_eex_expresion?(_), do: false
 
-  defp maybe_force_text_on_newline({:text, text, %{newlines: 0} = meta}) do
-    {:text, text, Map.put(meta, :newlines, 1)}
-  end
-
-  defp maybe_force_text_on_newline(text), do: text
-
   # In case the given tag is inline and the there is no white spaces in the next
   # text, we want to set mode as preserve. So this tag will not be formatted.
   defp may_set_preserve([{:tag_block, name, attrs, block, meta} | list], text)

--- a/lib/phoenix_live_view/html_formatter.ex
+++ b/lib/phoenix_live_view/html_formatter.ex
@@ -21,9 +21,10 @@ defmodule Phoenix.LiveView.HTMLFormatter do
 
   > ### For umbrella projects {: .info}
   >
-  > In umbrella projects, you must also add `:phoenix_live_view` to your `deps`
-  > in the `mix.exs` file at the umbrella root. This is because the formatter
-  > does not attempt to load the dependencies of all children applications.
+  > In umbrella projects you must also change two files at the umbrella root,
+  > add `:phoenix_live_view` to your `deps` in the `mix.exs` file
+  > and add `plugins: [Phoenix.LiveView.HTMLFormatter]` in the `.formatter.exs` file.
+  > This is because the formatter does not attempt to load the dependencies of all children applications.
 
   ## Options
 

--- a/lib/phoenix_live_view/html_formatter.ex
+++ b/lib/phoenix_live_view/html_formatter.ex
@@ -544,12 +544,8 @@ defmodule Phoenix.LiveView.HTMLFormatter do
 
   # Return true if the first element of the given buffer is a EEx expression,
   # otherwise return false.
-  defp head_is_eex_expresion?(upper_buffer) do
-    case List.first(upper_buffer) do
-      {:eex, _text, _meta} -> true
-      _ -> false
-    end
-  end
+  defp head_is_eex_expresion?([{:eex, _, _} | _]), do: true
+  defp head_is_eex_expresion?(_), do: false
 
   defp maybe_force_text_on_newline({:text, text, %{newlines: 0} = meta}) do
     {:text, text, Map.put(meta, :newlines, 1)}

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -1313,19 +1313,13 @@ if Version.match?(System.version(), ">= 1.13.0") do
       )
     end
 
-    test "force inline element into a newline when followed by a eex expression" do
-      input = """
+    test "preserve inline element on the same newline when followed by a eex expression without whitespace" do
+      assert_formatter_doesnt_change(
+        """
         <%= some_function("arg") %><span>content</span>
-      """
-
-      expected = """
-      <%= some_function("arg") %>
-      <span>
-        content
-      </span>
-      """
-
-      assert_formatter_output(input, expected, line_length: 25)
+        """,
+        line_length: 25
+      )
     end
 
     test "does not format when contenteditable is present" do

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -1313,7 +1313,7 @@ if Version.match?(System.version(), ">= 1.13.0") do
       )
     end
 
-    test "preserve inline element on the same newline when followed by a eex expression without whitespace" do
+    test "preserve inline element on the same line when followed by a eex expression without whitespaces" do
       assert_formatter_doesnt_change(
         """
         <%= some_function("arg") %><span>content</span>

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -1313,6 +1313,21 @@ if Version.match?(System.version(), ">= 1.13.0") do
       )
     end
 
+    test "force inline element into a newline when followed by a eex expression" do
+      input = """
+        <%= some_function("arg") %><span>content</span>
+      """
+
+      expected = """
+      <%= some_function("arg") %>
+      <span>
+        content
+      </span>
+      """
+
+      assert_formatter_output(input, expected, line_length: 25)
+    end
+
     test "does not format when contenteditable is present" do
       assert_formatter_doesnt_change(
         """


### PR DESCRIPTION
Running the formatter I noticed that https://github.com/phoenixframework/phoenix_live_view/pull/1964 may have introduced a bug.

Consider a line length of 25 and the template `<%= some_function("arg") %><span>content</span>`, it's rendered as:

```elixir
<%= some_function("arg") %><span>
  content
</span>
```

Which is expected because the whole inline element doesn't fit on the line, but the problem is if you run mix format again you end up with:

```elixir
<%= some_function("arg") %>
<span>
  content
</span>
```

Which is also expected because the inline element's meta is parsed with `newlines: 1` after the first pass.

_So currently it's like you have to run mix format twice to get the "final" version_

One possible solution is to force that inline element to be parsed with a newline on the first pass to get the same result (the current proposed change), another solution is to `:preserve` instead but eex blocks may be too long so I'm not sure which one fits better.

Thoughts on a better solution?