### PR TITLE
Doc: replace live_title_tag with live_title

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -218,7 +218,7 @@ The layout given to `put_root_layout` is typically very barebones, with mostly `
 <html lang="en">
   <head>
     <%= csrf_meta_tag() %>
-    <%= live_title_tag assigns[:page_title] || "MyApp" %>
+    <Phoenix.Component.live_title><%= assigns[:page_title] || "MyApp" %></Phoenix.Component.live_title>
     <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>
     <script defer type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
   </head>

--- a/guides/server/live-layouts.md
+++ b/guides/server/live-layouts.md
@@ -102,12 +102,14 @@ Then access `@page_title` in the root layout:
 <title><%= @page_title %></title>
 ```
 
-You can also use `Phoenix.LiveView.Helpers.live_title_tag/2` to support
+You can also use the `Phoenix.Component.live_title/1` component to support
 adding automatic prefix and suffix to the page title when rendered and
 on subsequent updates:
 
 ```heex
-<%= live_title_tag assigns[:page_title] || "Welcome", prefix: "MyApp – " %>
+<Phoenix.Component.live_title prefix="MyApp – ">
+  <%= assigns[:page_title] || "Welcome" %>
+</Phoenix.Component.live_title>
 ```
 
 Although the root layout is not updated by LiveView, by simply assigning


### PR DESCRIPTION
2 documentation pages still mention `live_title_tag` and need to be updated.

Current installations break on this, so it should be mentioned in the changelog too (not included).