### PR TITLE
Provide new assigns to fn in assign_new

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -768,6 +768,13 @@ defmodule Phoenix.LiveView do
     end
   end
 
+  def assign_new(%{__changed__: changed} = assigns, key, fun) when is_function(fun, 0) do
+    case assigns do
+      %{^key => _} -> assigns
+      %{} -> Phoenix.LiveView.Utils.force_assign(assigns, changed, key, fun.())
+    end
+  end
+
   def assign_new(assigns, _key, fun) when is_function(fun, 0) do
     raise_bad_socket_or_assign!("assign_new/3", assigns)
   end

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -741,9 +741,10 @@ defmodule Phoenix.LiveView do
   as above, the assign will be fetched from the parent LiveView, once again
   avoiding additional database queries.
 
-  assign_new also provides asscess to the new assigns in the fn:
+  Note that `fun` also provides access to the previously assigned values:
 
-      assigns = assigns
+      assigns =
+          assigns
           |> assign_new(:foo, fn -> "foo")
           |> assign_new(:bar, fn %{foo: foo} -> foo <> "bar")
   '''

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -740,6 +740,12 @@ defmodule Phoenix.LiveView do
   also uses `assign_new/3` to fetch the `:current_user` in its `mount/3` callback,
   as above, the assign will be fetched from the parent LiveView, once again
   avoiding additional database queries.
+
+  assign_new also provides asscess to the new assigns in the fn when using an assigns:
+
+      assigns = assigns
+          |> assign_new(:foo, fn _ -> "foo")
+          |> assign_new(:bar, fn %{foo: foo} -> foo <> "bar")
   '''
   def assign_new(socket_or_assigns, key, fun)
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -745,8 +745,8 @@ defmodule Phoenix.LiveView do
 
       assigns =
           assigns
-          |> assign_new(:foo, fn -> "foo")
-          |> assign_new(:bar, fn %{foo: foo} -> foo <> "bar")
+          |> assign_new(:foo, fn -> "foo" end)
+          |> assign_new(:bar, fn %{foo: foo} -> foo <> "bar" end)
   '''
   def assign_new(socket_or_assigns, key, fun)
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -749,6 +749,29 @@ defmodule Phoenix.LiveView do
   '''
   def assign_new(socket_or_assigns, key, fun)
 
+  def assign_new(%Socket{} = socket, key, fun) when is_function(fun, 1) do
+    validate_assign_key!(key)
+
+    case socket do
+      %{assigns: %{^key => _}} ->
+        socket
+
+      %{private: %{assign_new: {assigns, keys}}} ->
+        # It is important to store the keys even if they are not in assigns
+        # because maybe the controller doesn't have it but the view does.
+        socket = put_in(socket.private.assign_new, {assigns, [key | keys]})
+
+        Phoenix.LiveView.Utils.force_assign(
+          socket,
+          key,
+          Map.get_lazy(assigns, key, fn -> fun.(socket.assigns) end)
+        )
+
+      %{assigns: assigns} ->
+        Phoenix.LiveView.Utils.force_assign(socket, key, fun.(assigns))
+    end
+  end
+
   def assign_new(%Socket{} = socket, key, fun) when is_function(fun, 0) do
     validate_assign_key!(key)
 
@@ -781,7 +804,7 @@ defmodule Phoenix.LiveView do
     end
   end
 
-  def assign_new(assigns, _key, fun) when is_function(fun, 0) do
+  def assign_new(assigns, _key, fun) when is_function(fun, 0) or is_function(fun, 1) do
     raise_bad_socket_or_assign!("assign_new/3", assigns)
   end
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -741,10 +741,10 @@ defmodule Phoenix.LiveView do
   as above, the assign will be fetched from the parent LiveView, once again
   avoiding additional database queries.
 
-  assign_new also provides asscess to the new assigns in the fn when using an assigns:
+  assign_new also provides asscess to the new assigns in the fn:
 
       assigns = assigns
