### PR TITLE
Make the examples for async updating a component work by default

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1619,7 +1619,7 @@ defmodule Phoenix.LiveView do
         ...
         pid = self()
 
-        Task.async(fn ->
+        Task.start(fn ->
           # Do something asynchronously
           send_update(pid, Cart, id: "cart", status: "cancelled")
         end)
@@ -1652,7 +1652,7 @@ defmodule Phoenix.LiveView do
         ...
         pid = self()
 
-        Task.async(fn ->
+        Task.start(fn ->
           # Do something asynchronously
           send_update_after(pid, Cart, [id: "cart", status: "cancelled"], 3000)
         end)


### PR DESCRIPTION
As any sane developer I copied the example to be able to send my component an update asynchronously. It took me a fair while before I realised why it didn't work. My process received `{Reference.t, msg}` instead of `msg` because there was no `Task.await` in the example meaning that the result would be send to the process starting the task. Since the example is trying to update itself asynchronously I think `Task.start` is a better fit for the example. It also makes the examples when copy-pasted Just Work ™️ .

I almost got concerned that liveview didn't have the feature I was looking for. So I'm really happy it's there 👍 