### PR TITLE
Support `:examples` and `:values` for declarative attributes

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1452,6 +1452,12 @@ defmodule Phoenix.Component do
   * `:default` - the default value for the attribute if not provided. If this option is
     not set and the attribute is not given, accessing the attribute will fail unless a
     value is explicitly set with `assign_new/3`.
+    
+  * `:examples` - a non-exhaustive list of values accepted by the attribute, used for documentation
+    purposes.
+
+  * `:values` - an exhaustive list of values accepted by the attributes. If a caller passes a literal
+    not contained in this list, a compile warning is issued.
 
   * `:doc` - documentation for the attribute.
 
@@ -1467,6 +1473,8 @@ defmodule Phoenix.Component do
   * You specify a literal attribute (such as `value="string"` or `value`, but not `value={expr}`)
   and the type does not match. The following types currently support literal validation:
   `:string`, `:atom`, `:boolean`, `:integer`, `:float`, and `:list`.
+
+  * You specify a literal attribute and it is not a member of the `:values` list.
 
   LiveView does not perform any validation at runtime. This means the type information is mostly
   used for documentation and reflection purposes.
@@ -2075,7 +2083,7 @@ defmodule Phoenix.Component do
   ```
   """
   @doc type: :component
-  attr.(:id, :string, required: true, doc: "The DOM identifier of the contianer tag.")
+  attr.(:id, :string, required: true, doc: "The DOM identifier of the container tag.")
 
   attr.(:rest, :global, doc: "Additional HTML attributes to add to the container tag.")
 

--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -281,6 +281,14 @@ defmodule Phoenix.Component.Declarative do
       compile_error!(line, file, "global attributes do not support the :required option")
     end
 
+    if type == :global and Keyword.has_key?(opts, :values) do
+      compile_error!(line, file, "global attributes do not support the :values option")
+    end
+
+    if type == :global and Keyword.has_key?(opts, :examples) do
+      compile_error!(line, file, "global attributes do not support the :examples option")
+    end
+
     {doc, opts} = Keyword.pop(opts, :doc, nil)
 
     unless is_binary(doc) or is_nil(doc) or doc == false do

--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -823,7 +823,10 @@ defmodule Phoenix.Component.Declarative do
           build_attr_name(attr),
           build_attr_type(attr),
           build_attr_required(attr),
-          build_attr_doc_and_default(attr, "  ")
+          build_hyphen(attr),
+          build_attr_doc_and_default(attr, "  "),
+          build_attr_values(attr),
+          build_attr_examples(attr)
         ]
       end
     ]
@@ -861,7 +864,10 @@ defmodule Phoenix.Component.Declarative do
         build_attr_name(slot_attr),
         build_attr_type(slot_attr),
         build_attr_required(slot_attr),
-        build_attr_doc_and_default(slot_attr, "    ")
+        build_hyphen(slot_attr),
+        build_attr_doc_and_default(slot_attr, "    "),
+        build_attr_values(slot_attr),
+        build_attr_examples(slot_attr)
       ]
     end
   end
@@ -895,17 +901,11 @@ defmodule Phoenix.Component.Declarative do
   end
 
   defp build_attr_doc_and_default(%{doc: nil, opts: [default: default]}, _indent) do
-    [" - Defaults to `", inspect(default), "`."]
+    ["Defaults to `", inspect(default), "`."]
   end
 
   defp build_attr_doc_and_default(%{doc: doc, opts: [default: default]}, indent) do
-    [
-      " - ",
-      build_doc(doc, indent, true),
-      "Defaults to `",
-      inspect(default),
-      "`."
-    ]
+    [build_doc(doc, indent, true), "Defaults to `", inspect(default), "`."]
   end
 
   defp build_attr_doc_and_default(%{doc: nil}, _indent) do
@@ -913,7 +913,7 @@ defmodule Phoenix.Component.Declarative do
   end
 
   defp build_attr_doc_and_default(%{doc: doc}, indent) do
-    [" - ", build_doc(doc, indent, false)]
+    [build_doc(doc, indent, false)]
   end
 
   defp build_doc(doc, indent, text_after?) do
@@ -944,8 +944,43 @@ defmodule Phoenix.Component.Declarative do
     end
   end
 
