### PR TITLE
Use the correct data attribute for auto upload on `live_file_input/1`

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2231,7 +2231,7 @@ defmodule Phoenix.Component do
       data-phx-active-refs={Enum.map_join(conf.entries, ",", & &1.ref)}
       data-phx-done-refs={Enum.map_join(done_entries, ",", & &1.ref)}
       data-phx-preflighted-refs={Enum.map_join(preflighted_entries, ",", & &1.ref)}
-      data-phx-auto_upload={valid? && conf.auto_upload?}
+      data-phx-auto-upload={valid? && conf.auto_upload?}
       {@rest}
     />
     """

--- a/test/phoenix_component/components_test.exs
+++ b/test/phoenix_component/components_test.exs
@@ -397,4 +397,20 @@ defmodule Phoenix.LiveView.ComponentsTest do
              ] = html
     end
   end
+
+  describe "live_file_input/1" do
+    test "renders attributes" do
+      assigns = %{}
+
+      conf = %Phoenix.LiveView.UploadConfig{
+        auto_upload?: true,
+        entries: [%{preflighted?: false, done?: false, ref: "foo"}]
+      }
+
+      assert render(
+               ~H|<.live_file_input upload={conf} class={"<script>alert('nice try');</script>"} />|
+             ) ==
+               ~s|<input type="file" accept="" data-phx-hook="Phoenix.LiveFileUpload" data-phx-update="ignore" data-phx-active-refs="foo" data-phx-done-refs="" data-phx-preflighted-refs="" data-phx-auto-upload class="&lt;script&gt;alert(&#39;nice try&#39;);&lt;/script&gt;">|
+    end
+  end
 end


### PR DESCRIPTION
I noticed that auto-uploads have not been working on the master branch - after a bit of digging I found the issue and this change should resolve it.

The `live_file_input/1` data attributes were inlined in https://github.com/phoenixframework/phoenix_live_view/commit/4f2d5550a93391d3aca9e5b33a981b70ec31740b and the `data-phx-auto-upload` attribute was given an underscore rather than a hypen. 