### PR TITLE
Special case JS.set_attribute for the `value` attribute

### DIFF
--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -204,7 +204,14 @@ let JS = {
 
     DOM.putSticky(el, "attrs", currentEl => {
       newRemoves.forEach(attr => currentEl.removeAttribute(attr))
-      newSets.forEach(([attr, val]) => currentEl.setAttribute(attr, val))
+      newSets.forEach(([attr, val]) => {
+        // Special case for input value, see https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute#gecko_notes
+        if(attr === "value"){
+          currentEl.value = val
+        } else {
+          currentEl.setAttribute(attr, val)
+        }
+      })
       return [newSets, newRemoves]
     })
   },

--- a/assets/test/js_test.js
+++ b/assets/test/js_test.js
@@ -564,5 +564,23 @@ describe("JS", () => {
       JS.exec("click", setTrue.getAttribute("phx-click"), view, setTrue)
       expect(modal.getAttribute("aria-expanded")).toEqual("true")
     })
+
+    test("setting an input's value updates the value", () => {
+      let view = setupView(`
+      <form id="my-form" phx-change="validate" phx-submit='[["push", {"event": "save"}]]'>
+        <input type="text" name="username" id="username" value="initial value"/>
+      </form>
+      <div id="set-value" phx-click='[["set_attr", {"to": "#username", "attr": ["value", "new value"]}]]'></div>
+      `)
+      let input = document.querySelector("#username")
+      let setValue = document.querySelector("#set-value")
+      expect(input.value).toEqual("initial value")
+
+      // Modify the input's value directly, simulating form input
+      input.value = "set directly"
+
+      JS.exec("click", setValue.getAttribute("phx-click"), view, setValue)
+      expect(input.value).toEqual("new value")
+    })
   })
 })


### PR DESCRIPTION
This PR fixes a bug where `JS.set_attribute({"value", ...})` doesn't work to set the value of an input tag after it's been interacted with.

See https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute#gecko_notes
> Using `setAttribute()` to modify certain attributes, most notably `value` in XUL, works inconsistently, as the attribute specifies the default value. To access or modify the current values, you should use the properties. For example, use `Element.value` instead of `Element.setAttribute()`.

This, unfortunately, is the best documentation I could find about about the it. There may be other attribute names we want to special case later but I don't know where to find them 🙃 