+  defp build_attr_values(%{opts: [values: values]}) do
+    ["Must be one of ", build_literals_list(values, "or"), ?.]
+  end
+
+  defp build_attr_values(_attr) do
+    []
+  end
+
+  defp build_attr_examples(%{opts: [examples: examples]}) do
+    ["Examples include ", build_literals_list(examples, "and"), ?.]
+  end
+
+  defp build_attr_examples(_attr) do
+    []
+  end
+
+  defp build_literals_list(literals, condition) do
+    literals
+    |> Enum.map(&[?`, inspect(&1), ?`])
+    |> Enum.intersperse([", "])
+    |> List.insert_at(-2, [condition, " "])
+  end
+
+  defp build_hyphen(%{doc: doc}) when is_binary(doc) do
+    [" - "]
+  end
+
+  defp build_hyphen(%{opts: []}) do
+    []
+  end
+
+  defp build_hyphen(%{opts: _opts}) do
+    [" - "]
+  end
+
   defp build_right_doc("") do
-    [""]
+    []
   end
 
   defp build_right_doc(right) do

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -1447,10 +1447,36 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     msg = ~r"global attributes do not support the :required option"
 
     assert_raise CompileError, msg, fn ->
-      defmodule Phoenix.ComponentTest.GlobalOpts do
+      defmodule Phoenix.ComponentTest.GlobalRequiredOpts do
         use Elixir.Phoenix.Component
 
         attr :rest, :global, required: true
+        def func(assigns), do: ~H[<%= @rest %>]
+      end
+    end
+  end
+
+  test "raise if global provides :values" do
+    msg = ~r"global attributes do not support the :values option"
+
+    assert_raise CompileError, msg, fn ->
+      defmodule Phoenix.ComponentTest.GlobalValueOpts do
+        use Elixir.Phoenix.Component
+
+        attr :rest, :global, values: ["placeholder", "rel"]
+        def func(assigns), do: ~H[<%= @rest %>]
+      end
+    end
+  end
+
+  test "raise if global provides :examples" do
+    msg = ~r"global attributes do not support the :examples option"
+
+    assert_raise CompileError, msg, fn ->
+      defmodule Phoenix.ComponentTest.GlobalExampleOpts do
+        use Elixir.Phoenix.Component
+
+        attr :rest, :global, examples: ["placeholder", "rel"]
         def func(assigns), do: ~H[<%= @rest %>]
       end
     end

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -740,7 +740,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
            }
   end
 
-  test "inserts attr docs to function component @doc string" do
+  test "inserts attr & slot docs into function component @doc string" do
     {_, _, :elixir, "text/markdown", _, _, docs} =
       Code.fetch_docs(Phoenix.LiveViewTest.FunctionComponentWithAttrs)
 

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -1119,7 +1119,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     end
   end
 
-  test "raise if attr value does not match the type" do
+  test "raise if attr :values does not match the type" do
     msg = ~r"expected the values for attr :foo to be a :string, got: :not_a_string"
 
     assert_raise CompileError, msg, fn ->
@@ -1133,7 +1133,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     end
   end
 
-  test "raise if attr example does not match the type" do
+  test "raise if attr :example does not match the type" do
     msg = ~r"expected the examples for attr :foo to be a :string, got: :not_a_string"
 
     assert_raise CompileError, msg, fn ->
@@ -1147,7 +1147,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     end
   end
 
-  test "raise if attr values is not a list" do
+  test "raise if attr :values is not a list" do
     msg = ~r":values must be a non-empty list, got: :ok"
 
     assert_raise CompileError, msg, fn ->
@@ -1161,7 +1161,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     end
   end
 
-  test "raise if attr examples is not a list" do
+  test "raise if attr :examples is not a list" do
     msg = ~r":examples must be a non-empty list, got: :ok"
 
     assert_raise CompileError, msg, fn ->
@@ -1175,7 +1175,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     end
   end
 
-  test "raise if attr values is an empty list" do
+  test "raise if attr :values is an empty list" do
     msg = ~r":values must be a non-empty list, got: \[\]"
 
     assert_raise CompileError, msg, fn ->
@@ -1189,7 +1189,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     end
   end
 
-  test "raise if attr examples is an empty list" do
+  test "raise if attr :examples is an empty list" do
     msg = ~r":examples must be a non-empty list, got: \[\]"
 
     assert_raise CompileError, msg, fn ->
@@ -1203,7 +1203,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     end
   end
 
-  test "raise if attrs has both values and examples" do
+  test "raise if attr has both :values and :examples" do
     msg = ~r"only one of :values or :examples must be given"
 
     assert_raise CompileError, msg, fn ->
@@ -1217,7 +1217,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     end
   end
 
