### PR TITLE
Exclude live_action and live_module in assigns_to_attributes

### DIFF
--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -230,7 +230,7 @@ defmodule Phoenix.LiveView.Helpers do
   do not belong in the markup, or are already handled explicitly by the component.
   '''
   def assigns_to_attributes(assigns, exclude \\ []) do
-    excluded_keys = [:__changed__, :__slot__, :inner_block, :myself, :flash, :socket] ++ exclude
+    excluded_keys = [:__changed__, :__slot__, :inner_block, :myself, :flash, :socket, :live_action, :live_module] ++ exclude
     for {key, val} <- assigns, key not in excluded_keys, into: [], do: {key, val}
   end
 

--- a/test/phoenix_live_view/helpers_test.exs
+++ b/test/phoenix_live_view/helpers_test.exs
@@ -239,5 +239,7 @@ defmodule Phoenix.LiveView.HelpersTest do
     assert assigns_to_attributes(%{__changed__: %{}, one: 1, two: 2}, [:one]) == [two: 2]
     assert assigns_to_attributes(%{__changed__: %{}, inner_block: fn -> :ok end, a: 1}) == [a: 1]
     assert assigns_to_attributes(%{__slot__: :foo, inner_block: fn -> :ok end, a: 1}) == [a: 1]
+    assert assigns_to_attributes(%{live_action: :action, one: 1, two: 2}, [:one]) == [two: 2]
+    assert assigns_to_attributes(%{live_module: :module, one: 1, two: 2}, [:one]) == [two: 2]
   end
 end


### PR DESCRIPTION
Would you consider this change? Both keys are reserved and that function is useful for https://github.com/phoenixframework/phoenix_live_view/pull/1997 and https://github.com/phoenixframework/phoenix_live_view/pull/1999, see https://github.com/phoenixframework/phoenix_live_view/pull/1999#discussion_r862013992

Of course one can pass additional keys to `exclude` but It may be worth adding `live_action` and `live_module`.