### PR TITLE
Fix HEEX template example

### DIFF
--- a/guides/server/uploads.md
+++ b/guides/server/uploads.md
@@ -93,7 +93,7 @@ Let's look at an annotated example:
     <progress value={entry.progress} max="100"> <%= entry.progress %>% </progress>
 
     <%# a regular click event whose handler will invoke Phoenix.LiveView.cancel_upload/3 %>
-    <button phx-click="cancel-upload" phx-value-ref={entry.ref} aria-label="cancel">&times;</button>
+    <button type="button" phx-click="cancel-upload" phx-value-ref={entry.ref} aria-label="cancel">&times;</button>
 
     <%# Phoenix.Component.upload_errors/2 returns a list of error atoms %>
     <%= for err <- upload_errors(@uploads.avatar, entry) do %>


### PR DESCRIPTION
Add `type="button` to the cancel upload `<button>`, otherwise most browsers will treat it as a submit button and undesirably submit the form.