-          |> assign_new(:foo, fn _ -> "foo")
+          |> assign_new(:foo, fn -> "foo")
           |> assign_new(:bar, fn %{foo: foo} -> foo <> "bar")
   '''
   def assign_new(socket_or_assigns, key, fun)

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -762,16 +762,15 @@ defmodule Phoenix.LiveView do
         # because maybe the controller doesn't have it but the view does.
         socket = put_in(socket.private.assign_new, {assigns, [key | keys]})
 
-        # take only public assigns from `socket.assigns`
-        new_assigns =
-          socket.assigns
-          |> Map.take(Map.keys(socket.assigns.__changed__))
-          |> Map.merge(assigns)
 
         Phoenix.LiveView.Utils.force_assign(
           socket,
           key,
-          Map.get_lazy(assigns, key, fn -> fun.(new_assigns) end)
+          case assigns do
+            %{^key => value} -> value
+            %{} -> fun.(socket.assigns)
+          end
+        )
         )
 
       %{assigns: assigns} ->

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -761,10 +761,16 @@ defmodule Phoenix.LiveView do
         # because maybe the controller doesn't have it but the view does.
         socket = put_in(socket.private.assign_new, {assigns, [key | keys]})
 
+        # take only public assigns from `socket.assigns`
+        new_assigns =
+          socket.assigns
+          |> Map.take(Map.keys(socket.assigns.__changed__))
+          |> Map.merge(assigns)
+
         Phoenix.LiveView.Utils.force_assign(
           socket,
           key,
-          Map.get_lazy(assigns, key, fn -> fun.(socket.assigns) end)
+          Map.get_lazy(assigns, key, fn -> fun.(new_assigns) end)
         )
 
       %{assigns: assigns} ->

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -762,7 +762,6 @@ defmodule Phoenix.LiveView do
         # because maybe the controller doesn't have it but the view does.
         socket = put_in(socket.private.assign_new, {assigns, [key | keys]})
 
-
         Phoenix.LiveView.Utils.force_assign(
           socket,
           key,
@@ -770,7 +769,6 @@ defmodule Phoenix.LiveView do
             %{^key => value} -> value
             %{} -> fun.(socket.assigns)
           end
-        )
         )
 
       %{assigns: assigns} ->

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -761,10 +761,10 @@ defmodule Phoenix.LiveView do
     end
   end
 
-  def assign_new(%{__changed__: changed} = assigns, key, fun) when is_function(fun, 0) do
+  def assign_new(%{__changed__: changed} = assigns, key, fun) when is_function(fun, 1) do
     case assigns do
       %{^key => _} -> assigns
-      %{} -> Phoenix.LiveView.Utils.force_assign(assigns, changed, key, fun.())
+      %{} -> Phoenix.LiveView.Utils.force_assign(assigns, changed, key, fun.(assigns))
     end
   end
 

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -11,7 +11,7 @@ defmodule Phoenix.ComponentTest do
 
   describe "rendering" do
     defp hello(assigns) do
-      assigns = assign_new(assigns, :name, fn -> "World" end)
+      assigns = assign_new(assigns, :name, fn _ -> "World" end)
       ~H"""
       Hello <%= @name %>
       """

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -11,7 +11,7 @@ defmodule Phoenix.ComponentTest do
 
   describe "rendering" do
     defp hello(assigns) do
-      assigns = assign_new(assigns, :name, fn _ -> "World" end)
+      assigns = assign_new(assigns, :name, fn -> "World" end)
       ~H"""
       Hello <%= @name %>
       """

--- a/test/phoenix_live_view_test.exs
+++ b/test/phoenix_live_view_test.exs
@@ -295,23 +295,23 @@ defmodule Phoenix.LiveViewUnitTest do
 
   describe "assign_new with assigns" do
     test "tracks changes" do
-      assigns = assign_new(@assigns_changes, :key, fn _ -> raise "won't be invoked" end)
+      assigns = assign_new(@assigns_changes, :key, fn -> raise "won't be invoked" end)
       assert assigns.key == "value"
       refute changed?(assigns, :key)
       refute assigns.__changed__[:key]
 
-      assigns = assign_new(@assigns_changes, :another, fn _ -> "changed" end)
+      assigns = assign_new(@assigns_changes, :another, fn -> "changed" end)
       assert assigns.another == "changed"
       assert changed?(assigns, :another)
 
-      assigns = assign_new(@assigns_nil_changes, :another, fn _ -> "changed" end)
+      assigns = assign_new(@assigns_nil_changes, :another, fn -> "changed" end)
       assert assigns.another == "changed"
       assert changed?(assigns, :another)
       assert assigns.__changed__ == nil
     end
 
     test "has access to new assigns" do
-      assigns = assign_new(@assigns_changes, :another, fn _ -> "changed" end)
+      assigns = assign_new(@assigns_changes, :another, fn -> "changed" end)
       |> assign_new(:and_another, fn %{another: another} -> another end)
 
       assert assigns.and_another == "changed"

--- a/test/phoenix_live_view_test.exs
+++ b/test/phoenix_live_view_test.exs
@@ -295,19 +295,28 @@ defmodule Phoenix.LiveViewUnitTest do
 
   describe "assign_new with assigns" do
     test "tracks changes" do
-      assigns = assign_new(@assigns_changes, :key, fn -> raise "won't be invoked" end)
+      assigns = assign_new(@assigns_changes, :key, fn _ -> raise "won't be invoked" end)
       assert assigns.key == "value"
       refute changed?(assigns, :key)
       refute assigns.__changed__[:key]
 
-      assigns = assign_new(@assigns_changes, :another, fn -> "changed" end)
+      assigns = assign_new(@assigns_changes, :another, fn _ -> "changed" end)
       assert assigns.another == "changed"
       assert changed?(assigns, :another)
 
-      assigns = assign_new(@assigns_nil_changes, :another, fn -> "changed" end)
+      assigns = assign_new(@assigns_nil_changes, :another, fn _ -> "changed" end)
       assert assigns.another == "changed"
       assert changed?(assigns, :another)
       assert assigns.__changed__ == nil
+    end
+
+    test "has access to new assigns" do
+      assigns = assign_new(@assigns_changes, :another, fn _ -> "changed" end)
+      |> assign_new(:and_another, fn %{another: another} -> another end)
+
+      assert assigns.and_another == "changed"
+      assert changed?(assigns, :another)
+      assert changed?(assigns, :and_another)
     end
   end
 

--- a/test/phoenix_live_view_test.exs
+++ b/test/phoenix_live_view_test.exs
@@ -291,6 +291,34 @@ defmodule Phoenix.LiveViewUnitTest do
                __changed__: %{existing: true, notexisting: true, existing2: true}
              }
     end
+
+    test "has access to assigns" do
+      socket =
+        put_in(@socket.private[:assign_new], {%{existing: "existing-parent"}, []})
+        |> assign(existing2: "existing2")
+        |> assign_new(:existing, fn _ -> "new-existing" end)
+        |> assign_new(:existing2, fn _ -> "new-existing2" end)
+        |> assign_new(:notexisting, fn %{existing: existing} -> existing end)
+        |> assign_new(:notexisting2, fn %{existing2: existing2} -> existing2 end)
+        |> assign_new(:notexisting3, fn %{notexisting: notexisting} -> notexisting end)
+
+      assert socket.assigns == %{
+               existing: "existing-parent",
+               existing2: "existing2",
+               notexisting: "existing-parent",
+               notexisting2: "existing2",
+               notexisting3: "existing-parent",
+               live_action: nil,
+               flash: %{},
+               __changed__: %{
+                 existing: true,
+                 existing2: true,
+                 notexisting: true,
+                 notexisting2: true,
+                 notexisting3: true
+               }
+             }
+    end
   end
 
   describe "assign_new with assigns" do


### PR DESCRIPTION
Would like input. 🙏
The idea is simply to provide access to the new assigns in the fn of assign_new 

Example. 
```
assigns = assigns
        |> assign_new(:foo, fn  -> "foo")
        |> assign_new(:bar, fn %{foo: foo} -> foo <> "bar")
```