-  test "raise if attr default does not match the type" do
+  test "raise if attr :default does not match the type" do
     msg = ~r"expected the default value for attr :foo to be a :string, got: :not_a_string"
 
     assert_raise CompileError, msg, fn ->
@@ -1231,7 +1231,22 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     end
   end
 
-  test "raise if slot attr has default" do
+  test "raise if attr :default is not one of :values" do
+    msg =
+      ~r'expected the default value for attr :foo to be one of \["foo", "bar", "baz"\], got: "boom"'
+
+    assert_raise CompileError, msg, fn ->
+      defmodule Phoenix.ComponentTest.AttrDefaultValuesMismatch do
+        use Elixir.Phoenix.Component
+
+        attr :foo, :string, default: "boom", values: ["foo", "bar", "baz"]
+
+        def func(assigns), do: ~H[]
+      end
+    end
+  end
+
+  test "raise if slot attr has :default" do
     msg = ~r" invalid option :default for attr :foo in slot :named"
 
     assert_raise CompileError, msg, fn ->

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -62,10 +62,14 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     def button_with_defaults_line, do: __ENV__.line
     attr :rest, :global, default: %{class: "primary"}
     def button_with_defaults(assigns), do: ~H[<button {@rest}/>]
-    
+
     def button_with_values_line, do: __ENV__.line
     attr :text, :string, values: ["Save", "Cancel"]
     def button_with_values(assigns), do: ~H[<button><%= @text %></button>]
+
+    def button_with_examples_line, do: __ENV__.line
+    attr :text, :string, examples: ["Save", "Cancel"]
+    def button_with_examples(assigns), do: ~H[<button><%= @text %></button>]
 
     def render_line, do: __ENV__.line
 
@@ -112,6 +116,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     with_global_line = FunctionComponentWithAttrs.with_global_line()
     button_with_defaults_line = FunctionComponentWithAttrs.button_with_defaults_line()
     button_with_values_line = FunctionComponentWithAttrs.button_with_values_line()
+    button_with_examples_line = FunctionComponentWithAttrs.button_with_examples_line()
 
     assert FunctionComponentWithAttrs.__components__() == %{
              func1: %{
@@ -225,21 +230,36 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                ],
                slots: []
              },
-            button_with_values: %{
-              kind: :def,
-              attrs: [
-                %{
-                  line: button_with_values_line + 1,
-                  name: :text,
-                  opts: [values: ["Save", "Cancel"]],
-                  required: false,
-                  doc: nil,
-                  slot: nil,
-                  type: :string
-                }
-              ],
-              slots: []
-            }
+             button_with_values: %{
+               kind: :def,
+               attrs: [
+                 %{
+                   line: button_with_values_line + 1,
+                   name: :text,
+                   opts: [values: ["Save", "Cancel"]],
+                   required: false,
+                   doc: nil,
+                   slot: nil,
+                   type: :string
+                 }
+               ],
+               slots: []
+             },
+             button_with_examples: %{
+               kind: :def,
+               attrs: [
+                 %{
+                   line: button_with_examples_line + 1,
+                   name: :text,
+                   opts: [examples: ["Save", "Cancel"]],
+                   required: false,
+                   doc: nil,
+                   slot: nil,
+                   type: :string
+                 }
+               ],
+               slots: []
+             }
            }
   end
 
@@ -996,7 +1016,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       end
     end
   end
-  
+
   test "raise if attr value does not match the type" do
     msg = ~r"expected the values for attr :foo to be a :string, got: :not_a_string"
 
@@ -1005,6 +1025,90 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
         use Elixir.Phoenix.Component
 
         attr :foo, :string, values: ["a string", :not_a_string]
