### PR TITLE
Add :for attr 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Enhancements
   - [Formatter] Introduce special attr phx-no-format to skip formatting
+  - Add new attrs `:let` and `:for`. We still support `let` but the Formatter will convert it to `:let` and soon it will be deprecated.
 
 ## 0.17.9 (2022-04-07)
 

--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -176,11 +176,28 @@ defmodule Phoenix.LiveView.Helpers do
   ### HEEx extension: special attributes
 
   Apart from normal HTML attributes, HEEx also support some special attributes
-  such as `:for` and `:let`.
+  such as `:let` and `:for`.
+
+  #### :let
+
+  This is used by components and slots that want to yield a value back to the
+  caller. For an example, see how `form/1` works:
+
+  ```heex
+  <.form :let={f} for={@changeset} phx-change="validate" phx-submit="save">
+    <%= label(f, :username) %>
+    <%= text_input(f, :username) %>
+    ...
+  </.form>
+  ```
+
+  Notice how the variable `f`, defined by `.form`, is used by `label` and
+  `text_input`. The `Phoenix.Component` module has detailed documentation on
+  how to use and implement such functionality.
 
   #### :for
 
-  It is a syntax sugar for `<%= for .. do %>` that can be used only in normal HTML
+  It is a syntax sugar for `<%= for .. do %>` that can be used only in regular HTML
   tags, therefore `:for` will not work on components.
 
   ```heex
@@ -191,21 +208,7 @@ defmodule Phoenix.LiveView.Helpers do
   <table>
   ```
 
-  The snippet above will generate a list of `td` as you would expect.
-
-  #### :let
-
-  Useful for binding variables that will be used by the children elements.
-
-  ```heex
-  <.form :let={f} for={@changeset} phx-change="validate" phx-submit="save">
-    <%= label(f, :username) %>
-    <%= text_input(f, :username) %>
-    ...
-  </.form>
-  ```
-
-  Notice how the variable `f` is used by `label` and `text_input`.
+  The snippet above will generate a `tr` per user as you would expect.
   '''
   defmacro sigil_H({:<<>>, meta, [expr]}, []) do
     unless Macro.Env.has_var?(__CALLER__, {:assigns, nil}) do

--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -172,6 +172,40 @@ defmodule Phoenix.LiveView.Helpers do
   opposed to having many modules with a single `render/1` function. Function
   components support other important features, such as slots. You can learn
   more about components in `Phoenix.Component`.
+
+  ### HEEx extension: special attributes
+
+  Apart from normal HTML attributes, HEEx also support some special attributes
+  such as `:for` and `:let`.
+
+  #### :for
+
+  It is a syntax sugar for `<%= for .. do %>` that can used only in normal HTML
+  tags. Therefore `:for` will not work on components.
+
+  ```eex
+  <table id="my-table">
+    <tr :for={user <- @users}>
+      <td><%= user.name %>
+    </tr>
+  <table>
+  ```
+
+  The snippet above will generate a list of `td` as you would expect.
+
+  #### :let
+
+  Useful for binding variables that will be used by the children elements.
+
+  ```eex
+  <.form :let={f} for={@changeset} phx-change="validate" phx-submit="save">
+    <%= label f, :username %>
+    <%= text_input f, :username %>
+    ...
+  </.form>
+  ```
+
+  Notice how the variable `f` is used by `label` and `text_input`.
   '''
   defmacro sigil_H({:<<>>, meta, [expr]}, []) do
     unless Macro.Env.has_var?(__CALLER__, {:assigns, nil}) do
