### PR TITLE
Fix preserve on pre and textarea

### DIFF
--- a/lib/phoenix_live_view/html_formatter.ex
+++ b/lib/phoenix_live_view/html_formatter.ex
@@ -459,9 +459,9 @@ defmodule Phoenix.LiveView.HTMLFormatter do
   end
 
   defp to_tree(
-         [{:tag_close, name, _close_meta} | tokens],
+         [{:tag_close, name, close_meta} | tokens],
          buffer,
-         [{name, attrs, _open_meta, upper_buffer} | stack]
+         [{name, attrs, open_meta, upper_buffer} | stack]
        ) do
     mode =
       cond do
@@ -471,7 +471,8 @@ defmodule Phoenix.LiveView.HTMLFormatter do
       end
 
     buffer = buffer |> Enum.reverse() |> may_set_preserve_on_text(mode, name)
-    tag_block = {:tag_block, name, attrs, buffer, %{mode: mode}}
+    meta = %{mode: mode, offset_start: open_meta.offset, offset_end: close_meta.offset}
+    tag_block = {:tag_block, name, attrs, buffer, meta}
 
     to_tree(tokens, [tag_block | upper_buffer], stack)
   end

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -1612,6 +1612,20 @@ if Version.match?(System.version(), ">= 1.13.0") do
         """,
         line_length: 5
       )
+
+      assert_formatter_doesnt_change(
+        """
+        <textarea>
+          <div
+          class="one"
+          id="two"
+        >
+        <outside />
+          </div>
+        </textarea>
+        """,
+        line_length: 5
+      )
     end
 
     test "keeps right format for inline elements within block elements" do
@@ -1666,6 +1680,20 @@ if Version.match?(System.version(), ">= 1.13.0") do
             </li>
           <% end %><!-- comment
         --></ul>
+        """,
+        line_length: 100
+      )
+
+      assert_formatter_doesnt_change(
+        """
+        <ul class="root" phx-no-format>
+        <li class="list">
+            <div
+            class="child1">
+          <span class="child2">text</span>
+            </div>
+        </li>
+        </ul>
         """,
         line_length: 100
       )


### PR DESCRIPTION
We don't want to indent its children. It should remain as is.