### PR TITLE
Add `phx-dblclick` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Additionally, the special `let` attribute on function components have been depre
   - [JS] Add new JS commands for `focus`, `focus_first`, `push_focus`, and `pop_focus` for accessbility
   - Add new attrs `:let` and `:for`. We still support `let` but the Formatter will convert it to `:let` and soon it will be deprecated.
   - Support sharing `Phoenix.LiveView.Socket` with regular channels via `use Phoenix.LiveView.Socket`
+  - Add `phx-dblclick` event
 
 ### Bug fixes
   - Fix external upload issue where listeners are not cleaned up when an external failure happens on the client

--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -594,6 +594,7 @@ export default class LiveSocket {
   bindClicks(){
     window.addEventListener("mousedown", e => this.clickStartedAtTarget = e.target)
     this.bindClick("click", "click", false)
+    this.bindClick("dblclick", "dblclick", false)
     this.bindClick("mousedown", "capture-click", true)
   }
 

--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -16,7 +16,7 @@ callback, for example:
 | Binding                | Attributes |
 |------------------------|------------|
 | [Params](#click-events) | `phx-value-*` |
-| [Click Events](#click-events) | `phx-click`, `phx-click-away` |
+| [Click Events](#click-events) | `phx-click`, `phx-click-away`, `phx-dblclick` |
 | [Form Events](form-bindings.md) | `phx-change`, `phx-submit`, `phx-feedback-for`, `phx-disable-with`, `phx-trigger-action`, `phx-auto-recover` |
 | [Focus Events](#focus-and-blur-events) | `phx-blur`, `phx-focus`, `phx-window-blur`, `phx-window-focus` |
 | [Key Events](#key-events) | `phx-keydown`, `phx-keyup`, `phx-window-keydown`, `phx-window-keyup`, `phx-key` |
@@ -67,6 +67,10 @@ sent to the server will be chosen with the following priority:
 
 The `phx-click-away` event is fired when a click event happens outside of the element.
 This is useful for hiding toggled containers like drop-downs.
+
+The `phx-dblclick` event is fired when an element is doubled clicked.
+
+Note: when `phx-dblclick` is used together with `phx-click`, the `phx-click` event will fire on both clicks.
 
 ## Focus and Blur Events
 


### PR DESCRIPTION
Allows usage of `phx-dblclick` to fire when an element is double clicked.

Uses the DOM `dblclick` event: https://developer.mozilla.org/en-US/docs/Web/API/Element/dblclick_event

I realize this was discussed previously in the elixir forum thread linked below. The suggestion at the time was to use Hooks and pushEvent to avoid introducing too many data attributes.

https://elixirforum.com/t/phoenix-liveview-request-proposal-mouse-events/31213/5