### PR TITLE
HTMLFormatter - text between inline elements

### DIFF
--- a/lib/phoenix_live_view/html_algebra.ex
+++ b/lib/phoenix_live_view/html_algebra.ex
@@ -98,8 +98,7 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
             ""
         end
 
-      inline?(prev_node) and text_starts_with_line_break?(next_node) and
-          text_ends_with_line_break?(next_node) ->
+      text_starts_with_line_break?(next_node) and text_ends_with_line_break?(next_node) ->
         break(" ")
 
       text_ends_with_space?(prev_node) or text_starts_with_space?(next_node) ->

--- a/lib/phoenix_live_view/html_algebra.ex
+++ b/lib/phoenix_live_view/html_algebra.ex
@@ -87,9 +87,20 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
   defp inline_break(prev_node, next_node) do
     cond do
       block_preserve?(prev_node) or block_preserve?(next_node) ->
-        if text_ends_with_space?(prev_node) or text_starts_with_space?(next_node),
-          do: " ",
-          else: ""
+        cond do
+          text_ends_with_line_break?(prev_node) ->
+            flex_break(" ")
+
+          text_ends_with_space?(prev_node) or text_starts_with_space?(next_node) ->
+            " "
+
+          true ->
+            ""
+        end
+
+      inline?(prev_node) and text_starts_with_line_break?(next_node) and
+          text_ends_with_line_break?(next_node) ->
+        break(" ")
 
       text_ends_with_space?(prev_node) or text_starts_with_space?(next_node) ->
         flex_break(" ")
@@ -110,6 +121,16 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
     do: :binary.last(text) in @codepoints
 
   defp text_ends_with_space?(_node), do: false
+
+  defp text_starts_with_line_break?({:text, text, _meta}) when text != "",
+    do: :binary.first(text) in '\n\r'
+
+  defp text_starts_with_line_break?(_node), do: false
+
+  defp text_ends_with_line_break?({:text, text, _meta}) when text != "",
+    do: :binary.last(text) in '\n\r'
+
+  defp text_ends_with_line_break?(_node), do: false
 
   defp block_preserve?({:tag_block, _, _, _, %{mode: :preserve}}), do: true
   defp block_preserve?({:eex, _, _}), do: true


### PR DESCRIPTION
An attempt to fix #2008

The core issue with those examples is they get into an "incomplete" state on the first format, causing `mix format --check-formatted` to fail. A couple of examples on master:

```
iex> input = """
...> <span><%= link("Edit", to: Routes.post_path(@conn, :edit, @post)) %></span> |
...> <span><%= link("Back", to: Routes.post_path(@conn, :index)) %></span>
...> """

iex> IO.puts formatted = Phoenix.LiveView.HTMLFormatter.format(input, [])
<span><%= link("Edit", to: Routes.post_path(@conn, :edit, @post)) %></span>
| <span><%= link("Back", to: Routes.post_path(@conn, :index)) %></span>

iex> IO.puts Phoenix.LiveView.HTMLFormatter.format(formatted, [])
<span><%= link("Edit", to: Routes.post_path(@conn, :edit, @post)) %></span> |
<span><%= link("Back", to: Routes.post_path(@conn, :index)) %></span>
```

```
iex> input = """
...> <span><%= @user_a %></span> X <span><%= @user_b %></span>
...> """

iex> IO.puts formatted = Phoenix.LiveView.HTMLFormatter.format(input, [line_length: 5])
<span>
  <%= @user_a %>
</span>
X
<span>
  <%= @user_b %>
</span>

iex> IO.puts Phoenix.LiveView.HTMLFormatter.format(formatted, [line_length: 5])
<span>
  <%= @user_a %>
</span>
X <span>
  <%= @user_b %>
</span>
```

/cc @feliperenan @josevalim 