### PR TITLE
Add `type` attribute to globals

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -113,6 +113,7 @@ defmodule Phoenix.Component.Declarative do
     target
     title
     translate
+    type
     method
     required
     for


### PR DESCRIPTION
This attribute applies to inputs, like [`<input type="button">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/button).