### PR TITLE
Allow `:layout` to be set from `live_session`

### DIFF
--- a/lib/phoenix_live_view/plug.ex
+++ b/lib/phoenix_live_view/plug.ex
@@ -17,6 +17,7 @@ defmodule Phoenix.LiveView.Plug do
     conn
     |> Phoenix.Controller.put_layout(false)
     |> put_root_layout_from_router(live_session_extra)
+    |> put_layout_from_router(live_session_extra)
     |> Phoenix.LiveView.Controller.live_render(view, opts)
   end
 
@@ -36,6 +37,13 @@ defmodule Phoenix.LiveView.Plug do
   defp put_root_layout_from_router(conn, extra) do
     case Map.fetch(extra, :root_layout) do
       {:ok, layout} -> Phoenix.Controller.put_root_layout(conn, layout)
+      :error -> conn
+    end
+  end
+
+  defp put_layout_from_router(conn, extra) do
+    case Map.fetch(extra, :layout) do
+      {:ok, layout} ->  Plug.Conn.put_private(conn, :phoenix_live_layout, layout)
       :error -> conn
     end
   end

--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -143,6 +143,8 @@ defmodule Phoenix.LiveView.Router do
       each LiveView in the session_. See `Phoenix.LiveView.on_mount/1`. Passing a
       single value is also accepted.
 
+    * `:layout` - The optional layout the LiveView will be rendered in.
+
   ## Examples
 
       scope "/", MyAppWeb do
@@ -242,7 +244,7 @@ defmodule Phoenix.LiveView.Router do
     Module.put_attribute(module, :phoenix_live_sessions, %{name: name, extra: extra, vsn: vsn})
   end
 
-  @live_session_opts [:on_mount, :root_layout, :session]
+  @live_session_opts [:layout, :on_mount, :root_layout, :session]
   defp validate_live_session_opts(opts, module, _name) when is_list(opts) do
     opts
     |> Keyword.put_new(:session, %{})
@@ -269,6 +271,22 @@ defmodule Phoenix.LiveView.Router do
       {:root_layout, bad_layout}, _acc ->
         raise ArgumentError, """
         invalid live_session :root_layout
+
+        expected a tuple with the view module and template string or atom name, got #{inspect(bad_layout)}
+        """
+
+      {:layout, {mod, template}}, acc when is_atom(mod) and is_binary(template) ->
+        Map.put(acc, :layout, {mod, template})
+
+      {:layout, {mod, template}}, acc when is_atom(mod) and is_atom(template) ->
+        Map.put(acc, :layout, {mod, "#{template}.html"})
+
+      {:layout, false}, acc ->
+        Map.put(acc, :layout, false)
+
+      {:layout, bad_layout}, _acc ->
+        raise ArgumentError, """
+        invalid live_session :layout
 
         expected a tuple with the view module and template string or atom name, got #{inspect(bad_layout)}
         """

--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -516,6 +516,7 @@ defmodule Phoenix.LiveView.Utils do
   defp layout(socket, view) do
     case socket.private do
       %{phoenix_live_layout: layout} -> layout
+      %{connect_info: %{private: %{phoenix_live_layout: layout}}} -> layout
       %{} -> view.__live__()[:layout] || false
     end
   end

--- a/test/phoenix_live_view/router_test.exs
+++ b/test/phoenix_live_view/router_test.exs
@@ -244,5 +244,22 @@ defmodule Phoenix.LiveView.RouterTest do
         )
       end)
     end
+
+    test "with layout override", %{conn: conn} do
+      path = "/dashboard-live-session-layout"
+
+      assert {:internal, route} =
+               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
+
+      assert route.live_session.extra == %{
+        layout: {Phoenix.LiveViewTest.LayoutView, "live-override.html"},
+        session: %{}
+      }
+
+      {:ok, _, html} = live(conn, path)
+
+      assert html =~
+        ~r|<div[^>]+>LIVEOVERRIDESTART\-123\-The value is: 123\-LIVEOVERRIDEEND|
+    end
   end
 end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -162,6 +162,10 @@ defmodule Phoenix.LiveViewTest.Router do
       ] do
       live "/lifecycle/mount-mods-args", HooksLive.Noop
     end
+
+    live_session :layout, layout: {Phoenix.LiveViewTest.LayoutView, "live-override.html"} do
+      live "/dashboard-live-session-layout", LayoutLive
+    end
   end
 
   scope "/", as: :user_defined_metadata, alias: Phoenix.LiveViewTest do


### PR DESCRIPTION
Allows the `:layout` as an option to be set in `live_session` in the router.

```
live_session :admin, layout: {MyApp.LayoutView, :admin_layout} do
  #...
end
```

Closes #2071 