### PR TITLE
Set last_modified for upload's serializer

### DIFF
--- a/assets/js/phoenix_live_view/live_uploader.js
+++ b/assets/js/phoenix_live_view/live_uploader.js
@@ -46,6 +46,7 @@ export default class LiveUploader {
       let uploadRef = inputEl.getAttribute(PHX_UPLOAD_REF)
       fileData[uploadRef] = fileData[uploadRef] || []
       entry.ref = this.genFileRef(file)
+      entry.last_modified = file.lastModified
       entry.name = file.name || entry.ref
       entry.relative_path = file.webkitRelativePath
       entry.type = file.type


### PR DESCRIPTION
For some reason the `serializeUploads` method did not pass the uploaded file's modification timestamp, so `last_modified` in `%UploadEntry{}` would always be `nil`.

before:
```elixir
%Phoenix.LiveView.UploadEntry{
  cancelled?: false,
  client_last_modified: nil,
  client_name: "privacy.html",
  client_relative_path: "",
   ...
}
```

after:
```elixir
%Phoenix.LiveView.UploadEntry{
  cancelled?: false,
  client_last_modified: 1660645834947,
  client_name: "privacy.html",
  client_relative_path: "",
   ...
}
```