### PR TITLE
HTML Tokenizer - Fix tokens emitted for comments

### DIFF
--- a/lib/phoenix_live_view/html_tokenizer.ex
+++ b/lib/phoenix_live_view/html_tokenizer.ex
@@ -553,13 +553,17 @@ defmodule Phoenix.LiveView.HTMLTokenizer do
 
     meta =
       if context = get_context(context) do
-        Map.put(meta, :context, Enum.uniq(context))
+        Map.put(meta, :context, trim_context(context))
       else
         meta
       end
 
     [{:text, buffer_to_string(buffer), meta} | acc]
   end
+
+  defp trim_context([:comment_start, :comment_end | [_ | _] = rest]), do: trim_context(rest)
+
+  defp trim_context(rest), do: rest
 
   defp get_context([]), do: nil
   defp get_context(context), do: Enum.reverse(context)

--- a/lib/phoenix_live_view/html_tokenizer.ex
+++ b/lib/phoenix_live_view/html_tokenizer.ex
@@ -562,7 +562,6 @@ defmodule Phoenix.LiveView.HTMLTokenizer do
   end
 
   defp trim_context([:comment_start, :comment_end | [_ | _] = rest]), do: trim_context(rest)
-
   defp trim_context(rest), do: rest
 
   defp get_context([]), do: nil

--- a/lib/phoenix_live_view/html_tokenizer.ex
+++ b/lib/phoenix_live_view/html_tokenizer.ex
@@ -553,7 +553,7 @@ defmodule Phoenix.LiveView.HTMLTokenizer do
 
     meta =
       if context = get_context(context) do
-        Map.put(meta, :context, context)
+        Map.put(meta, :context, Enum.uniq(context))
       else
         meta
       end

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -1224,41 +1224,45 @@ if Version.match?(System.version(), ">= 1.13.0") do
     end
 
     test "handle HTML comments but doens't format it" do
-      input = """
-          <!-- Inline comment -->
-      <section>
-        <!-- commenting out this div
-        <div>
-          <p><%= @user.name %></p>
-          <p
-            class="my-class">
-            text
-          </p>
-        </div>
-           -->
-      </section>
-      """
-
-      expected = """
-      <!-- Inline comment -->
-      <section>
-        <!-- commenting out this div
-        <div>
-          <p><%= @user.name %></p>
-          <p
-            class="my-class">
-            text
-          </p>
-        </div>
-           -->
-      </section>
-      """
-
-      assert_formatter_output(input, expected)
+      assert_formatter_output(
+        """
+            <!-- Inline comment -->
+        <section>
+          <!-- commenting out this div
+          <div>
+            <p><%= @user.name %></p>
+            <p
+              class="my-class">
+              text
+            </p>
+          </div>
+             -->
+        </section>
+        """,
+        """
+        <!-- Inline comment -->
+        <section>
+          <!-- commenting out this div
+          <div>
+            <p><%= @user.name %></p>
+            <p
+              class="my-class">
+              text
+            </p>
+          </div>
+             -->
+        </section>
+        """
+      )
 
       assert_formatter_doesnt_change("""
       <!-- Modal content -->
       <%= render_slot(@inner_block) %>
+      """)
+
+      assert_formatter_doesnt_change("""
+      <!-- a comment -->
+      <!-- a comment -->
       """)
     end
 


### PR DESCRIPTION
The tokenizer would duplicate `[:comment_end and :comment_start]` if there were multiple comments in a row:

```
<!-- a comment -->
<!-- a comment -->
```

would emit:

```
[
  {:text, "<!-- a comment -->\n<!-- a comment -->\n",
   %{column_end: 1, context: [:comment_start, :comment_end, :comment_start, :comment_end], line_end: 3}}
]
```

That would break the HTML formatter.

This commit makes sure the comments metada token are unique so now it would emit like this:

```
[
  {:text, "<!-- a comment -->\n<!-- a comment -->\n",
   %{column_end: 1, context: [:comment_start, :comment_end], line_end: 3}}
]
```