### PR TITLE
Clarify slots documentation

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -309,7 +309,7 @@ defmodule Phoenix.Component do
           <%= user.name %>
         </:col>
 
-        <:col :let={user} label="Address" if={ @current_user.role == :admin }>
+        <:col :let={user} label="Address" if={@current_user.role == :admin}>
           <%= user.address %>
         </:col>
       </.table>

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -136,9 +136,14 @@ defmodule Phoenix.Component do
   the `@inner_block` assign and then we use `Phoenix.LiveView.Helpers.render_slot/2`
   to render it.
 
-  You can even have the component give a value back to the caller,
-  by using the special attribute `:let` (note the leading `:`).
-  Imagine this component:
+  This gives us a separation of concerns: the component specifies reusable
+  markup for a button, and the caller specifies the contents for a specific
+  button.
+
+  But what if the contents themselves need to be dynamic?
+
+  In that case, you can have the component give a value back to the caller
+  by passing it as the second argument to `render_slot/2`:
 
       def unordered_list(assigns) do
         ~H"""
@@ -150,11 +155,17 @@ defmodule Phoenix.Component do
         """
       end
 
-  And now you can invoke it as:
+  When calling the component, you can use the special attribute `:let` (note
+  the leading `:`) to take the value that the component passes back and bind it
+  to a variable:
 
-      <.unordered_list :let={entry} entries={~w(apple banana cherry)}>
-        I like <%= entry %>
+      <.unordered_list :let={an_entry} entries={~w(apple banana cherry)}>
+        I like <%= an_entry %>
       </.unordered_list>
+
+  In this way, the separation of concerns is maintained: the caller can specify
+  multiple items of dynamic content without having to specify the markup that
+  surrounds and separates them.
 
   You can also pattern match the arguments provided to the render block. Let's
   make our `unordered_list` component fancier:
@@ -171,8 +182,8 @@ defmodule Phoenix.Component do
 
   And now we can invoke it like this:
 
-      <.unordered_list :let={%{entry: entry, gif_url: url}}>
-        I like <%= entry %>. <img src={url} />
+      <.unordered_list :let={%{entry: an_entry, gif_url: url}} entries={~w(apple banana cherry)}>
+        I like <%= an_entry %>. <img src={url} />
       </.unordered_list>
 
   ### Named slots
@@ -193,6 +204,8 @@ defmodule Phoenix.Component do
         <:footer>
           <button>Save</button>
         </:footer>
+
+        This is also included in @inner_block.
       </.modal>
 
   The component itself could be implemented like this:

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -314,7 +314,6 @@ defmodule Phoenix.Component do
         </:col>
       </.table>
 
-
   Then you can check for that attribute within the component:
 
       def table(assigns) do

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -298,6 +298,44 @@ defmodule Phoenix.Component do
   the label as `col.label`. This gives us complete control over how
   we render them.
 
+  What if you need to conditionally render a slot - for example, to only render
+  the user's address if the current user is an admin?
+  You can't wrap a conditional around a slot because a slot entry must be
+  a direct child of a component.
+  But you can accomplish this by passing an attribute.
+
+      <.table rows={@users}>
+        <:col :let={user} label="Name">
+          <%= user.name %>
+        </:col>
+
+        <:col :let={user} label="Address" if={ @current_user.role == :admin }>
+          <%= user.address %>
+        </:col>
+      </.table>
+
+
+  Then you can check for that attribute within the component:
+
+      def table(assigns) do
+        ~H"""
+        <table>
+          <tr>
+            <%= for col <- @col, col[:if] != false do %>
+              <th><%= col.label %></th>
+            <% end %>
+          </tr>
+          <%= for row <- @rows do %>
+            <tr>
+              <%= for col <- @col, col[:if] != false do %>
+                <td><%= render_slot(col, row) %></td>
+              <% end %>
+            </tr>
+          <% end %>
+        </table>
+        """
+      end
+
   ## Attributes
 
   Function components support declarative assigns with compile-time

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -321,13 +321,13 @@ defmodule Phoenix.Component do
         ~H"""
         <table>
           <tr>
-            <%= for col <- @col, col[:if] != false do %>
+            <%= for col <- @col, Map.get(col, :if, true) do %>
               <th><%= col.label %></th>
             <% end %>
           </tr>
           <%= for row <- @rows do %>
             <tr>
-              <%= for col <- @col, col[:if] != false do %>
+              <%= for col <- @col, Map.get(col, :if, true) do %>
                 <td><%= render_slot(col, row) %></td>
               <% end %>
             </tr>


### PR DESCRIPTION
- Expand the explanations a bit
- Fix: pass `entries` in the pattern matching example
- Show that `:let` defines the variable name for the block
-  Show how to conditionally render a slot