### PR TITLE
Feature Request: Add `Phoenix.LiveView.JS` `@type`

### DIFF
--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -115,6 +115,8 @@ defmodule Phoenix.LiveView.JS do
 
   defstruct ops: []
 
+  @type t :: %__MODULE__{ops: [[String.t() | map()]]}
+
   @default_transition_time 200
 
   defimpl Phoenix.HTML.Safe, for: Phoenix.LiveView.JS do


### PR DESCRIPTION
I've been adding a number of functions containing `Phoenix.LiveView.JS` operations and it would be nice to have the type accessible to my application specs. In any case, thanks again for this wonderful library, and all of you are awesome!