### PR TITLE
Update sessionStorage docs InMemoryStorage example

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -62,7 +62,7 @@
  *
  *     class InMemoryStorage {
  *       constructor() { this.storage = {} }
- *       getItem(keyName) { return this.storage[keyName] }
+ *       getItem(keyName) { return this.storage[keyName] || null }
  *       removeItem(keyName) { delete this.storage[keyName] }
  *       setItem(keyName, keyValue) { this.storage[keyName] = keyValue }
  *     }


### PR DESCRIPTION
This is change ensures the `InMemoryStorage` example code returns `null` when a key is not found.

LiveView stores data in localStorage in JSON, and a missing key will return `null`. The current `InMemoryStorageClass` example will return `undefined` which is not valid JSON and causes an exception.


<img width="1054" alt="CleanShot 2022-05-10 at 15 54 12@2x" src="https://user-images.githubusercontent.com/22266/167557864-45ae24e8-cb18-4201-9823-970f25af91c1.png">

Note: `null` is considered [valid JSON in browserland](https://stackoverflow.com/questions/46464447/json-parse-allows-null-as-value)

