### PR TITLE
Fix formatter when there is HTML + EEx expressions

### DIFF
--- a/lib/phoenix_live_view/html_tokenizer.ex
+++ b/lib/phoenix_live_view/html_tokenizer.ex
@@ -103,8 +103,8 @@ defmodule Phoenix.LiveView.HTMLTokenizer do
     handle_text(rest, line, column + 1, [char_or_bin(c) | buffer], acc, state)
   end
 
-  defp handle_text(<<>>, line, column, buffer, acc, _state) do
-    ok(text_to_acc(buffer, acc, line, column, []), :text)
+  defp handle_text(<<>>, line, column, buffer, acc, state) do
+    ok(text_to_acc(buffer, acc, line, column, state.context), :text)
   end
 
   ## handle_doctype

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -1695,6 +1695,19 @@ if Version.match?(System.version(), ">= 1.13.0") do
       )
     end
 
+    test "handle html comments + eex expressions" do
+      assert_formatter_output(
+        """
+        <%= if @comment do %><!-- <%= @comment %> --><% end %>
+        """,
+        """
+        <%= if @comment do %>
+          <!-- <%= @comment %> -->
+        <% end %>
+        """
+      )
+    end
+
     # TODO: Remove this `if` after Elixir versions before than 1.14 are no
     # longer supported.
     if function_exported?(EEx, :tokenize, 2) do

--- a/test/phoenix_live_view/html_tokenizer_test.exs
+++ b/test/phoenix_live_view/html_tokenizer_test.exs
@@ -50,7 +50,8 @@ defmodule Phoenix.LiveView.HTMLTokenizerTest do
   describe "comment" do
     test "generated as text" do
       assert tokenize("Begin<!-- comment -->End") == [
-               {:text, "Begin<!-- comment -->End", %{line_end: 1, column_end: 25}}
+               {:text, "Begin<!-- comment -->End",
+                %{line_end: 1, column_end: 25, context: [:comment_start, :comment_end]}}
              ]
     end
 
@@ -378,7 +379,8 @@ defmodule Phoenix.LiveView.HTMLTokenizerTest do
         """)
 
       assert [
-               {:tag_open, "div", [{"title", {:string, "first\n  second\nthird", _meta}, %{}}], %{}},
+               {:tag_open, "div", [{"title", {:string, "first\n  second\nthird", _meta}, %{}}],
+                %{}},
                {:tag_open, "span", [], %{line: 3, column: 8}}
              ] = tokens
     end
@@ -424,7 +426,8 @@ defmodule Phoenix.LiveView.HTMLTokenizerTest do
         """)
 
       assert [
-               {:tag_open, "div", [{"title", {:string, "first\n  second\nthird", _meta}, %{}}], %{}},
+               {:tag_open, "div", [{"title", {:string, "first\n  second\nthird", _meta}, %{}}],
+                %{}},
                {:tag_open, "span", [], %{line: 3, column: 8}}
              ] = tokens
     end
@@ -561,8 +564,9 @@ defmodule Phoenix.LiveView.HTMLTokenizerTest do
         """)
 
       assert [
-               {:root, {:expr, "@root1", %{line: 2, column: 4}},%{line: 2, column: 4}},
-               {:root, {:expr, "\n      @root2\n    ", %{line: 3, column: 6}}, %{line: 3, column: 6}},
+               {:root, {:expr, "@root1", %{line: 2, column: 4}}, %{line: 2, column: 4}},
+               {:root, {:expr, "\n      @root2\n    ", %{line: 3, column: 6}},
+                %{line: 3, column: 6}},
                {:root, {:expr, "@root3", %{line: 6, column: 4}}, %{line: 6, column: 4}}
              ] = attrs
     end
@@ -622,7 +626,8 @@ defmodule Phoenix.LiveView.HTMLTokenizerTest do
       assert tokenize("""
              <script src="foo.js" />
              """) == [
-               {:tag_open, "script", [{"src", {:string, "foo.js", %{delimiter: 34}}, %{column: 9, line: 1}}],
+               {:tag_open, "script",
+                [{"src", {:string, "foo.js", %{delimiter: 34}}, %{column: 9, line: 1}}],
                 %{column: 1, line: 1, self_close: true}},
                {:text, "\n", %{column_end: 1, line_end: 2}}
              ]
@@ -647,7 +652,8 @@ defmodule Phoenix.LiveView.HTMLTokenizerTest do
       assert tokenize("""
              <style src="foo.js" />
              """) == [
-               {:tag_open, "style", [{"src", {:string, "foo.js", %{delimiter: 34}}, %{column: 8, line: 1}}],
+               {:tag_open, "style",
+                [{"src", {:string, "foo.js", %{delimiter: 34}}, %{column: 8, line: 1}}],
                 %{column: 1, line: 1, self_close: true}},
                {:text, "\n", %{column_end: 1, line_end: 2}}
              ]


### PR DESCRIPTION
Without this fix, the formatter will thrown an match error because the
HTML comment token doesn't contain the `:comment_end` in this case. This
commit aims to fix that.