### PR TITLE
Support component attr :doc for documentation generation

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -521,13 +521,14 @@ defmodule Phoenix.Component do
   end
 
   @doc ~S'''
-  Declares attributes for a HEEx templates with compile-time verification.
+  Declares attributes for a HEEx function components with compile-time verification and documentation generation.
 
   ## Options
 
     * `:required` - marks an attribute as required. If a caller does not pass
-      the given attribute, a compile warning is issued
+      the given attribute, a compile warning is issued.
     * `:default` - the default value for the attribute if not provided
+    * `:doc` - documentation for the attribute
 
   ## Types
 
@@ -536,6 +537,10 @@ defmodule Phoenix.Component do
 
     * `:any` - any term
     * `:string` - any binary string
+    * `:atom` - any atom
+    * `:boolean` - any boolean
+    * `:integer` - any integer
+    * `:float` - any float
     * `:list` - a List of any aribitrary types
     * `:global` - represents all other undefined attributes
       passed by the caller that match common HTML attributes as well as
@@ -557,7 +562,7 @@ defmodule Phoenix.Component do
     * if you specify a literal attribute (such as `value="string"` or `value`,
       but not `value={expr}`) and the type does not match
 
-  Livebook does not perform any validation at runtime. This means the type
+  LiveView does not perform any validation at runtime. This means the type
   information is mostly used for documentation and reflection purposes.
 
   On the side of the LiveView component itself, defining attributes provides
@@ -572,6 +577,32 @@ defmodule Phoenix.Component do
       will be emitted
 
   This list may increase in the future.
+
+  ## Documentation
+
+  Public function components that define attributes will have their attribute 
+  types and docs injected into the function's documentation, depending on the 
+  value of the `@doc` module attribute:
+
+    * if `@doc` is a string, the attribute docs are injected into that string. 
+      The optional placeholder `[[INJECT ATTRDOCS]]` can be used to specify where 
+      in the string the docs are injected. Otherwise, the docs are appended 
+      to the end of the `@doc` string.
+      
+    * if `@doc` is unspecified, the attribute docs are used as the 
+      default `@doc` string.
+      
+    * if `@doc` is false, the attribute docs are omitted entirely.
+    
+  The injected attribute docs are formatted as a markdown list:
+
+    ```markdown
+    * *name* _`:type, opts`_, doc
+    ```
+    
+  By default, all attributes will have their types and docs injected into
+  the function `@doc` string. To hide a specific attribute, you can set 
+  the value of `:doc` to `false`.
 
   ## Examples
 

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -610,6 +610,12 @@ defmodule Phoenix.Component do
       true ->
         :ok
     end
+    
+    {desc, opts} = Keyword.pop(opts, :desc, "")
+    
+    unless is_binary(desc) do
+      compile_error!(line, file, ":desc must be a string, got: #{inspect(desc)}")
+    end
 
     {required, opts} = Keyword.pop(opts, :required, false)
 
@@ -629,6 +635,7 @@ defmodule Phoenix.Component do
       type: type,
       required: required,
       opts: opts,
+      desc: desc,
       line: line
     })
   end

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -852,16 +852,7 @@ defmodule Phoenix.Component do
       attrs != [] ->
         check_if_defined? and raise_if_function_already_defined!(env, name, attrs)
 
-        case Module.get_attribute(env.module, :doc) do
-          {_line, false} ->
-            :ok
-
-          {line, doc} ->
-            Module.put_attribute(env.module, :doc, {line, build_component_doc(doc, attrs)})
-
-          nil ->
-            Module.put_attribute(env.module, :doc, {env.line, build_component_doc(attrs)})
-        end
+        register_component_doc(env, kind, attrs)
 
         components =
           env.module
@@ -879,6 +870,23 @@ defmodule Phoenix.Component do
       true ->
         []
     end
+  end
+
+  defp register_component_doc(env, :def, attrs) do
+    case Module.get_attribute(env.module, :doc) do
+      {_line, false} ->
+        :ok
+
+      {line, doc} ->
+        Module.put_attribute(env.module, :doc, {line, build_component_doc(doc, attrs)})
+
+      nil ->
+        Module.put_attribute(env.module, :doc, {env.line, build_component_doc(attrs)})
+    end
+  end
+
+  defp register_component_doc(_env, :defp, _attrs) do
+    :ok
   end
 
   defp build_component_doc(doc \\ "", attrs) do

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -597,7 +597,7 @@ defmodule Phoenix.Component do
   The injected attribute docs are formatted as a markdown list:
 
     ```markdown
-    * *name* _`:type, opts`_, doc
+    * `name` (`:type`) (required) - attr docs. Defaults to `:default`.
     ```
     
   By default, all attributes will have their types and docs injected into
@@ -923,7 +923,7 @@ defmodule Phoenix.Component do
   defp build_component_doc(doc \\ "", attrs) do
     [left | right] = String.split(doc, "[[INSERT ATTRDOCS]]")
 
-    :erlang.iolist_to_binary([
+    IO.iodata_to_binary([
       build_left_doc(left),
       build_attr_docs(attrs),
       build_right_doc(right)
@@ -947,46 +947,48 @@ defmodule Phoenix.Component do
           ?\n,
           "* ",
           build_attr_name(attr),
-          "_",
           build_attr_type(attr),
-          build_attr_meta(attr),
-          "_",
-          build_attr_doc(attr)
+          build_attr_required(attr),
+          build_attr_doc_and_default(attr)
         ]
       end
     ]
   end
 
   defp build_attr_name(%{name: name}) do
-    ["*", Atom.to_string(name), "* "]
+    ["`", Atom.to_string(name), "` "]
   end
 
   defp build_attr_type(%{type: {:struct, type}}) do
-    ["`", inspect(type), "`"]
+    ["(`", inspect(type), "`)"]
   end
 
   defp build_attr_type(%{type: type}) do
-    ["`", inspect(type), "`"]
+    ["(`", inspect(type), "`)"]
   end
 
-  defp build_attr_meta(%{required: true}) do
-    [", required: `true`"]
+  defp build_attr_required(%{required: true}) do
+    [" (required)"]
   end
 
-  defp build_attr_meta(%{opts: [default: default]}) do
-    [", default: `", inspect(default), "`"]
-  end
-
-  defp build_attr_meta(_attr) do
+  defp build_attr_required(_attr) do
     []
   end
 
-  defp build_attr_doc(%{doc: nil}) do
+  defp build_attr_doc_and_default(%{doc: nil, opts: [default: default]}) do
+    [" - Defaults to `", inspect(default), "`."]
+  end
+
+  defp build_attr_doc_and_default(%{doc: doc, opts: [default: default]}) do
+    [" - ", doc, " Defaults to `", inspect(default), "`."]
+  end
+
+  defp build_attr_doc_and_default(%{doc: nil}) do
     []
   end
 
-  defp build_attr_doc(%{doc: doc}) do
-    [", ", doc]
+  defp build_attr_doc_and_default(%{doc: doc}) do
+    [" - ", doc]
   end
 
   defp build_right_doc("") do

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -652,11 +652,37 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "appends attr docs to function component @doc string if present" do
-      # Code.fetch_docs/1 needs a compiled BEAM file
       {_, _, :elixir, "text/markdown", _, _, docs} =
         Code.fetch_docs(Phoenix.LiveViewTest.FunctionComponentWithAttrs)
 
-      # TODO: assertions for docs
+      assert [
+               _,
+               _,
+               {{:function, :fun_attr_any, 1}, _, ["fun_attr_any(assigns)"],
+                %{"en" => "## Attributes\n\n* *attr* _`:any`_\n"}, _},
+               {{:function, :fun_attr_default, 1}, _, ["fun_attr_default(assigns)"],
+                %{"en" => "## Attributes\n\n* *attr* _`:any`, default: `%{}`_\n"}, _},
+               {{:function, :fun_attr_global, 1}, _, ["fun_attr_global(assigns)"],
+                %{"en" => "## Attributes\n\n* *attr* _`:global`_\n"}, _},
+               {{:function, :fun_attr_list, 1}, _, ["fun_attr_list(assigns)"],
+                %{"en" => "## Attributes\n\n* *attr* _`:list`_\n"}, _},
+               {{:function, :fun_attr_required, 1}, _, ["fun_attr_required(assigns)"],
+                %{"en" => "## Attributes\n\n* *attr* _`:any`, required: `true`_\n"}, _},
+               {{:function, :fun_attr_string, 1}, _, ["fun_attr_string(assigns)"],
+                %{"en" => "## Attributes\n\n* *attr* _`:string`_\n"}, _},
+               {{:function, :fun_attr_struct, 1}, _, ["fun_attr_struct(assigns)"],
+                %{
+                  "en" =>
+                    "## Attributes\n\n* *attr* _`Phoenix.LiveViewTest.FunctionComponentWithAttrs.Struct`_\n"
+                }, _},
+               {{:function, :fun_doc_false, 1}, _, ["fun_doc_false(assigns)"], :hidden, _},
+               {{:function, :fun_doc_injection, 1}, _, ["fun_doc_injection(assigns)"],
+                %{"en" => "fun docs\n\n## Attributes\n\n* *attr* _`:any`_\n\nfun docs\n"}, _},
+               {{:function, :fun_multiple_attr, 1}, _, ["fun_multiple_attr(assigns)"],
+                %{"en" => "## Attributes\n\n* *attr1* _`:any`_\n* *attr2* _`:any`_\n"}, _},
+               {{:function, :fun_with_doc, 1}, _, ["fun_with_doc(assigns)"],
+                %{"en" => "fun docs\n## Attributes\n\n* *attr* _`:any`_\n"}, _}
+             ] = docs
     end
 
     test "raise if attr is not declared before the first function definition" do

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -585,6 +585,7 @@ defmodule Phoenix.ComponentTest do
 
         attr :no_doc, :any
 
+        @doc "my function component with attrs"
         def func_with_attr_descs(assigns), do: ~H[]
       end
 
@@ -637,7 +638,7 @@ defmodule Phoenix.ComponentTest do
              }
     end
 
-    test "raise if :desc is not a stirng" do
+    test "raise if :desc is not a string" do
       msg = ~r/desc must be a string, got: :foo/
 
       assert_raise CompileError, msg, fn ->
@@ -648,6 +649,24 @@ defmodule Phoenix.ComponentTest do
           def func(assigns), do: ~H[]
         end
       end
+    end
+
+    test "appends attr docs to function component @doc string if present" do
+      # Code.fetch_docs/1 needs a compiled BEAM file
+      assert {:docs_v1, _, :elixir, "text/markdown", :none, %{},
+              [
+                _,
+                _,
+                {{:function, :func_with_attrs, 1}, _, ["func_with_attrs(assigns)"],
+                 %{
+                   "en" => "a function component\n## Attributes\n* value: optional(any) - a value"
+                 }, %{}},
+                {{:function, :func_with_attrs2, 1}, _, ["func_with_attrs2(assigns)"],
+                 %{
+                   "en" =>
+                     "a second function component\n## Attributes\n* value1: optional(any) - a value\n* value2: optional(any) - another value"
+                 }, %{}}
+              ]} = Code.fetch_docs(Phoenix.LiveViewTest.FunctionComponentWithAttrs)
     end
 
     test "raise if attr is not declared before the first function definition" do

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -560,8 +560,8 @@ defmodule Phoenix.ComponentTest do
       end
     end
 
-    test "supports :desc for attr documentation" do
-      defmodule Descriptions do
+    test "supports :doc for attr documentation" do
+      defmodule AttrDocs do
         use Phoenix.Component
 
         attr :single, :any, doc: "a single line description"
@@ -589,7 +589,7 @@ defmodule Phoenix.ComponentTest do
         def func_with_attr_docs(assigns), do: ~H[]
       end
 
-      assert Descriptions.__components__() == %{
+      assert AttrDocs.__components__() == %{
                func_with_attr_docs: %{
                  kind: :def,
                  attrs: [
@@ -642,7 +642,7 @@ defmodule Phoenix.ComponentTest do
       msg = ~r/doc must be a string or false, got: :foo/
 
       assert_raise CompileError, msg, fn ->
-        defmodule Phoenix.ComponentTest.AttrDescInvalidType do
+        defmodule Phoenix.ComponentTest.AttrDocsInvalidType do
           use Elixir.Phoenix.Component
 
           attr :invalid, :any, doc: :foo
@@ -653,19 +653,10 @@ defmodule Phoenix.ComponentTest do
 
     test "appends attr docs to function component @doc string if present" do
       # Code.fetch_docs/1 needs a compiled BEAM file
-      assert {:docs_v1, _, :elixir, "text/markdown", :none, %{},
-              [
-                _,
-                _,
-                {{:function, :func_with_attrs, 1}, _, ["func_with_attrs(assigns)"],
-                 %{
-                   "en" => "a function component"
-                 }, %{}},
-                {{:function, :func_with_attrs2, 1}, _, ["func_with_attrs2(assigns)"],
-                 %{
-                   "en" => "a second function componentdoc"
-                 }, %{}}
-              ]} = Code.fetch_docs(Phoenix.LiveViewTest.FunctionComponentWithAttrs)
+      {_, _, :elixir, "text/markdown", _, _, docs} =
+        Code.fetch_docs(Phoenix.LiveViewTest.FunctionComponentWithAttrs)
+
+      # TODO: assertions for docs
     end
 
     test "raise if attr is not declared before the first function definition" do

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -348,7 +348,7 @@ defmodule Phoenix.ComponentTest do
                      type: :any,
                      opts: [default: nil],
                      required: false,
-                     desc: "",
+                     doc: nil,
                      line: func1_line + 2
                    },
                    %{
@@ -356,7 +356,7 @@ defmodule Phoenix.ComponentTest do
                      type: :any,
                      opts: [],
                      required: true,
-                     desc: "",
+                     doc: nil,
                      line: func1_line + 1
                    }
                  ]
@@ -369,7 +369,7 @@ defmodule Phoenix.ComponentTest do
                      type: :integer,
                      opts: [default: 0],
                      required: false,
-                     desc: "",
+                     doc: nil,
                      line: func2_line + 2
                    },
                    %{
@@ -377,7 +377,7 @@ defmodule Phoenix.ComponentTest do
                      type: :any,
                      opts: [],
                      required: true,
-                     desc: "",
+                     doc: nil,
                      line: func2_line + 1
                    }
                  ]
@@ -389,7 +389,7 @@ defmodule Phoenix.ComponentTest do
                      name: :id,
                      opts: [default: "container"],
                      required: false,
-                     desc: "",
+                     doc: nil,
                      type: :string
                    }
                  ],
@@ -402,7 +402,7 @@ defmodule Phoenix.ComponentTest do
                      name: :rest,
                      opts: [default: %{class: "primary"}],
                      required: false,
-                     desc: "",
+                     doc: nil,
                      type: :global
                    }
                  ],
@@ -415,15 +415,15 @@ defmodule Phoenix.ComponentTest do
                      name: :id,
                      opts: [],
                      required: true,
-                     type: :string,
-                     desc: ""
+                     doc: nil,
+                     type: :string
                    },
                    %{
                      line: with_global_line + 5,
                      name: :rest,
                      opts: [],
                      required: false,
-                     desc: "",
+                     doc: nil,
                      type: :global
                    }
                  ],
@@ -505,7 +505,7 @@ defmodule Phoenix.ComponentTest do
                      line: __ENV__.line - 13,
                      name: :example,
                      opts: [],
-                     desc: "",
+                     doc: nil,
                      required: true,
                      type: :any
                    }
@@ -564,20 +564,20 @@ defmodule Phoenix.ComponentTest do
       defmodule Descriptions do
         use Phoenix.Component
 
-        attr :single, :any, desc: "a single line description"
+        attr :single, :any, doc: "a single line description"
 
-        attr :break, :any, desc: "a description
+        attr :break, :any, doc: "a description
         with a line break"
 
         attr :multi, :any,
-          desc: """
+          doc: """
           a description
           that spans
           multiple lines
           """
 
         attr :sigil, :any,
-          desc: ~S"""
+          doc: ~S"""
           a description
           within a multi-line
           sigil
@@ -586,11 +586,11 @@ defmodule Phoenix.ComponentTest do
         attr :no_doc, :any
 
         @doc "my function component with attrs"
-        def func_with_attr_descs(assigns), do: ~H[]
+        def func_with_attr_docs(assigns), do: ~H[]
       end
 
       assert Descriptions.__components__() == %{
-               func_with_attr_descs: %{
+               func_with_attr_docs: %{
                  kind: :def,
                  attrs: [
                    %{
@@ -599,7 +599,7 @@ defmodule Phoenix.ComponentTest do
                      opts: [],
                      required: false,
                      type: :any,
-                     desc: "a description\n        with a line break"
+                     doc: "a description\n        with a line break"
                    },
                    %{
                      line: 572,
@@ -607,7 +607,7 @@ defmodule Phoenix.ComponentTest do
                      opts: [],
                      required: false,
                      type: :any,
-                     desc: "a description\nthat spans\nmultiple lines\n"
+                     doc: "a description\nthat spans\nmultiple lines\n"
                    },
                    %{
                      line: 586,
@@ -615,7 +615,7 @@ defmodule Phoenix.ComponentTest do
                      opts: [],
                      required: false,
                      type: :any,
-                     desc: ""
+                     doc: nil
                    },
                    %{
                      line: 579,
@@ -623,7 +623,7 @@ defmodule Phoenix.ComponentTest do
                      opts: [],
                      required: false,
                      type: :any,
-                     desc: "a description\nwithin a multi-line\nsigil\n"
+                     doc: "a description\nwithin a multi-line\nsigil\n"
                    },
                    %{
                      line: 567,
@@ -631,21 +631,21 @@ defmodule Phoenix.ComponentTest do
                      opts: [],
                      required: false,
                      type: :any,
-                     desc: "a single line description"
+                     doc: "a single line description"
                    }
                  ]
                }
              }
     end
 
-    test "raise if :desc is not a string" do
-      msg = ~r/desc must be a string, got: :foo/
+    test "raise if :doc is not a string" do
+      msg = ~r/doc must be a string or false, got: :foo/
 
       assert_raise CompileError, msg, fn ->
         defmodule Phoenix.ComponentTest.AttrDescInvalidType do
           use Elixir.Phoenix.Component
 
-          attr :invalid, :any, desc: :foo
+          attr :invalid, :any, doc: :foo
           def func(assigns), do: ~H[]
         end
       end
@@ -659,12 +659,11 @@ defmodule Phoenix.ComponentTest do
                 _,
                 {{:function, :func_with_attrs, 1}, _, ["func_with_attrs(assigns)"],
                  %{
-                   "en" => "a function component\n## Attributes\n* value: optional(any) - a value"
+                   "en" => "a function component"
                  }, %{}},
                 {{:function, :func_with_attrs2, 1}, _, ["func_with_attrs2(assigns)"],
                  %{
-                   "en" =>
-                     "a second function component\n## Attributes\n* value1: optional(any) - a value\n* value2: optional(any) - another value"
+                   "en" => "a second function componentdoc"
                  }, %{}}
               ]} = Code.fetch_docs(Phoenix.LiveViewTest.FunctionComponentWithAttrs)
     end

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -348,6 +348,7 @@ defmodule Phoenix.ComponentTest do
                      type: :any,
                      opts: [default: nil],
                      required: false,
+                     desc: "",
                      line: func1_line + 2
                    },
                    %{
@@ -355,6 +356,7 @@ defmodule Phoenix.ComponentTest do
                      type: :any,
                      opts: [],
                      required: true,
+                     desc: "",
                      line: func1_line + 1
                    }
                  ]
@@ -367,6 +369,7 @@ defmodule Phoenix.ComponentTest do
                      type: :integer,
                      opts: [default: 0],
                      required: false,
+                     desc: "",
                      line: func2_line + 2
                    },
                    %{
@@ -374,6 +377,7 @@ defmodule Phoenix.ComponentTest do
                      type: :any,
                      opts: [],
                      required: true,
+                     desc: "",
                      line: func2_line + 1
                    }
                  ]
@@ -385,6 +389,7 @@ defmodule Phoenix.ComponentTest do
                      name: :id,
                      opts: [default: "container"],
                      required: false,
+                     desc: "",
                      type: :string
                    }
                  ],
@@ -397,6 +402,7 @@ defmodule Phoenix.ComponentTest do
                      name: :rest,
                      opts: [default: %{class: "primary"}],
                      required: false,
+                     desc: "",
                      type: :global
                    }
                  ],
@@ -409,13 +415,15 @@ defmodule Phoenix.ComponentTest do
                      name: :id,
                      opts: [],
                      required: true,
-                     type: :string
+                     type: :string,
+                     desc: ""
                    },
                    %{
                      line: with_global_line + 5,
                      name: :rest,
                      opts: [],
                      required: false,
+                     desc: "",
                      type: :global
                    }
                  ],
@@ -497,6 +505,7 @@ defmodule Phoenix.ComponentTest do
                      line: __ENV__.line - 13,
                      name: :example,
                      opts: [],
+                     desc: "",
                      required: true,
                      type: :any
                    }
@@ -548,6 +557,96 @@ defmodule Phoenix.ComponentTest do
 
       assert_raise KeyError, ~r/:value not found/, fn ->
         render(Defaults, :no_default, %{})
+      end
+    end
+
+    test "supports :desc for attr documentation" do
+      defmodule Descriptions do
+        use Phoenix.Component
+
+        attr :single, :any, desc: "a single line description"
+
+        attr :break, :any, desc: "a description
+        with a line break"
+
+        attr :multi, :any,
+          desc: """
+          a description
+          that spans
+          multiple lines
+          """
+
+        attr :sigil, :any,
+          desc: ~S"""
+          a description
+          within a multi-line
+          sigil
+          """
+
+        attr :no_doc, :any
+
+        def func_with_attr_descs(assigns), do: ~H[]
+      end
+
+      assert Descriptions.__components__() == %{
+               func_with_attr_descs: %{
+                 kind: :def,
+                 attrs: [
+                   %{
+                     line: 569,
+                     name: :break,
+                     opts: [],
+                     required: false,
+                     type: :any,
+                     desc: "a description\n        with a line break"
+                   },
+                   %{
+                     line: 572,
+                     name: :multi,
+                     opts: [],
+                     required: false,
+                     type: :any,
+                     desc: "a description\nthat spans\nmultiple lines\n"
+                   },
+                   %{
+                     line: 586,
+                     name: :no_doc,
+                     opts: [],
+                     required: false,
+                     type: :any,
+                     desc: ""
+                   },
+                   %{
+                     line: 579,
+                     name: :sigil,
+                     opts: [],
+                     required: false,
+                     type: :any,
+                     desc: "a description\nwithin a multi-line\nsigil\n"
+                   },
+                   %{
+                     line: 567,
+                     name: :single,
+                     opts: [],
+                     required: false,
+                     type: :any,
+                     desc: "a single line description"
+                   }
+                 ]
+               }
+             }
+    end
+
+    test "raise if :desc is not a stirng" do
+      msg = ~r/desc must be a string, got: :foo/
+
+      assert_raise CompileError, msg, fn ->
+        defmodule Phoenix.ComponentTest.AttrDescInvalidType do
+          use Elixir.Phoenix.Component
+
+          attr :invalid, :any, desc: :foo
+          def func(assigns), do: ~H[]
+        end
       end
     end
 

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -651,38 +651,34 @@ defmodule Phoenix.ComponentTest do
       end
     end
 
-    test "appends attr docs to function component @doc string if present" do
+    test "injects attr docs to function component @doc string" do
       {_, _, :elixir, "text/markdown", _, _, docs} =
         Code.fetch_docs(Phoenix.LiveViewTest.FunctionComponentWithAttrs)
 
-      assert [
-               _,
-               _,
-               {{:function, :fun_attr_any, 1}, _, ["fun_attr_any(assigns)"],
-                %{"en" => "## Attributes\n\n* *attr* _`:any`_\n"}, _},
-               {{:function, :fun_attr_default, 1}, _, ["fun_attr_default(assigns)"],
-                %{"en" => "## Attributes\n\n* *attr* _`:any`, default: `%{}`_\n"}, _},
-               {{:function, :fun_attr_global, 1}, _, ["fun_attr_global(assigns)"],
-                %{"en" => "## Attributes\n\n* *attr* _`:global`_\n"}, _},
-               {{:function, :fun_attr_list, 1}, _, ["fun_attr_list(assigns)"],
-                %{"en" => "## Attributes\n\n* *attr* _`:list`_\n"}, _},
-               {{:function, :fun_attr_required, 1}, _, ["fun_attr_required(assigns)"],
-                %{"en" => "## Attributes\n\n* *attr* _`:any`, required: `true`_\n"}, _},
-               {{:function, :fun_attr_string, 1}, _, ["fun_attr_string(assigns)"],
-                %{"en" => "## Attributes\n\n* *attr* _`:string`_\n"}, _},
-               {{:function, :fun_attr_struct, 1}, _, ["fun_attr_struct(assigns)"],
-                %{
-                  "en" =>
-                    "## Attributes\n\n* *attr* _`Phoenix.LiveViewTest.FunctionComponentWithAttrs.Struct`_\n"
-                }, _},
-               {{:function, :fun_doc_false, 1}, _, ["fun_doc_false(assigns)"], :hidden, _},
-               {{:function, :fun_doc_injection, 1}, _, ["fun_doc_injection(assigns)"],
-                %{"en" => "fun docs\n\n## Attributes\n\n* *attr* _`:any`_\n\nfun docs\n"}, _},
-               {{:function, :fun_multiple_attr, 1}, _, ["fun_multiple_attr(assigns)"],
-                %{"en" => "## Attributes\n\n* *attr1* _`:any`_\n* *attr2* _`:any`_\n"}, _},
-               {{:function, :fun_with_doc, 1}, _, ["fun_with_doc(assigns)"],
-                %{"en" => "fun docs\n## Attributes\n\n* *attr* _`:any`_\n"}, _}
-             ] = docs
+      components = %{
+        fun_attr_any: "## Attributes\n\n* *attr* _`:any`_\n",
+        fun_attr_string: "## Attributes\n\n* *attr* _`:string`_\n",
+        fun_attr_atom: "## Attributes\n\n* *attr* _`:atom`_\n",
+        fun_attr_boolean: "## Attributes\n\n* *attr* _`:boolean`_\n",
+        fun_attr_integer: "## Attributes\n\n* *attr* _`:integer`_\n",
+        fun_attr_float: "## Attributes\n\n* *attr* _`:float`_\n",
+        fun_attr_list: "## Attributes\n\n* *attr* _`:list`_\n",
+        fun_attr_global: "## Attributes\n\n* *attr* _`:global`_\n",
+        fun_attr_struct:
+          "## Attributes\n\n* *attr* _`Phoenix.LiveViewTest.FunctionComponentWithAttrs.Struct`_\n",
+        fun_attr_required: "## Attributes\n\n* *attr* _`:any`, required: `true`_\n",
+        fun_attr_default: "## Attributes\n\n* *attr* _`:any`, default: `%{}`_\n",
+        fun_doc_false: :hidden,
+        fun_doc_injection: "fun docs\n\n## Attributes\n\n* *attr* _`:any`_\n\nfun docs\n",
+        fun_multiple_attr: "## Attributes\n\n* *attr1* _`:any`_\n* *attr2* _`:any`_\n",
+        fun_with_attr_doc: "## Attributes\n\n* *attr* _`:any`_, attr docs\n",
+        fun_with_hidden_attr: "## Attributes\n\n* *attr1* _`:any`_\n",
+        fun_with_doc: "fun docs\n## Attributes\n\n* *attr* _`:any`_\n"
+      }
+
+      for {{_, fun, _}, _, _, %{"en" => doc}, _} <- docs do
+        assert components[fun] == doc
+      end
     end
 
     test "raise if attr is not declared before the first function definition" do

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -656,24 +656,24 @@ defmodule Phoenix.ComponentTest do
         Code.fetch_docs(Phoenix.LiveViewTest.FunctionComponentWithAttrs)
 
       components = %{
-        fun_attr_any: "## Attributes\n\n* *attr* _`:any`_\n",
-        fun_attr_string: "## Attributes\n\n* *attr* _`:string`_\n",
-        fun_attr_atom: "## Attributes\n\n* *attr* _`:atom`_\n",
-        fun_attr_boolean: "## Attributes\n\n* *attr* _`:boolean`_\n",
-        fun_attr_integer: "## Attributes\n\n* *attr* _`:integer`_\n",
-        fun_attr_float: "## Attributes\n\n* *attr* _`:float`_\n",
-        fun_attr_list: "## Attributes\n\n* *attr* _`:list`_\n",
-        fun_attr_global: "## Attributes\n\n* *attr* _`:global`_\n",
+        fun_attr_any: "## Attributes\n\n* `attr` (`:any`)\n",
+        fun_attr_string: "## Attributes\n\n* `attr` (`:string`)\n",
+        fun_attr_atom: "## Attributes\n\n* `attr` (`:atom`)\n",
+        fun_attr_boolean: "## Attributes\n\n* `attr` (`:boolean`)\n",
+        fun_attr_integer: "## Attributes\n\n* `attr` (`:integer`)\n",
+        fun_attr_float: "## Attributes\n\n* `attr` (`:float`)\n",
+        fun_attr_list: "## Attributes\n\n* `attr` (`:list`)\n",
+        fun_attr_global: "## Attributes\n\n* `attr` (`:global`)\n",
         fun_attr_struct:
-          "## Attributes\n\n* *attr* _`Phoenix.LiveViewTest.FunctionComponentWithAttrs.Struct`_\n",
-        fun_attr_required: "## Attributes\n\n* *attr* _`:any`, required: `true`_\n",
-        fun_attr_default: "## Attributes\n\n* *attr* _`:any`, default: `%{}`_\n",
+          "## Attributes\n\n* `attr` (`Phoenix.LiveViewTest.FunctionComponentWithAttrs.Struct`)\n",
+        fun_attr_required: "## Attributes\n\n* `attr` (`:any`) (required)\n",
+        fun_attr_default: "## Attributes\n\n* `attr` (`:any`) - Defaults to `%{}`.\n",
         fun_doc_false: :hidden,
-        fun_doc_injection: "fun docs\n\n## Attributes\n\n* *attr* _`:any`_\n\nfun docs\n",
-        fun_multiple_attr: "## Attributes\n\n* *attr1* _`:any`_\n* *attr2* _`:any`_\n",
-        fun_with_attr_doc: "## Attributes\n\n* *attr* _`:any`_, attr docs\n",
-        fun_with_hidden_attr: "## Attributes\n\n* *attr1* _`:any`_\n",
-        fun_with_doc: "fun docs\n## Attributes\n\n* *attr* _`:any`_\n"
+        fun_doc_injection: "fun docs\n\n## Attributes\n\n* `attr` (`:any`)\n\nfun docs\n",
+        fun_multiple_attr: "## Attributes\n\n* `attr1` (`:any`)\n* `attr2` (`:any`)\n",
+        fun_with_attr_doc: "## Attributes\n\n* `attr` (`:any`) - attr docs\n",
+        fun_with_hidden_attr: "## Attributes\n\n* `attr1` (`:any`)\n",
+        fun_with_doc: "fun docs\n## Attributes\n\n* `attr` (`:any`)\n"
       }
 
       for {{_, fun, _}, _, _, %{"en" => doc}, _} <- docs do

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -62,6 +62,9 @@ defmodule Phoenix.LiveViewTest.FunctionComponentWithAttrs do
   attr :attr, :any
   @doc false
   def fun_doc_false(assigns), do: ~H[]
+
+  attr :attr, :any
+  defp private_fun(assigns), do: ~H[]
 end
 
 defmodule Phoenix.LiveViewTest.StatefulComponent do

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -14,6 +14,30 @@ defmodule Phoenix.LiveViewTest.FunctionComponent do
   end
 end
 
+defmodule Phoenix.LiveViewTest.FunctionComponentWithAttrs do
+  use Phoenix.Component
+
+  attr :value, :any, doc: "a value"
+
+  @doc "a function component"
+  def func_with_attrs(assigns) do
+    ~H"""
+    COMPONENT: <%= @value %>
+    """
+  end
+
+  attr :value1, :any, doc: "a value"
+  attr :value2, :any, doc: "another value"
+
+  @doc "a second function component"
+  @spec func_with_attrs2(map) :: any()
+  def func_with_attrs2(assigns) do
+    ~H"""
+    COMPONENT: <%= @value %>
+    """
+  end
+end
+
 defmodule Phoenix.LiveViewTest.StatefulComponent do
   use Phoenix.LiveComponent
 
@@ -136,13 +160,13 @@ defmodule Phoenix.LiveViewTest.WithMultipleTargets do
   def mount(_params, %{"names" => names, "from" => from} = session, socket) do
     {
       :ok,
-      assign(socket, [
+      assign(socket,
         names: names,
         from: from,
         disabled: [],
         message: nil,
         parent_selector: Map.get(session, "parent_selector", "#parent_id")
-      ])
+      )
     }
   end
 

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -27,6 +27,18 @@ defmodule Phoenix.LiveViewTest.FunctionComponentWithAttrs do
   attr :attr, :string
   def fun_attr_string(assigns), do: ~H[]
 
+  attr :attr, :atom
+  def fun_attr_atom(assigns), do: ~H[]
+
+  attr :attr, :boolean
+  def fun_attr_boolean(assigns), do: ~H[]
+
+  attr :attr, :integer
+  def fun_attr_integer(assigns), do: ~H[]
+
+  attr :attr, :float
+  def fun_attr_float(assigns), do: ~H[]
+
   attr :attr, :list
   def fun_attr_list(assigns), do: ~H[]
 
@@ -45,6 +57,13 @@ defmodule Phoenix.LiveViewTest.FunctionComponentWithAttrs do
   attr :attr1, :any
   attr :attr2, :any
   def fun_multiple_attr(assigns), do: ~H[]
+
+  attr :attr, :any, doc: "attr docs"
+  def fun_with_attr_doc(assigns), do: ~H[]
+
+  attr :attr1, :any
+  attr :attr2, :any, doc: false
+  def fun_with_hidden_attr(assigns), do: ~H[]
 
   attr :attr, :any
   @doc "fun docs"

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -17,25 +17,51 @@ end
 defmodule Phoenix.LiveViewTest.FunctionComponentWithAttrs do
   use Phoenix.Component
 
-  attr :value, :any, doc: "a value"
-
-  @doc "a function component"
-  def func_with_attrs(assigns) do
-    ~H"""
-    COMPONENT: <%= @value %>
-    """
+  defmodule Struct do
+    defstruct []
   end
 
-  attr :value1, :any, doc: "a value"
-  attr :value2, :any, doc: "another value"
+  attr :attr, :any
+  def fun_attr_any(assigns), do: ~H[]
 
-  @doc "a second function component"
-  @spec func_with_attrs2(map) :: any()
-  def func_with_attrs2(assigns) do
-    ~H"""
-    COMPONENT: <%= @value %>
-    """
-  end
+  attr :attr, :string
+  def fun_attr_string(assigns), do: ~H[]
+
+  attr :attr, :list
+  def fun_attr_list(assigns), do: ~H[]
+
+  attr :attr, :global
+  def fun_attr_global(assigns), do: ~H[]
+
+  attr :attr, Struct
+  def fun_attr_struct(assigns), do: ~H[]
+
+  attr :attr, :any, required: true
+  def fun_attr_required(assigns), do: ~H[]
+
+  attr :attr, :any, default: %{}
+  def fun_attr_default(assigns), do: ~H[]
+
+  attr :attr1, :any
+  attr :attr2, :any
+  def fun_multiple_attr(assigns), do: ~H[]
+
+  attr :attr, :any
+  @doc "fun docs"
+  def fun_with_doc(assigns), do: ~H[]
+
+  attr :attr, :any
+
+  @doc """
+  fun docs
+  [[INSERT ATTRDOCS]]
+  fun docs
+  """
+  def fun_doc_injection(assigns), do: ~H[]
+
+  attr :attr, :any
+  @doc false
+  def fun_doc_false(assigns), do: ~H[]
 end
 
 defmodule Phoenix.LiveViewTest.StatefulComponent do


### PR DESCRIPTION
Relates to #2016 

Adds the `:doc` option to `Phoenix.Component.attr/3` to support documentation generation for declarative attributes.