+
+        def func(assigns), do: ~H[]
+      end
+    end
+  end
+
+  test "raise if attr example does not match the type" do
+    msg = ~r"expected the examples for attr :foo to be a :string, got: :not_a_string"
+
+    assert_raise CompileError, msg, fn ->
+      defmodule Phoenix.ComponentTest.AttrExampleTypeMismatch do
+        use Elixir.Phoenix.Component
+
+        attr :foo, :string, examples: ["a string", :not_a_string]
+
+        def func(assigns), do: ~H[]
+      end
+    end
+  end
+
+  test "raise if attr values is not a list" do
+    msg = ~r":values must be a non-empty list, got: :ok"
+
+    assert_raise CompileError, msg, fn ->
+      defmodule Phoenix.ComponentTest.AttrsValuesNotAList do
+        use Elixir.Phoenix.Component
+
+        attr :foo, :string, values: :ok
+
+        def func(assigns), do: ~H[]
+      end
+    end
+  end
+
+  test "raise if attr examples is not a list" do
+    msg = ~r":examples must be a non-empty list, got: :ok"
+
+    assert_raise CompileError, msg, fn ->
+      defmodule Phoenix.ComponentTest.AttrsExamplesNotAList do
+        use Elixir.Phoenix.Component
+
+        attr :foo, :string, examples: :ok
+
+        def func(assigns), do: ~H[]
+      end
+    end
+  end
+
+  test "raise if attr values is an empty list" do
+    msg = ~r":values must be a non-empty list, got: \[\]"
+
+    assert_raise CompileError, msg, fn ->
+      defmodule Phoenix.ComponentTest.AttrsValuesEmptyList do
+        use Elixir.Phoenix.Component
+
+        attr :foo, :string, values: []
+
+        def func(assigns), do: ~H[]
+      end
+    end
+  end
+
+  test "raise if attr examples is an empty list" do
+    msg = ~r":examples must be a non-empty list, got: \[\]"
+
+    assert_raise CompileError, msg, fn ->
+      defmodule Phoenix.ComponentTest.AttrsExamplesEmptyList do
+        use Elixir.Phoenix.Component
+
+        attr :foo, :string, examples: []
+
+        def func(assigns), do: ~H[]
+      end
+    end
+  end
+
+  test "raise if attrs has both values and examples" do
+    msg = ~r"only one of :values or :examples must be given"
+
+    assert_raise CompileError, msg, fn ->
+      defmodule Phoenix.ComponentTest.AttrDefaultTypeMismatch do
+        use Elixir.Phoenix.Component
+
+        attr :foo, :string, values: ["a string"], examples: ["a string"]
 
         def func(assigns), do: ~H[]
       end

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -745,24 +745,87 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       Code.fetch_docs(Phoenix.LiveViewTest.FunctionComponentWithAttrs)
 
     components = %{
-      fun_attr_any: "## Attributes\n\n* `attr` (`:any`)\n",
-      fun_attr_string: "## Attributes\n\n* `attr` (`:string`)\n",
-      fun_attr_atom: "## Attributes\n\n* `attr` (`:atom`)\n",
-      fun_attr_boolean: "## Attributes\n\n* `attr` (`:boolean`)\n",
-      fun_attr_integer: "## Attributes\n\n* `attr` (`:integer`)\n",
-      fun_attr_float: "## Attributes\n\n* `attr` (`:float`)\n",
-      fun_attr_list: "## Attributes\n\n* `attr` (`:list`)\n",
-      fun_attr_global: "## Attributes\n\n* `attr` (`:global`)\n",
-      fun_attr_struct:
-        "## Attributes\n\n* `attr` (`Phoenix.LiveViewTest.FunctionComponentWithAttrs.Struct`)\n",
-      fun_attr_required: "## Attributes\n\n* `attr` (`:any`) (required)\n",
-      fun_attr_default: "## Attributes\n\n* `attr` (`:any`) - Defaults to `%{}`.\n",
+      fun_attr_any: """
+      ## Attributes
+
+      * `attr` (`:any`)
+      """,
+      fun_attr_string: """
+      ## Attributes
+
+      * `attr` (`:string`)
+      """,
+      fun_attr_atom: """
+      ## Attributes
+
+      * `attr` (`:atom`)
+      """,
+      fun_attr_boolean: """
+      ## Attributes
+
+      * `attr` (`:boolean`)
+      """,
+      fun_attr_integer: """
+      ## Attributes
+
+      * `attr` (`:integer`)
+      """,
+      fun_attr_float: """
+      ## Attributes
+
+      * `attr` (`:float`)
+      """,
+      fun_attr_list: """
+      ## Attributes
+
+      * `attr` (`:list`)
+      """,
+      fun_attr_global: """
+      ## Attributes
+
+      * `attr` (`:global`)
+      """,
+      fun_attr_struct: """
+      ## Attributes
+
+      * `attr` (`Phoenix.LiveViewTest.FunctionComponentWithAttrs.Struct`)
+      """,
+      fun_attr_required: """
+      ## Attributes
+
+      * `attr` (`:any`) (required)
+      """,
+      fun_attr_default: """
+      ## Attributes
+
+      * `attr` (`:any`) - Defaults to `%{}`.
+      """,
       fun_doc_false: :hidden,
-      fun_doc_injection: "fun docs\n\n## Attributes\n\n* `attr` (`:any`)\n\nfun docs\n",
-      fun_multiple_attr: "## Attributes\n\n* `attr1` (`:any`)\n* `attr2` (`:any`)\n",
-      fun_with_attr_doc: "## Attributes\n\n* `attr` (`:any`) - attr docs.\n",
-      fun_with_attr_doc_period:
-        "## Attributes\n\n* `attr` (`:any`) - attr docs. Defaults to `\"foo\"`.\n",
+      fun_doc_injection: """
+      fun docs
+
+      ## Attributes
+
+      * `attr` (`:any`)
+
+      fun docs
+      """,
+      fun_multiple_attr: """
+      ## Attributes
+
+      * `attr1` (`:any`)
+      * `attr2` (`:any`)
+      """,
+      fun_with_attr_doc: """
+      ## Attributes
+
+      * `attr` (`:any`) - attr docs.
+      """,
+      fun_with_attr_doc_period: """
+      ## Attributes
+
+      * `attr` (`:any`) - attr docs. Defaults to `\"foo\"`.
+      """,
       fun_with_attr_doc_multiline: """
       ## Attributes
 
@@ -775,15 +838,48 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
 
         Defaults to `"foo"`.
       """,
-      fun_with_hidden_attr: "## Attributes\n\n* `attr1` (`:any`)\n",
-      fun_with_doc: "fun docs\n## Attributes\n\n* `attr` (`:any`)\n",
-      fun_slot: "## Slots\n\n* `inner_block`\n",
-      fun_slot_doc: "## Slots\n\n* `inner_block` - slot docs.\n",
-      fun_slot_required: "## Slots\n\n* `inner_block` (required)\n",
-      fun_slot_with_attrs:
-        "## Slots\n\n* `named` (required) - a named slot. Accepts attributes:\n\n  * `attr1` (`:any`) (required) - a slot attr doc.\n  * `attr2` (`:any`) - a slot attr doc.\n",
-      fun_slot_no_doc_with_attrs:
-        "## Slots\n\n* `named` (required) - Accepts attributes:\n\n  * `attr1` (`:any`) (required) - a slot attr doc.\n  * `attr2` (`:any`) - a slot attr doc.\n",
+      fun_with_hidden_attr: """
+      ## Attributes
+
+      * `attr1` (`:any`)
+      """,
+      fun_with_doc: """
+      fun docs
+      ## Attributes
+
+      * `attr` (`:any`)
+      """,
+      fun_slot: """
+      ## Slots
+
+      * `inner_block`
+      """,
+      fun_slot_doc: """
+      ## Slots
+
+      * `inner_block` - slot docs.
+      """,
+      fun_slot_required: """
+      ## Slots
+
+      * `inner_block` (required)
+      """,
+      fun_slot_with_attrs: """
+      ## Slots
+
+      * `named` (required) - a named slot. Accepts attributes:
+
+        * `attr1` (`:any`) (required) - a slot attr doc.
+        * `attr2` (`:any`) - a slot attr doc.
+      """,
+      fun_slot_no_doc_with_attrs: """
+      ## Slots
+
+      * `named` (required) - Accepts attributes:
+
+        * `attr1` (`:any`) (required) - a slot attr doc.
+        * `attr2` (`:any`) - a slot attr doc.
+      """,
       fun_slot_doc_multiline_with_attrs: """
       ## Slots
 
@@ -810,6 +906,12 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
           and that's it.
 
         * `attr2` (`:any`) - a slot attr doc.
+      """,
+      fun_attr_values_examples: """
+      ## Attributes
+
+      * `attr1` (`:atom`) - Must be one of `:foo`, `:bar`, or `:baz`.
+      * `attr2` (`:atom`) - Examples include `:foo`, `:bar`, and `:baz`.
       """
     }
 

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -62,6 +62,10 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     def button_with_defaults_line, do: __ENV__.line
     attr :rest, :global, default: %{class: "primary"}
     def button_with_defaults(assigns), do: ~H[<button {@rest}/>]
