### PR TITLE
`phx_feedback_for` without trailing `[]` for multiple_select should also be processed when adding the `phx-no-feedback` class.

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -222,7 +222,7 @@ let DOM = {
   discardError(container, el, phxFeedbackFor){
     let field = el.getAttribute && el.getAttribute(phxFeedbackFor)
     // TODO: Remove id lookup after we update Phoenix to use input_name instead of input_id
-    let input = field && container.querySelector(`[id="${field}"], [name="${field}"]`)
+    let input = field && container.querySelector(`[id="${field}"], [name="${field}"], [name="${field}[]"]`)
     if(!input){ return }
 
     if(!(this.private(input, PHX_HAS_FOCUSED) || this.private(input.form, PHX_HAS_SUBMITTED))){


### PR DESCRIPTION
Since `Phoenix.HTML.multiple_select/4` generates a select tag
with a name attribute containing a trailing `[]` to capture multiple options,
these elements should also be found when processing the
feedback elements with a `phx_feedback_for` attribute.
The value of the `phx_feedback_for` attribute is typically set with
`Phoenix.HTML.input_name/2` (as generated in the
`MyAppWeb.ErrorHelpers.error_tag/2` module), which does not add these
trailing square brackets, and hence the mismatch without this fix.