### PR TITLE
Declarative Slots & Literal Type Validations

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,6 +1,9 @@
 locals_without_parens = [
   attr: 2,
-  attr: 3
+  attr: 3,
+  slot: 1,
+  slot: 2,
+  slot: 3
 ]
 
 [

--- a/lib/mix/tasks/compile/phoenix_live_view.ex
+++ b/lib/mix/tasks/compile/phoenix_live_view.ex
@@ -109,8 +109,10 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
             case {type, value} do
               # missing required attr
               {_type, nil} when not root and required ->
-                message =
-                  "missing required attribute \"#{name}\" for component #{component(call)}"
+                message = """
+                missing required attribute \"#{name}\" \
+                for component #{component(call)}\
+                """
 
                 [error(message, call.file, call.line)]
 
@@ -120,8 +122,11 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
 
               # global attrs cannot be directly used
               {:global, {line, _column, _kind, _value}} ->
-                message =
-                  "global attribute \"#{name}\" in component #{component(call)} may not be provided directly"
+                message = """
+                global attribute \"#{name}\" \
+                in component #{component(call)} \
+                may not be provided directly\
+                """
 
                 [error(message, call.file, line)]
 
@@ -131,50 +136,78 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
 
               # string attribute type mismatch
               {:string, {line, _column, _kind, value}} when not is_binary(value) ->
-                message =
-                  "attribute \"#{name}\" in component #{component(call)} must be a :string, got: #{inspect(value)}"
+                message = """
+                attribute \"#{name}\" \
+                in component #{component(call)} \
+                must be a :string, \
+                got: #{inspect(value)}\
+                """
 
                 [error(message, call.file, line)]
 
               # atom attribute type mismatch
               {:atom, {line, _column, kind, value}} when kind != :lit or not is_atom(value) ->
-                message =
-                  "attribute \"#{name}\" in component #{component(call)} must be an :atom, got: #{inspect(value)}"
+                message = """
+                attribute \"#{name}\" \
+                in component #{component(call)} \
+                must be an :atom, \
+                got: #{inspect(value)}\
+                """
 
                 [error(message, call.file, line)]
 
               # boolean attribute type mismatch
               {:boolean, {line, _column, _kind, value}} when not is_boolean(value) ->
-                message =
-                  "attribute \"#{name}\" in component #{component(call)} must be a :boolean, got: #{inspect(value)}"
+                message = """
+                attribute \"#{name}\" \
+                in component #{component(call)} \
+                must be a :boolean, \
+                got: #{inspect(value)}\
+                """
 
                 [error(message, call.file, line)]
 
               # integer attribute type mismatch
               {:integer, {line, _column, _kind, value}} when not is_integer(value) ->
-                message =
-                  "attribute \"#{name}\" in component #{component(call)} must be an :integer, got: #{inspect(value)}"
+                message = """
+                attribute \"#{name}\" \
+                in component #{component(call)} \
+                must be an :integer, \
+                got: #{inspect(value)}\
+                """
 
                 [error(message, call.file, line)]
 
               # float attribute type mismatch
               {:float, {line, _column, _kind, value}} when not is_float(value) ->
-                message =
-                  "attribute \"#{name}\" in component #{component(call)} must be a :float, got: #{inspect(value)}"
+                message = """
+                attribute \"#{name}\" \
+                in component #{component(call)} \
+                must be a :float, \
+                got: #{inspect(value)}\
+                """
 
                 [error(message, call.file, line)]
 
               # list attribute type mismatch
               {:list, {line, _column, _kind, value}} when not is_list(value) ->
-                message =
-                  "attribute \"#{name}\" in component #{component(call)} must be a :list, got: #{inspect(value)}"
+                message = """
+                attribute \"#{name}\" \
+                in component #{component(call)} \
+                must be a :list, \
+                got: #{inspect(value)}\
+                """
 
                 [error(message, call.file, line)]
 
               # struct attribute type mismatch
               {{:struct, mod}, {line, _column, kind, value}} when kind != :struct ->
-                message =
-                  "attribute \"#{name}\" in component #{component(call)} must be a #{inspect(mod)}, got: #{inspect(value)}"
+                message = """
+                attribute \"#{name}\" \
+                in component #{component(call)} \
+                must be a #{inspect(mod)}, \
+                got: #{inspect(value)}\
+                """
 
                 [error(message, call.file, line)]
 
@@ -189,7 +222,11 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
     attrs_undefined =
       for {name, {line, _column, _kind, _value}} <- attrs,
           not (has_global? and Phoenix.Component.__global__?(caller_module, Atom.to_string(name))) do
-        message = "undefined attribute \"#{name}\" for component #{component(call)}"
+        message = """
+        undefined attribute \"#{name}\" \
+        for component #{component(call)}\
+        """
+
         error(message, call.file, line)
       end
 
@@ -203,7 +240,11 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
           case {slot_values, slot_attr_defs} do
             # missing required slot
             {nil, _slot_attr_defs} when required ->
-              message = "missing required slot \"#{slot_name}\" for component #{component(call)}"
+              message = """
+              missing required slot \"#{slot_name}\" \
+              for component #{component(call)}\
+              """
+
               [error(message, call.file, call.line)]
 
             # missing optional slot
@@ -215,11 +256,13 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
               missing_slot_attrs =
                 for slot_value <- slot_values,
                     {attr_name, %{required: true}} <- slot_attr_defs,
-                    {line, _column, _attr_kind, _attr_value} =
-                      Map.fetch!(slot_value, :inner_block),
+                    {line, _, _, _} = Map.fetch!(slot_value, :inner_block),
                     not Map.has_key?(slot_value, attr_name) do
-                  message =
-                    "missing required attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component(call)}"
+                  message = """
+                  missing required attribute \"#{attr_name}\" \
+                  in slot \"#{slot_name}\" \
+                  for component #{component(call)}\
+                  """
 
                   error(message, call.file, line)
                 end
@@ -234,8 +277,11 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
                     case {attr_def, attr_kind, attr_value} do
                       # undefined attribute
                       {:undef, _attr_kind, _attr_value} when attr_name != :inner_block ->
-                        message =
-                          "undefined attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component(call)}"
+                        message = """
+                        undefined attribute \"#{attr_name}\" \
+                        in slot \"#{slot_name}\" \
+                        for component #{component(call)}\
+                        """
 
                         [error(message, call.file, line) | errors]
 
@@ -246,54 +292,89 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
                       # string attribute type mismatch
                       {%{type: :string}, attr_kind, attr_value}
                       when attr_kind != :lit or not is_binary(attr_value) ->
-                        message =
-                          "attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component(call)} must be a :string, got: #{inspect(attr_value)}"
+                        message = """
+                        attribute \"#{attr_name}\" \
+                        in slot \"#{slot_name}\" \
+                        for component #{component(call)} \
+                        must be a :string, \
+                        got: #{inspect(attr_value)}\
+                        """
 
                         [error(message, call.file, line) | errors]
 
                       # atom attribute type mismatch
                       {%{type: :atom}, attr_kind, attr_value}
                       when attr_kind != :lit or not is_atom(attr_value) ->
-                        message =
-                          "attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component(call)} must be an :atom, got: #{inspect(attr_value)}"
+                        message = """
+                        attribute \"#{attr_name}\" \
+                        in slot \"#{slot_name}\" \
+                        for component #{component(call)} \
+                        must be an :atom, \
+                        got: #{inspect(attr_value)}\
+                        """
 
                         [error(message, call.file, line) | errors]
 
                       # boolean attribute type mismatch
                       {%{type: :boolean}, attr_kind, attr_value}
                       when attr_kind != :lit or not is_boolean(attr_value) ->
-                        message =
-                          "attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component(call)} must be a :boolean, got: #{inspect(attr_value)}"
+                        message = """
+                        attribute \"#{attr_name}\" \
+                        in slot \"#{slot_name}\" \
+                        for component #{component(call)} \
+                        must be a :boolean, \
+                        got: #{inspect(attr_value)}\
+                        """
 
                         [error(message, call.file, line) | errors]
 
                       # integer attribute type mismatch
                       {%{type: :integer}, attr_kind, attr_value}
                       when attr_kind != :lit or not is_integer(attr_value) ->
-                        message =
-                          "attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component(call)} must be a :integer, got: #{inspect(attr_value)}"
+                        message = """
+                        attribute \"#{attr_name}\" \
+                        in slot \"#{slot_name}\" \
+                        for component #{component(call)} \
+                        must be an :integer, \
+                        got: #{inspect(attr_value)}\
+                        """
 
                         [error(message, call.file, line) | errors]
 
                       # float attribute type mismatch
                       {%{type: :float}, attr_kind, attr_value}
                       when attr_kind != :lit or not is_float(attr_value) ->
-                        message =
-                          "attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component(call)} must be a :float, got: #{inspect(attr_value)}"
+                        message = """
+                        attribute \"#{attr_name}\" \
+                        in slot \"#{slot_name}\" \
+                        for component #{component(call)} \
+                        must be a :float, \
+                        got: #{inspect(attr_value)}\
+                        """
 
                         [error(message, call.file, line) | errors]
 
                       # list attribute type mismatch
                       {%{type: :list}, attr_kind, attr_value} when attr_kind != :list ->
-                        message =
-                          "attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component(call)} must be a :list, got: #{inspect(attr_value)}"
+                        message = """
+                        attribute \"#{attr_name}\" \
+                        in slot \"#{slot_name}\" \
+                        for component #{component(call)} \
+                        must be a :list, \
+                        got: #{inspect(attr_value)}\
+                        """
 
                         [error(message, call.file, line) | errors]
 
                       # struct attribute type mismatch
                       {%{type: {:struct, mod}}, attr_kind, attr_value} when attr_kind != :struct ->
-                        message =
-                          "attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component(call)} must be a #{inspect(mod)}, got: #{inspect(attr_value)}"
+                        message = """
+                        attribute \"#{attr_name}\" \
+                        in slot \"#{slot_name}\" \
+                        for component #{component(call)} \
+                        must be a #{inspect(mod)}, \
+                        got: #{inspect(attr_value)}\
+                        """
 
                         [error(message, call.file, line) | errors]
 

--- a/lib/mix/tasks/compile/phoenix_live_view.ex
+++ b/lib/mix/tasks/compile/phoenix_live_view.ex
@@ -264,31 +264,19 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
   end
 
   defp valid_type?(:any, _kind, _value), do: true
-
   defp valid_type?(_type, :expr, _value), do: true
-
   defp valid_type?(:string, :lit, value), do: is_binary(value)
-
   defp valid_type?(:atom, :lit, value), do: is_atom(value)
-
   defp valid_type?(:boolean, :lit, value), do: is_boolean(value)
-
   defp valid_type?(:integer, :lit, value), do: is_integer(value)
-
   defp valid_type?(:float, :lit, value), do: is_float(value)
-
   defp valid_type?(:list, :list, _value), do: true
-
   defp valid_type?(:list, :lit, value), do: is_list(value)
-
   defp valid_type?({:struct, _mod}, :struct, _value), do: true
-
   defp valid_type?(_type, _kind, _value), do: false
 
   defp type_with_article({:struct, mod}), do: type_with_article(mod)
-
   defp type_with_article(type) when type in [:atom, :integer], do: "an #{inspect(type)}"
-
   defp type_with_article(type), do: "a #{inspect(type)}"
 
   defp component(%{component: {mod, fun}}) do

--- a/lib/mix/tasks/compile/phoenix_live_view.ex
+++ b/lib/mix/tasks/compile/phoenix_live_view.ex
@@ -92,7 +92,11 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
         do: diagnostic
   end
 
-  defp diagnostics(caller_module, %{attrs: attrs, root: root} = call, %{attrs: attrs_defs}) do
+  defp diagnostics(caller_module, %{attrs: attrs, root: root} = call, %{
+         attrs: attrs_defs,
+         slots: _slots_defs
+       }) do
+    # TODO: provide diagnostics for slots
     {warnings, {attrs, has_global?}} =
       Enum.flat_map_reduce(attrs_defs, {attrs, false}, fn attr_def, {attrs, has_global?} ->
         %{name: name, required: required, type: type} = attr_def

--- a/lib/mix/tasks/compile/phoenix_live_view.ex
+++ b/lib/mix/tasks/compile/phoenix_live_view.ex
@@ -206,11 +206,15 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
               message = "missing required slot \"#{slot_name}\" for component #{component(call)}"
               [error(message, call.file, call.line)]
 
+            # missing optional slot
+            {nil, _slot_attr_defs} ->
+              []
+
             # slot with attributes
             {slot_values, slot_attr_defs} ->
               for slot_value <- slot_values,
                   {attr_name, {line, _column, attr_kind, attr_value}} <- slot_value,
-                  attr_def = Map.get(slot_attr_defs, attr_name, :undef),
+                  {attr_def, slot_attr_defs} = Map.pop(slot_attr_defs, attr_name, :undef),
                   reduce: [] do
                 errors ->
                   type_mismatch_slot_attr_warnings =

--- a/lib/mix/tasks/compile/phoenix_live_view.ex
+++ b/lib/mix/tasks/compile/phoenix_live_view.ex
@@ -174,10 +174,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
 
                       [error(message, call.file, line) | errors]
 
-                    # attribute with an expression for its value
-                    {%{type: _attr_type}, :expr} ->
-                      errors
-
                     # string attribute type mismatch
                     {%{type: :string}, attr_value} when not is_binary(attr_value) ->
                       message =
@@ -194,15 +190,47 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
 
                       [error(message, call.file, line) | errors]
 
-                    # nil attribute value type mismatch
-                    {%{type: attr_type}, nil} when attr_type not in [:any, :boolean] ->
+                    # boolean attribute type mismatch
+                    {%{type: :boolean}, attr_value} when not is_boolean(attr_value) ->
                       message =
                         "attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component(call)} " <>
-                          "must be a #{inspect(attr_type)}, got boolean: true"
+                          "must be a :boolean, got: #{inspect(attr_value)}"
 
                       [error(message, call.file, line) | errors]
 
-                    # attribute type and value match
+                    # integer attribute type mismatch
+                    {%{type: :integer}, attr_value} when not is_integer(attr_value) ->
+                      message =
+                        "attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component(call)} " <>
+                          "must be a :integer, got: #{inspect(attr_value)}"
+
+                      [error(message, call.file, line) | errors]
+
+                    # float attribute type mismatch
+                    {%{type: :float}, attr_value} when not is_float(attr_value) ->
+                      message =
+                        "attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component(call)} " <>
+                          "must be a :float, got: #{inspect(attr_value)}"
+
+                      [error(message, call.file, line) | errors]
+
+                    # struct attribute type mismatch
+                    {%{type: :list}, attr_value} when attr_value != :list ->
+                      message =
+                        "attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component(call)} " <>
+                          "must be a :list, got: #{inspect(attr_value)}"
+
+                      [error(message, call.file, line) | errors]
+
+                    # struct attribute type mismatch
+                    {%{type: {:struct, mod}}, attr_value} when attr_value != :struct ->
+                      message =
+                        "attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component(call)} " <>
+                          "must be a #{inspect(mod)}, got: #{inspect(attr_value)}"
+
+                      [error(message, call.file, line) | errors]
+
+                    # attribute type and value match, or an expression
                     {%{type: _attr_type}, _attr_value} ->
                       errors
                   end

--- a/lib/mix/tasks/compile/phoenix_live_view.ex
+++ b/lib/mix/tasks/compile/phoenix_live_view.ex
@@ -161,8 +161,8 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
 
     {slots_warnings, slots} =
       Enum.flat_map_reduce(slots_defs, slots, fn slot_def, slots ->
-        %{name: slot_name, required: required} = slot_def
-        slot_attr_defs = get_slot_attr_defs(attrs_defs, slot_name)
+        %{name: slot_name, required: required, attrs: attrs} = slot_def
+        slot_attr_defs = Enum.into(attrs, %{}, &{&1.name, &1})
         {slot_values, slots} = Map.pop(slots, slot_name)
 
         warnings =
@@ -202,7 +202,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
                     attr_def = Map.get(slot_attr_defs, attr_name, :undef),
                     reduce: [] do
                   errors ->
-                    # type_mismatch_slot_attr_warnings =
                     case {attr_def, attr_kind, attr_value} do
                       # undefined attribute
                       {:undef, _attr_kind, _attr_value} ->
@@ -250,13 +249,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
       end
 
     slots_warnings ++ slots_undefined ++ attrs_warnings ++ attrs_undefined
-  end
-
-  defp get_slot_attr_defs(attr_defs, slot_name) do
-    for attr_def <- attr_defs,
-        attr_def.slot == slot_name,
-        into: %{},
-        do: {attr_def.name, attr_def}
   end
 
   defp valid_type?(:any, _kind, _value), do: true

--- a/lib/mix/tasks/compile/phoenix_live_view.ex
+++ b/lib/mix/tasks/compile/phoenix_live_view.ex
@@ -119,67 +119,67 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
                 []
 
               # global attrs cannot be directly used
-              {:global, {line, _column, {_kind, _value}}} ->
+              {:global, {line, _column, _kind, _value}} ->
                 message =
                   "global attribute \"#{name}\" in component #{component(call)} may not be provided directly"
 
                 [error(message, call.file, line)]
 
               # expressions cannot be type checked
-              {_type, {_line, _column, {:expr, _value}}} ->
+              {_type, {_line, _column, :expr, _value}} ->
                 []
 
               # string attribute type mismatch
-              {:string, {line, _column, {_kind, value}}} when not is_binary(value) ->
+              {:string, {line, _column, _kind, value}} when not is_binary(value) ->
                 message =
                   "attribute \"#{name}\" in component #{component(call)} must be a :string, got: #{inspect(value)}"
 
                 [error(message, call.file, line)]
 
               # atom attribute type mismatch
-              {:atom, {line, _column, {kind, value}}} when kind != :lit or not is_atom(value) ->
+              {:atom, {line, _column, kind, value}} when kind != :lit or not is_atom(value) ->
                 message =
                   "attribute \"#{name}\" in component #{component(call)} must be an :atom, got: #{inspect(value)}"
 
                 [error(message, call.file, line)]
 
               # boolean attribute type mismatch
-              {:boolean, {line, _column, {_kind, value}}} when not is_boolean(value) ->
+              {:boolean, {line, _column, _kind, value}} when not is_boolean(value) ->
                 message =
                   "attribute \"#{name}\" in component #{component(call)} must be a :boolean, got: #{inspect(value)}"
 
                 [error(message, call.file, line)]
 
               # integer attribute type mismatch
-              {:integer, {line, _column, {_kind, value}}} when not is_integer(value) ->
+              {:integer, {line, _column, _kind, value}} when not is_integer(value) ->
                 message =
                   "attribute \"#{name}\" in component #{component(call)} must be an :integer, got: #{inspect(value)}"
 
                 [error(message, call.file, line)]
 
               # float attribute type mismatch
-              {:float, {line, _column, {_kind, value}}} when not is_float(value) ->
+              {:float, {line, _column, _kind, value}} when not is_float(value) ->
                 message =
                   "attribute \"#{name}\" in component #{component(call)} must be a :float, got: #{inspect(value)}"
 
                 [error(message, call.file, line)]
 
               # list attribute type mismatch
-              {:list, {line, _column, {_kind, value}}} when not is_list(value) ->
+              {:list, {line, _column, _kind, value}} when not is_list(value) ->
                 message =
                   "attribute \"#{name}\" in component #{component(call)} must be a :list, got: #{inspect(value)}"
 
                 [error(message, call.file, line)]
 
               # struct attribute type mismatch
-              {{:struct, mod}, {line, _column, {kind, value}}} when kind != :struct ->
+              {{:struct, mod}, {line, _column, kind, value}} when kind != :struct ->
                 message =
                   "attribute \"#{name}\" in component #{component(call)} must be a #{inspect(mod)}, got: #{inspect(value)}"
 
                 [error(message, call.file, line)]
 
               # attribute type match
-              {_type, {_line, _column, {_kind, _value}}} ->
+              {_type, {_line, _column, _kind, _value}} ->
                 []
             end
 
@@ -187,7 +187,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
       end)
 
     attrs_undefined =
-      for {name, {line, _column, {_kind, _value}}} <- attrs,
+      for {name, {line, _column, _kind, _value}} <- attrs,
           not (has_global? and Phoenix.Component.__global__?(caller_module, Atom.to_string(name))) do
         message = "undefined attribute \"#{name}\" for component #{component(call)}"
         error(message, call.file, line)
@@ -321,7 +321,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
   end
 
   defp get_slot_attr_defs(attr_defs, slot_name) do
-    # TODO: don't convert this to a map, keep it a list
     for attr_def <- attr_defs,
         attr_def.slot == slot_name,
         into: %{},
@@ -346,7 +345,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
   defp print_diagnostics(diagnostics) do
     for %Diagnostic{file: file, position: line, message: message} <- diagnostics do
       rel_file = file |> Path.relative_to_cwd() |> to_charlist()
-      # Use IO.warn(message, file: ..., line: ...) on Elixir v1.14+
+      # TODO: Use IO.warn(message, file: ..., line: ...) on Elixir v1.14+
       IO.warn(message, [{nil, :__FILE__, 1, [file: rel_file, line: line]}])
     end
   end

--- a/lib/mix/tasks/compile/phoenix_live_view.ex
+++ b/lib/mix/tasks/compile/phoenix_live_view.ex
@@ -92,10 +92,11 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
         do: diagnostic
   end
 
-  defp diagnostics(caller_module, %{slots: slots, attrs: attrs, root: root} = call, %{
-         slots: slots_defs,
-         attrs: attrs_defs
-       }) do
+  defp diagnostics(
+         caller_module,
+         %{slots: slots, attrs: attrs, root: root} = call,
+         %{slots: slots_defs, attrs: attrs_defs}
+       ) do
     {attrs_warnings, {attrs, has_global?}} =
       Enum.flat_map_reduce(attrs_defs, {attrs, false}, fn attr_def, {attrs, has_global?} ->
         %{name: name, required: required, type: type} = attr_def
@@ -163,9 +164,9 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
         {slot_values, slots} = Map.pop(slots, slot_name)
 
         warnings =
-          case {slot_values, slot_attr_defs} do
+          case slot_values do
             # missing required slot
-            {nil, _slot_attr_defs} when required ->
+            nil when required ->
               message = """
               missing required slot \"#{slot_name}\" \
               for component #{component(call)}\
@@ -174,11 +175,11 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
               [error(message, call.file, call.line)]
 
             # missing optional slot
-            {nil, _slot_attr_defs} ->
+            nil ->
               []
 
             # slot with attributes
-            {slot_values, slot_attr_defs} ->
+            slot_values ->
               missing_slot_attrs =
                 for slot_value <- slot_values,
                     {attr_name, %{required: true}} <- slot_attr_defs,

--- a/lib/mix/tasks/compile/phoenix_live_view.ex
+++ b/lib/mix/tasks/compile/phoenix_live_view.ex
@@ -176,7 +176,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
                       errors
 
                     # string attribute type mismatch
-                    {%{type: :string}, :lit, attr_value} when not is_binary(attr_value) ->
+                    {%{type: :string}, attr_kind, attr_value} when attr_kind != :lit or not is_binary(attr_value) ->
                       message =
                         "attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component(call)} " <>
                           "must be a :string, got: #{inspect(attr_value)}"
@@ -184,7 +184,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
                       [error(message, call.file, line) | errors]
 
                     # atom attribute type mismatch
-                    {%{type: :atom}, :lit, attr_value} when not is_atom(attr_value) ->
+                    {%{type: :atom}, attr_kind, attr_value} when attr_kind != :lit or not is_atom(attr_value) ->
                       message =
                         "attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component(call)} " <>
                           "must be an :atom, got: #{inspect(attr_value)}"
@@ -192,7 +192,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
                       [error(message, call.file, line) | errors]
 
                     # boolean attribute type mismatch
-                    {%{type: :boolean}, :lit, attr_value} when not is_boolean(attr_value) ->
+                    {%{type: :boolean}, attr_kind, attr_value} when attr_kind != :lit or not is_boolean(attr_value) ->
                       message =
                         "attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component(call)} " <>
                           "must be a :boolean, got: #{inspect(attr_value)}"
@@ -200,7 +200,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
                       [error(message, call.file, line) | errors]
 
                     # integer attribute type mismatch
-                    {%{type: :integer}, :lit, attr_value} when not is_integer(attr_value) ->
+                    {%{type: :integer}, attr_kind, attr_value} when attr_kind != :lit or not is_integer(attr_value) ->
                       message =
                         "attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component(call)} " <>
                           "must be a :integer, got: #{inspect(attr_value)}"
@@ -208,7 +208,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
                       [error(message, call.file, line) | errors]
 
                     # float attribute type mismatch
-                    {%{type: :float}, :lit, attr_value} when not is_float(attr_value) ->
+                    {%{type: :float}, attr_kind, attr_value} when attr_kind != :lit or not is_float(attr_value) ->
                       message =
                         "attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component(call)} " <>
                           "must be a :float, got: #{inspect(attr_value)}"

--- a/lib/mix/tasks/compile/phoenix_live_view.ex
+++ b/lib/mix/tasks/compile/phoenix_live_view.ex
@@ -92,9 +92,9 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
         do: diagnostic
   end
 
-  defp diagnostics(caller_module, %{attrs: attrs, root: root} = call, %{
-         attrs: attrs_defs,
-         slots: _slots_defs
+  defp diagnostics(caller_module, %{slots: _slots, attrs: attrs, root: root} = call, %{
+         slots: _slots_defs,
+         attrs: attrs_defs
        }) do
     # TODO: provide diagnostics for slots
     {warnings, {attrs, has_global?}} =

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -774,27 +774,10 @@ defmodule Phoenix.Component do
     end
   end
 
-  defp bad_default!(nil, name, type, default, line, file) when type in [:atom, :integer] do
-    compile_error!(line, file, """
-    expected the default value for attr #{inspect(name)} \
-    to be an #{inspect(type)}, \
-    got: #{inspect(default)}.
-    """)
-  end
-
   defp bad_default!(nil, name, type, default, line, file) do
     compile_error!(line, file, """
     expected the default value for attr #{inspect(name)} \
-    to be a #{inspect(type)}, \
-    got: #{inspect(default)}.
-    """)
-  end
-
-  defp bad_default!(slot, name, type, default, line, file) when type in [:atom, :integer] do
-    compile_error!(line, file, """
-    expected the default value for attr #{inspect(name)} \
-    in slot #{inspect(slot)} \
-    to be an #{inspect(type)}, \
+    to be #{type_with_article(type)}, \
     got: #{inspect(default)}.
     """)
   end
@@ -803,10 +786,14 @@ defmodule Phoenix.Component do
     compile_error!(line, file, """
     expected the default value for attr #{inspect(name)} \
     in slot #{inspect(slot)} \
-    to be a #{inspect(type)}, \
+    to be #{type_with_article(type)}, \
     got: #{inspect(default)}.
     """)
   end
+
+  defp type_with_article(type) when type in [:atom, :integer], do: "an #{inspect(type)}"
+
+  defp type_with_article(type), do: "a #{inspect(type)}"
 
   @valid_opts [:required, :default]
   defp validate_attr_opts!(nil, name, opts, line, file) do

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -793,44 +793,44 @@ defmodule Phoenix.Component do
       _ ->
         attrs = pop_attrs(env)
 
-        unless Enum.empty?(attrs) do
-          validate_misplaced_attrs!(attrs, env.file, fn ->
-            case length(args) do
-              1 ->
-                "could not define attributes for function #{name}/1. " <>
-                  "Components cannot be dynamically defined or have default arguments"
+        validate_misplaced_attrs!(attrs, env.file, fn ->
+          case length(args) do
+            1 ->
+              "could not define attributes for function #{name}/1. " <>
+                "Components cannot be dynamically defined or have default arguments"
 
-              arity ->
-                "cannot declare attributes for function #{name}/#{arity}. Components must be functions with arity 1"
-            end
-          end)
-        end
+            arity ->
+              "cannot declare attributes for function #{name}/#{arity}. Components must be functions with arity 1"
+          end
+        end)
 
         slots = pop_slots(env)
 
-        unless Enum.empty?(slots) do
-          validate_misplaced_slots!(slots, env.file, fn ->
-            case length(args) do
-              1 ->
-                "could not define slots for function #{name}/1. " <>
-                  "Components cannot be dynamically defined or have default arguments"
+        validate_misplaced_slots!(slots, env.file, fn ->
+          case length(args) do
+            1 ->
+              "could not define slots for function #{name}/1. " <>
+                "Components cannot be dynamically defined or have default arguments"
 
-              arity ->
-                "cannot declare slots for function #{name}/#{arity}. Components must be functions with arity 1"
-            end
-          end)
-        end
+            arity ->
+              "cannot declare slots for function #{name}/#{arity}. Components must be functions with arity 1"
+          end
+        end)
     end
   end
 
   @doc false
   defmacro __before_compile__(env) do
     attrs = pop_attrs(env)
-    # TODO: validate_misplaced_slots!
-    _slots = pop_slots(env)
 
     validate_misplaced_attrs!(attrs, env.file, fn ->
       "cannot define attributes without a related function component"
+    end)
+
+    slots = pop_slots(env)
+
+    validate_misplaced_slots!(slots, env.file, fn ->
+      "cannot define slots without a related function component"
     end)
 
     components = Module.get_attribute(env.module, :__components__)

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -810,6 +810,7 @@ defmodule Phoenix.Component do
   @doc false
   defmacro __before_compile__(env) do
     attrs = pop_attrs(env)
+    # TODO: validate_misplaced_slots!
     _slots = pop_slots(env)
 
     validate_misplaced_attrs!(attrs, env.file, fn ->

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1058,15 +1058,25 @@ defmodule Phoenix.Component do
     slots
   end
 
-  defp raise_if_function_already_defined!(env, name, _slots, attrs) do
-    # TODO: handle first_slot_line
+  defp raise_if_function_already_defined!(env, name, slots, attrs) do
     if Module.defines?(env.module, {name, 1}) do
       {:v1, _, meta, _} = Module.get_definition(env.module, {name, 1})
-      [%{line: first_attr_line} | _] = attrs
 
-      compile_error!(first_attr_line, env.file, """
-      attributes must be defined before the first function clause at line #{meta[:line]}
-      """)
+      unless Enum.empty?(attrs) do
+        [%{line: first_attr_line} | _] = attrs
+
+        compile_error!(first_attr_line, env.file, """
+        attributes must be defined before the first function clause at line #{meta[:line]}
+        """)
+      end
+
+      unless Enum.empty?(slots) do
+        [%{line: first_slot_line} | _] = slots
+
+        compile_error!(first_slot_line, env.file, """
+        slots must be defined before the first function clause at line #{meta[:line]}
+        """)
+      end
     end
   end
 

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1116,7 +1116,7 @@ defmodule Phoenix.Component do
   end
 
   defp build_attr_doc_and_default(%{doc: doc, opts: [default: default]}) do
-    [" - ", doc, " Defaults to `", inspect(default), "`."]
+    [" - ", doc, ". Defaults to `", inspect(default), "`."]
   end
 
   defp build_attr_doc_and_default(%{doc: nil}) do

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -12,7 +12,7 @@ defmodule Phoenix.Component do
         use Phoenix.Component
 
         # Optionally also bring the HTML helpers
-        # use Phoenix.HTML
+        # import Phoenix.LiveView.Helpers
 
         def greet(assigns) do
           ~H"""
@@ -719,20 +719,9 @@ defmodule Phoenix.Component do
     raise CompileError, line: line, file: file, description: msg
   end
 
-  defp bad_type!(nil, name, type, line, file) do
-    compile_error!(line, file, """
-    invalid type #{inspect(type)} for attr #{inspect(name)}. \
-    The following types are supported:
-
-      * any Elixir struct, such as URI, MyApp.User, etc
-      * one of #{Enum.map_join(@builtin_types, ", ", &inspect/1)}
-      * :any for all other types
-    """)
-  end
-
   defp bad_type!(slot, name, type, line, file) do
     compile_error!(line, file, """
-    invalid type #{inspect(type)} for attr #{inspect(name)} in slot #{inspect(slot)}. \
+    invalid type #{inspect(type)} for #{attr_slot(name, slot)}. \
     The following types are supported:
 
       * any Elixir struct, such as URI, MyApp.User, etc
@@ -740,6 +729,9 @@ defmodule Phoenix.Component do
       * :any for all other types
     """)
   end
+
+  defp attr_slot(name, nil), do: "attr #{inspect(name)}"
+  defp attr_slot(name, slot), do: "attr #{inspect(name)} in slot #{inspect(slot)}"
 
   defp validate_attr_default!(slot, name, type, default, line, file) do
     case {type, default} do
@@ -775,20 +767,10 @@ defmodule Phoenix.Component do
     end
   end
 
-  defp bad_default!(nil, name, type, default, line, file) do
-    compile_error!(line, file, """
-    expected the default value for attr #{inspect(name)} \
-    to be #{type_with_article(type)}, \
-    got: #{inspect(default)}.
-    """)
-  end
-
   defp bad_default!(slot, name, type, default, line, file) do
     compile_error!(line, file, """
-    expected the default value for attr #{inspect(name)} \
-    in slot #{inspect(slot)} \
-    to be #{type_with_article(type)}, \
-    got: #{inspect(default)}.
+    expected the default value for #{attr_slot(name, slot)} to be #{type_with_article(type)}, \
+    got: #{inspect(default)}
     """)
   end
 
@@ -797,19 +779,10 @@ defmodule Phoenix.Component do
   defp type_with_article(type), do: "a #{inspect(type)}"
 
   @valid_opts [:required, :default]
-  defp validate_attr_opts!(nil, name, opts, line, file) do
-    for {key, _} <- opts, key not in @valid_opts do
-      compile_error!(line, file, """
-      invalid option #{inspect(key)} for attr #{inspect(name)}. \
-      The supported options are: #{inspect(@valid_opts)}
-      """)
-    end
-  end
-
   defp validate_attr_opts!(slot, name, opts, line, file) do
     for {key, _} <- opts, key not in @valid_opts do
       compile_error!(line, file, """
-      invalid option #{inspect(key)} for attr #{inspect(name)} in slot #{inspect(slot)}. \
+      invalid option #{inspect(key)} for #{attr_slot(name, slot)}. \
       The supported options are: #{inspect(@valid_opts)}
       """)
     end

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -586,7 +586,7 @@ defmodule Phoenix.Component do
   value of the `@doc` module attribute:
 
     * if `@doc` is a string, the attribute docs are injected into that string.
-      The optional placeholder `[[INJECT ATTRDOCS]]` can be used to specify where
+      The optional placeholder `[[INJECT LVDOCS]]` can be used to specify where
       in the string the docs are injected. Otherwise, the docs are appended
       to the end of the `@doc` string.
 
@@ -957,17 +957,16 @@ defmodule Phoenix.Component do
     end
   end
 
-  defp register_component_doc(env, :def, _slots, attrs) do
-    # TODO: implement slot docs
+  defp register_component_doc(env, :def, slots, attrs) do
     case Module.get_attribute(env.module, :doc) do
       {_line, false} ->
         :ok
 
       {line, doc} ->
-        Module.put_attribute(env.module, :doc, {line, build_component_doc(doc, attrs)})
+        Module.put_attribute(env.module, :doc, {line, build_component_doc(doc, slots, attrs)})
 
       nil ->
-        Module.put_attribute(env.module, :doc, {env.line, build_component_doc(attrs)})
+        Module.put_attribute(env.module, :doc, {env.line, build_component_doc(slots, attrs)})
     end
   end
 
@@ -975,12 +974,12 @@ defmodule Phoenix.Component do
     :ok
   end
 
-  defp build_component_doc(doc \\ "", attrs) do
-    [left | right] = String.split(doc, "[[INSERT ATTRDOCS]]")
+  defp build_component_doc(doc \\ "", slots, attrs) do
+    [left | right] = String.split(doc, "[[INSERT LVDOCS]]")
 
     IO.iodata_to_binary([
       build_left_doc(left),
-      build_attr_docs(attrs),
+      build_component_docs(slots, attrs),
       build_right_doc(right)
     ])
   end
@@ -993,7 +992,7 @@ defmodule Phoenix.Component do
     [left, ?\n]
   end
 
-  defp build_attr_docs(attrs) do
+  defp build_component_docs(_slots, attrs) do
     [
       "## Attributes",
       ?\n,

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -693,7 +693,6 @@ defmodule Phoenix.Component do
         a duplicate attribute with name #{inspect(name)} already exists\
         """)
 
-      # TODO: can slot attributes be global?
       existing = type == :global && Enum.find(attrs, fn attr -> attr.type == :global end) ->
         compile_error!(line, file, """
         cannot define global attribute #{inspect(name)} because one is already defined under #{inspect(existing.name)}.
@@ -1354,6 +1353,14 @@ defmodule Phoenix.Component do
         %{line: line} <- attr_defs do
       compile_error!(line, file, """
       a duplicate attribute with name #{inspect(attr_name)} in slot #{inspect(slot.name)} already exists
+      """)
+    end
+
+    for {:global, attr_defs} <- Enum.group_by(slot.attrs, & &1.type),
+        length(attr_defs) > 1,
+        %{line: line} <- attr_defs do
+      compile_error!(line, file, """
+      cannot define multiple global attributes in slot #{inspect(slot.name)}
       """)
     end
   end

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -767,7 +767,7 @@ defmodule Phoenix.Component do
       {:list, default} when not is_list(default) ->
         bad_default!(slot, name, type, default, line, file)
 
-      {{:struct, mod}, default} when not is_struct(default, mod) ->
+      {{:struct, mod}, default} when not is_struct(default) ->
         bad_default!(slot, name, mod, default, line, file)
 
       {_type, _default} ->

--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -1110,7 +1110,6 @@ defmodule Phoenix.LiveView.Helpers do
     * `:csrf_token` - a custom token to use for links with a method
       other than `:get`.
 
-
      * `:replace` - when using `:patch` or `:navigate`, whether to replace the
        browser's pushState history. Default false.
 
@@ -1198,8 +1197,8 @@ defmodule Phoenix.LiveView.Helpers do
   attr :navigate, :string
   attr :patch, :string
   attr :href, :any
-  attr :replace, :string, default: nil
-  attr :method, :atom, default: :get
+  attr :replace, :boolean, default: false
+  attr :method, :string, default: "get"
   attr :csrf_token, :string
   attr :rest, :global
 
@@ -1242,10 +1241,10 @@ defmodule Phoenix.LiveView.Helpers do
 
     ~H"""
     <a
-      href={if @method == :get, do: @href, else: "#"}
-      data-method={if @method != :get, do: @method}
-      data-csrf={if @method != :get, do: @csrf_token}
-      data-to={if @method != :get, do: @href}
+      href={if @method == "get", do: @href, else: "#"}
+      data-method={if @method != "get", do: @method}
+      data-csrf={if @method != "get", do: @csrf_token}
+      data-to={if @method != "get", do: @href}
       {@rest}
     ><%= render_slot(@inner_block) %></a>
     """

--- a/lib/phoenix_live_view/helpers.ex
+++ b/lib/phoenix_live_view/helpers.ex
@@ -889,12 +889,12 @@ defmodule Phoenix.LiveView.Helpers do
       <.live_title suffix="- MyApp"><%= assigns[:page_title] || "Welcome" %></.live_title>
 
   """
-  attr :prefix, :string, default: false
-  attr :suffix, :string, default: false
+  attr :prefix, :string, default: nil
+  attr :suffix, :string, default: nil
 
   def live_title(assigns) do
     ~H"""
-    <title data-prefix={@prefix} data-suffix={@suffix}><%= @prefix || "" %><%= render_slot(@inner_block) %><%= @suffix || "" %></title>
+    <title data-prefix={@prefix} data-suffix={@suffix}><%= @prefix %><%= render_slot(@inner_block) %><%= @suffix %></title>
     """
   end
 
@@ -1198,8 +1198,8 @@ defmodule Phoenix.LiveView.Helpers do
   attr :navigate, :string
   attr :patch, :string
   attr :href, :any
-  attr :replace, :string, default: false
-  attr :method, :atom, default: "get"
+  attr :replace, :string, default: nil
+  attr :method, :atom, default: :get
   attr :csrf_token, :string
   attr :rest, :global
 
@@ -1240,14 +1240,12 @@ defmodule Phoenix.LiveView.Helpers do
           assign(assigns, :href, href)
       end
 
-    assigns = assign(assigns, :method, to_string(assigns.method))
-
     ~H"""
     <a
-      href={if @method == "get", do: @href, else: "#"}
-      data-method={if @method != "get", do: @method}
-      data-csrf={if @method != "get", do: @csrf_token}
-      data-to={if @method != "get", do: @href}
+      href={if @method == :get, do: @href, else: "#"}
+      data-method={if @method != :get, do: @method}
+      data-csrf={if @method != :get, do: @csrf_token}
+      data-to={if @method != :get, do: @href}
       {@rest}
     ><%= render_slot(@inner_block) %></a>
     """

--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -1102,25 +1102,22 @@ defmodule Phoenix.LiveView.HTMLEngine do
     end
   end
 
-  # TODO: do we really need both function heads here?
   defp slot_call_value({{_, _, slot_attrs}, %{line: line, column: column}}) do
     for {name, value} <- slot_attrs, name != :__slot__, into: %{} do
       case value do
+        # lists
+        {ast, _, _} when is_list(ast) ->
+          {name, {line, column, :list}}
+
+        # structs
+        {:%, _, _} ->
+          {name, {line, column, :struct}}
+
+        # expressions
         {_, _, _} ->
           {name, {line, column, :expr}}
 
-        value ->
-          {name, {line, column, value}}
-      end
-    end
-  end
-
-  defp slot_call_value({[{_, _, slot_attrs}], %{line: line, column: column}}) do
-    for {name, value} <- slot_attrs, name != :__slot__, into: %{} do
-      case value do
-        {_, _, _} ->
-          {name, {line, column, :expr}}
-
+        # literals
         value ->
           {name, {line, column, value}}
       end

--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -1102,9 +1102,8 @@ defmodule Phoenix.LiveView.HTMLEngine do
       pruned_attrs =
         for {attr, value, meta} <- attrs,
             is_binary(attr) and not String.starts_with?(attr, ":"),
-            do:
-              {String.to_atom(attr),
-               {meta[:line], meta[:column], component_call_value(value, env)}},
+            {kind, value} = component_call_value(value, env),
+            do: {String.to_atom(attr), {meta[:line], meta[:column], kind, value}},
             into: %{}
 
       root = List.keymember?(attrs, :root, 0)
@@ -1127,7 +1126,7 @@ defmodule Phoenix.LiveView.HTMLEngine do
   end
 
   defp component_call_value(nil, _env) do
-    nil
+    {:lit, true}
   end
 
   defp component_call_value({:expr, value, %{line: line, column: column}}, env) do

--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -926,25 +926,8 @@ defmodule Phoenix.LiveView.HTMLEngine do
     {slots, state} = pop_slots(state)
 
     slot_assigns =
-      if function_exported?(mod, :__components__, 0) do
-        for {slot_name, slot_values} <- slots do
-          defaults =
-            for slot <- mod.__components__()[fun][:slots],
-                slot.name == slot_name,
-                %{name: name, opts: [default: default]} <- slot.attrs,
-                do: {name, default}
-
-          values_with_defaults =
-            for {{:%{}, [], values}, _meta} <- slot_values do
-              {:%{}, [], Keyword.merge(defaults, values)}
-            end
-
-          {slot_name, values_with_defaults}
-        end
-      else
-        for {slot_name, slot_values} <- slots do
-          {slot_name, Enum.map(slot_values, &elem(&1, 0))}
-        end
+      for {slot_name, slot_values} <- slots do
+        {slot_name, Enum.map(slot_values, &elem(&1, 0))}
       end
 
     attrs = attrs ++ [{:inner_block, [inner_block_assigns]} | slot_assigns]

--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -911,7 +911,7 @@ defmodule Phoenix.LiveView.HTMLEngine do
     {merge_component_attrs(roots, attrs, line), state}
   end
 
-  defp build_component_assigns(mod, fun, attrs, line, %{file: file} = state) do
+  defp build_component_assigns(_mod, _fun, attrs, line, %{file: file} = state) do
     {let, roots, attrs} = split_component_attrs(attrs, file)
     clauses = build_component_clauses(let, state)
 
@@ -1133,7 +1133,7 @@ defmodule Phoenix.LiveView.HTMLEngine do
     |> attr_type()
   end
 
-  defp slot_call_value({{_, _, slot_attrs}, %{line: line, column: column}}, env) do
+  defp slot_call_value({{_, _, slot_attrs}, %{line: line, column: column}}, _env) do
     for {name, value} <- slot_attrs, name != :__slot__, into: %{} do
       {name, {line, column, attr_type(value)}}
     end
@@ -1146,7 +1146,7 @@ defmodule Phoenix.LiveView.HTMLEngine do
   defp attr_type(value) when is_float(value), do: {:float, value}
   defp attr_type(value) when is_boolean(value), do: {:boolean, value}
   defp attr_type(value) when is_atom(value), do: {:atom, value}
-  defp attr_type(value), do: :any
+  defp attr_type(_value), do: :any
 
   ## Helpers
 

--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -929,9 +929,10 @@ defmodule Phoenix.LiveView.HTMLEngine do
       if function_exported?(mod, :__components__, 0) do
         for {slot_name, slot_values} <- slots do
           defaults =
-            mod.__components__()[fun][:attrs]
-            |> Enum.reject(&(&1.slot != slot_name or not Keyword.has_key?(&1.opts, :default)))
-            |> Enum.map(&{&1.name, &1.opts[:default]})
+            for slot <- mod.__components__()[fun][:slots],
+                slot.name == slot_name,
+                %{name: name, opts: [default: default]} <- slot.attrs,
+                do: {name, default}
 
           values_with_defaults =
             for {{:%{}, [], values}, _meta} <- slot_values do

--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -1106,25 +1106,25 @@ defmodule Phoenix.LiveView.HTMLEngine do
     for {name, value} <- slot_attrs, name != :__slot__, into: %{} do
       case value do
         # lists
-        {ast, _, _} when is_list(ast) ->
-          {name, {line, column, :list}}
+        {ast, _, _} = value when is_list(ast) ->
+          {name, {line, column, :list, value}}
 
         # structs
-        {:%, _, _} ->
-          {name, {line, column, :struct}}
+        {:%, _, _} = value ->
+          {name, {line, column, :struct, value}}
 
         # expressions
-        {_, _, _} ->
-          {name, {line, column, :expr}}
+        {_, _, _} = value ->
+          {name, {line, column, :expr, value}}
 
         # literals
         value ->
-          {name, {line, column, value}}
+          {name, {line, column, :lit, value}}
       end
     end
   end
 
-  defp component_call_value({:expr, _, _}), do: :expr
+  defp component_call_value({:expr, value, _}), do: value
   defp component_call_value({:string, string, _}), do: string
   defp component_call_value(nil), do: nil
 

--- a/test/mix/tasks/compile/phoenix_live_view_test.exs
+++ b/test/mix/tasks/compile/phoenix_live_view_test.exs
@@ -455,13 +455,12 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
       string_warnings =
         for {value, line} <- [
               {nil, 7},
-              # {:struct, 6},
+              {Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct, 6},
               {[], 5},
               {1.0, 4},
               {1, 3},
               {true, 2},
               {:string, 1}
-              # {"string", 0},
             ] do
           %Diagnostic{
             compiler_name: "phoenix_live_view",
@@ -476,13 +475,10 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
 
       atom_warnings =
         for {value, line} <- [
-              # {nil, 7},
-              # {:struct, 6}, # TODO: this should not cause a warning
+              {Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct, 6},
               {[], 5},
               {1.0, 4},
               {1, 3},
-              # {true, 2},
-              # {:atom, 1},
               {"atom", 0}
             ] do
           %Diagnostic{
@@ -499,11 +495,10 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
       boolean_warnings =
         for {value, line} <- [
               {nil, 7},
-              # {:struct, 6},
+              {Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct, 6},
               {[], 5},
               {1.0, 4},
               {1, 3},
-              # {true, 2},
               {:boolean, 1},
               {"boolean", 0}
             ] do
@@ -521,10 +516,9 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
       integer_warnings =
         for {value, line} <- [
               {nil, 7},
-              # {:struct, 6},
+              {Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct, 6},
               {[], 5},
               {1.0, 4},
-              # {1, 3},
               {true, 2},
               {:integer, 1},
               {"integer", 0}
@@ -543,9 +537,8 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
       float_warnings =
         for {value, line} <- [
               {nil, 7},
-              # {:struct, 6},
+              {Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct, 6},
               {[], 5},
-              # {1.0, 4},
               {1, 3},
               {true, 2},
               {:float, 1},
@@ -565,8 +558,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
       list_warnings =
         for {value, line} <- [
               {nil, 7},
-              {{:%, [line: 428],
-                [{:__aliases__, [line: 428], [:Struct]}, {:%{}, [line: 428], []}]}, 6},
+              {Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct, 6},
               {[], 5},
               {1.0, 4},
               {1, 3},
@@ -592,7 +584,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
               {1.0, 4},
               {1, 3},
               {true, 2},
-              # TODO: fix this, should be a warning
               {:struct, 1},
               {"struct", 0}
             ] do

--- a/test/mix/tasks/compile/phoenix_live_view_test.exs
+++ b/test/mix/tasks/compile/phoenix_live_view_test.exs
@@ -213,6 +213,41 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
 
       assert diagnostics == []
     end
+
+    defmodule RequiredSlots do
+      use Phoenix.Component
+
+      slot :inner_block, required: true
+
+      def func(assigns), do: ~H[]
+
+      def line, do: __ENV__.line + 4
+
+      def render(assigns) do
+        ~H"""
+        <.func/>
+        <.func>
+        </.func>
+        """
+      end
+    end
+
+    test "validate required slots" do
+      line = get_line(RequiredAttrs)
+      diagnostics = Mix.Tasks.Compile.PhoenixLiveView.validate_components_calls([RequiredSlots])
+
+      assert diagnostics == [
+               %Mix.Task.Compiler.Diagnostic{
+                 compiler_name: "phoenix_live_view",
+                 details: nil,
+                 file: __ENV__.file,
+                 message:
+                   "missing required slot \"inner_block\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.RequiredSlots.func/1",
+                 position: line,
+                 severity: :warning
+               }
+             ]
+    end
   end
 
   describe "integration tests" do

--- a/test/mix/tasks/compile/phoenix_live_view_test.exs
+++ b/test/mix/tasks/compile/phoenix_live_view_test.exs
@@ -891,7 +891,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
         for {value, line} <- [
               {nil, 7},
               {Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct, 6},
-              {[], 5},
               {1.0, 4},
               {1, 3},
               {true, 2},

--- a/test/mix/tasks/compile/phoenix_live_view_test.exs
+++ b/test/mix/tasks/compile/phoenix_live_view_test.exs
@@ -96,16 +96,20 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
                %Diagnostic{
                  compiler_name: "phoenix_live_view",
                  file: __ENV__.file,
-                 message:
-                   "undefined attribute \"size\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.UndefinedAttrs.func/1",
+                 message: """
+                 undefined attribute \"size\" \
+                 for component Mix.Tasks.Compile.PhoenixLiveViewTest.UndefinedAttrs.func/1\
+                 """,
                  position: line,
                  severity: :warning
                },
                %Diagnostic{
                  compiler_name: "phoenix_live_view",
                  file: __ENV__.file,
-                 message:
-                   "undefined attribute \"width\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.UndefinedAttrs.func/1",
+                 message: """
+                 undefined attribute \"width\" \
+                 for component Mix.Tasks.Compile.PhoenixLiveViewTest.UndefinedAttrs.func/1\
+                 """,
                  position: line,
                  severity: :warning
                }
@@ -144,16 +148,21 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
                %Diagnostic{
                  compiler_name: "phoenix_live_view",
                  file: __ENV__.file,
-                 message:
-                   "missing required attribute \"attr\" in slot \"named\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.External.render/1",
+                 message: """
+                 missing required attribute \"attr\" \
+                 in slot \"named\" \
+                 for component Mix.Tasks.Compile.PhoenixLiveViewTest.External.render/1\
+                 """,
                  position: ExternalCalls.line() + 1,
                  severity: :warning
                },
                %Diagnostic{
                  compiler_name: "phoenix_live_view",
                  file: __ENV__.file,
-                 message:
-                   "missing required attribute \"id\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.External.render/1",
+                 message: """
+                 missing required attribute \"id\" \
+                 for component Mix.Tasks.Compile.PhoenixLiveViewTest.External.render/1\
+                 """,
                  position: ExternalCalls.line(),
                  severity: :warning
                }
@@ -320,8 +329,12 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
             file: __ENV__.file,
             severity: :warning,
             position: TypeAttrs.render_string_line() + line,
-            message:
-              "attribute \"string\" in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 must be a :string, got: #{inspect(value)}"
+            message: """
+            attribute \"string\" \
+            in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 \
+            must be a :string, \
+            got: #{inspect(value)}\
+            """
           }
         end
 
@@ -339,8 +352,12 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
             file: __ENV__.file,
             severity: :warning,
             position: TypeAttrs.render_atom_line() + line,
-            message:
-              "attribute \"atom\" in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 must be an :atom, got: #{inspect(value)}"
+            message: """
+            attribute \"atom\" \
+            in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 \
+            must be an :atom, \
+            got: #{inspect(value)}\
+            """
           }
         end
 
@@ -360,8 +377,12 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
             file: __ENV__.file,
             severity: :warning,
             position: TypeAttrs.render_boolean_line() + line,
-            message:
-              "attribute \"boolean\" in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 must be a :boolean, got: #{inspect(value)}"
+            message: """
+            attribute \"boolean\" \
+            in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 \
+            must be a :boolean, \
+            got: #{inspect(value)}\
+            """
           }
         end
 