+    
+    def button_with_values_line, do: __ENV__.line
+    attr :text, :string, values: ["Save", "Cancel"]
+    def button_with_values(assigns), do: ~H[<button><%= @text %></button>]
 
     def render_line, do: __ENV__.line
 
@@ -107,6 +111,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     func2_line = FunctionComponentWithAttrs.func2_line()
     with_global_line = FunctionComponentWithAttrs.with_global_line()
     button_with_defaults_line = FunctionComponentWithAttrs.button_with_defaults_line()
+    button_with_values_line = FunctionComponentWithAttrs.button_with_values_line()
 
     assert FunctionComponentWithAttrs.__components__() == %{
              func1: %{
@@ -219,7 +224,22 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                  }
                ],
                slots: []
-             }
+             },
+            button_with_values: %{
+              kind: :def,
+              attrs: [
+                %{
+                  line: button_with_values_line + 1,
+                  name: :text,
+                  opts: [values: ["Save", "Cancel"]],
+                  required: false,
+                  doc: nil,
+                  slot: nil,
+                  type: :string
+                }
+              ],
+              slots: []
+            }
            }
   end
 
@@ -971,6 +991,20 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
         slot :named do
           raise "boom!"
         end
+
+        def func(assigns), do: ~H[]
+      end
+    end
+  end
+  
+  test "raise if attr value does not match the type" do
+    msg = ~r"expected the values for attr :foo to be a :string, got: :not_a_string"
+
+    assert_raise CompileError, msg, fn ->
+      defmodule Phoenix.ComponentTest.AttrValueTypeMismatch do
+        use Elixir.Phoenix.Component
+
+        attr :foo, :string, values: ["a string", :not_a_string]
 
         def func(assigns), do: ~H[]
       end

