### PR TITLE
Update phoenix_component.ex

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1308,6 +1308,7 @@ defmodule Phoenix.Component do
     itemscope
     itemtype
     lang
+    method
     nonce
     part
     role


### PR DESCRIPTION
For the button and links, we pass the `method="post"` or `method="put"` attributes. So added method attribute to the globals list to remove warning for such inclusions.