@@ -381,8 +402,12 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
             file: __ENV__.file,
             severity: :warning,
             position: TypeAttrs.render_integer_line() + line,
-            message:
-              "attribute \"integer\" in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 must be an :integer, got: #{inspect(value)}"
+            message: """
+            attribute \"integer\" \
+            in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 \
+            must be an :integer, \
+            got: #{inspect(value)}\
+            """
           }
         end
 
@@ -402,8 +427,12 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
             file: __ENV__.file,
             severity: :warning,
             position: TypeAttrs.render_float_line() + line,
-            message:
-              "attribute \"float\" in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 must be a :float, got: #{inspect(value)}"
+            message: """
+            attribute \"float\" \
+            in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 \
+            must be a :float, \
+            got: #{inspect(value)}\
+            """
           }
         end
 
@@ -423,8 +452,12 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
             file: __ENV__.file,
             severity: :warning,
             position: TypeAttrs.render_list_line() + line,
-            message:
-              "attribute \"list\" in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 must be a :list, got: #{inspect(value)}"
+            message: """
+            attribute \"list\" \
+            in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 \
+            must be a :list, \
+            got: #{inspect(value)}\
+            """
           }
         end
 
@@ -444,8 +477,12 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
             file: __ENV__.file,
             severity: :warning,
             position: TypeAttrs.render_struct_line() + line,
