### PR TITLE
Fix inline elements without whitespaces among them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Bug fixes
   - [Formatter] Preserve single quote delimiter on attrs
-  - [Formatter] Fix inline elements surrounded by texts without whitespaces
+  - [Formatter] Do not format inline elements surrounded by texts without whitespaces
   - [Formatter] Keep text and eex along when there isn't a whitespace
   - [Formatter] Fix intentional line breaks after eex expressions
   - [Formatter] Handle self close tags as inline
+  - [Formatter] Do not format inline elements without whitespaces among them
+  - [Formatter] Do not format when attr contenteditable is present
 
+### Enhancements
+  - [Formatter] Introduce special attr phx-no-format to skip formatting
 
 ## 0.17.9 (2022-04-07)
 

--- a/lib/phoenix_live_view/html_algebra.ex
+++ b/lib/phoenix_live_view/html_algebra.ex
@@ -38,6 +38,13 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
       |> maybe_force_unfit()
 
     Enum.reduce(tail, {head, type, doc}, fn next_node, {prev_node, prev_type, prev_doc} ->
+      context =
+        if inline?(prev_node) and inline?(next_node) do
+          %{context | mode: :preserve}
+        else
+          context
+        end
+
       {next_type, next_doc} =
         next_node
         |> to_algebra(context)
@@ -423,4 +430,7 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
   defp remove_indentation(<<?\t, rest::binary>>, indent), do: remove_indentation(rest, indent - 2)
   defp remove_indentation(<<?\s, rest::binary>>, indent), do: remove_indentation(rest, indent - 1)
   defp remove_indentation(rest, _indent), do: rest
+
+  defp inline?({:tag_block, _, _, _, %{mode: :inline}}), do: true
+  defp inline?(_), do: false
 end

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -1313,6 +1313,33 @@ if Version.match?(System.version(), ">= 1.13.0") do
       )
     end
 
+    test "preserve inline element when there aren't whitespaces" do
+      assert_formatter_doesnt_change(
+        """
+        <b>foo</b><i><span>bar</span></i><span>baz</span>
+        """,
+        line_length: 20
+      )
+
+      assert_formatter_output(
+        """
+        <b>Foo</b><i>bar</i> <span>baz</span>
+        """,
+        """
+        <b>Foo</b><i>bar</i>
+        <span>baz</span>
+        """,
+        line_length: 20
+      )
+
+      assert_formatter_doesnt_change(
+        """
+        <b>foo</b><i>bar</i><%= @user.name %><span>baz</span>
+        """,
+        line_length: 20
+      )
+    end
+
     test "preserve inline element on the same line when followed by a eex expression without whitespaces" do
       assert_formatter_doesnt_change(
         """

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -1338,6 +1338,26 @@ if Version.match?(System.version(), ">= 1.13.0") do
         """,
         line_length: 20
       )
+
+      assert_formatter_output(
+        """
+        <b>foo</b><i><span id="myspan" class="a long list of classes">bar</span></i><span>baz</span>
+        """,
+        """
+        <b>foo</b><i><span
+          id="myspan"
+          class="a long list of classes"
+        >bar</span></i><span>baz</span>
+        """,
+        line_length: 20
+      )
+
+      assert_formatter_doesnt_change(
+        """
+        <b>foo</b><i><span><div>bar</div></span></i><span>baz</span>
+        """,
+        line_length: 20
+      )
     end
 
     test "preserve inline element on the same line when followed by a eex expression without whitespaces" do


### PR DESCRIPTION
We should also preserve the format in case there aren't whitespaces
among inline elments.

```
<b>foo</b><i><span>bar</span></i><span>baz</span>
```