### PR TITLE
Doc generation: add missing dash separator before "Accepts attributes"

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -731,7 +731,7 @@ defmodule Phoenix.Component.Declarative do
   end
 
   defp build_slot_doc(%{doc: nil}, slot_attrs) do
-    ["Accepts attributes: ", build_slot_attrs_docs(slot_attrs)]
+    [" - ", "Accepts attributes: ", build_slot_attrs_docs(slot_attrs)]
   end
 
   defp build_slot_doc(%{doc: doc}, slot_attrs) do

--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -731,7 +731,7 @@ defmodule Phoenix.Component.Declarative do
   end
 
   defp build_slot_doc(%{doc: nil}, slot_attrs) do
-    [" - ", "Accepts attributes: ", build_slot_attrs_docs(slot_attrs)]
+    [" - Accepts attributes: ", build_slot_attrs_docs(slot_attrs)]
   end
 
   defp build_slot_doc(%{doc: doc}, slot_attrs) do


### PR DESCRIPTION
Fixes #2193