-            message:
-              "attribute \"struct\" in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 must be a Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.Struct, got: #{inspect(value)}"
+            message: """
+            attribute \"struct\" \
+            in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 \
+            must be a Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.Struct, \
+            got: #{inspect(value)}\
+            """
           }
         end
 
@@ -540,8 +577,10 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
                  compiler_name: "phoenix_live_view",
                  details: nil,
                  file: __ENV__.file,
-                 message:
-                   "missing required slot \"inner_block\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.RequiredSlots.func/1",
+                 message: """
+                 missing required slot \"inner_block\" \
+                 for component Mix.Tasks.Compile.PhoenixLiveViewTest.RequiredSlots.func/1\
+                 """,
                  position: line + 3,
                  severity: :warning
                },
@@ -549,8 +588,10 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
                  compiler_name: "phoenix_live_view",
                  details: nil,
                  file: __ENV__.file,
-                 message:
-                   "missing required slot \"named\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.RequiredSlots.func_named_slot/1",
+                 message: """
+                 missing required slot \"named\" \
+                 for component Mix.Tasks.Compile.PhoenixLiveViewTest.RequiredSlots.func_named_slot/1\
+                 """,
                  position: line + 12,
                  severity: :warning
                }
@@ -734,8 +775,13 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
             file: __ENV__.file,
             severity: :warning,
             position: SlotAttrs.render_string_line() + line,
-            message:
-              "attribute \"string\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :string, got: #{inspect(value)}"
+            message: """
+            attribute \"string\" \
+            in slot \"slot\" \
+            for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 \
+            must be a :string, \
+            got: #{inspect(value)}\
+            """
           }
         end
 
@@ -753,8 +799,13 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
             file: __ENV__.file,
             severity: :warning,
             position: SlotAttrs.render_atom_line() + line,
-            message:
-              "attribute \"atom\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be an :atom, got: #{inspect(value)}"
+            message: """
+            attribute \"atom\" \
+            in slot \"slot\" \
+            for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 \
+            must be an :atom, \
+            got: #{inspect(value)}\
+            """
           }
         end
 
@@ -774,8 +825,13 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
             file: __ENV__.file,
             severity: :warning,
             position: SlotAttrs.render_boolean_line() + line,
-            message:
-              "attribute \"boolean\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :boolean, got: #{inspect(value)}"
+            message: """
+            attribute \"boolean\" \
+            in slot \"slot\" \
+            for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 \
+            must be a :boolean, \
+            got: #{inspect(value)}\
+            """
           }
         end
 
@@ -795,8 +851,13 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
             file: __ENV__.file,
             severity: :warning,
             position: SlotAttrs.render_integer_line() + line,
-            message:
-              "attribute \"integer\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :integer, got: #{inspect(value)}"
+            message: """
+            attribute \"integer\" \
+            in slot \"slot\" \
+            for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 \
+            must be an :integer, \
+            got: #{inspect(value)}\
+            """
           }
         end
 
@@ -816,8 +877,13 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
             file: __ENV__.file,
             severity: :warning,
             position: SlotAttrs.render_float_line() + line,
-            message:
-              "attribute \"float\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :float, got: #{inspect(value)}"
+            message: """
+            attribute \"float\" \
+            in slot \"slot\" \
+            for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 \
+            must be a :float, \
+            got: #{inspect(value)}\
+            """
           }
         end
 
@@ -838,8 +904,13 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
             file: __ENV__.file,
             severity: :warning,
             position: SlotAttrs.render_list_line() + line,
-            message:
-              "attribute \"list\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :list, got: #{inspect(value)}"
+            message: """
+            attribute \"list\" \
+            in slot \"slot\" \
+            for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 \
+            must be a :list, \
+            got: #{inspect(value)}\
+            """
           }
         end
 
@@ -859,8 +930,13 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
             file: __ENV__.file,
             severity: :warning,
             position: SlotAttrs.render_struct_line() + line,
-            message:
-              "attribute \"struct\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct, got: #{inspect(value)}"
+            message: """
+            attribute \"struct\" \
+            in slot \"slot\" \
+            for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 \
+            must be a Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct, \
+            got: #{inspect(value)}\
+            """
           }
         end
 
@@ -920,8 +996,11 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
                  file: __ENV__.file,
                  severity: :warning,
                  position: RequiredSlotAttrs.render_line() + 1,
-                 message:
-                   "missing required attribute \"attr\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.RequiredSlotAttrs.func/1"
+                 message: """
+                 missing required attribute \"attr\" \
+                 in slot \"slot\" \
+                 for component Mix.Tasks.Compile.PhoenixLiveViewTest.RequiredSlotAttrs.func/1\
+                 """
                },
                %Diagnostic{
                  compiler_name: "phoenix_live_view",
@@ -929,8 +1008,11 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
                  file: __ENV__.file,
                  severity: :warning,
                  position: RequiredSlotAttrs.render_line() + 3,
-                 message:
-                   "missing required attribute \"attr\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.RequiredSlotAttrs.func/1"
+                 message: """
+                 missing required attribute \"attr\" \
+                 in slot \"slot\" \
+                 for component Mix.Tasks.Compile.PhoenixLiveViewTest.RequiredSlotAttrs.func/1\
+                 """
                }
              ]
     end
@@ -973,8 +1055,10 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
                  compiler_name: "phoenix_live_view",
                  details: nil,
                  file: __ENV__.file,
-                 message:
-                   "undefined slot \"undefined\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.UndefinedSlots.func/1",
+                 message: """
+                 undefined slot \"undefined\" \
+                 for component Mix.Tasks.Compile.PhoenixLiveViewTest.UndefinedSlots.func/1\
+                 """,
                  position: line + 4,
                  severity: :warning
                },
@@ -982,8 +1066,11 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
                  compiler_name: "phoenix_live_view",
                  details: nil,
                  file: __ENV__.file,
-                 message:
-                   "undefined attribute \"undefined\" in slot \"named\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.UndefinedSlots.func_undefined_slot_attrs/1",
+                 message: """
+                 undefined attribute \"undefined\" \
+                 in slot \"named\" \
+                 for component Mix.Tasks.Compile.PhoenixLiveViewTest.UndefinedSlots.func_undefined_slot_attrs/1\
+                 """,
                  position: line + 10,
                  severity: :warning
                },
@@ -991,8 +1078,10 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
                  compiler_name: "phoenix_live_view",
                  details: nil,
                  file: __ENV__.file,
-                 message:
-                   "undefined attribute \"undefined\" in slot \"named\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.UndefinedSlots.func_undefined_slot_attrs/1",
+                 message: """
+                 undefined attribute \"undefined\" \
+                 in slot \"named\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.UndefinedSlots.func_undefined_slot_attrs/1\
+                 """,
                  position: line + 9,
                  severity: :warning
                }

--- a/test/mix/tasks/compile/phoenix_live_view_test.exs
+++ b/test/mix/tasks/compile/phoenix_live_view_test.exs
@@ -312,12 +312,12 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
 
       def func(assigns), do: ~H[]
 
-      def render_line, do: __ENV__.line + 2
+      def render_any_line, do: __ENV__.line + 5
 
-      def render(assigns) do
+      def render_any(assigns) do
         ~H"""
         <.func>
-          <!-- any type should never raise a warning -->
+          <:slot any />
           <:slot any="any" />
           <:slot any={:any} />
           <:slot any={true} />
@@ -325,114 +325,296 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
           <:slot any={1.0} />
           <:slot any={[]} />
           <:slot any={%Struct{}} />
+        </.func>
+        """
+      end
 
-          <!-- string warnings -->
+      def render_string_line, do: __ENV__.line + 5
+
+      def render_string(assigns) do
+        ~H"""
+        <.func>
+          <:slot string="string" />
           <:slot string={:string} />
+          <:slot string={true} />
+          <:slot string={1} />
+          <:slot string={1.0} />
+          <:slot string={[]} />
+          <:slot string={%Struct{}} />
+          <:slot string={nil} />
+        </.func>
+        """
+      end
 
-          <!-- atom warnings -->
+      def render_atom_line, do: __ENV__.line + 5
+
+      def render_atom(assigns) do
+        ~H"""
+        <.func>
           <:slot atom="atom" />
+          <:slot atom={:atom} />
+          <:slot atom={true} />
+          <:slot atom={1} />
+          <:slot atom={1.0} />
+          <:slot atom={[]} />
+          <:slot atom={%Struct{}} />
+          <:slot atom={nil} />
+        </.func>
+        """
+      end
 
-          <!-- boolean warnings -->
+      def render_boolean_line, do: __ENV__.line + 5
+
+      def render_boolean(assigns) do
+        ~H"""
+        <.func>
           <:slot boolean="boolean" />
+          <:slot boolean={:boolean} />
+          <:slot boolean={true} />
+          <:slot boolean={1} />
+          <:slot boolean={1.0} />
+          <:slot boolean={[]} />
+          <:slot boolean={%Struct{}} />
+          <:slot boolean={nil} />
+        </.func>
+        """
+      end
 
-          <!-- integer warnings -->
+      def render_integer_line, do: __ENV__.line + 5
+
+      def render_integer(assigns) do
+        ~H"""
+        <.func>
           <:slot integer="integer" />
+          <:slot integer={:integer} />
+          <:slot integer={true} />
+          <:slot integer={1} />
+          <:slot integer={1.0} />
+          <:slot integer={[]} />
+          <:slot integer={%Struct{}} />
+          <:slot integer={nil} />
+        </.func>
+        """
+      end
 
-          <!-- float warnings -->
+      def render_float_line, do: __ENV__.line + 5
+
+      def render_float(assigns) do
+        ~H"""
+        <.func>
           <:slot float="float" />
+          <:slot float={:float} />
+          <:slot float={true} />
+          <:slot float={1} />
+          <:slot float={1.0} />
+          <:slot float={[]} />
+          <:slot float={%Struct{}} />
+          <:slot float={nil} />
+        </.func>
+        """
+      end
 
-          <!-- list warnings -->
+      def render_list_line, do: __ENV__.line + 5
+
+      def render_list(assigns) do
+        ~H"""
+        <.func>
           <:slot list="list" />
+          <:slot list={:list} />
+          <:slot list={true} />
+          <:slot list={1} />
+          <:slot list={1.0} />
+          <:slot list={[]} />
+          <:slot list={%Struct{}} />
+          <:slot list={nil} />
+        </.func>
+        """
+      end
 
