### PR TITLE
Add reference to inputs_for in form bindings guide

### DIFF
--- a/guides/client/form-bindings.md
+++ b/guides/client/form-bindings.md
@@ -173,7 +173,7 @@ requires explicitly setting the `:value` in your markup, for example:
 Nested inputs are handled using `inputs_for` form helpers. There are two versions
 of `inputs_for` - one that takes an anonymous function and one that doesn't. The version
 that takes an anonymous function won't work properly with LiveView as it prevents rendering
-of LiveComponents. Instead of using this form:
+of LiveComponents. Instead of using this:
 
 ```heex
 <%= inputs_for f, :friend, fn fp -> %>
@@ -185,10 +185,12 @@ you should use this:
 
 ```heex
 <%= for fp <- inputs_for(f, :friends) do %>
+  <%= hidden_inputs_for(fp) %>
   <%= text_input fp, :name %>
 <% end %>
 ```
 
+Note that you will need to include a call to `hidden_inputs_for` as the version of inputs_for that does not take an anonymous function also does not automatically generate any necessary hidden fields for tracking ids of Ecto associations.
 
 ## File inputs
 

--- a/guides/client/form-bindings.md
+++ b/guides/client/form-bindings.md
@@ -168,6 +168,28 @@ requires explicitly setting the `:value` in your markup, for example:
 <%= error_tag f, :password_confirmation %>
 ```
 
+## Nested inputs
+
+Nested inputs are handled using `inputs_for` form helpers. There are two versions
+of `inputs_for` - one that takes an anonymous function and one that doesn't. The version
+that takes an anonymous function won't work properly with LiveView as it prevents rendering
+of LiveComponents. Instead of using this form:
+
+```heex
+<%= inputs_for f, :friend, fn fp -> %>
+  <%= text_input fp, :url %>
+<% end %>
+```
+
+you should use this:
+
+```heex
+<%= for fp <- inputs_for(f, :friends) do %>
+  <%= text_input fp, :name %>
+<% end %>
+```
+
+
 ## File inputs
 
 LiveView forms support [reactive file inputs](uploads.md),


### PR DESCRIPTION
Using the anonymous function version of `Phoenix.HTML.Form.inputs_for` will break if LiveComponents are used within the nested input. This update adds a section to the form bindings guide to that effect.

See https://github.com/phoenixframework/phoenix_html/pull/292 for further information.