### PR TITLE
Fix typos in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 0.18.0
 
 ### Deprecations
-  - `live_redirect` - deprecate in favor of new `<link redirect={..}>` component of `Pnoenix.LiveView.Helpers`
-  - `live_patch` - deprecate in favor of new `<link patch={..}>` component of `Pnoenix.LiveView.Helpers`
+  - `live_redirect` - deprecate in favor of new `<link redirect={..}>` component of `Phoenix.LiveView.Helpers`
+  - `live_patch` - deprecate in favor of new `<link patch={..}>` component of `Phoenix.LiveView.Helpers`
   - `push_redirect` - deprecate in favor of new `push_navigate` function on `Phoenix.LiveView`
 
 ## 0.17.10 (Unreleased)


### PR DESCRIPTION
Fixes a couple of typos of `Phoenix`