### PR TITLE
Remove Latency Simulation Console Logger (Again)

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -291,7 +291,6 @@ export default class LiveSocket {
       }
     }
 
-    console.log(`simulating ${latency}ms of latency from client to server`)
     let fakePush = {
       receives: [],
       receive(kind, cb){ this.receives.push([kind, cb]) }


### PR DESCRIPTION
Follow up to #2142. I missed that these lines happen in both directions in the previous PR. Sorry about that. This removes the other call.