### PR TITLE
HTMLFormatter - Improve inline and eex tags break

### DIFF
--- a/lib/phoenix_live_view/html_algebra.ex
+++ b/lib/phoenix_live_view/html_algebra.ex
@@ -91,10 +91,10 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
 
   defp inline_break(head_node, prev_node, next_node) do
     cond do
-      is_text_node?(head_node) and is_eex_node?(prev_node) and text_starts_with_space?(next_node) ->
+      is_eex_node?(prev_node) and is_text_node?(head_node) and text_starts_with_space?(next_node) ->
         " "
 
-      text_ends_with_space?(prev_node) and is_eex_node?(next_node) ->
+      is_eex_node?(next_node) and text_ends_with_space?(prev_node) ->
         " "
 
       text_ends_with_space?(prev_node) or text_starts_with_space?(next_node) ->
@@ -117,7 +117,7 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
 
   defp text_ends_with_space?(_node), do: false
 
-  defp is_text_node?({:text, _expr, _meta}), do: true
+  defp is_text_node?({:text, _text, _meta}), do: true
   defp is_text_node?(_node), do: false
 
   defp is_eex_node?({:eex, _expr, _meta}), do: true

--- a/lib/phoenix_live_view/html_algebra.ex
+++ b/lib/phoenix_live_view/html_algebra.ex
@@ -91,10 +91,11 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
 
   defp inline_break(head_node, prev_node, next_node) do
     cond do
-      is_eex_node?(prev_node) and is_text_node?(head_node) and text_starts_with_space?(next_node) ->
+      tag_inline?(prev_node) and is_text_node?(head_node) and
+          text_starts_with_space?(next_node) ->
         " "
 
-      is_eex_node?(next_node) and text_ends_with_space?(prev_node) ->
+      (block_preserve?(next_node) or tag_inline?(next_node)) and text_ends_with_space?(prev_node) ->
         " "
 
       text_ends_with_space?(prev_node) or text_starts_with_space?(next_node) ->
@@ -120,8 +121,11 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
   defp is_text_node?({:text, _text, _meta}), do: true
   defp is_text_node?(_node), do: false
 
-  defp is_eex_node?({:eex, _expr, _meta}), do: true
-  defp is_eex_node?(_node), do: false
+  defp tag_inline?({_, _, %{mode: :inline}}), do: true
+  defp tag_inline?(_node), do: false
+
+  defp block_preserve?({:tag_block, _, _, _, %{mode: :preserve}}), do: true
+  defp block_preserve?(_node), do: false
 
   defp to_algebra({:html_comment, block}, context) do
     children = block_to_algebra(block, %{context | mode: :preserve})

--- a/lib/phoenix_live_view/html_formatter.ex
+++ b/lib/phoenix_live_view/html_formatter.ex
@@ -495,7 +495,6 @@ defmodule Phoenix.LiveView.HTMLFormatter do
   end
 
   defp to_tree([{:eex, _type, expr, meta} | tokens], buffer, stack) do
-    meta = Map.put(meta, :mode, :inline)
     to_tree(tokens, [{:eex, expr, meta} | buffer], stack)
   end
 

--- a/lib/phoenix_live_view/html_formatter.ex
+++ b/lib/phoenix_live_view/html_formatter.ex
@@ -495,6 +495,7 @@ defmodule Phoenix.LiveView.HTMLFormatter do
   end
 
   defp to_tree([{:eex, _type, expr, meta} | tokens], buffer, stack) do
+    meta = Map.put(meta, :mode, :inline)
     to_tree(tokens, [{:eex, expr, meta} | buffer], stack)
   end
 

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -111,6 +111,19 @@ if Version.match?(System.version(), ">= 1.13.0") do
         """,
         line_length: 20
       )
+
+      assert_formatter_output(
+        """
+        <p>first<%= @name %> second<div>block</div></p>
+        """,
+        """
+        <p>
+          first<%= @name %> second
+          <div>block</div>
+        </p>
+        """,
+        line_length: 20
+      )
     end
 
     test "remove unwanted empty lines" do

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -97,7 +97,7 @@ if Version.match?(System.version(), ">= 1.13.0") do
           first <%= @name %>second
         </p>
         """,