-          <!-- struct warnings -->
+      def render_struct_line, do: __ENV__.line + 5
+
+      def render_struct(assigns) do
+        ~H"""
+        <.func>
           <:slot struct="struct" />
-          
-          <!-- attrs with no expression -->
-          <:slot boolean />
-          <:slot string />
+          <:slot struct={:struct} />
+          <:slot struct={true} />
+          <:slot struct={1} />
+          <:slot struct={1.0} />
+          <:slot struct={[]} />
+          <:slot struct={%Struct{}} />
+          <:slot struct={nil} />
         </.func>
         """
       end
     end
 
     test "validate slot attr types" do
-      line = SlotAttrs.render_line()
       diagnostics = Mix.Tasks.Compile.PhoenixLiveView.validate_components_calls([SlotAttrs])
 
-      assert diagnostics == [
-               %Diagnostic{
-                 compiler_name: "phoenix_live_view",
-                 details: nil,
-                 file: __ENV__.file,
-                 message:
-                   "attribute \"string\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :string, got: true",
-                 position: line + 35,
-                 severity: :warning
-               },
-               %Diagnostic{
-                 compiler_name: "phoenix_live_view",
-                 details: nil,
-                 file: __ENV__.file,
-                 message:
-                   "attribute \"struct\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct, got: \"struct\"",
-                 position: line + 31,
-                 severity: :warning
-               },
-               %Diagnostic{
-                 compiler_name: "phoenix_live_view",
-                 details: nil,
-                 file: __ENV__.file,
-                 message:
-                   "attribute \"list\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :list, got: \"list\"",
-                 position: line + 28,
-                 severity: :warning
-               },
-               %Diagnostic{
-                 compiler_name: "phoenix_live_view",
-                 details: nil,
-                 file: __ENV__.file,
-                 message:
-                   "attribute \"float\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :float, got: \"float\"",
-                 position: line + 25,
-                 severity: :warning
-               },
-               %Diagnostic{
-                 compiler_name: "phoenix_live_view",
-                 details: nil,
-                 file: __ENV__.file,
-                 message:
-                   "attribute \"integer\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :integer, got: \"integer\"",
-                 position: line + 22,
-                 severity: :warning
-               },
-               %Diagnostic{
-                 compiler_name: "phoenix_live_view",
-                 details: nil,
-                 file: __ENV__.file,
-                 message:
-                   "attribute \"boolean\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :boolean, got: \"boolean\"",
-                 position: line + 19,
-                 severity: :warning
-               },
-               %Diagnostic{
-                 compiler_name: "phoenix_live_view",
-                 details: nil,
-                 file: __ENV__.file,
-                 message:
-                   "attribute \"atom\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be an :atom, got: \"atom\"",
-                 position: line + 16,
-                 severity: :warning
-               },
-               %Diagnostic{
-                 compiler_name: "phoenix_live_view",
-                 details: nil,
-                 file: __ENV__.file,
-                 message:
-                   "attribute \"string\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :string, got: :string",
-                 position: line + 13,
-                 severity: :warning
-               }
-             ]
+      string_warnings =
+        for {value, line} <- [
+              {nil, 7},
+              {:struct, 6},
+              {[], 5},
+              {1.0, 4},
+              {1, 3},
+              {true, 2},
+              {:string, 1}
+              # {"string", 0},
+            ] do
+          %Diagnostic{
+            compiler_name: "phoenix_live_view",
+            details: nil,
+            file: __ENV__.file,
+            severity: :warning,
+            position: SlotAttrs.render_string_line() + line,
+            message:
+              "attribute \"string\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :string, got: #{inspect(value)}"
+          }
+        end
+
+      atom_warnings =
+        for {value, line} <- [
+              # {nil, 7},
+              # {:struct, 6}, # TODO: this should not cause a warning
+              {[], 5},
+              {1.0, 4},
+              {1, 3},
+              # {true, 2},
+              # {:atom, 1},
+              {"atom", 0}
+            ] do
+          %Diagnostic{
+            compiler_name: "phoenix_live_view",
+            details: nil,
+            file: __ENV__.file,
+            severity: :warning,
+            position: SlotAttrs.render_atom_line() + line,
+            message:
+              "attribute \"atom\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be an :atom, got: #{inspect(value)}"
+          }
+        end
+
+      boolean_warnings =
+        for {value, line} <- [
+              {nil, 7},
+              {:struct, 6},
+              {[], 5},
+              {1.0, 4},
+              {1, 3},
+              # {true, 2},
+              {:boolean, 1},
+              {"boolean", 0}
+            ] do
+          %Diagnostic{
+            compiler_name: "phoenix_live_view",
+            details: nil,
+            file: __ENV__.file,
+            severity: :warning,
+            position: SlotAttrs.render_boolean_line() + line,
+            message:
+              "attribute \"boolean\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :boolean, got: #{inspect(value)}"
+          }
+        end
+
+      integer_warnings =
+        for {value, line} <- [
+              {nil, 7},
+              {:struct, 6},
+              {[], 5},
+              {1.0, 4},
+              # {1, 3},
+              {true, 2},
+              {:integer, 1},
+              {"integer", 0}
+            ] do
+          %Diagnostic{
+            compiler_name: "phoenix_live_view",
+            details: nil,
+            file: __ENV__.file,
+            severity: :warning,
+            position: SlotAttrs.render_integer_line() + line,
+            message:
+              "attribute \"integer\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :integer, got: #{inspect(value)}"
+          }
+        end
+
+      float_warnings =
+        for {value, line} <- [
+              {nil, 7},
+              {:struct, 6},
+              {[], 5},
+              # {1.0, 4},
+              {1, 3},
+              {true, 2},
+              {:float, 1},
+              {"float", 0}
+            ] do
+          %Diagnostic{
+            compiler_name: "phoenix_live_view",
+            details: nil,
+            file: __ENV__.file,
+            severity: :warning,
+            position: SlotAttrs.render_float_line() + line,
+            message:
+              "attribute \"float\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :float, got: #{inspect(value)}"
+          }
+        end
+
+      list_warnings =
+        for {value, line} <- [
+              {nil, 7},
+              {:struct, 6},
+              # TODO: this should not cause a warning
+              {[], 5},
+              {1.0, 4},
+              {1, 3},
+              {true, 2},
+              # {:list, 1},
+              {"list", 0}
+            ] do
+          %Diagnostic{
+            compiler_name: "phoenix_live_view",
+            details: nil,
+            file: __ENV__.file,
+            severity: :warning,
+            position: SlotAttrs.render_list_line() + line,
+            message:
+              "attribute \"list\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :list, got: #{inspect(value)}"
+          }
+        end
+
+      struct_warnings =
+        for {value, line} <- [
+              {nil, 7},
+              # {:struct, 6},
+              {[], 5},
+              {1.0, 4},
+              {1, 3},
+              {true, 2},
+              # {:struct, 1}, # TODO: fix this, should be a warning
+              {"struct", 0}
+            ] do
+          %Diagnostic{
+            compiler_name: "phoenix_live_view",
+            details: nil,
+            file: __ENV__.file,
+            severity: :warning,
+            position: SlotAttrs.render_struct_line() + line,
+            message:
+              "attribute \"struct\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct, got: #{inspect(value)}"
+          }
+        end
+
+      assert diagnostics ==
+               string_warnings ++
+                 atom_warnings ++
+                 boolean_warnings ++
+                 integer_warnings ++
+                 float_warnings ++
+                 list_warnings ++
+                 struct_warnings
     end
 
     defmodule UndefinedSlots do
@@ -457,6 +639,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
 
         <!-- slot with undefined attrs -->
         <.func_undefined_slot_attrs>
+          <:named undefined />
           <:named undefined="undefined" />
         </.func_undefined_slot_attrs>
         """
@@ -475,6 +658,15 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
                  message:
                    "undefined slot \"undefined\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.UndefinedSlots.func/1",
                  position: line + 4,
+                 severity: :warning
+               },
+               %Diagnostic{
+                 compiler_name: "phoenix_live_view",
+                 details: nil,
+                 file: __ENV__.file,
+                 message:
+                   "undefined attribute \"undefined\" in slot \"named\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.UndefinedSlots.func_undefined_slot_attrs/1",
+                 position: line + 10,
                  severity: :warning
                },
                %Diagnostic{

--- a/test/mix/tasks/compile/phoenix_live_view_test.exs
+++ b/test/mix/tasks/compile/phoenix_live_view_test.exs
@@ -295,8 +295,19 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
     defmodule SlotAttrs do
       use Phoenix.Component
 
-      slot :named do
-        attr :label, :string
+      defmodule Struct do
+        defstruct []
+      end
+
+      slot :slot do
+        attr :any, :any
+        attr :string, :string
+        attr :atom, :atom
+        attr :boolean, :boolean
+        attr :integer, :integer
+        attr :float, :float
+        attr :list, :list
+        attr :struct, Struct
       end
 
       def func(assigns), do: ~H[]
@@ -306,20 +317,45 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
       def render(assigns) do
         ~H"""
         <.func>
-          <!-- correct type literal provided -->
-          <:named label="Label"/>
-          <!-- incorrect type literal provided -->
-          <:named label={:boom} />
-          <!-- no value provided (boolean: true) -->
-          <:named label />
-          <!-- expression provided -->
-          <:named label={@label} />
+          <!-- any type should never raise a warning -->
+          <:slot any="any" />
+          <:slot any={:any} />
+          <:slot any={true} />
+          <:slot any={1} />
+          <:slot any={1.0} />
+          <:slot any={[]} />
+          <:slot any={%Struct{}} />
+
+          <!-- string warnings -->
+          <:slot string={:string} />
+
+          <!-- atom warnings -->
+          <:slot atom="atom" />
+
+          <!-- boolean warnings -->
+          <:slot boolean="boolean" />
+
+          <!-- integer warnings -->
+          <:slot integer="integer" />
+
+          <!-- float warnings -->
+          <:slot float="float" />
+
+          <!-- list warnings -->
+          <:slot list="list" />
+
+          <!-- struct warnings -->
+          <:slot struct="struct" />
+          
+          <!-- attrs with no expression -->
+          <:slot boolean />
+          <:slot string />
         </.func>
         """
       end
     end
 
-    test "validate slot attrs" do
+    test "validate slot attr types" do
       line = SlotAttrs.render_line()
       diagnostics = Mix.Tasks.Compile.PhoenixLiveView.validate_components_calls([SlotAttrs])
 
@@ -329,8 +365,8 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
                  details: nil,
                  file: __ENV__.file,
                  message:
-                   "attribute \"label\" in slot \"named\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :string, got: true",
-                 position: line + 8,
+                   "attribute \"string\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :string, got: true",
+                 position: line + 35,
                  severity: :warning
                },
                %Diagnostic{
@@ -338,8 +374,62 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
                  details: nil,
                  file: __ENV__.file,
                  message:
-                   "attribute \"label\" in slot \"named\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :string, got: :boom",
-                 position: line + 6,
+                   "attribute \"struct\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct, got: \"struct\"",
+                 position: line + 31,
+                 severity: :warning
+               },
+               %Diagnostic{
+                 compiler_name: "phoenix_live_view",
+                 details: nil,
+                 file: __ENV__.file,
+                 message:
+                   "attribute \"list\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :list, got: \"list\"",
+                 position: line + 28,
+                 severity: :warning
+               },
+               %Diagnostic{
+                 compiler_name: "phoenix_live_view",
+                 details: nil,
+                 file: __ENV__.file,
+                 message:
+                   "attribute \"float\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :float, got: \"float\"",
+                 position: line + 25,
+                 severity: :warning
+               },
+               %Diagnostic{
+                 compiler_name: "phoenix_live_view",
+                 details: nil,
+                 file: __ENV__.file,
+                 message:
+                   "attribute \"integer\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :integer, got: \"integer\"",
+                 position: line + 22,
+                 severity: :warning
+               },
+               %Diagnostic{
+                 compiler_name: "phoenix_live_view",
+                 details: nil,
+                 file: __ENV__.file,
+                 message:
+                   "attribute \"boolean\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :boolean, got: \"boolean\"",
+                 position: line + 19,
+                 severity: :warning
+               },
+               %Diagnostic{
+                 compiler_name: "phoenix_live_view",
+                 details: nil,
+                 file: __ENV__.file,
+                 message:
+                   "attribute \"atom\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be an :atom, got: \"atom\"",
+                 position: line + 16,
+                 severity: :warning
+               },
+               %Diagnostic{
+                 compiler_name: "phoenix_live_view",
+                 details: nil,
+                 file: __ENV__.file,
+                 message:
+                   "attribute \"string\" in slot \"slot\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 must be a :string, got: :string",
+                 position: line + 13,
                  severity: :warning
                }
              ]

--- a/test/mix/tasks/compile/phoenix_live_view_test.exs
+++ b/test/mix/tasks/compile/phoenix_live_view_test.exs
@@ -137,7 +137,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
         <.func boolean="btn"/>
         <.func string/>
         <.func boolean string="string"/>
-        <.func boolean={"can't validate"} string={:wont_validate}/>
+        <!-- <.func boolean={"can't validate"} string={:wont_validate}/> -->
         <.local_button id="foo" class="my-class" myprefix-thing="value"/>
         <.local_button id="foo" unknown-global="bad"/>
         <.local_button id="foo" rest="nope"/>
@@ -455,7 +455,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
       string_warnings =
         for {value, line} <- [
               {nil, 7},
-              {:struct, 6},
+              # {:struct, 6},
               {[], 5},
               {1.0, 4},
               {1, 3},
@@ -499,7 +499,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
       boolean_warnings =
         for {value, line} <- [
               {nil, 7},
-              {:struct, 6},
+              # {:struct, 6},
               {[], 5},
               {1.0, 4},
               {1, 3},
@@ -521,7 +521,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
       integer_warnings =
         for {value, line} <- [
               {nil, 7},
-              {:struct, 6},
+              # {:struct, 6},
               {[], 5},
               {1.0, 4},
               # {1, 3},
@@ -543,7 +543,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
       float_warnings =
         for {value, line} <- [
               {nil, 7},
-              {:struct, 6},
+              # {:struct, 6},
               {[], 5},
               # {1.0, 4},
               {1, 3},
@@ -565,13 +565,13 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
       list_warnings =
         for {value, line} <- [
               {nil, 7},
-              {:struct, 6},
-              # TODO: this should not cause a warning
+              {{:%, [line: 428],
+                [{:__aliases__, [line: 428], [:Struct]}, {:%{}, [line: 428], []}]}, 6},
               {[], 5},
               {1.0, 4},
               {1, 3},
               {true, 2},
-              # {:list, 1},
+              {:list, 1},
               {"list", 0}
             ] do
           %Diagnostic{
@@ -588,12 +588,12 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
       struct_warnings =
         for {value, line} <- [
               {nil, 7},
-              # {:struct, 6},
               {[], 5},
               {1.0, 4},
               {1, 3},
               {true, 2},
-              # {:struct, 1}, # TODO: fix this, should be a warning
+              # TODO: fix this, should be a warning
+              {:struct, 1},
               {"struct", 0}
             ] do
           %Diagnostic{

--- a/test/mix/tasks/compile/phoenix_live_view_test.exs
+++ b/test/mix/tasks/compile/phoenix_live_view_test.exs
@@ -122,78 +122,310 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
     defmodule TypeAttrs do
       use Phoenix.Component, global_prefixes: ~w(myprefix-)
 
-      attr :boolean, :boolean
+      defmodule Struct do
+        defstruct []
+      end
+
+      attr :any, :any
       attr :string, :string
+      attr :atom, :atom
+      attr :boolean, :boolean
+      attr :integer, :integer
+      attr :float, :float
+      attr :list, :list
+      attr :struct, Struct
+      attr :global, :global
+
       def func(assigns), do: ~H[]
 
-      attr :id, :string, required: true
-      attr :rest, :global
-      def local_button(assigns), do: ~H[<button id={@id} {@rest}/>]
+      def any_line, do: __ENV__.line + 4
 
-      def line, do: __ENV__.line + 4
-
-      def render(assigns) do
+      def any_render(assigns) do
         ~H"""
-        <.func boolean="btn"/>
-        <.func string/>
-        <.func boolean string="string"/>
-        <!-- <.func boolean={"can't validate"} string={:wont_validate}/> -->
-        <.local_button id="foo" class="my-class" myprefix-thing="value"/>
-        <.local_button id="foo" unknown-global="bad"/>
-        <.local_button id="foo" rest="nope"/>
-        <External.button id="foo" class="external" myprefix-external="value"/>
-        <External.button id="foo" unknown-global-external="bad"/>
+        <.func any="any" />
+        <.func any={:any} />
+        <.func any={true} />
+        <.func any={1} />
+        <.func any={1.0} />
+        <.func any={[]} />
+        <.func any={%Struct{}} />
+        <.func any={nil} />
+        """
+      end
+
+      def render_string_line, do: __ENV__.line + 4
+
+      def string_render(assigns) do
+        ~H"""
+        <.func string="string" />
+        <.func string={:string} />
+        <.func string={true} />
+        <.func string={1} />
+        <.func string={1.0} />
+        <.func string={[]} />
+        <.func string={%Struct{}} />
+        <.func string={nil} />
+        """
+      end
+
+      def render_atom_line, do: __ENV__.line + 4
+
+      def atom_render(assigns) do
+        ~H"""
+        <.func atom="atom" />
+        <.func atom={:atom} />
+        <.func atom={true} />
+        <.func atom={1} />
+        <.func atom={1.0} />
+        <.func atom={[]} />
+        <.func atom={%Struct{}} />
+        <.func atom={nil} />
+        """
+      end
+
+      def render_boolean_line, do: __ENV__.line + 4
+
+      def boolean_render(assigns) do
+        ~H"""
+        <.func boolean="boolean" />
+        <.func boolean={:boolean} />
+        <.func boolean={true} />
+        <.func boolean={1} />
+        <.func boolean={1.0} />
+        <.func boolean={[]} />
+        <.func boolean={%Struct{}} />
+        <.func boolean={nil} />
+        """
+      end
+
+      def render_integer_line, do: __ENV__.line + 4
+
+      def integer_render(assigns) do
+        ~H"""
+        <.func integer="integer" />
+        <.func integer={:integer} />
+        <.func integer={true} />
+        <.func integer={1} />
+        <.func integer={1.0} />
+        <.func integer={[]} />
+        <.func integer={%Struct{}} />
+        <.func integer={nil} />
+        """
+      end
+
+      def render_float_line, do: __ENV__.line + 4
+
+      def float_render(assigns) do
+        ~H"""
+        <.func float="float" />
+        <.func float={:float} />
+        <.func float={true} />
+        <.func float={1} />
+        <.func float={1.0} />
+        <.func float={[]} />
+        <.func float={%Struct{}} />
+        <.func float={nil} />
+        """
+      end
+
+      def render_list_line, do: __ENV__.line + 4
+
+      def list_render(assigns) do
+        ~H"""
+        <.func list="list" />
+        <.func list={:list} />
+        <.func list={true} />
+        <.func list={1} />
+        <.func list={1.0} />
+        <.func list={[]} />
+        <.func list={%Struct{}} />
+        <.func list={nil} />
+        """
+      end
+
+      def render_struct_line, do: __ENV__.line + 4
+
+      def struct_render(assigns) do
+        ~H"""
+        <.func struct="struct" />
+        <.func struct={:struct} />
+        <.func struct={true} />
+        <.func struct={1} />
+        <.func struct={1.0} />
+        <.func struct={[]} />
+        <.func struct={%Struct{}} />
+        <.func struct={nil} />
         """
       end
     end
 
     test "validate literal types" do
-      line = get_line(TypeAttrs)
       diagnostics = Mix.Tasks.Compile.PhoenixLiveView.validate_components_calls([TypeAttrs])
 
-      assert diagnostics == [
-               %Diagnostic{
-                 compiler_name: "phoenix_live_view",
-                 file: __ENV__.file,
-                 message:
-                   "attribute \"boolean\" in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 must be a :boolean, got string: \"btn\"",
-                 position: line,
-                 severity: :warning
-               },
-               %Diagnostic{
-                 compiler_name: "phoenix_live_view",
-                 file: __ENV__.file,
-                 message:
-                   "attribute \"string\" in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 must be a :string, got boolean: true",
-                 position: line + 1,
-                 severity: :warning
-               },
-               %Mix.Task.Compiler.Diagnostic{
-                 compiler_name: "phoenix_live_view",
-                 file: __ENV__.file,
-                 message:
-                   "undefined attribute \"unknown-global\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.local_button/1",
-                 position: line + 5,
-                 severity: :warning
-               },
-               %Mix.Task.Compiler.Diagnostic{
-                 compiler_name: "phoenix_live_view",
-                 file: __ENV__.file,
-                 message:
-                   "global attribute \"rest\" in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.local_button/1 may not be provided directly",
-                 position: line + 6,
-                 severity: :warning
-               },
-               %Mix.Task.Compiler.Diagnostic{
-                 compiler_name: "phoenix_live_view",
-                 details: nil,
-                 file: __ENV__.file,
-                 message:
-                   "undefined attribute \"unknown-global-external\" for component Mix.Tasks.Compile.PhoenixLiveViewTest.External.button/1",
-                 position: line + 8,
-                 severity: :warning
-               }
-             ]
+      string_warnings =
+        for {value, line} <- [
+              # {"string", 0},
+              {:string, 1},
+              {true, 2},
+              {1, 3},
+              {1.0, 4},
+              {[], 5},
+              {Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.Struct, 6},
+              {nil, 7}
+            ] do
+          %Diagnostic{
+            compiler_name: "phoenix_live_view",
+            details: nil,
+            file: __ENV__.file,
+            severity: :warning,
+            position: TypeAttrs.render_string_line() + line,
+            message:
+              "attribute \"string\" in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 must be a :string, got: #{inspect(value)}"
+          }
+        end
+
+      atom_warnings =
+        for {value, line} <- [
+              {"atom", 0},
+              # {:atom, 1},
+              # {true, 2},
+              {1, 3},
+              {1.0, 4},
+              {[], 5},
+              {Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.Struct, 6}
+              # {nil, 7},
+            ] do
+          %Diagnostic{
+            compiler_name: "phoenix_live_view",
+            details: nil,
+            file: __ENV__.file,
+            severity: :warning,
+            position: TypeAttrs.render_atom_line() + line,
+            message:
+              "attribute \"atom\" in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 must be an :atom, got: #{inspect(value)}"
+          }
+        end
+
+      boolean_warnings =
+        for {value, line} <- [
+              {"boolean", 0},
+              {:boolean, 1},
+              # {true, 2},
+              {1, 3},
+              {1.0, 4},
+              {[], 5},
+              {Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.Struct, 6},
+              {nil, 7}
+            ] do
+          %Diagnostic{
+            compiler_name: "phoenix_live_view",
+            details: nil,
+            file: __ENV__.file,
+            severity: :warning,
+            position: TypeAttrs.render_boolean_line() + line,
+            message:
+              "attribute \"boolean\" in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 must be a :boolean, got: #{inspect(value)}"
+          }
+        end
+
+      integer_warnings =
+        for {value, line} <- [
+              {"integer", 0},
+              {:integer, 1},
+              {true, 2},
+              # {1, 3},
+              {1.0, 4},
+              {[], 5},
+              {Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.Struct, 6},
+              {nil, 7}
+            ] do
+          %Diagnostic{
+            compiler_name: "phoenix_live_view",
+            details: nil,
+            file: __ENV__.file,
+            severity: :warning,
+            position: TypeAttrs.render_integer_line() + line,
+            message:
+              "attribute \"integer\" in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 must be an :integer, got: #{inspect(value)}"
+          }
+        end
+
+      float_warnings =
+        for {value, line} <- [
+              {"float", 0},
+              {:float, 1},
+              {true, 2},
+              {1, 3},
+              # {1.0, 4},
+              {[], 5},
+              {Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.Struct, 6},
+              {nil, 7}
+            ] do
+          %Diagnostic{
+            compiler_name: "phoenix_live_view",
+            details: nil,
+            file: __ENV__.file,
+            severity: :warning,
+            position: TypeAttrs.render_float_line() + line,
+            message:
+              "attribute \"float\" in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 must be a :float, got: #{inspect(value)}"
+          }
+        end
+
+      list_warnings =
+        for {value, line} <- [
+              {"list", 0},
+              {:list, 1},
+              {true, 2},
+              {1, 3},
+              {1.0, 4},
+              # {[], 5},
+              {Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.Struct, 6},
+              {nil, 7}
+            ] do
+          %Diagnostic{
+            compiler_name: "phoenix_live_view",
+            details: nil,
+            file: __ENV__.file,
+            severity: :warning,
+            position: TypeAttrs.render_list_line() + line,
+            message:
+              "attribute \"list\" in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 must be a :list, got: #{inspect(value)}"
+          }
+        end
+
+      struct_warnings =
+        for {value, line} <- [
+              {"struct", 0},
+              {:struct, 1},
+              {true, 2},
+              {1, 3},
+              {1.0, 4},
+              {[], 5},
+              # {Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.Struct, 6},
+              {nil, 7}
+            ] do
+          %Diagnostic{
+            compiler_name: "phoenix_live_view",
+            details: nil,
+            file: __ENV__.file,
+            severity: :warning,
+            position: TypeAttrs.render_struct_line() + line,
+            message:
+              "attribute \"struct\" in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 must be a Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.Struct, got: #{inspect(value)}"
+          }
+        end
+
+      assert diagnostics ==
+               List.flatten([
+                 string_warnings,
+                 atom_warnings,
+                 boolean_warnings,
+                 integer_warnings,
+                 float_warnings,
+                 list_warnings,
+                 struct_warnings
+               ])
     end
 
     defmodule NoAttrs do
@@ -444,6 +676,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
           <:slot struct={[]} />
           <:slot struct={%Struct{}} />
           <:slot struct={nil} />
+          <:slot struct={%Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct{}} />
         </.func>
         """
       end
