### PR TITLE
HTMLFormatter - keep inline element if starts with \n

### DIFF
--- a/lib/phoenix_live_view/html_formatter.ex
+++ b/lib/phoenix_live_view/html_formatter.ex
@@ -543,7 +543,7 @@ defmodule Phoenix.LiveView.HTMLFormatter do
   defp may_set_preserve([{:tag_block, name, attrs, block, meta} | list], text)
        when name in @inline_elements do
     mode =
-      if String.trim_leading(text) != "" and :binary.first(text) not in '\s\t' do
+      if String.trim_leading(text) != "" and :binary.first(text) not in '\s\t\n' do
         :preserve
       else
         meta.mode

--- a/lib/phoenix_live_view/html_formatter.ex
+++ b/lib/phoenix_live_view/html_formatter.ex
@@ -543,7 +543,7 @@ defmodule Phoenix.LiveView.HTMLFormatter do
   defp may_set_preserve([{:tag_block, name, attrs, block, meta} | list], text)
        when name in @inline_elements do
     mode =
-      if String.trim_leading(text) != "" and :binary.first(text) not in '\s\t\n' do
+      if String.trim_leading(text) != "" and :binary.first(text) not in '\s\t\n\r' do
         :preserve
       else
         meta.mode

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -1311,6 +1311,16 @@ if Version.match?(System.version(), ">= 1.13.0") do
         """,
         line_length: 50
       )
+
+      assert_formatter_doesnt_change(
+        """
+        <p>
+          long line of text <span>span 1</span>
+          more text <span>span 2</span>
+        </p>
+        """,
+        line_length: 45
+      )
     end
 
     test "preserve inline element when there aren't whitespaces" do


### PR DESCRIPTION
The formatter is correctly breaking inline elements into new lines if it doesn't fit into a single line:

```
iex> input = """
...> <p>long line of text <span>span 1</span> more text <span>span 2</span></p>
...> """

iex> IO.puts Phoenix.LiveView.HTMLFormatter.format input, line_length: 45
<p>
  long line of text <span>span 1</span>
  more text <span>span 2</span>
</p>
```

So one would expect that running the formatter again on that formatted template would not change the outcome, but that's not the case:

```
iex> input = """
...> <p>
...>   long line of text <span>span 1</span>
...>   more text <span>span 2</span>
...> </p>
...> """

iex> IO.puts Phoenix.LiveView.HTMLFormatter.format input, line_length: 45
<p>
  long line of text
  <span>span 1</span> more text
  <span>span 2</span>
</p>
```

Which seems like shouldn't not happen as the line `   long line of text <span>span 1</span>` fits into length 45, and I believe the issue is on the logic to set `:preserve`.