### PR TITLE
Fix `form/1` csrf_token generation

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1603,6 +1603,7 @@ defmodule Phoenix.Component do
   """
   @doc type: :component
   attr.(:prefix, :string, default: nil, doc: "A prefix added before the content of `inner_block`.")
+
   attr.(:suffix, :string, default: nil, doc: "A suffix added after the content of `inner_block`.")
   slot.(:inner_block, required: true, doc: "Content rendered inside the `title` tag.")
 
@@ -1726,11 +1727,10 @@ defmodule Phoenix.Component do
     """
   )
 
-  attr.(:csrf_token, :boolean,
-    default: false,
+  attr.(:csrf_token, :any,
     doc: """
     A token to authenticate the validity of requests.
-    Once is automatically generated when an action is given and the method is not `get`.
+    One is automatically generated when an action is given and the method is not `get`.
     When set to `false`, no token is generated.
     """
   )

--- a/test/phoenix_component/components_test.exs
+++ b/test/phoenix_component/components_test.exs
@@ -300,6 +300,28 @@ defmodule Phoenix.LiveView.ComponentsTest do
              ] = html
     end
 
+    test "generates a csrf_token if if an action is set" do
+      assigns = %{}
+
+      html =
+        parse(~H"""
+        <.form :let={f} for={:myform} action="/">
+          <%= text_input f, :foo %>
+        </.form>
+        """)
+
+      csrf_token = Plug.CSRFProtection.get_csrf_token_for("/")
+
+      assert [
+               {"form", [{"action", "/"}, {"method", "post"}],
+                [
+                  {"input", [{"name", "_csrf_token"}, {"type", "hidden"}, {"value", ^csrf_token}],
+                   []},
+                  {"input", [{"id", "myform_foo"}, {"name", "myform[foo]"}, {"type", "text"}], []}
+                ]}
+             ] = html
+    end
+
     test "does not generate csrf_token if method is not post or if no action" do
       assigns = %{}
 


### PR DESCRIPTION
This broke recently when I set the default value of `csrf_token` to `false`, causing `Keyword.pop_lazy/3` to never be called to generate a token 🙃 

This PR fixes that bug and adds a test verifying that functionality.