@@ -221,9 +255,9 @@ defmodule Phoenix.LiveView.Helpers do
         </a>
         """
       end
-      
+
   The above would result in the following rendered HTML:
-  
+
       <a href="/" target="_blank" id="1" class="my-class">Home</a>
 
   The second argument (optional) to `assigns_to_attributes` is a list of keys to

--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -180,10 +180,10 @@ defmodule Phoenix.LiveView.Helpers do
 
   #### :for
 
-  It is a syntax sugar for `<%= for .. do %>` that can used only in normal HTML
-  tags. Therefore `:for` will not work on components.
+  It is a syntax sugar for `<%= for .. do %>` that can be used only in normal HTML
+  tags, therefore `:for` will not work on components.
 
-  ```eex
+  ```heex
   <table id="my-table">
     <tr :for={user <- @users}>
       <td><%= user.name %>
@@ -197,10 +197,10 @@ defmodule Phoenix.LiveView.Helpers do
 
   Useful for binding variables that will be used by the children elements.
 
-  ```eex
+  ```heex
   <.form :let={f} for={@changeset} phx-change="validate" phx-submit="save">
-    <%= label f, :username %>
-    <%= text_input f, :username %>
+    <%= label(f, :username) %>
+    <%= text_input(f, :username) %>
     ...
   </.form>
   ```

--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -452,7 +452,6 @@ defmodule Phoenix.LiveView.HTMLEngine do
 
         state
         |> update_subengine(:handle_begin, [])
-        # TODO: test me
         |> set_root_on_not_tag()
         |> push_tag({:tag_open, name, attrs, Map.put(tag_meta, :for, {expr, state})})
         |> handle_tag_and_attrs(name, attrs, ">", to_location(tag_meta))

--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -507,7 +507,7 @@ defmodule Phoenix.LiveView.HTMLEngine do
     case List.keytake(attrs, attr, 0) do
       {{attr, _expr, meta}, _attrs} ->
         message =
-          "cannot define multiple #{inspect(attr)} attributes. Another #{inspect(attr)} has already been defined at line 3"
+          "cannot define multiple #{inspect(attr)} attributes. Another #{inspect(attr)} has already been defined at line #{meta.line}"
 
         raise ParseError,
           line: meta.line,

--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -717,7 +717,6 @@ defmodule Phoenix.LiveView.HTMLEngine do
   end
 
   defp split_component_attr({":let", _, meta}, _state, file) do
-    # TODO: test me
     raise ParseError,
       line: meta.line,
       column: meta.column,
@@ -726,7 +725,6 @@ defmodule Phoenix.LiveView.HTMLEngine do
   end
 
   defp split_component_attr({":" <> _ = name, _, meta}, _state, file) do
-    # TODO: test me
     raise ParseError,
       line: meta.line,
       column: meta.column,
@@ -932,7 +930,6 @@ defmodule Phoenix.LiveView.HTMLEngine do
 
   defp validate_phx_attrs!([{loop, _, attr_meta} | _], _meta, state, _attr, _id?)
        when loop in @loop do
-    # TODO: test me
     raise ParseError,
       line: attr_meta.line,
       column: attr_meta.column,
@@ -941,7 +938,6 @@ defmodule Phoenix.LiveView.HTMLEngine do
   end
 
   defp validate_phx_attrs!([{":" <> _ = name, _, attr_meta} | _], _meta, state, _attr, _id?) do
-    # TODO: test me
     raise ParseError,
       line: attr_meta.line,
       column: attr_meta.column,

--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -435,7 +435,7 @@ defmodule Phoenix.LiveView.HTMLEngine do
     attrs = remove_phx_no_break(attrs)
     validate_phx_attrs!(attrs, tag_meta, state)
 
-    case pop_special_attr!(attrs, "for", state) do
+    case pop_special_attr!(attrs, ":for", state) do
       {{":for", expr, _meta}, attrs} ->
         ast =
           state
@@ -458,7 +458,7 @@ defmodule Phoenix.LiveView.HTMLEngine do
     validate_phx_attrs!(attrs, tag_meta, state)
     attrs = remove_phx_no_break(attrs)
 
-    case pop_special_attr!(attrs, "for", state) do
+    case pop_special_attr!(attrs, ":for", state) do
       {{":for", expr, _meta}, attrs} ->
         state
         |> update_subengine(:handle_begin, [])
@@ -494,15 +494,15 @@ defmodule Phoenix.LiveView.HTMLEngine do
   # Examples:
   #
   #   attrs = [{":for", {...}}, {"class", {...}}]
-  #   pop_special_attr!(state, attrs, "for")
+  #   pop_special_attr!(state, attrs, ":for")
   #   => {{":for", {...}}, [{"class", {...}]}
   #
   #   attrs = [{"class", {...}}]
-  #   pop_special_attr!(state, attrs, "for")
+  #   pop_special_attr!(state, attrs, ":for")
   #   => nil
   defp pop_special_attr!(attrs, attr, state) do
     attrs
-    |> List.keytake(":" <> attr, 0)
+    |> List.keytake(attr, 0)
     |> raise_if_duplicated_special_attr!(state)
   end
 

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -1418,4 +1418,30 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
       )
     end
   end
+
+  describe ":for attr" do
+    test "handle :for attr" do
+      expected = """
+      <table id="table">
+        <%= for user <- @users do %>
+          <tr>
+            <td>foo</td>
+            <td>bar</td>
+            <td>baz</td>
+          </tr>
+        <% end %>
+      </table>
+      """
+
+      assigns = %{items: ["foo", "bar", "baz"]}
+
+      assert compile("""
+             <table id="table">
+               <tr :for={item <- @items}>
+                 <td><%= @item %></td>
+               </tr>
+             </table>
+             """) =~ expected
+    end
+  end
 end

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -1538,7 +1538,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
 
     test "raise on duplicated :for" do
       message =
-        ~r/cannot define multiple \":for\" attributes. Another \":for\" has already been defined at line 3/
+        ~r/cannot define multiple \":for\" attributes. Another \":for\" has already been defined at line 1/
 
       assert_raise(ParseError, message, fn ->
         eval("""

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -1481,13 +1481,23 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
   end
 
   describe ":for attr" do
