### PR TITLE
Use clearTimeout when calling reset() on TransitionSet

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -847,7 +847,7 @@ class TransitionSet {
 
   reset(){
     this.transitions.forEach(timer => {
-      cancelTimeout(timer)
+      clearTimeout(timer)
       this.transitions.delete(timer)
     })
     this.flushPendingOps()


### PR DESCRIPTION
Hello 👋 I might be missing some context, but while updating the TS type definitions for this library I stumbled upon this instance of `cancelTimeout`. I can't find any other mention of `cancelTimeout` except in the JS for the `phoenix` package - however there it takes 0 arguments rather than the timer ID. Should this be [clearTimeout](https://developer.mozilla.org/en-US/docs/Web/API/clearTimeout) instead?