### PR TITLE
Add :let attr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,7 +340,7 @@ component named `form`:
 
 ```elixir
 ~H"""
-<.form let={f} for={@changeset}>
+<.form :let={f} for={@changeset}>
   <%= input f, :foo %>
 </.form>
 """

--- a/guides/client/form-bindings.md
+++ b/guides/client/form-bindings.md
@@ -24,7 +24,7 @@ For example, to handle real-time form validation and saving, your form would
 use both `phx-change` and `phx-submit` bindings:
 
 ```
-<.form let={f} for={@changeset} phx-change="validate" phx-submit="save">
+<.form :let={f} for={@changeset} phx-change="validate" phx-submit="save">
   <%= label f, :username %>
   <%= text_input f, :username %>
   <%= error_tag f, :username %>
@@ -83,7 +83,7 @@ a different component. This can be accomplished by annotating the input itself
 with `phx-change`, for example:
 
 ```
-<.form let={f} for={@changeset} phx-change="validate" phx-submit="save">
+<.form :let={f} for={@changeset} phx-change="validate" phx-submit="save">
   ...
   <%= label f, :county %>
   <%= text_input f, :email, phx_change: "email_changed", phx_target: @myself %>
@@ -193,7 +193,7 @@ Plug session mutation. For example, in your LiveView template you can
 annotate the `phx-trigger-action` with a boolean assign:
 
 ```heex
-<.form let={f} for={@changeset}
+<.form :let={f} for={@changeset}
   action={Routes.reset_password_path(@socket, :create)}
   phx-submit="save",
   phx-trigger-action={@trigger_submit}>

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -137,7 +137,8 @@ defmodule Phoenix.Component do
   to render it.
 
   You can even have the component give a value back to the caller,
-  by using `:let`. Imagine this component:
+  by using the special attribute `:let` (note the leading `:`).
+  Imagine this component:
 
       def unordered_list(assigns) do
         ~H"""

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -137,7 +137,7 @@ defmodule Phoenix.Component do
   to render it.
 
   You can even have the component give a value back to the caller,
-  by using `let`. Imagine this component:
+  by using `:let`. Imagine this component:
 
       def unordered_list(assigns) do
         ~H"""
@@ -151,7 +151,7 @@ defmodule Phoenix.Component do
 
   And now you can invoke it as:
 
-      <.unordered_list let={entry} entries={~w(apple banana cherry)}>
+      <.unordered_list :let={entry} entries={~w(apple banana cherry)}>
         I like <%= entry %>
       </.unordered_list>
 
@@ -170,7 +170,7 @@ defmodule Phoenix.Component do
 
   And now we can invoke it like this:
 
-      <.unordered_list let={%{entry: entry, gif_url: url}}>
+      <.unordered_list :let={%{entry: entry, gif_url: url}}>
         I like <%= entry %>. <img src={url} />
       </.unordered_list>
 
@@ -243,11 +243,11 @@ defmodule Phoenix.Component do
   For example, imagine a table component:
 
       <.table rows={@users}>
-        <:col let={user} label="Name">
+        <:col :let={user} label="Name">
           <%= user.name %>
         </:col>
 
-        <:col let={user} label="Address">
+        <:col :let={user} label="Address">
           <%= user.address %>
         </:col>
       </.table>

--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -688,11 +688,11 @@ defmodule Phoenix.LiveView.Helpers do
   For example, imagine a table component:
 
       <.table rows={@users}>
-        <:col let={user} label="Name">
+        <:col :let={user} label="Name">
           <%= user.name %>
         </:col>
 
-        <:col let={user} label="Address">
+        <:col :let={user} label="Address">
           <%= user.address %>
         </:col>
       </.table>
