### PR TITLE
Only forms with `id` attribute are recovered

### DIFF
--- a/guides/client/form-bindings.md
+++ b/guides/client/form-bindings.md
@@ -240,10 +240,11 @@ Once `phx-trigger-action` is true, LiveView disconnects and then submits the for
 
 ## Recovery following crashes or disconnects
 
-By default, all forms marked with `phx-change` will recover input values
-automatically after the user has reconnected or the LiveView has remounted
-after a crash. This is achieved by the client triggering the same `phx-change`
-to the server as soon as the mount has been completed.
+By default, all forms marked with `phx-change` and having `id`
+attribute will recover input values automatically after the user has
+reconnected or the LiveView has remounted after a crash. This is
+achieved by the client triggering the same `phx-change` to the server
+as soon as the mount has been completed.
 
 **Note:** if you want to see form recovery working in development, please
 make sure to disable live reloading in development by commenting out the
@@ -261,7 +262,7 @@ to trigger for recovery, which will receive the form params as usual. For exampl
 imagine a LiveView wizard form where the form is stateful and built based on what
 step the user is on and by prior selections:
 
-    <form phx-change="validate_wizard_step" phx-auto-recover="recover_wizard">
+    <form id="wizard" phx-change="validate_wizard_step" phx-auto-recover="recover_wizard">
 
 On the server, the `"validate_wizard_step"` event is only concerned with the
 current client form data, but the server maintains the entire state of the wizard.


### PR DESCRIPTION
How to reproduce

```sh
$ mix phx.new myapp && cd myapp/ && mix ecto.create
$ mix phx.gen.live Accounts User users name:string
# copy routes from output to router.ex
$ mix ecto.migrate
```

Now, 
- remove `id` attribute from a form in `lib/myapp_web/live/user_live/form_component.html.heex`, 
- start the server, 
- visit `/users/new` 
- and type something into the form's field, 
- restart the server.

The form's state wouldn't recover.