### PR TITLE
Add `on_mount` examples to Gettext docs

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -246,7 +246,7 @@ The change is to define the `live_view` and `live_component` functions in your `
     quote do
       use Phoenix.View,
         root: "lib/<%= lib_web_name %>/templates",
-        namespace: <%= web_namespace %>
+        namespace: MyAppWeb
 
       # Import convenience functions from controllers
       import Phoenix.Controller,
@@ -260,7 +260,7 @@ The change is to define the `live_view` and `live_component` functions in your `
   def live_view do
     quote do
       use Phoenix.LiveView,
-        layout: {<%= web_namespace %>.LayoutView, "live.html"}
+        layout: {MyAppWeb.LayoutView, "live.html"}
 
       unquote(view_helpers())
     end
@@ -296,7 +296,7 @@ Note that LiveViews are automatically configured to use a "live.html.heex" layou
 
 ```elixir
 use Phoenix.LiveView,
-  layout: {<%= web_namespace %>.LayoutView, "live.html"}
+  layout: {MyAppWeb.LayoutView, "live.html"}
 ```
 
 "layouts/root.html.heex" is shared by regular and live views, "app.html.heex" is rendered inside the root layout for regular views, and "live.html.heex" is rendered inside the root layout for LiveViews. "live.html.heex" typically starts out as a copy of "app.html.heex", but using the `@socket` assign instead of `@conn`. Check the [Live Layouts](live-layouts.md) guide for more information.

--- a/guides/server/security-model.md
+++ b/guides/server/security-model.md
@@ -99,7 +99,7 @@ to run it on all LiveViews by default:
     def live_view do
       quote do
         use Phoenix.LiveView,
-          layout: {<%= web_namespace %>.LayoutView, "live.html"}
+          layout: {MyAppWeb.LayoutView, "live.html"}
 
         on_mount MyAppWeb.UserLiveAuth
         unquote(view_helpers())

--- a/guides/server/using-gettext.md
+++ b/guides/server/using-gettext.md
@@ -20,3 +20,28 @@ Then in your LiveView `mount/3`, you can restore the locale:
       Gettext.put_locale(MyApp.Gettext, locale)
       {:ok, socket}
     end
+
+You can also use the `on_mount` (`Phoenix.LiveView.on_mount/1`) hook to
+automatically restore the locale for every LiveView in your application:
+
+    defmodule MyAppWeb.RestoreLocale do
+      import Phoenix.LiveView
+
+      def on_mount(:default, params, %{"locale" => locale} = _session, socket) do
+        Gettext.put_locale(MyApp.Gettext, locale)
+        {:cont, socket}
+      end
+    end
+
+Then, add this hook to `def live_view` under `MyAppWeb`, to run it on all
+LiveViews by default:
+
+    def live_view do
+      quote do
+        use Phoenix.LiveView,
+          layout: {MyAppWeb.LayoutView, "live.html"}
+
+        on_mount MyAppWeb.RestoreLocale
+        unquote(view_helpers())
+      end
+    end

--- a/guides/server/using-gettext.md
+++ b/guides/server/using-gettext.md
@@ -27,10 +27,13 @@ automatically restore the locale for every LiveView in your application:
     defmodule MyAppWeb.RestoreLocale do
       import Phoenix.LiveView
 
-      def on_mount(:default, params, %{"locale" => locale} = _session, socket) do
+      def on_mount(:default, _params, %{"locale" => locale} = _session, socket) do
         Gettext.put_locale(MyApp.Gettext, locale)
         {:cont, socket}
       end
+
+      # for any logged out routes
+      def on_mount(:default, _params, _session, socket), do: {:cont, socket}
     end
 
 Then, add this hook to `def live_view` under `MyAppWeb`, to run it on all


### PR DESCRIPTION
Since setting the locale on a LiveView is something that will commonly need to be done for every LiveView in an application, I've added examples to the Gettext docs using the `on_mount` hook to apply the locale.

I've also replaced all the instances of `<%= web_namespace %>` in the doc examples with `MyAppWeb`, to be a bit more consistent with the rest of the documentation.

Please let me know if you have any suggestions. Thank you!