@@ -599,13 +832,15 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
         end
 
       assert diagnostics ==
-               string_warnings ++
-                 atom_warnings ++
-                 boolean_warnings ++
-                 integer_warnings ++
-                 float_warnings ++
-                 list_warnings ++
+               List.flatten([
+                 string_warnings,
+                 atom_warnings,
+                 boolean_warnings,
+                 integer_warnings,
+                 float_warnings,
+                 list_warnings,
                  struct_warnings
+               ])
     end
 
     defmodule UndefinedSlots do

--- a/test/mix/tasks/compile/phoenix_live_view_test.exs
+++ b/test/mix/tasks/compile/phoenix_live_view_test.exs
@@ -172,10 +172,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
     defmodule TypeAttrs do
       use Phoenix.Component, global_prefixes: ~w(myprefix-)
 
-      defmodule Struct do
-        defstruct []
-      end
-
       attr :any, :any
       attr :string, :string
       attr :atom, :atom
@@ -183,7 +179,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
       attr :integer, :integer
       attr :float, :float
       attr :list, :list
-      attr :struct, Struct
       attr :global, :global
 
       def func(assigns), do: ~H[]
@@ -207,7 +202,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
         <.func any={1} />
         <.func any={1.0} />
         <.func any={[]} />
-        <.func any={%Struct{}} />
         <.func any={nil} />
         """
       end
@@ -222,7 +216,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
         <.func string={1} />
         <.func string={1.0} />
         <.func string={[]} />
-        <.func string={%Struct{}} />
         <.func string={nil} />
         """
       end
@@ -237,7 +230,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
         <.func atom={1} />
         <.func atom={1.0} />
         <.func atom={[]} />
-        <.func atom={%Struct{}} />
         <.func atom={nil} />
         """
       end
@@ -252,7 +244,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
         <.func boolean={1} />
         <.func boolean={1.0} />
         <.func boolean={[]} />
-        <.func boolean={%Struct{}} />
         <.func boolean={nil} />
         """
       end
@@ -267,7 +258,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
         <.func integer={1} />
         <.func integer={1.0} />
         <.func integer={[]} />
-        <.func integer={%Struct{}} />
         <.func integer={nil} />
         """
       end
@@ -282,7 +272,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
         <.func float={1} />
         <.func float={1.0} />
         <.func float={[]} />
-        <.func float={%Struct{}} />
         <.func float={nil} />
         """
       end
@@ -297,23 +286,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
         <.func list={1} />
         <.func list={1.0} />
         <.func list={[]} />
-        <.func list={%Struct{}} />
         <.func list={nil} />
-        """
-      end
-
-      def render_struct_line, do: __ENV__.line + 4
-
-      def struct_render(assigns) do
-        ~H"""
-        <.func struct="struct" />
-        <.func struct={:struct} />
-        <.func struct={true} />
-        <.func struct={1} />
-        <.func struct={1.0} />
-        <.func struct={[]} />
-        <.func struct={%Struct{}} />
-        <.func struct={nil} />
         """
       end
     end
@@ -343,8 +316,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
               {1, 3},
               {1.0, 4},
               {[], 5},
-              {Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.Struct, 6},
-              {nil, 7}
+              {nil, 6}
             ] do
           %Diagnostic{
             compiler_name: "phoenix_live_view",
@@ -366,8 +338,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
               {"atom", 0},
               {1, 3},
               {1.0, 4},
-              {[], 5},
-              {Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.Struct, 6}
+              {[], 5}
             ] do
           %Diagnostic{
             compiler_name: "phoenix_live_view",
@@ -391,8 +362,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
               {1, 3},
               {1.0, 4},
               {[], 5},
-              {Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.Struct, 6},
-              {nil, 7}
+              {nil, 6}
             ] do
           %Diagnostic{
             compiler_name: "phoenix_live_view",
@@ -416,8 +386,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
               {true, 2},
               {1.0, 4},
               {[], 5},
-              {Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.Struct, 6},
-              {nil, 7}
+              {nil, 6}
             ] do
           %Diagnostic{
             compiler_name: "phoenix_live_view",
@@ -441,8 +410,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
               {true, 2},
               {1, 3},
               {[], 5},
-              {Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.Struct, 6},
-              {nil, 7}
+              {nil, 6}
             ] do
           %Diagnostic{
             compiler_name: "phoenix_live_view",
@@ -466,8 +434,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
               {true, 2},
               {1, 3},
               {1.0, 4},
-              {Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.Struct, 6},
-              {nil, 7}
+              {nil, 6}
             ] do
           %Diagnostic{
             compiler_name: "phoenix_live_view",
@@ -484,31 +451,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
           }
         end
 
-      struct_warnings =
-        for {value, line} <- [
-              {"struct", 0},
-              {:struct, 1},
-              {true, 2},
-              {1, 3},
-              {1.0, 4},
-              {[], 5},
-              {nil, 7}
-            ] do
-          %Diagnostic{
-            compiler_name: "phoenix_live_view",
-            details: nil,
-            file: __ENV__.file,
-            severity: :warning,
-            position: TypeAttrs.render_struct_line() + line,
-            message: """
-            attribute \"struct\" \
-            in component Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.func/1 \
-            must be a Mix.Tasks.Compile.PhoenixLiveViewTest.TypeAttrs.Struct, \
-            got: #{inspect(value)}\
-            """
-          }
-        end
-
       assert diagnostics ==
                List.flatten([
                  global_warnings,
@@ -518,7 +460,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
                  integer_warnings,
                  float_warnings,
                  list_warnings,
-                 struct_warnings
                ])
     end
 
@@ -625,10 +566,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
     defmodule SlotAttrs do
       use Phoenix.Component
 
-      defmodule Struct do
-        defstruct []
-      end
-
       slot :slot do
         attr :any, :any
         attr :string, :string
@@ -637,7 +574,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
         attr :integer, :integer
         attr :float, :float
         attr :list, :list
-        attr :struct, Struct
         attr :global, :global
       end
 
@@ -666,7 +602,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
           <:slot any={1} />
           <:slot any={1.0} />
           <:slot any={[]} />
-          <:slot any={%Struct{}} />
         </.func>
         """
       end
@@ -682,7 +617,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
           <:slot string={1} />
           <:slot string={1.0} />
           <:slot string={[]} />
-          <:slot string={%Struct{}} />
           <:slot string={nil} />
         </.func>
         """
@@ -699,7 +633,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
           <:slot atom={1} />
           <:slot atom={1.0} />
           <:slot atom={[]} />
-          <:slot atom={%Struct{}} />
           <:slot atom={nil} />
         </.func>
         """
@@ -716,7 +649,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
           <:slot boolean={1} />
           <:slot boolean={1.0} />
           <:slot boolean={[]} />
-          <:slot boolean={%Struct{}} />
           <:slot boolean={nil} />
         </.func>
         """
@@ -733,7 +665,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
           <:slot integer={1} />
           <:slot integer={1.0} />
           <:slot integer={[]} />
-          <:slot integer={%Struct{}} />
           <:slot integer={nil} />
         </.func>
         """
@@ -750,7 +681,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
           <:slot float={1} />
           <:slot float={1.0} />
           <:slot float={[]} />
-          <:slot float={%Struct{}} />
           <:slot float={nil} />
         </.func>
         """
@@ -767,26 +697,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
           <:slot list={1} />
           <:slot list={1.0} />
           <:slot list={[]} />
-          <:slot list={%Struct{}} />
           <:slot list={nil} />
-        </.func>
-        """
-      end
-
-      def render_struct_line, do: __ENV__.line + 5
-
-      def render_struct(assigns) do
-        ~H"""
-        <.func>
-          <:slot struct="struct" />
-          <:slot struct={:struct} />
-          <:slot struct={true} />
-          <:slot struct={1} />
-          <:slot struct={1.0} />
-          <:slot struct={[]} />
-          <:slot struct={%Struct{}} />
-          <:slot struct={nil} />
-          <:slot struct={%Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct{}} />
         </.func>
         """
       end
@@ -813,8 +724,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
 
       string_warnings =
         for {value, line} <- [
-              {nil, 7},
-              {Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct, 6},
+              {nil, 6},
               {[], 5},
               {1.0, 4},
               {1, 3},
@@ -839,7 +749,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
 
       atom_warnings =
         for {value, line} <- [
-              {Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct, 6},
               {[], 5},
               {1.0, 4},
               {1, 3},
@@ -863,8 +772,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
 
       boolean_warnings =
         for {value, line} <- [
-              {nil, 7},
-              {Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct, 6},
+              {nil, 6},
               {[], 5},
               {1.0, 4},
               {1, 3},
@@ -889,8 +797,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
 
       integer_warnings =
         for {value, line} <- [
-              {nil, 7},
-              {Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct, 6},
+              {nil, 6},
               {[], 5},
               {1.0, 4},
               {true, 2},
@@ -915,8 +822,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
 
       float_warnings =
         for {value, line} <- [
-              {nil, 7},
-              {Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct, 6},
+              {nil, 6},
               {[], 5},
               {1, 3},
               {true, 2},
@@ -941,8 +847,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
 
       list_warnings =
         for {value, line} <- [
-              {nil, 7},
-              {Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct, 6},
+              {nil, 6},
               {1.0, 4},
               {1, 3},
               {true, 2},
@@ -965,32 +870,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
           }
         end
 
-      struct_warnings =
-        for {value, line} <- [
-              {nil, 7},
-              {[], 5},
-              {1.0, 4},
-              {1, 3},
-              {true, 2},
-              {:struct, 1},
-              {"struct", 0}
-            ] do
-          %Diagnostic{
-            compiler_name: "phoenix_live_view",
-            details: nil,
-            file: __ENV__.file,
-            severity: :warning,
-            position: SlotAttrs.render_struct_line() + line,
-            message: """
-            attribute \"struct\" \
-            in slot \"slot\" \
-            for component Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.func/1 \
-            must be a Mix.Tasks.Compile.PhoenixLiveViewTest.SlotAttrs.Struct, \
-            got: #{inspect(value)}\
-            """
-          }
-        end
-
       assert diagnostics ==
                List.flatten([
                  global_warnings,
@@ -999,8 +878,7 @@ defmodule Mix.Tasks.Compile.PhoenixLiveViewTest do
                  boolean_warnings,
                  integer_warnings,
                  float_warnings,
-                 list_warnings,
-                 struct_warnings
+                 list_warnings
                ])
     end
 

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -1277,7 +1277,7 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "raise if attr default does not match the type" do
-      msg = ~r"expected the default value for attr :foo to be a :string, got: :not_a_string."
+      msg = ~r"expected the default value for attr :foo to be a :string, got: :not_a_string"
 
       assert_raise CompileError, msg, fn ->
         defmodule Phoenix.ComponentTest.AttrDefaultTypeMismatch do
@@ -1292,7 +1292,7 @@ defmodule Phoenix.ComponentTest do
 
     test "raise if slot attr default does not match the type" do
       msg =
-        ~r"expected the default value for attr :foo in slot :named to be a :string, got: :not_a_string."
+        ~r"expected the default value for attr :foo in slot :named to be a :string, got: :not_a_string"
 
       assert_raise CompileError, msg, fn ->
         defmodule Phoenix.ComponentTest.SlotAttrDefaultTypeMismatch do

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -525,7 +525,7 @@ defmodule Phoenix.ComponentTest do
 
       def fun_with_slot_line, do: __ENV__.line + 3
 
-      slot :default
+      slot :inner_block
       def fun_with_slot(assigns), do: ~H[]
 
       def fun_with_named_slots_line, do: __ENV__.line + 4

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -921,19 +921,6 @@ defmodule Phoenix.ComponentTest do
              }
     end
 
-    test "raise if :doc is not a string" do
-      msg = ~r/doc must be a string or false, got: :foo/
-
-      assert_raise CompileError, msg, fn ->
-        defmodule Phoenix.ComponentTest.AttrDocsInvalidType do
-          use Elixir.Phoenix.Component
-
-          attr :invalid, :any, doc: :foo
-          def func(assigns), do: ~H[]
-        end
-      end
-    end
-
     test "injects attr docs to function component @doc string" do
       {_, _, :elixir, "text/markdown", _, _, docs} =
         Code.fetch_docs(Phoenix.LiveViewTest.FunctionComponentWithAttrs)
@@ -961,6 +948,45 @@ defmodule Phoenix.ComponentTest do
 
       for {{_, fun, _}, _, _, %{"en" => doc}, _} <- docs do
         assert components[fun] == doc
+      end
+    end
+
+    test "raise if :doc is not a string" do
+      msg = ~r/doc must be a string or false, got: :foo/
+
+      assert_raise CompileError, msg, fn ->
+        defmodule Phoenix.ComponentTest.AttrDocsInvalidType do
+          use Elixir.Phoenix.Component
+
+          attr :invalid, :any, doc: :foo
+          def func(assigns), do: ~H[]
+        end
+      end
+    end
+
+    test "raise if attr name is not an atom" do
+      msg = ~r/attribute names must be atoms, got: "not_an_atom"/
+
+      assert_raise CompileError, msg, fn ->
+        defmodule Phoenix.ComponentTest.AttrNameInvalidType do
+          use Elixir.Phoenix.Component
+
+          attr "not_an_atom", :any
+          def func(assigns), do: ~H[]
+        end
+      end
+    end
+
+    test "raise if slot name is not an atom" do
+      msg = ~r/slot names must be atoms, got: "not_an_atom"/
+
+      assert_raise CompileError, msg, fn ->
+        defmodule Phoenix.ComponentTest.SlotNameInvalidType do
+          use Elixir.Phoenix.Component
+
+          slot "not_an_atom"
+          def func(assigns), do: ~H[]
+        end
       end
     end
 

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -352,6 +352,29 @@ defmodule Phoenix.ComponentTest do
       end
     end
 
+    defmodule FunctionComponentWithSlots do
+      use Phoenix.Component
+
+      slot :header
+      def func_with_slot(assigns), do: ~H[]
+
+      slot :header do
+        attr :name, :any
+      end
+
+      def func_with_slot_attr(assigns), do: ~H[]
+
+      slot :header do
+        attr :name, :any
+        attr :color, :any
+      end
+
+      def func_with_slot_attrs(assigns), do: ~H[]
+
+      slot :slot, required: true
+      def func_with_required_slot(assigns), do: ~H[]
+    end
+
     test "stores attributes definitions" do
       func1_line = FunctionComponentWithAttrs.func1_line()
       func2_line = FunctionComponentWithAttrs.func2_line()
@@ -368,6 +391,7 @@ defmodule Phoenix.ComponentTest do
                      opts: [default: nil],
                      required: false,
                      doc: nil,
+                     slot: nil,
                      line: func1_line + 2
                    },
                    %{
@@ -376,9 +400,11 @@ defmodule Phoenix.ComponentTest do
                      opts: [],
                      required: true,
                      doc: nil,
+                     slot: nil,
                      line: func1_line + 1
                    }
-                 ]
+                 ],
+                 slots: []
                },
                func2: %{
                  kind: :def,
@@ -389,6 +415,7 @@ defmodule Phoenix.ComponentTest do
                      opts: [default: 0],
                      required: false,
                      doc: nil,
+                     slot: nil,
                      line: func2_line + 2
                    },
                    %{
@@ -397,11 +424,14 @@ defmodule Phoenix.ComponentTest do
                      opts: [],
                      required: true,
                      doc: nil,
+                     slot: nil,
                      line: func2_line + 1
                    }
-                 ]
+                 ],
+                 slots: []
                },
                with_global: %{
+                 kind: :def,
                  attrs: [
                    %{
                      line: with_global_line + 1,
@@ -409,12 +439,14 @@ defmodule Phoenix.ComponentTest do
                      opts: [default: "container"],
                      required: false,
                      doc: nil,
+                     slot: nil,
                      type: :string
                    }
                  ],
-                 kind: :def
+                 slots: []
                },
                button_with_defaults: %{
+                 kind: :def,
                  attrs: [
                    %{
                      line: button_with_defaults_line + 1,
@@ -422,12 +454,14 @@ defmodule Phoenix.ComponentTest do
                      opts: [default: %{class: "primary"}],
                      required: false,
                      doc: nil,
+                     slot: nil,
                      type: :global
                    }
                  ],
-                 kind: :def
+                 slots: []
                },
                button: %{
+                 kind: :def,
                  attrs: [
                    %{
                      line: with_global_line + 4,
@@ -435,6 +469,7 @@ defmodule Phoenix.ComponentTest do
                      opts: [],
                      required: true,
                      doc: nil,
+                     slot: nil,
                      type: :string
                    },
                    %{
@@ -443,10 +478,65 @@ defmodule Phoenix.ComponentTest do
                      opts: [],
                      required: false,
                      doc: nil,
+                     slot: nil,
                      type: :global
                    }
                  ],
-                 kind: :def
+                 slots: []
+               }
+             }
+    end
+
+    test "stores slots definitions" do
+      assert FunctionComponentWithSlots.__components__() == %{
+               func_with_required_slot: %{
+                 attrs: [],
+                 kind: :def,
+                 slots: [%{doc: nil, line: 374, name: :slot, opts: [], required: true}]
+               },
+               func_with_slot: %{
+                 attrs: [],
+                 kind: :def,
+                 slots: [%{doc: nil, line: 358, name: :header, opts: [], required: false}]
+               },
+               func_with_slot_attr: %{
+                 attrs: [
+                   %{
+                     doc: nil,
+                     line: 362,
+                     name: :name,
+                     opts: [],
+                     required: false,
+                     slot: :header,
+                     type: :any
+                   }
+                 ],
+                 kind: :def,
+                 slots: [%{doc: nil, line: 361, name: :header, opts: [], required: false}]
+               },
+               func_with_slot_attrs: %{
+                 attrs: [
+                   %{
+                     doc: nil,
+                     line: 369,
+                     name: :color,
+                     opts: [],
+                     required: false,
+                     slot: :header,
+                     type: :any
+                   },
+                   %{
+                     doc: nil,
+                     line: 368,
+                     name: :name,
+                     opts: [],
+                     required: false,
+                     slot: :header,
+                     type: :any
+                   }
+                 ],
+                 kind: :def,
+                 slots: [%{doc: nil, line: 367, name: :header, opts: [], required: false}]
                }
              }
     end
