### PR TITLE
Formatter - Keep intentional lines for slots

### DIFF
--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -301,9 +301,13 @@ defmodule Phoenix.LiveView.HTMLEngine do
   defp handle_token({:text, text, %{line_end: line, column_end: column}}, state) do
     text = if state.previous_token_slot?, do: String.trim_leading(text), else: text
 
-    state
-    |> set_root_on_not_tag()
-    |> update_subengine(:handle_text, [[line: line, column: column], text])
+    if text == "" do
+      state
+    else
+      state
+      |> set_root_on_not_tag()
+      |> update_subengine(:handle_text, [[line: line, column: column], text])
+    end
   end
 
   # Remote function component (self close)

--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -107,7 +107,8 @@ defmodule Phoenix.LiveView.HTMLEngine do
       module: module,
       file: Keyword.get(opts, :file, "nofile"),
       indentation: Keyword.get(opts, :indentation, 0),
-      caller: Keyword.get(opts, :caller)
+      caller: Keyword.get(opts, :caller),
+      previous_token_slot?: false
     }
   end
 
@@ -165,7 +166,8 @@ defmodule Phoenix.LiveView.HTMLEngine do
       slots: [],
       module: module,
       caller: caller,
-      root: root
+      root: root,
+      previous_token_slot?: false
     }
   end
 
@@ -207,7 +209,7 @@ defmodule Phoenix.LiveView.HTMLEngine do
   end
 
   defp update_subengine(state, fun, args) do
-    %{state | substate: invoke_subengine(state, fun, args)}
+    %{state | substate: invoke_subengine(state, fun, args), previous_token_slot?: false}
   end
 
   defp init_slots(state) do
@@ -221,7 +223,7 @@ defmodule Phoenix.LiveView.HTMLEngine do
          _meta
        )
        when first in ?A..?Z or first == ?. do
-    %{state | slots: [[slot | slots] | other_slots]}
+    %{state | slots: [[slot | slots] | other_slots], previous_token_slot?: true}
   end
 
   defp add_slot!(state, slot, meta) do
@@ -297,6 +299,8 @@ defmodule Phoenix.LiveView.HTMLEngine do
   # Text
 
   defp handle_token({:text, text, %{line_end: line, column_end: column}}, state) do
+    text = if state.previous_token_slot?, do: String.trim_leading(text), else: text
+
     state
     |> set_root_on_not_tag()
     |> update_subengine(:handle_text, [[line: line, column: column], text])

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -1708,6 +1708,36 @@ if Version.match?(System.version(), ">= 1.13.0") do
       )
     end
 
+    test "keep intentional lines breakes between slots" do
+      assert_formatter_doesnt_change("""
+      <.component>
+        <:title>Guides & Docs</:title>
+
+        <:desc>View our step-by-step guides, or browse the comprehensive API docs</:desc>
+      </.component>
+      """)
+
+      assert_formatter_output(
+        """
+        <.component>
+
+          <:title>Guides & Docs</:title>
+
+
+          <:desc>View our step-by-step guides, or browse the comprehensive API docs</:desc>
+
+        </.component>
+        """,
+        """
+        <.component>
+          <:title>Guides & Docs</:title>
+
+          <:desc>View our step-by-step guides, or browse the comprehensive API docs</:desc>
+        </.component>
+        """
+      )
+    end
+
     # TODO: Remove this `if` after Elixir versions before than 1.14 are no
     # longer supported.
     if function_exported?(EEx, :tokenize, 2) do


### PR DESCRIPTION
I changed the HTML tokenizer to emit the lines breaks since the Formatter knows how
to deal with them already. It also required to change HTML Compiler to not render the
lines breaks to keep it working as it is intended to.