### PR TITLE
Fix tiny typo in `JS.add_class` example.

### DIFF
--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -77,7 +77,7 @@ defmodule Phoenix.LiveView.JS do
 
       <div phx-click={
         JS.push("inc", loading: ".thermo", target: @myself)
-        |> JS.add_class(".warmer", to: ".thermo")
+        |> JS.add_class("warmer", to: ".thermo")
       }>+</div>
 
   ## Custom JS events with `JS.dispatch/1` and `window.addEventListener`


### PR DESCRIPTION
Hi. This is absolutely tiny but I figured I'd point it out in the name of documentation quality and consistency 😃 

The `Phoenix.LiveView.JS` moduledoc contains the following code example:

```elixir
<div phx-click={
  JS.push("inc", loading: ".thermo", target: @myself)
  |> JS.add_class(".warmer", to: ".thermo")
}>+</div>
```

The class to be applied by `JS.add_class/2` should be `warmer` and not `.warmer`. 

Thanks!