@@ -526,9 +616,11 @@ defmodule Phoenix.ComponentTest do
                      opts: [],
                      doc: nil,
                      required: true,
-                     type: :any
+                     type: :any,
+                     slot: nil
                    }
-                 ]
+                 ],
+                 slots: []
                }
              }
     end
@@ -613,49 +705,55 @@ defmodule Phoenix.ComponentTest do
 
       assert AttrDocs.__components__() == %{
                func_with_attr_docs: %{
-                 kind: :def,
                  attrs: [
                    %{
                      line: line + 3,
+                     doc: "a description\n        with a line break",
+                     slot: nil,
                      name: :break,
                      opts: [],
                      required: false,
-                     type: :any,
-                     doc: "a description\n        with a line break"
+                     type: :any
                    },
                    %{
                      line: line + 6,
+                     doc: "a description\nthat spans\nmultiple lines\n",
+                     slot: nil,
                      name: :multi,
                      opts: [],
                      required: false,
-                     type: :any,
-                     doc: "a description\nthat spans\nmultiple lines\n"
+                     type: :any
                    },
                    %{
                      line: line + 20,
+                     doc: nil,
+                     slot: nil,
                      name: :no_doc,
                      opts: [],
                      required: false,
-                     type: :any,
-                     doc: nil
+                     type: :any
                    },
                    %{
                      line: line + 13,
+                     doc: "a description\nwithin a multi-line\nsigil\n",
+                     slot: nil,
                      name: :sigil,
                      opts: [],
                      required: false,
-                     type: :any,
-                     doc: "a description\nwithin a multi-line\nsigil\n"
+                     type: :any
                    },
                    %{
                      line: line + 1,
+                     doc: "a single line description",
+                     slot: nil,
                      name: :single,
                      opts: [],
                      required: false,
-                     type: :any,
-                     doc: "a single line description"
+                     type: :any
                    }
-                 ]
+                 ],
+                 kind: :def,
+                 slots: []
                }
              }
     end

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -536,7 +536,7 @@ defmodule Phoenix.ComponentTest do
 
       def fun_with_slot_attrs_line, do: __ENV__.line + 6
 
-      slot :slot do
+      slot :slot, required: true do
         attr :attr, :any
       end
 
@@ -660,7 +660,7 @@ defmodule Phoenix.ComponentTest do
                      line: FunctionComponentWithSlots.fun_with_slot_attrs_line() - 4,
                      name: :slot,
                      opts: [],
-                     required: false
+                     required: true
                    }
                  ]
                },

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -484,36 +484,36 @@ defmodule Phoenix.ComponentTest do
                %{
                  component: {FunctionComponentWithAttrs, :func1},
                  slots: %{},
-                 attrs: %{id: {_, _, "1"}},
+                 attrs: %{id: {_, _, {:lit, "1"}}},
                  file: ^file,
                  line: ^call_1_line
                },
                %{
                  component: {FunctionComponentWithAttrs, :func1},
                  slots: %{},
-                 attrs: %{id: {_, _, "2"}, email: {_, _, nil}}
+                 attrs: %{id: {_, _, {:lit, "2"}}, email: {_, _, nil}}
                },
                %{
                  slots: %{},
-                 attrs: %{id: {_, _, "3"}},
+                 attrs: %{id: {_, _, {:lit, "3"}}},
                  component: {RemoteFunctionComponentWithAttrs, :remote},
                  file: ^file,
                  line: ^call_3_line
                },
                %{
                  slots: %{},
-                 attrs: %{id: {_, _, "4"}},
+                 attrs: %{id: {_, _, {:lit, "4"}}},
                  component: {RemoteFunctionComponentWithAttrs, :remote}
                },
                %{
                  slots: %{},
-                 attrs: %{id: {_, _, "5"}},
+                 attrs: %{id: {_, _, {:lit, "5"}}},
                  component: {RemoteFunctionComponentWithAttrs, :remote},
                  root: false
                },
                %{
                  slots: %{},
-                 attrs: %{id: {_, _, "6"}},
+                 attrs: %{id: {_, _, {:lit, "6"}}},
                  component: {RemoteFunctionComponentWithAttrs, :remote},
                  root: true
                }

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -990,7 +990,12 @@ defmodule Phoenix.ComponentTest do
         fun_multiple_attr: "## Attributes\n\n* `attr1` (`:any`)\n* `attr2` (`:any`)\n",
         fun_with_attr_doc: "## Attributes\n\n* `attr` (`:any`) - attr docs\n",
         fun_with_hidden_attr: "## Attributes\n\n* `attr1` (`:any`)\n",
-        fun_with_doc: "fun docs\n## Attributes\n\n* `attr` (`:any`)\n"
+        fun_with_doc: "fun docs\n## Attributes\n\n* `attr` (`:any`)\n",
+        fun_slot: "## Slots\n\n* `inner_block`\n",
+        fun_slot_doc: "## Slots\n\n* `inner_block` - slot docs\n",
+        fun_slot_required: "## Slots\n\n* `inner_block` (required)\n",
+        fun_slot_with_attrs:
+          "## Slots\n\n* `named` (required) - a named slot. Accepts attributes: \n\t* `attr1` (`:any`) (required) - a slot attr doc\n\t* `attr2` (`:any`) (required) - a slot attr doc\n"
       }
 
       for {{_, fun, _}, _, _, %{"en" => doc}, _} <- docs do

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -477,7 +477,7 @@ defmodule Phoenix.ComponentTest do
       assert [
                %{
                  slots: %{},
-                 attrs: %{id: {_, _, _, _}},
+                 attrs: %{id: {_, _, _, _}, "aria-hidden": {_, _, _, _}, class: {_, _, _, _}},
                  component: {Phoenix.ComponentTest.FunctionComponentWithAttrs, :button},
                  file: ^file,
                  line: ^with_global_line,
@@ -1426,6 +1426,23 @@ defmodule Phoenix.ComponentTest do
 
           attr :rest, :global
           attr :rest2, :global
+          def func(assigns), do: ~H[]
+        end
+      end
+    end
+
+    test "raise on more than one :global slot attr" do
+      msg = ~r"cannot define multiple global attributes in slot :named"
+
+      assert_raise CompileError, msg, fn ->
+        defmodule Phoenix.ComponentTest.MultiSlotGlobal do
+          use Elixir.Phoenix.Component
+
+          slot :named do
+            attr :rest, :global
+            attr :rest2, :global
+          end
+
           def func(assigns), do: ~H[]
         end
       end

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -1153,6 +1153,57 @@ defmodule Phoenix.ComponentTest do
              """)
     end
 
+    test "raise if an unknown expression is encountered in a slot block" do
+      msg =
+        ~r"unexpected expression encountered in slot :named, got: foobar\(\). The code given to slot/2 can only contain calls to attr/3 and Elixir comments."
+
+      assert_raise CompileError, msg, fn ->
+        defmodule Phoenix.ComponentTest.UnexpectedExpressionInSlotBlock do
+          use Elixir.Phoenix.Component
+
+          slot :named do
+            foobar()
+          end
+
+          def func(assigns), do: ~H[]
+        end
+      end
+    end
+
+    test "raise if an unknown literal is encountered in a slot block" do
+      msg =
+        ~r"unexpected literal encountered in slot :named, got: :ok. The code given to slot/2 can only contain calls to attr/3 and Elixir comments."
+
+      assert_raise CompileError, msg, fn ->
+        defmodule Phoenix.ComponentTest.UnexpectedLiteralInSlotBlock2 do
+          use Elixir.Phoenix.Component
+
+          slot :named do
+            :ok
+          end
+
+          def func(assigns), do: ~H[]
+        end
+      end
+    end
+
+    test "does not raise if code comments are in a slot block" do
+      assert Code.compile_string("""
+               defmodule CodeCommentsInSlotBlock do
+                 use Phoenix.Component
+                 
+                 slot :named do
+                   # a comment
+                   attr :foo, :any
+                   # another comment
+                   attr :bar, :any
+                 end
+
+                 def func(assigns), do: ~H[]
+               end
+             """)
+    end
+
     test "raise on more than one :global attr" do
       msg = ~r"cannot define global attribute :rest2 because one is already defined under :rest"
 

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -886,6 +886,12 @@ defmodule Phoenix.ComponentTest do
 
         @doc "my function component with attrs"
         def func_with_attr_docs(assigns), do: ~H[]
+
+        slot :slot, doc: "a named slot" do
+          attr :attr, :any, doc: "a slot attr"
+        end
+
+        def func_with_slot_docs(assigns), do: ~H[]
       end
 
       line = AttrDocs.attr_line()
@@ -941,6 +947,23 @@ defmodule Phoenix.ComponentTest do
                  ],
                  kind: :def,
                  slots: []
+               },
+               func_with_slot_docs: %{
+                 attrs: [
+                   %{
+                     doc: "a slot attr",
+                     line: line + 26,
+                     name: :attr,
+                     opts: [],
+                     required: false,
+                     slot: :slot,
+                     type: :any
+                   }
+                 ],
+                 kind: :def,
+                 slots: [
+                   %{doc: "a named slot", line: line + 25, name: :slot, opts: [], required: false}
+                 ]
                }
              }
     end
@@ -975,7 +998,7 @@ defmodule Phoenix.ComponentTest do
       end
     end
 
-    test "raise if :doc is not a string" do
+    test "raise if attr :doc is not a string" do
       msg = ~r"doc must be a string or false, got: :foo"
 
       assert_raise CompileError, msg, fn ->
@@ -983,6 +1006,19 @@ defmodule Phoenix.ComponentTest do
           use Elixir.Phoenix.Component
 
           attr :invalid, :any, doc: :foo
+          def func(assigns), do: ~H[]
+        end
+      end
+    end
+
+    test "raise if slot :doc is not a string" do
+      msg = ~r"doc must be a string or false, got: :foo"
+
+      assert_raise CompileError, msg, fn ->
+        defmodule Phoenix.ComponentTest.SlotDocsInvalidType do
+          use Elixir.Phoenix.Component
+
+          slot :invalid, doc: :foo
           def func(assigns), do: ~H[]
         end
       end

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -633,6 +633,7 @@ defmodule Phoenix.ComponentTest do
                      line: FunctionComponentWithSlots.fun_with_slot_line() - 1,
                      name: :inner_block,
                      opts: [],
+                     attrs: [],
                      required: false
                    }
                  ]
@@ -646,6 +647,7 @@ defmodule Phoenix.ComponentTest do
                      line: FunctionComponentWithSlots.fun_with_named_slots_line() - 1,
                      name: :footer,
                      opts: [],
+                     attrs: [],
                      required: false
                    },
                    %{
@@ -653,6 +655,7 @@ defmodule Phoenix.ComponentTest do
                      line: FunctionComponentWithSlots.fun_with_named_slots_line() - 2,
                      name: :header,
                      opts: [],
+                     attrs: [],
                      required: false
                    }
                  ]
@@ -676,6 +679,17 @@ defmodule Phoenix.ComponentTest do
                      line: FunctionComponentWithSlots.fun_with_slot_attrs_line() - 4,
                      name: :slot,
                      opts: [],
+                     attrs: [
+                       %{
+                         doc: nil,
+                         line: FunctionComponentWithSlots.fun_with_slot_attrs_line() - 3,
+                         name: :attr,
+                         opts: [],
+                         required: false,
+                         slot: :slot,
+                         type: :any
+                       }
+                     ],
                      required: true
                    }
                  ]
@@ -708,6 +722,17 @@ defmodule Phoenix.ComponentTest do
                      line: FunctionComponentWithSlots.table_line() - 6,
                      name: :col,
                      opts: [],
+                     attrs: [
+                       %{
+                         doc: nil,
+                         line: FunctionComponentWithSlots.table_line() - 5,
+                         name: :label,
+                         opts: [],
+                         required: false,
+                         slot: :col,
+                         type: :string
+                       }
+                     ],
                      required: false
                    }
                  ]
@@ -731,6 +756,17 @@ defmodule Phoenix.ComponentTest do
                      line: FunctionComponentWithSlots.fun_with_slot_attr_default_line() - 5,
                      name: :named,
                      opts: [],
+                     attrs: [
+                       %{
+                         doc: nil,
+                         line: FunctionComponentWithSlots.fun_with_slot_attr_default_line() - 4,
+                         name: :attr_with_default,
+                         opts: [default: "a default value"],
+                         required: false,
+                         slot: :named,
+                         type: :any
+                       }
+                     ],
                      required: false
                    }
                  ]
@@ -864,6 +900,7 @@ defmodule Phoenix.ComponentTest do
                      line: Bodyless.example2_line(),
                      name: :slot,
                      opts: [],
+                     attrs: [],
                      required: false
                    }
                  ]
@@ -1021,7 +1058,24 @@ defmodule Phoenix.ComponentTest do
                  ],
                  kind: :def,
                  slots: [
-                   %{doc: "a named slot", line: line + 25, name: :slot, opts: [], required: false}
+                   %{
+                     doc: "a named slot",
+                     line: line + 25,
+                     name: :slot,
+                     attrs: [
+                       %{
+                         doc: "a slot attr",
+                         line: line + 26,
+                         name: :attr,
+                         opts: [],
+                         required: false,
+                         slot: :slot,
+                         type: :any
+                       }
+                     ],
+                     opts: [],
+                     required: false
+                   }
                  ]
                }
              }
@@ -1240,6 +1294,20 @@ defmodule Phoenix.ComponentTest do
 
           slot :named do
             attr :foo, :not_a_type
+          end
+
+          def func(assigns), do: ~H[]
+        end
+      end
+    end
+
+    test "reraise exceptions in slot/3 blocks" do
+      assert_raise RuntimeError, "boom!", fn ->
+        defmodule Phoenix.ComponentTest.SlotExceptionRaised do
+          use Elixir.Phoenix.Component
+
+          slot :named do
+            raise "boom!"
           end
 
           def func(assigns), do: ~H[]

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -477,7 +477,7 @@ defmodule Phoenix.ComponentTest do
       assert [
                %{
                  slots: %{},
-                 attrs: %{id: {_, _, _, _}, "aria-hidden": {_, _, _, _}, class: {_, _, _, _}},
+                 attrs: %{id: {_, _, _}, "aria-hidden": {_, _, _}, class: {_, _, _}},
                  component: {Phoenix.ComponentTest.FunctionComponentWithAttrs, :button},
                  file: ^file,
                  line: ^with_global_line,
@@ -486,36 +486,36 @@ defmodule Phoenix.ComponentTest do
                %{
                  component: {FunctionComponentWithAttrs, :func1},
                  slots: %{},
-                 attrs: %{id: {_, _, :lit, "1"}},
+                 attrs: %{id: {_, _, {:string, "1"}}},
                  file: ^file,
                  line: ^call_1_line
                },
                %{
                  component: {FunctionComponentWithAttrs, :func1},
                  slots: %{},
-                 attrs: %{id: {_, _, :lit, "2"}, email: {_, _, :lit, true}}
+                 attrs: %{id: {_, _, {:string, "2"}}, email: {_, _, {:boolean, true}}}
                },
                %{
                  slots: %{},
-                 attrs: %{id: {_, _, :lit, "3"}},
+                 attrs: %{id: {_, _, {:string, "3"}}},
                  component: {RemoteFunctionComponentWithAttrs, :remote},
                  file: ^file,
                  line: ^call_3_line
                },
                %{
                  slots: %{},
-                 attrs: %{id: {_, _, :lit, "4"}},
+                 attrs: %{id: {_, _, {:string, "4"}}},
                  component: {RemoteFunctionComponentWithAttrs, :remote}
                },
                %{
                  slots: %{},
-                 attrs: %{id: {_, _, :lit, "5"}},
+                 attrs: %{id: {_, _, {:string, "5"}}},
                  component: {RemoteFunctionComponentWithAttrs, :remote},
                  root: false
                },
                %{
                  slots: %{},
-                 attrs: %{id: {_, _, :lit, "6"}},
+                 attrs: %{id: {_, _, {:string, "6"}}},
                  component: {RemoteFunctionComponentWithAttrs, :remote},
                  root: true
                }
@@ -755,7 +755,7 @@ defmodule Phoenix.ComponentTest do
                  file: ^file,
                  line: 592,
                  root: false,
-                 slots: %{inner_block: [%{inner_block: {594, 9, :expr, _}}]}
+                 slots: %{inner_block: [%{inner_block: {594, 9, :any}}]}
                },
                %{
                  attrs: %{},
@@ -765,9 +765,9 @@ defmodule Phoenix.ComponentTest do
                  line: 596,
                  root: false,
                  slots: %{
-                   footer: [%{inner_block: {603, 11, :expr, _}}],
-                   header: [%{inner_block: {597, 11, :expr, _}}],
-                   inner_block: [%{inner_block: {606, 9, :expr, _}}]
+                   footer: [%{inner_block: {603, 11, :any}}],
+                   header: [%{inner_block: {597, 11, :any}}],
+                   inner_block: [%{inner_block: {606, 9, :any}}]
                  }
                },
                %{
@@ -778,22 +778,22 @@ defmodule Phoenix.ComponentTest do
                  line: 608,
                  root: false,
                  slots: %{
-                   inner_block: [%{inner_block: {610, 9, :expr, _}}],
-                   slot: [%{attr: {609, 11, :lit, "1"}, inner_block: {609, 11, :lit, nil}}]
+                   inner_block: [%{inner_block: {610, 9, :any}}],
+                   slot: [%{attr: {609, 11, {:string, "1"}}, inner_block: {609, 11, {:atom, nil}}}]
                  }
                },
                %{
-                 attrs: %{rows: {612, 17, _kind, _value}},
+                 attrs: %{rows: {612, 17, _type_value}},
                  component: {Phoenix.ComponentTest.FunctionComponentWithSlots, :table},
                  file: ^file,
                  line: 612,
                  root: false,
                  slots: %{
                    col: [
-                     %{inner_block: {613, 11, :expr, _}, label: {613, 11, :expr, _}},
-                     %{inner_block: {617, 11, :expr, _}, label: {617, 11, :lit, "Address"}}
+                     %{inner_block: {613, 11, :any}, label: {613, 11, :any}},
+                     %{inner_block: {617, 11, :any}, label: {617, 11, {:string, "Address"}}}
                    ],
-                   inner_block: [%{inner_block: {620, 9, :expr, _}}]
+                   inner_block: [%{inner_block: {620, 9, :any}}]
                  }
                }
              ] = FunctionComponentWithSlots.__components_calls__()

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -963,7 +963,7 @@ defmodule Phoenix.ComponentTest do
       end
     end
 
-    test "raise if attr is not declared before the first function definition" do
+    test "raise if attr is declared between multiple function heads" do
       msg = ~r/attributes must be defined before the first function clause at line \d+/
 
       assert_raise CompileError, msg, fn ->
@@ -975,6 +975,23 @@ defmodule Phoenix.ComponentTest do
           def func(assigns = %{bar: _}), do: ~H[]
 
           attr :bar, :any
+          def func(assigns = %{baz: _}), do: ~H[]
+        end
+      end
+    end
+
+  test "raise if slot is declared between multiple function heads" do
+      msg = ~r/slots must be defined before the first function clause at line \d+/
+
+      assert_raise CompileError, msg, fn ->
+        defmodule Phoenix.ComponentTest.MultiClauseWrong do
+          use Elixir.Phoenix.Component
+
+          slot :inner_block
+          def func(assigns = %{foo: _}), do: ~H[]
+          def func(assigns = %{bar: _}), do: ~H[]
+
+          slot :named
           def func(assigns = %{baz: _}), do: ~H[]
         end
       end

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -1040,6 +1040,20 @@ defmodule Phoenix.ComponentTest do
       end
     end
 
+    test "raise if slot is declared without a related function" do
+      msg = ~r/cannot define slots without a related function component/
+
+      assert_raise CompileError, msg, fn ->
+        defmodule Phoenix.ComponentTest.SlotOnInvalidFunction do
+          use Elixir.Phoenix.Component
+
+          def func(assigns = %{baz: _}), do: ~H[]
+
+          slot :inner_block
+        end
+      end
+    end
+
     test "raise if attr type is not supported" do
       assert_raise CompileError, ~r/invalid type :not_a_type for attr :foo/, fn ->
         defmodule Phoenix.ComponentTest.AttrTypeNotSupported do

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -1,6 +1,8 @@
 defmodule Phoenix.ComponentTest do
   use ExUnit.Case, async: true
 
+  import Phoenix.LiveViewTest
+
   use Phoenix.Component
 
   defp render(mod, func, assigns) do
@@ -569,6 +571,20 @@ defmodule Phoenix.ComponentTest do
         """
       end
 
+      def fun_with_slot_attr_default_line, do: __ENV__.line + 7
+
+      slot :named do
+        attr :attr_with_default, :any, default: "a default value"
+      end
+
+      def fun_with_slot_attr_default(assigns) do
+        ~H"""
+        <%= for named <- @named do %>
+          <%= named.attr_with_default %>
+        <% end %>
+        """
+      end
+
       def render_line, do: __ENV__.line + 2
 
       def render(assigns) do
@@ -695,6 +711,29 @@ defmodule Phoenix.ComponentTest do
                      required: false
                    }
                  ]
+               },
+               fun_with_slot_attr_default: %{
+                 attrs: [
+                   %{
+                     doc: nil,
+                     line: FunctionComponentWithSlots.fun_with_slot_attr_default_line() - 4,
+                     name: :attr_with_default,
+                     opts: [default: "a default value"],
+                     required: false,
+                     slot: :named,
+                     type: :any
+                   }
+                 ],
+                 kind: :def,
+                 slots: [
+                   %{
+                     doc: nil,
+                     line: FunctionComponentWithSlots.fun_with_slot_attr_default_line() - 5,
+                     name: :named,
+                     opts: [],
+                     required: false
+                   }
+                 ]
                }
              }
     end
@@ -707,21 +746,21 @@ defmodule Phoenix.ComponentTest do
                  attrs: %{},
                  component: {Phoenix.ComponentTest.FunctionComponentWithSlots, :fun_with_slot},
                  file: ^file,