--- a/test/phoenix_component/verify_test.exs
+++ b/test/phoenix_component/verify_test.exs
@@ -372,14 +372,15 @@ defmodule Phoenix.ComponentVerifyTest do
 
           attr :attr, :atom, values: [:foo, :bar, :baz]
           def func_atom(assigns), do: ~H[]
-          
+
           def line, do: __ENV__.line + 2
 
           def render(assigns) do
             ~H"""
             <.func_string attr="boom" />
             <.func_atom attr={:boom} />
-            <.func_string attr={@attr} />
+            <.func_string attr={@string} />
+            <.func_atom attr={@atom} />
             """
           end
         end
@@ -397,6 +398,49 @@ defmodule Phoenix.ComponentVerifyTest do
     assert warnings =~ """
            attribute "attr" in component \
            Phoenix.ComponentVerifyTest.AttrValues.func_atom/1 \
+           must be one of [:foo, :bar, :baz], got: :boom
+             test/phoenix_component/verify_test.exs:#{line + 3}: (file)
+           """
+  end
+
+  test "validates slot attr values" do
+    warnings =
+      capture_io(:stderr, fn ->
+        defmodule SlotAttrValues do
+          use Phoenix.Component
+
+          slot :named do
+            attr :string, :string, values: ["foo", "bar", "baz"]
+            attr :atom, :atom, values: [:foo, :bar, :baz]
+          end
+
+          def func(assigns), do: ~H[]
+
+          def line, do: __ENV__.line + 2
+
+          def render(assigns) do
+            ~H"""
+            <.func>
+              <:named string="boom" atom={:boom} />
+              <:named string={@string} atom={@atom} />
+            </.func>
+            """
+          end
+        end
+      end)
+
+    line = get_line(__MODULE__.SlotAttrValues, :line)
+
+    assert warnings =~ """
+           attribute "string" in slot "named" for component \
+           Phoenix.ComponentVerifyTest.SlotAttrValues.func/1 \
+           must be one of ["foo", "bar", "baz"], got: "boom"
+             test/phoenix_component/verify_test.exs:#{line + 3}: (file)
+           """
+
+    assert warnings =~ """
+           attribute "atom" in slot "named" for component \
+           Phoenix.ComponentVerifyTest.SlotAttrValues.func/1 \
            must be one of [:foo, :bar, :baz], got: :boom
              test/phoenix_component/verify_test.exs:#{line + 3}: (file)
            """

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -154,6 +154,11 @@ defmodule Phoenix.LiveViewTest.FunctionComponentWithAttrs do
   end
 
   def fun_slot_doc_with_attrs_multiline(assigns), do: ~H[]
+  
+  attr :attr1, :atom, values: [:foo, :bar, :baz]
+  attr :attr2, :atom, examples: [:foo, :bar, :baz]
+  
+  def fun_attr_values_examples(assigns), do: ~H[]
 end
 
 defmodule Phoenix.LiveViewTest.StatefulComponent do


### PR DESCRIPTION
Resolves #2190