### PR TITLE
Documentation: add note about possibility of key events being triggered with no key field present

### DIFF
--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -125,6 +125,11 @@ available options can be found on
 [MDN](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values)
 or via the [Key Event Viewer](https://w3c.github.io/uievents/tools/key-event-viewer.html).
 
+Note: it is possible for certain browser features like autofill to trigger key events
+with no `"key"` field present in the value map sent to the server. For this reason, we
+strongly recommend always having a fallback catch-all `_value` event handler for any
+LiveView key event binding.
+
 By default, the bound element will be the event listener, but a
 window-level binding may be provided via `phx-window-keydown` or `phx-window-keyup`,
 for example:
@@ -147,7 +152,7 @@ for example:
       {:noreply, assign(socket, :temperature, new_temp)}
     end
 
-    def handle_event("update_temp", _key, socket) do
+    def handle_event("update_temp", _value, socket) do
       {:noreply, socket}
     end
 

--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -150,7 +150,7 @@ for example:
       {:noreply, assign(socket, :temperature, new_temp)}
     end
 
-    def handle_event("update_temp", _value, socket) do
+    def handle_event("update_temp", _, socket) do
       {:noreply, socket}
     end
 

--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -125,11 +125,9 @@ available options can be found on
 [MDN](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values)
 or via the [Key Event Viewer](https://w3c.github.io/uievents/tools/key-event-viewer.html).
 
-Note: it is possible for certain browser features like autofill to trigger key events
+*Note*: it is possible for certain browser features like autofill to trigger key events
 with no `"key"` field present in the value map sent to the server. For this reason, we
-strongly recommend always having a fallback catch-all `_value` event handler for any
-LiveView key event binding.
-
+recommend always having a fallback catch-all event handler for LiveView key bindings.
 By default, the bound element will be the event listener, but a
 window-level binding may be provided via `phx-window-keydown` or `phx-window-keyup`,
 for example:


### PR DESCRIPTION
Hi folks!

Wanted to propose a small documentation addition to convey that it is possible for key events to be triggered without the `key` field present in the value map sent to the server.

The code sample provided already covers this possibility with the catchall pattern match clause at the end, but wanted to explicitly state it since the current documentation makes it sound like there will always be a `key` field available to check.

I just ran into this issue personally so guessing others might too!

This may be a good use-case for an admonition block, LMK, happy to add/tweak wording.

Thanks so much for making LiveView & for taking the time to review!