### PR TITLE
Cleanup after upload entry error, closes #2037

### DIFF
--- a/assets/js/phoenix_live_view/upload_entry.js
+++ b/assets/js/phoenix_live_view/upload_entry.js
@@ -69,6 +69,7 @@ export default class UploadEntry {
   isDone(){ return this._isDone }
 
   error(reason = "failed"){
+    this.fileEl.removeEventListener(PHX_LIVE_FILE_UPDATED, this._onElUpdated)
     this.view.pushFileProgress(this.fileEl, this.ref, {error: reason})
     LiveUploader.clearFiles(this.fileEl)
   }


### PR DESCRIPTION
In order to ensure failed entries do not interfere with
further form actions, entries stop listening for update
events once error() is invoked.

Closes #2037 