### PR TITLE
Disabled `phx-click` targets with children should not fire click events.

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -612,7 +612,6 @@ export default class LiveSocket {
       }
       let phxEvent = target && target.getAttribute(click)
       if(!phxEvent){ return }
-      if(target.disabled){ return }
       if(target.getAttribute("href") === "#"){ e.preventDefault() }
 
       this.debounce(target, e, "click", () => {

--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -612,6 +612,7 @@ export default class LiveSocket {
       }
       let phxEvent = target && target.getAttribute(click)
       if(!phxEvent){ return }
+      if(target.disabled){ return }
       if(target.getAttribute("href") === "#"){ e.preventDefault() }
 
       this.debounce(target, e, "click", () => {

--- a/assets/js/phoenix_live_view/utils.js
+++ b/assets/js/phoenix_live_view/utils.js
@@ -36,7 +36,7 @@ export let clone = (obj) => { return JSON.parse(JSON.stringify(obj)) }
 
 export let closestPhxBinding = (el, binding, borderEl) => {
   do {
-    if(el.matches(`[${binding}]`)){ return el }
+    if(el.matches(`[${binding}]`) && !el.disabled){ return el }
     el = el.parentElement || el.parentNode
   } while(el !== null && el.nodeType === 1 && !((borderEl && borderEl.isSameNode(el)) || el.matches(PHX_VIEW_SELECTOR)))
   return null

--- a/assets/test/utils_test.js
+++ b/assets/test/utils_test.js
@@ -1,0 +1,37 @@
+import {Socket} from "phoenix"
+import { closestPhxBinding } from "phoenix_live_view/utils"
+import LiveSocket from "phoenix_live_view/live_socket"
+import { simulateJoinedView, liveViewDOM } from "./test_helpers"
+
+let setupView = (content) => {
+  let el = liveViewDOM(content)
+  global.document.body.appendChild(el)
+  let liveSocket = new LiveSocket("/live", Socket)
+  return simulateJoinedView(el, liveSocket)
+}
+
+describe("utils", () => {
+  describe("closestPhxBinding", () => {
+    test("if an element's parent has a phx-click binding and is not disabled, return the parent", () => {
+      let view = setupView(`
+      <button id="button" phx-click="toggle">
+        <span id="innerContent">This is a button</span>
+      </button>
+      `)
+      let element = global.document.querySelector("#innerContent")
+      let parent = global.document.querySelector("#button")
+      expect(closestPhxBinding(element, "phx-click")).toBe(parent)
+    })
+
+    test("if an element's parent is disabled, return null", () => {
+      let view = setupView(`
+      <button id="button" phx-click="toggle" disabled>
+        <span id="innerContent">This is a button</span>
+      </button>
+      `)
+      let element = global.document.querySelector("#innerContent")
+      expect(closestPhxBinding(element, "phx-click")).toBe(null)
+    })
+  })
+})
+


### PR DESCRIPTION
If we define a `phx-click` event on an element with no children and set `disabled` on that element, `phx-click` will not fire. However, if that element has children and we click on those, the event will fire.

Compare:

```heex
<button disabled phx-click="increment">+ 1</button>
```
to
```heex
<button disabled phx-click="toggle">
  <span class="material-icon">add</span>
</button>
 ```
 
In the first example, the event will not fire. In the second one, the event will fire. This doesn't adhere to standard HTML behavior.
 
I've tested this on `<button>` elements, but I imagine the behavior is fairly general.