-    test "handle :for attr" do
+    test "handle :for attr on HTML element" do
       expected = "<div>foo</div><div>bar</div><div>baz</div>"
 
       assigns = %{items: ["foo", "bar", "baz"]}
 
       assert compile("""
                <div :for={item <- @items}><%= item %></div>
+             """) =~ expected
+    end
+
+    test "handle :for attr on self closed HTML element" do
+      expected = ~s(<div class="foo"></div><div class="foo"></div><div class="foo"></div>)
+
+      assigns = %{items: ["foo", "bar", "baz"]}
+
+      assert compile("""
+               <div class="foo" :for={_item <- @items} />
              """) =~ expected
     end
 

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -1501,7 +1501,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
              """) =~ expected
     end
 
-    test "raise on invalid :for" do
+    test "raise on invalid :for expr" do
       message = ~r/for comprehensions must start with a generator/
 
       assert_raise(CompileError, message, fn ->
@@ -1515,6 +1515,34 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
       assert_raise(ParseError, message, fn ->
         eval("""
         <div :for="1">Content</div>
+        """)
+      end)
+    end
+
+    test "raise when used in components" do
+      message = ~r/unsupported attribute \":for\" in component/
+
+      assert_raise(ParseError, message, fn ->
+        eval("""
+        <.local_function_component :for={item <- [1, 2]} />")
+        """)
+      end)
+
+      assert_raise(ParseError, message, fn ->
+        eval("""
+        <br>
+        <Phoenix.LiveView.HTMLEngineTest.remote_function_component value='1' :for={item <- [1, 2]}/>
+        """)
+      end)
+    end
+
+    test "raise on duplicated :for" do
+      message =
+        ~r/cannot define multiple \":for\" attributes. Another \":for\" has already been defined at line 3/
+
+      assert_raise(ParseError, message, fn ->
+        eval("""
+        <div :for={item <- [1, 2]} :for={item <- [1, 2]}>Content</div>
         """)
       end)
     end

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -1337,7 +1337,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
 
     test "validates phx-update values" do
       message =
-        ~r/.exs:1:(1:)? the value of the attribute \"phx-update\" must be: ignore, append or prepend/
+        ~r/.exs:1:(14:)? the value of the attribute \"phx-update\" must be: ignore, append or prepend/
 
       assert_raise(ParseError, message, fn ->
         eval("""


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix_live_view/issues/2017

This PR adds the sugar `:for` as you can see below:

```eex
  <table id="my-table">
     <tr :for={user <- @users}>
       <td><%= user.name %>
     </tr>
   <table>
```

### TODO: 

- [x] handle self closed tags
- [x] raise when both for and let is present
- [x] raise when for is present on components (non normal HTML tags)
- [x] raise on duplicated :for
- [x] add docs
- [x] update Changelog