-                 line: 576,
+                 line: 592,
                  root: false,
-                 slots: %{inner_block: [%{inner_block: {578, 9, :expr, _}}]}
+                 slots: %{inner_block: [%{inner_block: {594, 9, :expr, _}}]}
                },
                %{
                  attrs: %{},
                  component:
                    {Phoenix.ComponentTest.FunctionComponentWithSlots, :fun_with_named_slots},
                  file: ^file,
-                 line: 580,
+                 line: 596,
                  root: false,
                  slots: %{
-                   footer: [%{inner_block: {587, 11, :expr, _}}],
-                   header: [%{inner_block: {581, 11, :expr, _}}],
-                   inner_block: [%{inner_block: {590, 9, :expr, _}}]
+                   footer: [%{inner_block: {603, 11, :expr, _}}],
+                   header: [%{inner_block: {597, 11, :expr, _}}],
+                   inner_block: [%{inner_block: {606, 9, :expr, _}}]
                  }
                },
                %{
@@ -729,28 +768,48 @@ defmodule Phoenix.ComponentTest do
                  component:
                    {Phoenix.ComponentTest.FunctionComponentWithSlots, :fun_with_slot_attrs},
                  file: ^file,
-                 line: 592,
+                 line: 608,
                  root: false,
                  slots: %{
-                   inner_block: [%{inner_block: {594, 9, :expr, _}}],
-                   slot: [%{attr: {593, 11, :lit, "1"}, inner_block: {593, 11, :lit, nil}}]
+                   inner_block: [%{inner_block: {610, 9, :expr, _}}],
+                   slot: [%{attr: {609, 11, :lit, "1"}, inner_block: {609, 11, :lit, nil}}]
                  }
                },
                %{
-                 attrs: %{rows: {596, 17, _kind, _value}},
+                 attrs: %{rows: {612, 17, _kind, _value}},
                  component: {Phoenix.ComponentTest.FunctionComponentWithSlots, :table},
                  file: ^file,
-                 line: 596,
+                 line: 612,
                  root: false,
                  slots: %{
                    col: [
-                     %{inner_block: {597, 11, :expr, _}, label: {597, 11, :expr, _}},
-                     %{inner_block: {601, 11, :expr, _}, label: {601, 11, :lit, "Address"}}
+                     %{inner_block: {613, 11, :expr, _}, label: {613, 11, :expr, _}},
+                     %{inner_block: {617, 11, :expr, _}, label: {617, 11, :lit, "Address"}}
                    ],
-                   inner_block: [%{inner_block: {604, 9, :expr, _}}]
+                   inner_block: [%{inner_block: {620, 9, :expr, _}}]
                  }
                }
              ] = FunctionComponentWithSlots.__components_calls__()
+    end
+
+    test "renders slot attr defaults" do
+      assigns = %{}
+
+      rendered = ~H"""
+      <FunctionComponentWithSlots.fun_with_slot_attr_default>
+        <:named />
+      </FunctionComponentWithSlots.fun_with_slot_attr_default>
+      """
+
+      assert rendered_to_string(rendered) =~ "a default value"
+
+      rendered = ~H"""
+      <FunctionComponentWithSlots.fun_with_slot_attr_default>
+        <:named attr_with_default="some other value" />
+      </FunctionComponentWithSlots.fun_with_slot_attr_default>
+      """
+
+      assert rendered_to_string(rendered) =~ "some other value"
     end
 
     test "does not generate __components_calls__ if there's no call" do
@@ -995,7 +1054,7 @@ defmodule Phoenix.ComponentTest do
         fun_slot_doc: "## Slots\n\n* `inner_block` - slot docs\n",
         fun_slot_required: "## Slots\n\n* `inner_block` (required)\n",
         fun_slot_with_attrs:
-          "## Slots\n\n* `named` (required) - a named slot. Accepts attributes: \n\t* `attr1` (`:any`) (required) - a slot attr doc\n\t* `attr2` (`:any`) (required) - a slot attr doc\n"
+          "## Slots\n\n* `named` (required) - a named slot. Accepts attributes: \n\t* `attr1` (`:any`) (required) - a slot attr doc\n\t* `attr2` (`:any`) - a slot attr doc. Defaults to `\"some default\"`.\n"
       }
 
       for {{_, fun, _}, _, _, %{"en" => doc}, _} <- docs do

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -571,20 +571,6 @@ defmodule Phoenix.ComponentTest do
         """
       end
 
-      def fun_with_slot_attr_default_line, do: __ENV__.line + 7
-
-      slot :named do
-        attr :attr_with_default, :any, default: "a default value"
-      end
-
-      def fun_with_slot_attr_default(assigns) do
-        ~H"""
-        <%= for named <- @named do %>
-          <%= named.attr_with_default %>
-        <% end %>
-        """
-      end
-
       def render_line, do: __ENV__.line + 2
 
       def render(assigns) do
@@ -717,30 +703,6 @@ defmodule Phoenix.ComponentTest do
                      required: false
                    }
                  ]
-               },
-               fun_with_slot_attr_default: %{
-                 attrs: [],
-                 kind: :def,
-                 slots: [
-                   %{
-                     doc: nil,
-                     line: FunctionComponentWithSlots.fun_with_slot_attr_default_line() - 5,
-                     name: :named,
-                     opts: [],
-                     attrs: [
-                       %{
-                         doc: nil,
-                         line: FunctionComponentWithSlots.fun_with_slot_attr_default_line() - 4,
-                         name: :attr_with_default,
-                         opts: [default: "a default value"],
-                         required: false,
-                         slot: :named,
-                         type: :any
-                       }
-                     ],
-                     required: false
-                   }
-                 ]
                }
              }
     end
@@ -753,21 +715,21 @@ defmodule Phoenix.ComponentTest do
                  attrs: %{},
                  component: {Phoenix.ComponentTest.FunctionComponentWithSlots, :fun_with_slot},
                  file: ^file,
-                 line: 592,
+                 line: 578,
                  root: false,
-                 slots: %{inner_block: [%{inner_block: {594, 9, :any}}]}
+                 slots: %{inner_block: [%{inner_block: {580, 9, :any}}]}
                },
                %{
                  attrs: %{},
                  component:
                    {Phoenix.ComponentTest.FunctionComponentWithSlots, :fun_with_named_slots},
                  file: ^file,
-                 line: 596,
+                 line: 582,
                  root: false,
                  slots: %{
-                   footer: [%{inner_block: {603, 11, :any}}],
-                   header: [%{inner_block: {597, 11, :any}}],
-                   inner_block: [%{inner_block: {606, 9, :any}}]
+                   footer: [%{inner_block: {589, 11, :any}}],
+                   header: [%{inner_block: {583, 11, :any}}],
+                   inner_block: [%{inner_block: {592, 9, :any}}]
                  }
                },
                %{
@@ -775,48 +737,28 @@ defmodule Phoenix.ComponentTest do
                  component:
                    {Phoenix.ComponentTest.FunctionComponentWithSlots, :fun_with_slot_attrs},
                  file: ^file,
-                 line: 608,
+                 line: 594,
                  root: false,
                  slots: %{
-                   inner_block: [%{inner_block: {610, 9, :any}}],
-                   slot: [%{attr: {609, 11, {:string, "1"}}, inner_block: {609, 11, {:atom, nil}}}]
+                   inner_block: [%{inner_block: {596, 9, :any}}],
+                   slot: [%{attr: {595, 11, {:string, "1"}}, inner_block: {595, 11, {:atom, nil}}}]
                  }
                },
                %{
-                 attrs: %{rows: {612, 17, _type_value}},
+                 attrs: %{rows: {598, 17, _type_value}},
                  component: {Phoenix.ComponentTest.FunctionComponentWithSlots, :table},
                  file: ^file,
-                 line: 612,
+                 line: 598,
                  root: false,
                  slots: %{
                    col: [
-                     %{inner_block: {613, 11, :any}, label: {613, 11, :any}},
-                     %{inner_block: {617, 11, :any}, label: {617, 11, {:string, "Address"}}}
+                     %{inner_block: {599, 11, :any}, label: {599, 11, :any}},
+                     %{inner_block: {603, 11, :any}, label: {603, 11, {:string, "Address"}}}
                    ],
-                   inner_block: [%{inner_block: {620, 9, :any}}]
+                   inner_block: [%{inner_block: {606, 9, :any}}]
                  }
                }
              ] = FunctionComponentWithSlots.__components_calls__()
-    end
-
-    test "renders slot attr defaults" do
-      assigns = %{}
-
-      rendered = ~H"""
-      <FunctionComponentWithSlots.fun_with_slot_attr_default>
-        <:named />
-      </FunctionComponentWithSlots.fun_with_slot_attr_default>
-      """
-
-      assert rendered_to_string(rendered) =~ "a default value"
-
-      rendered = ~H"""
-      <FunctionComponentWithSlots.fun_with_slot_attr_default>
-        <:named attr_with_default="some other value" />
-      </FunctionComponentWithSlots.fun_with_slot_attr_default>
-      """
-
-      assert rendered_to_string(rendered) =~ "some other value"
     end
 
     test "does not generate __components_calls__ if there's no call" do
@@ -1069,7 +1011,7 @@ defmodule Phoenix.ComponentTest do
         fun_slot_doc: "## Slots\n\n* `inner_block` - slot docs\n",
         fun_slot_required: "## Slots\n\n* `inner_block` (required)\n",
         fun_slot_with_attrs:
-          "## Slots\n\n* `named` (required) - a named slot. Accepts attributes: \n\t* `attr1` (`:any`) (required) - a slot attr doc\n\t* `attr2` (`:any`) - a slot attr doc. Defaults to `\"some default\"`.\n"
+          "## Slots\n\n* `named` (required) - a named slot. Accepts attributes: \n\t* `attr1` (`:any`) (required) - a slot attr doc\n\t* `attr2` (`:any`) - a slot attr doc\n"
       }
 
       for {{_, fun, _}, _, _, %{"en" => doc}, _} <- docs do
@@ -1290,16 +1232,15 @@ defmodule Phoenix.ComponentTest do
       end
     end
 
-    test "raise if slot attr default does not match the type" do
-      msg =
-        ~r"expected the default value for attr :foo in slot :named to be a :string, got: :not_a_string"
+    test "raise if slot attr has default" do
+      msg = ~r" invalid option :default for attr :foo in slot :named"
 
       assert_raise CompileError, msg, fn ->
-        defmodule Phoenix.ComponentTest.SlotAttrDefaultTypeMismatch do
+        defmodule Phoenix.ComponentTest.SlotAttrDefault do
           use Elixir.Phoenix.Component
 
           slot :named do
-            attr :foo, :string, default: :not_a_string
+            attr :foo, :any, default: :whatever
           end
 
           def func(assigns), do: ~H[]

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -314,7 +314,7 @@ defmodule Phoenix.ComponentTest do
 
       def func1_line, do: __ENV__.line
       attr :id, :any, required: true
-      attr :email, :any, default: nil
+      attr :email, :string, default: nil
       def func1(assigns), do: ~H[]
 
       def func2_line, do: __ENV__.line
@@ -366,7 +366,7 @@ defmodule Phoenix.ComponentTest do
                  attrs: [
                    %{
                      name: :email,
-                     type: :any,
+                     type: :string,
                      opts: [default: nil],
                      required: false,
                      doc: nil,
@@ -1240,6 +1240,37 @@ defmodule Phoenix.ComponentTest do
 
           slot :named do
             attr :foo, :not_a_type
+          end
+
+          def func(assigns), do: ~H[]
+        end
+      end
+    end
+
+    test "raise if attr default does not match the type" do
+      msg = ~r"expected the default value for attr :foo to be a :string, got: :not_a_string."
+
+      assert_raise CompileError, msg, fn ->
+        defmodule Phoenix.ComponentTest.AttrDefaultTypeMismatch do
+          use Elixir.Phoenix.Component
+
+          attr :foo, :string, default: :not_a_string
+
+          def func(assigns), do: ~H[]
+        end
+      end
+    end
+
+    test "raise if slot attr default does not match the type" do
+      msg =
+        ~r"expected the default value for attr :foo in slot :named to be a :string, got: :not_a_string."
+
+      assert_raise CompileError, msg, fn ->
+        defmodule Phoenix.ComponentTest.SlotAttrDefaultTypeMismatch do
+          use Elixir.Phoenix.Component
+
+          slot :named do
+            attr :foo, :string, default: :not_a_string
           end
 
           def func(assigns), do: ~H[]

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -661,17 +661,7 @@ defmodule Phoenix.ComponentTest do
                  ]
                },
                fun_with_slot_attrs: %{
-                 attrs: [
-                   %{
-                     doc: nil,
-                     line: FunctionComponentWithSlots.fun_with_slot_attrs_line() - 3,
-                     name: :attr,
-                     opts: [],
-                     required: false,
-                     slot: :slot,
-                     type: :any
-                   }
-                 ],
+                 attrs: [],
                  kind: :def,
                  slots: [
                    %{
@@ -696,15 +686,6 @@ defmodule Phoenix.ComponentTest do
                },
                table: %{
                  attrs: [
-                   %{
-                     doc: nil,
-                     line: FunctionComponentWithSlots.table_line() - 5,
-                     name: :label,
-                     opts: [],
-                     required: false,
-                     slot: :col,
-                     type: :string
-                   },
                    %{
                      doc: nil,
                      line: FunctionComponentWithSlots.table_line() - 2,
@@ -738,17 +719,7 @@ defmodule Phoenix.ComponentTest do
                  ]
                },
                fun_with_slot_attr_default: %{
-                 attrs: [
-                   %{
-                     doc: nil,
-                     line: FunctionComponentWithSlots.fun_with_slot_attr_default_line() - 4,
-                     name: :attr_with_default,
-                     opts: [default: "a default value"],
-                     required: false,
-                     slot: :named,
-                     type: :any
-                   }
-                 ],
+                 attrs: [],
                  kind: :def,
                  slots: [
                    %{
@@ -1045,17 +1016,7 @@ defmodule Phoenix.ComponentTest do
                  slots: []
                },
                func_with_slot_docs: %{
-                 attrs: [
-                   %{
-                     doc: "a slot attr",
-                     line: line + 26,
-                     name: :attr,
-                     opts: [],
-                     required: false,
-                     slot: :slot,
-                     type: :any
-                   }
-                 ],
+                 attrs: [],
                  kind: :def,
                  slots: [
                    %{
@@ -1441,7 +1402,7 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "raise if slot with name :inner_block has slot attrs" do
-      msg = ~r"cannot define attributes for the slot :inner_block"
+      msg = ~r"cannot define attributes in slot :inner_block"
 
       assert_raise CompileError, msg, fn ->
         defmodule AttrsInDefaultSlot do

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -615,7 +615,7 @@ defmodule Phoenix.ComponentTest do
                    %{
                      doc: nil,
                      line: FunctionComponentWithSlots.fun_with_slot_line() - 1,
-                     name: :default,
+                     name: :inner_block,
                      opts: [],
                      required: false
                    }
@@ -704,31 +704,35 @@ defmodule Phoenix.ComponentTest do
                %{
                  attrs: %{},
                  component: {Phoenix.ComponentTest.FunctionComponentWithSlots, :fun_with_slot},
-                 file: "/home/connorlay/Code/phoenix_live_view/test/phoenix_component_test.exs",
+                 file: __ENV__.file,
                  line: 576,
                  root: false,
-                 slots: %{}
+                 slots: %{inner_block: [%{inner_block: {578, 9, :expr}}]}
                },
                %{
                  attrs: %{},
                  component:
                    {Phoenix.ComponentTest.FunctionComponentWithSlots, :fun_with_named_slots},
-                 file: "/home/connorlay/Code/phoenix_live_view/test/phoenix_component_test.exs",
+                 file: __ENV__.file,
                  line: 580,
                  root: false,
                  slots: %{
                    footer: [%{inner_block: {587, 11, :expr}}],
-                   header: [%{inner_block: {581, 11, :expr}}]
+                   header: [%{inner_block: {581, 11, :expr}}],
+                   inner_block: [%{inner_block: {590, 9, :expr}}]
                  }
                },
                %{
                  attrs: %{},
                  component:
                    {Phoenix.ComponentTest.FunctionComponentWithSlots, :fun_with_slot_attrs},
-                 file: "/home/connorlay/Code/phoenix_live_view/test/phoenix_component_test.exs",
+                 file: __ENV__.file,
                  line: 592,
                  root: false,
-                 slots: %{slot: [%{attr: {593, 11, "1"}, inner_block: {593, 11, nil}}]}
+                 slots: %{
+                   inner_block: [%{inner_block: {594, 9, :expr}}],
+                   slot: [%{attr: {593, 11, "1"}, inner_block: {593, 11, nil}}]
+                 }
                },
                %{
                  attrs: %{rows: {596, 17, :expr}},
@@ -739,9 +743,10 @@ defmodule Phoenix.ComponentTest do
                    col: [
                      %{inner_block: {597, 11, :expr}, label: {597, 11, :expr}},
                      %{inner_block: {601, 11, :expr}, label: {601, 11, "Address"}}
-                   ]
+                   ],
+                   inner_block: [%{inner_block: {604, 9, :expr}}]
                  },
-                 file: "/home/connorlay/Code/phoenix_live_view/test/phoenix_component_test.exs"
+                 file: __ENV__.file
                }
              ]
     end

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -475,7 +475,7 @@ defmodule Phoenix.ComponentTest do
       assert [
                %{
                  slots: %{},
-                 attrs: %{id: {_, _, _}},
+                 attrs: %{id: {_, _, _, _}},
                  component: {Phoenix.ComponentTest.FunctionComponentWithAttrs, :button},
                  file: ^file,
                  line: ^with_global_line,
@@ -484,36 +484,36 @@ defmodule Phoenix.ComponentTest do
                %{
                  component: {FunctionComponentWithAttrs, :func1},
                  slots: %{},
-                 attrs: %{id: {_, _, {:lit, "1"}}},
+                 attrs: %{id: {_, _, :lit, "1"}},
                  file: ^file,
                  line: ^call_1_line
                },
                %{
                  component: {FunctionComponentWithAttrs, :func1},
                  slots: %{},
-                 attrs: %{id: {_, _, {:lit, "2"}}, email: {_, _, nil}}
+                 attrs: %{id: {_, _, :lit, "2"}, email: {_, _, :lit, true}}
                },
                %{
                  slots: %{},
-                 attrs: %{id: {_, _, {:lit, "3"}}},
+                 attrs: %{id: {_, _, :lit, "3"}},
                  component: {RemoteFunctionComponentWithAttrs, :remote},
                  file: ^file,
                  line: ^call_3_line
                },
                %{
                  slots: %{},
-                 attrs: %{id: {_, _, {:lit, "4"}}},
+                 attrs: %{id: {_, _, :lit, "4"}},
                  component: {RemoteFunctionComponentWithAttrs, :remote}
                },
                %{
                  slots: %{},
-                 attrs: %{id: {_, _, {:lit, "5"}}},
+                 attrs: %{id: {_, _, :lit, "5"}},
                  component: {RemoteFunctionComponentWithAttrs, :remote},
                  root: false
                },
                %{
                  slots: %{},
-                 attrs: %{id: {_, _, {:lit, "6"}}},
+                 attrs: %{id: {_, _, :lit, "6"}},
                  component: {RemoteFunctionComponentWithAttrs, :remote},
                  root: true
                }
@@ -737,7 +737,7 @@ defmodule Phoenix.ComponentTest do
                  }
                },
                %{
-                 attrs: %{rows: {596, 17, _ast}},
+                 attrs: %{rows: {596, 17, _kind, _value}},
                  component: {Phoenix.ComponentTest.FunctionComponentWithSlots, :table},
                  file: ^file,
                  line: 596,

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -1136,21 +1136,23 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "does not raise if multiple slots with different names share the same attr names" do
-      assert Code.compile_string("""
-               defmodule MultipleSlotAttrs do
-                 use Phoenix.Component
-                 
-                 slot :foo do
-                   attr :attr, :any
-                 end
+      mod = fn ->
+        defmodule MultipleSlotAttrs do
+          use Phoenix.Component
 
-                 slot :bar do
-                   attr :attr, :any
-                 end
-                 
-                 def func(assigns), do: ~H[]
-               end
-             """)
+          slot :foo do
+            attr :attr, :any
+          end
+
+          slot :bar do
+            attr :attr, :any
+          end
+
+          def func(assigns), do: ~H[]
+        end
+      end
+
+      assert mod.()
     end
 
     test "raise if an unknown expression is encountered in a slot block" do
@@ -1188,20 +1190,22 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "does not raise if code comments are in a slot block" do
-      assert Code.compile_string("""
-               defmodule CodeCommentsInSlotBlock do
-                 use Phoenix.Component
-                 
-                 slot :named do
-                   # a comment
-                   attr :foo, :any
-                   # another comment
-                   attr :bar, :any
-                 end
+      mod = fn ->
+        defmodule CodeCommentsInSlotBlock do
+          use Phoenix.Component
 
-                 def func(assigns), do: ~H[]
-               end
-             """)
+          slot :named do
+            # a comment
+            attr :foo, :any
+            # another comment
+            attr :bar, :any
+          end
+
+          def func(assigns), do: ~H[]
+        end
+      end
+
+      assert mod.()
     end
 
     test "raise on more than one :global attr" do
@@ -1263,15 +1267,17 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "does not raise when there is a nested module" do
-      assert Code.compile_string("""
-               defmodule NestedModules do
-                 use Phoenix.Component
+      mod = fn ->
+        defmodule NestedModules do
+          use Phoenix.Component
 
