### PR TITLE
Remove Latency Sim Console Log

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -269,7 +269,6 @@ export default class LiveSocket {
       if(!latency){
         cb(data)
       } else {
-        console.log(`simulating ${latency}ms of latency from server to client`)
         setTimeout(() => cb(data), latency)
       }
     })


### PR DESCRIPTION
This PR removes a single line:

`console.log(simulating ${latency}ms of latency from server to client)`

The latency simulator is really helpful for debugging, but this line absolutely trashes the console when debugging JavaScript applications with a LiveView backend, the point where I think this amount of logging is actually having a performance impact on the application beyond the latency, and it making debugging in the console a lot harder.

It's really not necessary, as there is already `latency simulator enabled for the duration of this browser session. Call disableLatencySim() to disable` announcement in the console when it starts, so everything after that is redundant. It should just do its job and not announce itself every time it's called.