-        line_length: 20
+        line_length: 10
       )
 
       assert_formatter_output(
@@ -111,18 +111,31 @@ if Version.match?(System.version(), ">= 1.13.0") do
         """,
         line_length: 20
       )
+    end
 
+    test "do not break between inline tags when there is no space before or after" do
       assert_formatter_output(
         """
-        <p>first<%= @name %> second<div>block</div></p>
+        <p>first <span>name</span>second</p>
         """,
         """
         <p>
-          first<%= @name %> second
-          <div>block</div>
+          first <span>name</span>second
         </p>
         """,
-        line_length: 20
+        line_length: 10
+      )
+
+      assert_formatter_output(
+        """
+        <p>first<span>name</span> second</p>
+        """,
+        """
+        <p>
+          first<span>name</span> second
+        </p>
+        """,
+        line_length: 40
       )
     end
 
@@ -156,7 +169,7 @@ if Version.match?(System.version(), ">= 1.13.0") do
     test "texts with inline elements and block elements" do
       input = """
       <div>
-        Long long long loooooooooooong text: <i>...</i>.
+        Long long long loooooooooooong text: <i>...</i>
         <ul>
           <li>Item 1</li>
           <li>Item 2</li>
@@ -168,7 +181,7 @@ if Version.match?(System.version(), ">= 1.13.0") do
       expected = """
       <div>
         Long long long loooooooooooong text:
-        <i>...</i>.
+        <i>...</i>
         <ul>
           <li>Item 1</li>
           <li>Item 2</li>
@@ -1300,18 +1313,17 @@ if Version.match?(System.version(), ">= 1.13.0") do
       assert_formatter_output(
         """
         <p>
-          text text <a class="text-blue-500" href="" target="_blank" attr1="">link</a>text.
+          first first <a class="text-blue-500" href="" target="_blank" attr1="">link</a>second.
         </p>
         """,
         """
         <p>
-          text text
-          <a
+          first first <a
             class="text-blue-500"
             href=""
             target="_blank"
             attr1=""
-          >link</a>text.
+          >link</a>second.
         </p>
         """,
         line_length: 50

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -458,7 +458,7 @@ if Version.match?(System.version(), ">= 1.13.0") do
       )
     end
 
-    test "long lines with inline and eex tags" do
+    test "lines with inline or eex tags" do
       assert_formatter_output(
         """
           <p><span>this is a long long long long long looooooong text</span> <%= @product.value %> and more stuff over here</p>

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -87,6 +87,32 @@ if Version.match?(System.version(), ">= 1.13.0") do
       assert_formatter_doesnt_change(input)
     end
 
+    test "do not break between eex tags when there is no space before or after" do
+      assert_formatter_output(
+        """
+        <p>first <%= @name %>second</p>
+        """,
+        """
+        <p>
+          first <%= @name %>second
+        </p>
+        """,
+        line_length: 20
+      )
+
+      assert_formatter_output(
+        """
+        <p>first<%= @name %> second</p>
+        """,
+        """
+        <p>
+          first<%= @name %> second
+        </p>
+        """,
+        line_length: 20
+      )
+    end
+
     test "remove unwanted empty lines" do
       input = """
       <section>
@@ -743,13 +769,6 @@ if Version.match?(System.version(), ">= 1.13.0") do
 
     test "keep intentional line breaks" do
       assert_formatter_doesnt_change("""
-      <div>
-        Should not <%= "line break" %>.
-        But it does.
-      </div>
-      """)
-
-      assert_formatter_doesnt_change("""
       <section>
         <h1>
           <b>
@@ -1220,19 +1239,11 @@ if Version.match?(System.version(), ">= 1.13.0") do
       </div>
       """)
 
-      assert_formatter_output(
-        """
-        <div>
-          _______________________________________________________ result <%= if(@row_count != 1, do: "s") %>
-        </div>
-        """,
-        """
-        <div>
-          _______________________________________________________ result
-          <%= if(@row_count != 1, do: "s") %>
-        </div>
-        """
-      )
+      assert_formatter_doesnt_change("""
+      <div>
+        _______________________________________________________ result <%= if(@row_count != 1, do: "s") %>
+      </div>
+      """)
     end
 
     test "keep single quote delimiter when value has quotes" do

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -458,17 +458,32 @@ if Version.match?(System.version(), ">= 1.13.0") do
       )
     end
 
-    test "format long lines splitting into multiple lines" do
+    test "long lines with inline and eex tags" do
       assert_formatter_output(
         """
           <p><span>this is a long long long long long looooooong text</span> <%= @product.value %> and more stuff over here</p>
         """,
         """
         <p>
-          <span>this is a long long long long long looooooong text</span> <%= @product.value %>
-          and more stuff over here
+          <span>this is a long long long long long looooooong text</span> <%= @product.value %> and more stuff over here
         </p>
         """
+      )
+
+      assert_formatter_output(
+        """
+        <p>first <span>name</span> second</p>
+        """,
+        """
+        <p>
+          first
+          <span>
+            name
+          </span>
+          second
+        </p>
+        """,
+        line_length: 10
       )
     end
 


### PR DESCRIPTION
That's an attempt to improve and close #2001 
Ref https://github.com/phoenixframework/phoenix_live_view/issues/2001#issuecomment-1113645932

I had to fine tune the inline break rules a bit to deal with all possible cases, and we can add more tests if you have other edge cases in mind.

/cc @feliperenan thanks for commenting about that `flex_break`