-                 defmodule Nested do
-                   def fun(arg), do: arg
-                 end
-               end
-             """)
+          defmodule Nested do
+            def fun(arg), do: arg
+          end
+        end
+      end
+
+      assert mod.()
     end
   end
 end

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -1418,7 +1418,7 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "raise on more than one :global attr" do
-      msg = ~r"cannot define global attribute :rest2 because one is already defined under :rest"
+      msg = ~r"cannot define :global attribute :rest2 because one is already defined as :rest"
 
       assert_raise CompileError, msg, fn ->
         defmodule Phoenix.ComponentTest.MultiGlobal do
@@ -1432,7 +1432,7 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "raise on more than one :global slot attr" do
-      msg = ~r"cannot define multiple global attributes in slot :named"
+      msg = ~r"cannot define :global attribute :rest2 because one is already defined as :rest in slot :named"
 
       assert_raise CompileError, msg, fn ->
         defmodule Phoenix.ComponentTest.MultiSlotGlobal do

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -701,6 +701,7 @@ defmodule Phoenix.ComponentTest do
 
     test "stores component calls with slots" do
       file = __ENV__.file
+
       assert [
                %{
                  attrs: %{},
@@ -747,9 +748,9 @@ defmodule Phoenix.ComponentTest do
                      %{inner_block: {601, 11, :expr, _}, label: {601, 11, :lit, "Address"}}
                    ],
                    inner_block: [%{inner_block: {604, 9, :expr, _}}]
-                 },
+                 }
                }
-             ] = FunctionComponentWithSlots.__components_calls__() 
+             ] = FunctionComponentWithSlots.__components_calls__()
     end
 
     test "does not generate __components_calls__ if there's no call" do
@@ -980,7 +981,7 @@ defmodule Phoenix.ComponentTest do
       end
     end
 
-  test "raise if slot is declared between multiple function heads" do
+    test "raise if slot is declared between multiple function heads" do
       msg = ~r/slots must be defined before the first function clause at line \d+/
 
       assert_raise CompileError, msg, fn ->
@@ -1006,6 +1007,20 @@ defmodule Phoenix.ComponentTest do
           use Elixir.Phoenix.Component
 
           attr :foo, :any
+          def func(a, b), do: a + b
+        end
+      end
+    end
+
+    test "raise if slot is declared on an invalid function" do
+      msg =
+        ~r/cannot declare slots for function func\/2\. Components must be functions with arity 1/
+
+      assert_raise CompileError, msg, fn ->
+        defmodule Phoenix.ComponentTest.SlotOnInvalidFunction do
+          use Elixir.Phoenix.Component
+
+          slot :inner_block
           def func(a, b), do: a + b
         end
       end

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -475,7 +475,7 @@ defmodule Phoenix.ComponentTest do
       assert [
                %{
                  slots: %{},
-                 attrs: %{id: {_, _, :expr}},
+                 attrs: %{id: {_, _, _}},
                  component: {Phoenix.ComponentTest.FunctionComponentWithAttrs, :button},
                  file: ^file,
                  line: ^with_global_line,
@@ -700,55 +700,56 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "stores component calls with slots" do
-      assert FunctionComponentWithSlots.__components_calls__() == [
+      file = __ENV__.file
+      assert [
                %{
                  attrs: %{},
                  component: {Phoenix.ComponentTest.FunctionComponentWithSlots, :fun_with_slot},
-                 file: __ENV__.file,
+                 file: ^file,
                  line: 576,
                  root: false,
-                 slots: %{inner_block: [%{inner_block: {578, 9, :expr}}]}
+                 slots: %{inner_block: [%{inner_block: {578, 9, :expr, _}}]}
                },
                %{
                  attrs: %{},
                  component:
                    {Phoenix.ComponentTest.FunctionComponentWithSlots, :fun_with_named_slots},
-                 file: __ENV__.file,
+                 file: ^file,
                  line: 580,
                  root: false,
                  slots: %{
-                   footer: [%{inner_block: {587, 11, :expr}}],
-                   header: [%{inner_block: {581, 11, :expr}}],
-                   inner_block: [%{inner_block: {590, 9, :expr}}]
+                   footer: [%{inner_block: {587, 11, :expr, _}}],
+                   header: [%{inner_block: {581, 11, :expr, _}}],
+                   inner_block: [%{inner_block: {590, 9, :expr, _}}]
                  }
                },
                %{
                  attrs: %{},
                  component:
                    {Phoenix.ComponentTest.FunctionComponentWithSlots, :fun_with_slot_attrs},
-                 file: __ENV__.file,
+                 file: ^file,
                  line: 592,
                  root: false,
                  slots: %{
-                   inner_block: [%{inner_block: {594, 9, :expr}}],
-                   slot: [%{attr: {593, 11, "1"}, inner_block: {593, 11, nil}}]
+                   inner_block: [%{inner_block: {594, 9, :expr, _}}],
+                   slot: [%{attr: {593, 11, :lit, "1"}, inner_block: {593, 11, :lit, nil}}]
                  }
                },
                %{
-                 attrs: %{rows: {596, 17, :expr}},
+                 attrs: %{rows: {596, 17, _ast}},
                  component: {Phoenix.ComponentTest.FunctionComponentWithSlots, :table},
+                 file: ^file,
                  line: 596,
                  root: false,
                  slots: %{
                    col: [
-                     %{inner_block: {597, 11, :expr}, label: {597, 11, :expr}},
-                     %{inner_block: {601, 11, :expr}, label: {601, 11, "Address"}}
+                     %{inner_block: {597, 11, :expr, _}, label: {597, 11, :expr, _}},
+                     %{inner_block: {601, 11, :expr, _}, label: {601, 11, :lit, "Address"}}
                    ],
-                   inner_block: [%{inner_block: {604, 9, :expr}}]
+                   inner_block: [%{inner_block: {604, 9, :expr, _}}]
                  },
-                 file: __ENV__.file
                }
-             ]
+             ] = FunctionComponentWithSlots.__components_calls__() 
     end
 
     test "does not generate __components_calls__ if there's no call" do

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -716,7 +716,10 @@ defmodule Phoenix.ComponentTest do
                  file: "/home/connorlay/Code/phoenix_live_view/test/phoenix_component_test.exs",
                  line: 580,
                  root: false,
-                 slots: %{footer: [%{inner_block: :expr}], header: [%{inner_block: :expr}]}
+                 slots: %{
+                   footer: [%{inner_block: {587, 11, :expr}}],
+                   header: [%{inner_block: {581, 11, :expr}}]
+                 }
                },
                %{
                  attrs: %{},
@@ -725,20 +728,20 @@ defmodule Phoenix.ComponentTest do
                  file: "/home/connorlay/Code/phoenix_live_view/test/phoenix_component_test.exs",
                  line: 592,
                  root: false,
-                 slots: %{slot: [%{attr: "1", inner_block: nil}]}
+                 slots: %{slot: [%{attr: {593, 11, "1"}, inner_block: {593, 11, nil}}]}
                },
                %{
                  attrs: %{rows: {596, 17, :expr}},
                  component: {Phoenix.ComponentTest.FunctionComponentWithSlots, :table},
-                 file: "/home/connorlay/Code/phoenix_live_view/test/phoenix_component_test.exs",
                  line: 596,
                  root: false,
                  slots: %{
                    col: [
-                     %{inner_block: :expr, label: :expr},
-                     %{inner_block: :expr, label: "Address"}
+                     %{inner_block: {597, 11, :expr}, label: {597, 11, :expr}},
+                     %{inner_block: {601, 11, :expr}, label: {601, 11, "Address"}}
                    ]
-                 }
+                 },
+                 file: "/home/connorlay/Code/phoenix_live_view/test/phoenix_component_test.exs"
                }
              ]
     end

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -853,7 +853,7 @@ defmodule Phoenix.ComponentTest do
       assert render(Defaults, :example, %{}) == "nil"
       assert render(Defaults, :no_default, %{value: 123}) == "123"
 
-      assert_raise KeyError, ~r/:value not found/, fn ->
+      assert_raise KeyError, ~r":value not found", fn ->
         render(Defaults, :no_default, %{})
       end
     end
@@ -976,7 +976,7 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "raise if :doc is not a string" do
-      msg = ~r/doc must be a string or false, got: :foo/
+      msg = ~r"doc must be a string or false, got: :foo"
 
       assert_raise CompileError, msg, fn ->
         defmodule Phoenix.ComponentTest.AttrDocsInvalidType do
@@ -1029,7 +1029,7 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "raise if attr is declared between multiple function heads" do
-      msg = ~r/attributes must be defined before the first function clause at line \d+/
+      msg = ~r"attributes must be defined before the first function clause at line \d+"
 
       assert_raise CompileError, msg, fn ->
         defmodule Phoenix.ComponentTest.MultiClauseWrong do
@@ -1046,7 +1046,7 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "raise if slot is declared between multiple function heads" do
-      msg = ~r/slots must be defined before the first function clause at line \d+/
+      msg = ~r"slots must be defined before the first function clause at line \d+"
 
       assert_raise CompileError, msg, fn ->
         defmodule Phoenix.ComponentTest.MultiClauseWrong do
@@ -1064,7 +1064,7 @@ defmodule Phoenix.ComponentTest do
 
     test "raise if attr is declared on an invalid function" do
       msg =
-        ~r/cannot declare attributes for function func\/2\. Components must be functions with arity 1/
+        ~r"cannot declare attributes for function func\/2\. Components must be functions with arity 1"
 
       assert_raise CompileError, msg, fn ->
         defmodule Phoenix.ComponentTest.AttrOnInvalidFunction do
@@ -1078,7 +1078,7 @@ defmodule Phoenix.ComponentTest do
 
     test "raise if slot is declared on an invalid function" do
       msg =
-        ~r/cannot declare slots for function func\/2\. Components must be functions with arity 1/
+        ~r"cannot declare slots for function func\/2\. Components must be functions with arity 1"
 
       assert_raise CompileError, msg, fn ->
         defmodule Phoenix.ComponentTest.SlotOnInvalidFunction do
@@ -1091,7 +1091,7 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "raise if attr is declared without a related function" do
-      msg = ~r/cannot define attributes without a related function component/
+      msg = ~r"cannot define attributes without a related function component"
 
       assert_raise CompileError, msg, fn ->
         defmodule Phoenix.ComponentTest.AttrOnInvalidFunction do
@@ -1105,7 +1105,7 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "raise if slot is declared without a related function" do
-      msg = ~r/cannot define slots without a related function component/
+      msg = ~r"cannot define slots without a related function component"
 
       assert_raise CompileError, msg, fn ->
         defmodule Phoenix.ComponentTest.SlotOnInvalidFunction do
@@ -1119,7 +1119,9 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "raise if attr type is not supported" do
-      assert_raise CompileError, ~r/invalid type :not_a_type for attr :foo/, fn ->
+      msg = ~r"invalid type :not_a_type for attr :foo"
+
+      assert_raise CompileError, msg, fn ->
         defmodule Phoenix.ComponentTest.AttrTypeNotSupported do
           use Elixir.Phoenix.Component
 
@@ -1130,7 +1132,9 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "raise if slot attr type is not supported" do
-      assert_raise CompileError, ~r/invalid type :not_a_type for attr :foo in slot :named/, fn ->
+      msg = ~r"invalid type :not_a_type for attr :foo in slot :named"
+
+      assert_raise CompileError, msg, fn ->
         defmodule Phoenix.ComponentTest.SlotAttrTypeNotSupported do
           use Elixir.Phoenix.Component
 
@@ -1144,7 +1148,9 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "raise if attr option is not supported" do
-      assert_raise CompileError, ~r"invalid option :not_an_opt for attr :foo", fn ->
+      msg = ~r"invalid option :not_an_opt for attr :foo"
+
+      assert_raise CompileError, msg, fn ->
         defmodule Phoenix.ComponentTest.AttrOptionNotSupported do
           use Elixir.Phoenix.Component
 
@@ -1155,23 +1161,25 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "raise if slot attr option is not supported" do
-      assert_raise CompileError,
-                   ~r"invalid option :not_an_opt for attr :foo in slot :named",
-                   fn ->
-                     defmodule Phoenix.ComponentTest.SlotAttrOptionNotSupported do
-                       use Elixir.Phoenix.Component
+      msg = ~r"invalid option :not_an_opt for attr :foo in slot :named"
 
-                       slot :named do
-                         attr :foo, :any, not_an_opt: true
-                       end
+      assert_raise CompileError, msg, fn ->
+        defmodule Phoenix.ComponentTest.SlotAttrOptionNotSupported do
+          use Elixir.Phoenix.Component
 
-                       def func(assigns), do: ~H[]
-                     end
-                   end
+          slot :named do
+            attr :foo, :any, not_an_opt: true
+          end
+
+          def func(assigns), do: ~H[]
+        end
+      end
     end
 
     test "raise if attr is duplicated" do
-      assert_raise CompileError, ~r"a duplicate attribute with name :foo already exists", fn ->
+      msg = ~r"a duplicate attribute with name :foo already exists"
+
+      assert_raise CompileError, msg, fn ->
         defmodule Phoenix.ComponentTest.AttrDup do
           use Elixir.Phoenix.Component
 
@@ -1183,7 +1191,9 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "raise if slot is duplicated" do
-      assert_raise CompileError, ~r"a duplicate slot with name :foo already exists", fn ->
+      msg = ~r"a duplicate slot with name :foo already exists"
+
+      assert_raise CompileError, msg, fn ->
         defmodule Phoenix.ComponentTest.SlotDup do
           use Elixir.Phoenix.Component
 
@@ -1195,20 +1205,20 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "raise if slot attr is duplicated" do
-      assert_raise CompileError,
-                   ~r"a duplicate attribute with name :foo in slot :named already exists",
-                   fn ->
-                     defmodule Phoenix.ComponentTest.SlotAttrDup do
-                       use Elixir.Phoenix.Component
+      msg = ~r"a duplicate attribute with name :foo in slot :named already exists"
 
-                       slot :named do
-                         attr :foo, :any, required: true
-                         attr :foo, :string
-                       end
+      assert_raise CompileError, msg, fn ->
+        defmodule Phoenix.ComponentTest.SlotAttrDup do
+          use Elixir.Phoenix.Component
 
-                       def func(assigns), do: ~H[]
-                     end
-                   end
+          slot :named do
+            attr :foo, :any, required: true
+            attr :foo, :string
+          end
+
+          def func(assigns), do: ~H[]
+        end
+      end
     end
 
     test "does not raise if multiple slots with different names share the same attr names" do
@@ -1315,7 +1325,7 @@ defmodule Phoenix.ComponentTest do
     end
 
     test "raise if global provides :required" do
-      msg = ~r/global attributes do not support the :required option/
+      msg = ~r"global attributes do not support the :required option"
 
       assert_raise CompileError, msg, fn ->
         defmodule Phoenix.ComponentTest.GlobalOpts do

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -1372,59 +1372,6 @@ defmodule Phoenix.ComponentTest do
       assert mod.()
     end
 
-    test "raise if an unknown expression is encountered in a slot block" do
-      msg =
-        ~r"unexpected expression encountered in slot :named, got: foobar\(\). The code given to slot/2 can only contain calls to attr/3 and Elixir comments."
-
-      assert_raise CompileError, msg, fn ->
-        defmodule Phoenix.ComponentTest.UnexpectedExpressionInSlotBlock do
-          use Elixir.Phoenix.Component
-
-          slot :named do
-            foobar()
-          end
-
-          def func(assigns), do: ~H[]
-        end
-      end
-    end
-
-    test "raise if an unknown literal is encountered in a slot block" do
-      msg =
-        ~r"unexpected literal encountered in slot :named, got: :ok. The code given to slot/2 can only contain calls to attr/3 and Elixir comments."
-
-      assert_raise CompileError, msg, fn ->
-        defmodule Phoenix.ComponentTest.UnexpectedLiteralInSlotBlock2 do
-          use Elixir.Phoenix.Component
-
-          slot :named do
-            :ok
-          end
-
-          def func(assigns), do: ~H[]
-        end
-      end
-    end
-
-    test "does not raise if code comments are in a slot block" do
-      mod = fn ->
-        defmodule CodeCommentsInSlotBlock do
-          use Phoenix.Component
-
-          slot :named do
-            # a comment
-            attr :foo, :any
-            # another comment
-            attr :bar, :any
-          end
-
-          def func(assigns), do: ~H[]
-        end
-      end
-
-      assert mod.()
-    end
-
     test "raise if slot with name :inner_block has slot attrs" do
       msg = ~r"cannot define attributes for the slot :inner_block"
 

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -964,27 +964,41 @@ defmodule Phoenix.ComponentTest do
       end
     end
 
-    test "raise if attr name is not an atom" do
-      msg = ~r/attribute names must be atoms, got: "not_an_atom"/
-
-      assert_raise CompileError, msg, fn ->
-        defmodule Phoenix.ComponentTest.AttrNameInvalidType do
+    test "raise on invalid attr/2 args" do
+      assert_raise FunctionClauseError, fn ->
+        defmodule Phoenix.ComponentTest.AttrMacroInvalidName do
           use Elixir.Phoenix.Component
 
-          attr "not_an_atom", :any
+          attr "not an atom", :any
+          def func(assigns), do: ~H[]
+        end
+      end
+
+      assert_raise FunctionClauseError, fn ->
+        defmodule Phoenix.ComponentTest.AttrMacroInvalidOpts do
+          use Elixir.Phoenix.Component
+
+          attr :attr, :any, "not a list"
           def func(assigns), do: ~H[]
         end
       end
     end
 
-    test "raise if slot name is not an atom" do
-      msg = ~r/slot names must be atoms, got: "not_an_atom"/
-
-      assert_raise CompileError, msg, fn ->
-        defmodule Phoenix.ComponentTest.SlotNameInvalidType do
+    test "raise on invalid slot/3 args" do
+      assert_raise FunctionClauseError, fn ->
+        defmodule Phoenix.ComponentTest.SlotMacroInvalidName do
           use Elixir.Phoenix.Component
 
-          slot "not_an_atom"
+          slot "not an atom"
+          def func(assigns), do: ~H[]
+        end
+      end
+
+      assert_raise FunctionClauseError, fn ->
+        defmodule Phoenix.ComponentTest.SlotMacroInvalidOpts do
+          use Elixir.Phoenix.Component
+
+          slot :slot, "not a list"
           def func(assigns), do: ~H[]
         end
       end

--- a/test/phoenix_live_view/helpers_test.exs
+++ b/test/phoenix_live_view/helpers_test.exs
@@ -89,13 +89,13 @@ defmodule Phoenix.LiveView.HelpersTest do
       end
     end
 
-    test "csrf with :get method" do
+    test "csrf with get method" do
       assigns = %{}
 
-      assert render(~H|<.link href="/" method={:get}>text</.link>|) ==
+      assert render(~H|<.link href="/" method="get">text</.link>|) ==
                ~s|<a href="/">text</a>|
 
-      assert render(~H|<.link href="/" method={:get} csrf_token="123">text</.link>|) ==
+      assert render(~H|<.link href="/" method="get" csrf_token="123">text</.link>|) ==
                ~s|<a href="/">text</a>|
     end
 

--- a/test/phoenix_live_view/integrations/live_components_test.exs
+++ b/test/phoenix_live_view/integrations/live_components_test.exs
@@ -318,7 +318,7 @@ defmodule Phoenix.LiveView.LiveComponentsTest do
       assert ExUnit.CaptureLog.capture_log(fn ->
                send(view.pid, {:send_update, [{StatefulComponent, id: "nemo", name: "NEW-nemo"}]})
                render(view)
-               refute_received {:updated, _}
+               refute_receive {:updated, _}
              end) =~
                "send_update failed because component Phoenix.LiveViewTest.StatefulComponent with ID \"nemo\" does not exist or it has been removed"
     end

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -73,7 +73,7 @@ defmodule Phoenix.LiveViewTest.FunctionComponentWithAttrs do
 
   @doc """
   fun docs
-  [[INSERT ATTRDOCS]]
+  [[INSERT LVDOCS]]
   fun docs
   """
   def fun_doc_injection(assigns), do: ~H[]

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -96,7 +96,7 @@ defmodule Phoenix.LiveViewTest.FunctionComponentWithAttrs do
 
   slot :named, required: true, doc: "a named slot" do
     attr :attr1, :any, required: true, doc: "a slot attr doc"
-    attr :attr2, :any, default: "some default", doc: "a slot attr doc"
+    attr :attr2, :any, doc: "a slot attr doc"
   end
 
   def fun_slot_with_attrs(assigns), do: ~H[]

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -84,6 +84,22 @@ defmodule Phoenix.LiveViewTest.FunctionComponentWithAttrs do
 
   attr :attr, :any
   defp private_fun(assigns), do: ~H[]
+
+  slot :inner_block
+  def fun_slot(assigns), do: ~H[]
+
+  slot :inner_block, doc: "slot docs"
+  def fun_slot_doc(assigns), do: ~H[]
+
+  slot :inner_block, required: true
+  def fun_slot_required(assigns), do: ~H[]
+
+  slot :named, required: true, doc: "a named slot" do
+    attr :attr1, :any, required: true, doc: "a slot attr doc"
+    attr :attr2, :any, required: true, doc: "a slot attr doc"
+  end
+
+  def fun_slot_with_attrs(assigns), do: ~H[]
 end
 
 defmodule Phoenix.LiveViewTest.StatefulComponent do

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -96,7 +96,7 @@ defmodule Phoenix.LiveViewTest.FunctionComponentWithAttrs do
 
   slot :named, required: true, doc: "a named slot" do
     attr :attr1, :any, required: true, doc: "a slot attr doc"
-    attr :attr2, :any, required: true, doc: "a slot attr doc"
+    attr :attr2, :any, default: "some default", doc: "a slot attr doc"
   end
 
   def fun_slot_with_attrs(assigns), do: ~H[]


### PR DESCRIPTION
TODO:
- [x] slot macro
- [x] slot-aware attrs
- [x] literal type validations for slots
- [x] literal type validations for attrs
- [x] compile warnings for slot macro
- [x] slot auto-generating docs
- [x] slot attr defaults
- [x] type validations for attr and slot attr defaults 
- [x] refactor slot/3 to not traverse ast 
- [x] support global slot attrs
- [ ] provide `[]` as the default for optional slots
- [ ] documentation updates