### PR TITLE
Respect nesting of children when phx-no-format is present

### DIFF
--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -1399,6 +1399,23 @@ if Version.match?(System.version(), ">= 1.13.0") do
       )
     end
 
+    test "respect nesting of children when phx-no-format is present" do
+      assert_formatter_doesnt_change(
+        """
+        <ul class="root" phx-no-format><!-- comment
+        --><%= for user <- @users do %>
+            <li class="list">
+              <div class="child1">
+                <span class="child2">text</span>
+              </div>
+            </li>
+          <% end %><!-- comment
+        --></ul>
+        """,
+        line_length: 100
+      )
+    end
+
     # TODO: Remove this `if` after Elixir versions before than 1.14 are no
     # longer supported.
     if function_exported?(EEx, :tokenize, 2) do


### PR DESCRIPTION
Without this change the example on test is rendered as:

```
<ul class="root" phx-no-format><!-- comment
--><%= for user <- @users do %>
    <li
  class="list"
>
      <div class="child1">
        <span class="child2">text</span>
      </div>
    </li>
  <% end %><!-- comment
--></ul>
```

Note how the `li` attrs gets pushed back even though there's still room on the line (limited to 100). I believe that's because the current code does not reset nesting when the `context` is `:preserve`, which is done only when `meta` is set to `preserve`. So seems like when either context or meta is set to `preserve` it could reset nesting to generate a nicer output.