@@ -1047,11 +1047,11 @@ defmodule Phoenix.LiveView.Helpers do
 
   The `:for` attribute is typically an [`Ecto.Changeset`](https://hexdocs.pm/ecto/Ecto.Changeset.html):
 
-      <.form let={f} for={@changeset} phx-change="change_name">
+      <.form :let={f} for={@changeset} phx-change="change_name">
         <%= text_input f, :name %>
       </.form>
 
-      <.form let={user_form} for={@changeset} multipart phx-change="change_user" phx-submit="save_user">
+      <.form :let={user_form} for={@changeset} multipart phx-change="change_user" phx-submit="save_user">
         <%= text_input user_form, :name %>
         <%= submit "Save" %>
       </.form>
@@ -1068,7 +1068,7 @@ defmodule Phoenix.LiveView.Helpers do
   In this case, you need to pass the input values explicitly as they
   change (or use `phx-update="ignore"` as per the previous paragraph):
 
-      <.form let={user_form} for={:user} multipart phx-change="change_user" phx-submit="save_user">
+      <.form :let={user_form} for={:user} multipart phx-change="change_user" phx-submit="save_user">
         <%= text_input user_form, :name, value: @user_name %>
         <%= submit "Save" %>
       </.form>
@@ -1088,7 +1088,7 @@ defmodule Phoenix.LiveView.Helpers do
   Without said attribute, the `form` method and csrf token are
   discarded.
 
-      <.form let={f} for={@changeset} action={Routes.comment_path(:create, @comment)}>
+      <.form :let={f} for={@changeset} action={Routes.comment_path(:create, @comment)}>
         <%= text_input f, :body %>
       </.form>
   """

--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -95,7 +95,10 @@ defmodule Phoenix.LiveView.HTMLEngine do
     |> invoke_subengine(:handle_end, [])
   end
 
-  defp token_state(%{subengine: subengine, substate: substate, file: file, module: module, caller: caller}, root) do
+  defp token_state(
+         %{subengine: subengine, substate: substate, file: file, module: module, caller: caller},
+         root
+       ) do
     %{
       subengine: subengine,
       substate: substate,
@@ -245,7 +248,8 @@ defmodule Phoenix.LiveView.HTMLEngine do
   # Remote function component (self close)
 
   defp handle_token(
-         {:tag_open, <<first, _::binary>> = tag_name, attrs, %{self_close: true, line: line} = tag_meta},
+         {:tag_open, <<first, _::binary>> = tag_name, attrs,
+          %{self_close: true, line: line} = tag_meta},
          state
        )
        when first in ?A..?Z do
@@ -628,8 +632,10 @@ defmodule Phoenix.LiveView.HTMLEngine do
 
     inner_block_assigns =
       quote line: line do
-        %{__slot__: :inner_block,
-          inner_block: Phoenix.LiveView.Helpers.inner_block(:inner_block, do: unquote(clauses))}
+        %{
+          __slot__: :inner_block,
+          inner_block: Phoenix.LiveView.Helpers.inner_block(:inner_block, do: unquote(clauses))
+        }
       end
 
     {slots, state} = pop_slots(state)
@@ -791,14 +797,14 @@ defmodule Phoenix.LiveView.HTMLEngine do
 
   defp actual_component_module(env, fun) do
     case lookup_import(env, {fun, 1}) do
-      [{_, module}| _] -> module
+      [{_, module} | _] -> module
       _ -> env.module
     end
   end
 
   # TODO: Use Macro.Env.lookup_import/2 when we require Elixir v1.13+
   defp lookup_import(%Macro.Env{functions: functions, macros: macros}, {name, arity} = pair)
-      when is_atom(name) and is_integer(arity) do
+       when is_atom(name) and is_integer(arity) do
     f = for {mod, pairs} <- functions, :ordsets.is_element(pair, pairs), do: {:function, mod}
     m = for {mod, pairs} <- macros, :ordsets.is_element(pair, pairs), do: {:macro, mod}
     f ++ m

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -220,25 +220,25 @@ defmodule Phoenix.ComponentTest do
 
     test "with let" do
       assigns = %{foo: 1, __changed__: %{}}
-      assert eval(~H|<.inner_changed let={_foo} foo={@foo}></.inner_changed>|) == [nil]
+      assert eval(~H|<.inner_changed :let={_foo} foo={@foo}></.inner_changed>|) == [nil]
 
       assigns = %{foo: 1, __changed__: %{foo: true}}
 
-      assert eval(~H|<.inner_changed let={_foo} foo={@foo}></.inner_changed>|) ==
+      assert eval(~H|<.inner_changed :let={_foo} foo={@foo}></.inner_changed>|) ==
                [["%{foo: true}", nil]]
 
       assert eval(
-               ~H|<.inner_changed let={_foo} foo={@foo}><%= inspect(Map.get(assigns, :__changed__)) %></.inner_changed>|
+               ~H|<.inner_changed :let={_foo} foo={@foo}><%= inspect(Map.get(assigns, :__changed__)) %></.inner_changed>|
              ) ==
                [["%{foo: true, inner_block: true}", ["%{foo: true}"]]]
 
       assert eval(
-               ~H|<.inner_changed let={_foo} foo={@foo}><%= "constant" %><%= inspect(Map.get(assigns, :__changed__)) %></.inner_changed>|
+               ~H|<.inner_changed :let={_foo} foo={@foo}><%= "constant" %><%= inspect(Map.get(assigns, :__changed__)) %></.inner_changed>|
              ) ==
                [["%{foo: true, inner_block: true}", [nil, "%{foo: true}"]]]
 
       assert eval(
-               ~H|<.inner_changed let={foo} foo={@foo}><.inner_changed let={_bar} bar={foo}><%= "constant" %><%= inspect(Map.get(assigns, :__changed__)) %></.inner_changed></.inner_changed>|
+               ~H|<.inner_changed :let={foo} foo={@foo}><.inner_changed :let={_bar} bar={foo}><%= "constant" %><%= inspect(Map.get(assigns, :__changed__)) %></.inner_changed></.inner_changed>|
              ) ==
                [
                  [
@@ -248,12 +248,12 @@ defmodule Phoenix.ComponentTest do
                ]
 
       assert eval(
-               ~H|<.inner_changed let={foo} foo={@foo}><%= foo %><%= inspect(Map.get(assigns, :__changed__)) %></.inner_changed>|
+               ~H|<.inner_changed :let={foo} foo={@foo}><%= foo %><%= inspect(Map.get(assigns, :__changed__)) %></.inner_changed>|
              ) ==
                [["%{foo: true, inner_block: true}", ["var", "%{foo: true}"]]]
 
       assert eval(
-               ~H|<.inner_changed let={foo} foo={@foo}><.inner_changed let={bar} bar={foo}><%= bar %><%= inspect(Map.get(assigns, :__changed__)) %></.inner_changed></.inner_changed>|
+               ~H|<.inner_changed :let={foo} foo={@foo}><.inner_changed :let={bar} bar={foo}><%= bar %><%= inspect(Map.get(assigns, :__changed__)) %></.inner_changed></.inner_changed>|
              ) ==
                [
                  [

--- a/test/phoenix_live_view/diff_test.exs
+++ b/test/phoenix_live_view/diff_test.exs
@@ -475,7 +475,7 @@ defmodule Phoenix.LiveView.DiffTest do
     def render_with_live_component(assigns) do
       ~H"""
       COMPONENT
-      <.live_component module={SlotComponent} let={%{value: value}} id="WORLD">
+      <.live_component module={SlotComponent} :let={%{value: value}} id="WORLD">
         WITH VALUE <%= value %>
       </.live_component>
       """
@@ -634,7 +634,7 @@ defmodule Phoenix.LiveView.DiffTest do
 
     defp function_tracking(assigns) do
       ~H"""
-      <FunctionComponent.render_inner_block let={value} id={@id}>
+      <FunctionComponent.render_inner_block :let={value} id={@id}>
         WITH VALUE <%= value %> - <%= @value %>
       </FunctionComponent.render_inner_block>
       """
@@ -1521,7 +1521,7 @@ defmodule Phoenix.LiveView.DiffTest do
 
     defp tracking(assigns) do
       ~H"""
-      <.live_component module={SlotComponent} let={%{value: value}} id="TRACKING">
+      <.live_component module={SlotComponent} :let={%{value: value}} id="TRACKING">
         WITH PARENT VALUE <%= @parent_value %>
         WITH VALUE <%= value %>
       </.live_component>

--- a/test/phoenix_live_view/helpers_test.exs
+++ b/test/phoenix_live_view/helpers_test.exs
@@ -129,8 +129,9 @@ defmodule Phoenix.LiveView.HelpersTest do
     test "raises when missing required assigns" do
       assert_raise ArgumentError, ~r/missing :for assign/, fn ->
         assigns = %{}
+
         parse(~H"""
-        <.form let={f}>
+        <.form :let={f}>
           <%= text_input f, :foo %>
         </.form>
         """)
@@ -142,7 +143,7 @@ defmodule Phoenix.LiveView.HelpersTest do
 
       html =
         parse(~H"""
-        <.form let={f} for={:myform}>
+        <.form :let={f} for={:myform}>
           <%= text_input f, :foo %>
         </.form>
         """)
@@ -160,7 +161,7 @@ defmodule Phoenix.LiveView.HelpersTest do
 
       html =
         parse(~H"""
-        <.form let={f} for={:myform} method="get" action="/">
+        <.form :let={f} for={:myform} method="get" action="/">
           <%= text_input f, :foo %>
         </.form>
         """)
@@ -174,7 +175,7 @@ defmodule Phoenix.LiveView.HelpersTest do
 
       html =
         parse(~H"""
-        <.form let={f} for={:myform}>
+        <.form :let={f} for={:myform}>
           <%= text_input f, :foo %>
         </.form>
         """)
@@ -192,7 +193,7 @@ defmodule Phoenix.LiveView.HelpersTest do
 
       html =
         parse(~H"""
-        <.form let={user_form}
+        <.form :let={user_form}
           for={%Plug.Conn{}}
           id="form"
           action="/"

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -582,7 +582,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
       assert_raise(ParseError, message, fn ->
         eval("""
         <%= if true do %>
-          <.local_function_component value='1' let={var}>
+          <.local_function_component value='1' :let={var}>
         <% end %>
         """)
       end)

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -341,6 +341,27 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
              """) == "REMOTE COMPONENT: Value: 1, Content: \n  The inner content\n"
     end
 
+    test "remote call with :let" do
+      expected = """
+      LOCAL COMPONENT WITH ARGS: Value: aBcD
+
+        Upcase: ABCD
+        Downcase: abcd
+      """
+
+      assigns = %{}
+
+      assert compile("""
+             <.local_function_component_with_inner_block_args
+               value="aBcD"
+               :let={%{upcase: upcase, downcase: downcase}}
+             >
+               Upcase: <%= upcase %>
+               Downcase: <%= downcase %>
+             </.local_function_component_with_inner_block_args>
+             """) =~ expected
+    end
+
     test "remote call with inner content with args" do
       expected = """
       REMOTE COMPONENT WITH ARGS: Value: aBcD
@@ -354,7 +375,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
       assert compile("""
              <Phoenix.LiveView.HTMLEngineTest.remote_function_component_with_inner_block_args
                value="aBcD"
-               let={%{upcase: upcase, downcase: downcase}}
+               :let={%{upcase: upcase, downcase: downcase}}
              >
                Upcase: <%= upcase %>
                Downcase: <%= downcase %>
@@ -364,7 +385,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
 
     test "raise on remote call with inner content passing non-matching args" do
       message = ~r"""
-      cannot match arguments sent from `render_slot/2` against the pattern in `let`.
+      cannot match arguments sent from `render_slot/2` against the pattern in `:let`.
 
       Expected a value matching `%{wrong: _}`, got: `%{downcase: "abcd", upcase: "ABCD"}`.
       """
@@ -375,7 +396,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
         compile("""
         <Phoenix.LiveView.HTMLEngineTest.remote_function_component_with_inner_block_args
           {[value: "aBcD"]}
-          let={%{wrong: _}}
+          :let={%{wrong: _}}
         >
           ...
         </Phoenix.LiveView.HTMLEngineTest.remote_function_component_with_inner_block_args>
@@ -384,12 +405,12 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
     end
 
     test "raise on remote call passing args to self close components" do
-      message = ~r".exs:2: cannot use `let` on a component without inner content"
+      message = ~r".exs:2: cannot use `:let` on a component without inner content"
 
       assert_raise(CompileError, message, fn ->
         eval("""
         <br>
-        <Phoenix.LiveView.HTMLEngineTest.remote_function_component value='1' let={var}/>
+        <Phoenix.LiveView.HTMLEngineTest.remote_function_component value='1' :let={var}/>
         """)
       end)
     end
@@ -424,7 +445,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
       assert compile("""
              <.local_function_component_with_inner_block_args
                value="aBcD"
-               let={%{upcase: upcase, downcase: downcase}}
+               :let={%{upcase: upcase, downcase: downcase}}
              >
                Upcase: <%= upcase %>
                Downcase: <%= downcase %>
@@ -434,7 +455,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
       assert compile("""
              <.local_function_component_with_inner_block_args
                {[value: "aBcD"]}
-               let={%{upcase: upcase, downcase: downcase}}
+               :let={%{upcase: upcase, downcase: downcase}}
              >
                Upcase: <%= upcase %>
                Downcase: <%= downcase %>
@@ -444,7 +465,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
 
     test "raise on local call with inner content passing non-matching args" do
       message = ~r"""
-      cannot match arguments sent from `render_slot/2` against the pattern in `let`.
+      cannot match arguments sent from `render_slot/2` against the pattern in `:let`.
 
       Expected a value matching `%{wrong: _}`, got: `%{downcase: "abcd", upcase: "ABCD"}`.
       """
@@ -455,7 +476,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
         compile("""
         <.local_function_component_with_inner_block_args
           {[value: "aBcD"]}
-          let={%{wrong: _}}
+          :let={%{wrong: _}}
         >
           ...
         </.local_function_component_with_inner_block_args>
@@ -464,19 +485,45 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
     end
 
     test "raise on local call passing args to self close components" do
-      message = ~r".exs:2: cannot use `let` on a component without inner content"
+      message = ~r".exs:2: cannot use `:let` on a component without inner content"
 
       assert_raise(CompileError, message, fn ->
         eval("""
         <br>
-        <.local_function_component value='1' let={var}/>
+        <.local_function_component value='1' :let={var}/>
         """)
       end)
     end
 
-    test "raise on duplicated `let`" do
+    test "raise on duplicated `:let`" do
       message =
-        ~r".exs:4:(8:)? cannot define multiple `let` attributes. Another `let` has already been defined at line 3"
+        ~r".exs:4:(9:)? cannot define multiple `:let` attributes. Another `:let` has already been defined at line 3"
+
+      assert_raise(ParseError, message, fn ->
+        eval("""
+        <br>
+        <Phoenix.LiveView.HTMLEngineTest.remote_function_component value='1'
+          :let={var1}
+          :let={var2}
+        />
+        """)
+      end)
+
+      assert_raise(ParseError, message, fn ->
+        eval("""
+        <br>
+        <.local_function_component value='1'
+          :let={var1}
+          :let={var2}
+        />
+        """)
+      end)
+    end
+
+    # TODO: remove me once "let" is not supported anymore.
+    test "raise on duplicated old `let`" do
+      message =
+        ~r".exs:4:(8:)? cannot define multiple `:let` attributes. Another `:let` has already been defined at line 3"
 
       assert_raise(ParseError, message, fn ->
         eval("""
@@ -497,6 +544,26 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
         />
         """)
       end)
+
+      assert_raise(ParseError, message, fn ->
+        eval("""
+        <br>
+        <Phoenix.LiveView.HTMLEngineTest.remote_function_component value='1'
+          :let={var1}
+          let={var2}
+        />
+        """)
+      end)
+
+      assert_raise(ParseError, message, fn ->
+        eval("""
+        <br>
+        <.local_function_component value='1'
+          :let={var1}
+          let={var2}
+        />
+        """)
+      end)
     end
 
     test "raise on unclosed local call" do
@@ -505,7 +572,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
 
       assert_raise(ParseError, message, fn ->
         eval("""
-        <.local_function_component value='1' let={var}>
+        <.local_function_component value='1' :let={var}>
         """)
       end)
 
@@ -873,7 +940,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
       assert compile("""
              COMPONENT WITH SLOTS:
              <.function_component_with_slots_and_args>
-               <:sample let={arg}>
+               <:sample :let={arg}>
                  The sample slot
                  Arg: <%= arg %>
                </:sample>
@@ -883,7 +950,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
       assert compile("""
              COMPONENT WITH SLOTS:
              <Phoenix.LiveView.HTMLEngineTest.function_component_with_slots_and_args>
-               <:sample let={arg}>
+               <:sample :let={arg}>
                  The sample slot
                  Arg: <%= arg %>
                </:sample>
@@ -962,13 +1029,13 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
              """) == expected
     end
 
-    test "raise if self close slot uses let" do
-      message = ~r".exs:2:(24:)? cannot use `let` on a slot without inner content"
+    test "raise if self close slot uses :let" do
+      message = ~r".exs:2:(25:)? cannot use `:let` on a slot without inner content"
 
       assert_raise(ParseError, message, fn ->
         eval("""
         <.function_component_with_self_close_slots>
-          <:sample id="1" let={var}/>
+          <:sample id="1" :let={var}/>
         </.function_component_with_self_close_slots>
         """)
       end)


### PR DESCRIPTION
Add support for `:let`. We still are going to support `let` but soon it will be deprecated. That is because new special attrs are coming such as `:for`, so we are using this `:` prefix to differentiate from normal HTML attrs.