### PR TITLE
`use Phoenix.Component` supports custom global attributes

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -181,10 +181,10 @@ defmodule Phoenix.Component do
   <span class="bg-blue-200" phx-click="close">You've got mail!</span>
   ```
 
-  ### Custom Global Attribute Prefixes
+  ### Custom Global Attributes
 
-  You can extend the set of global attributes by providing a list of attribute prefixes to
-  `use Phoenix.Component`. Like the default attributes common to all HTML elements,
+  You can extend the set of global attributes by providing a list of attributes or attribute
+  prefixes to `use Phoenix.Component`. Like the default attributes common to all HTML elements,
   any number of attributes that start with a global prefix will be accepted by function
   components defined in this module. By default, the following prefixes are supported:
   `phx-`, `aria-`, and `data-`. For example, to support the `x-` prefix used by
@@ -195,6 +195,10 @@ defmodule Phoenix.Component do
 
   Now all function components defined in this module will accept any number of attributes prefixed
   with `x-`, in addition to the default global prefixes.
+
+  You can also pass a list of specific global attribute names:
+
+      use Phoenix.Component, globals: ~w(custom-attr)
 
   You can learn more about attributes by reading the documentation for `attr/3`.
 
@@ -1452,7 +1456,7 @@ defmodule Phoenix.Component do
   * `:default` - the default value for the attribute if not provided. If this option is
     not set and the attribute is not given, accessing the attribute will fail unless a
     value is explicitly set with `assign_new/3`.
-    
+
   * `:examples` - a non-exhaustive list of values accepted by the attribute, used for documentation
     purposes.
 

--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -174,9 +174,15 @@ defmodule Phoenix.Component.Declarative do
   ## Attrs/slots
 
   @doc false
-  @valid_opts [:global_prefixes]
+  @valid_opts [:globals, :global_prefixes]
   def __setup__(module, opts) do
+    {globals, opts} = Keyword.pop(opts, :globals, [])
     {prefixes, invalid_opts} = Keyword.pop(opts, :global_prefixes, [])
+
+    matches =
+      for global <- globals do
+        quote(do: {unquote(global), true})
+      end
 
     prefix_matches =
       for prefix <- prefixes do
@@ -205,10 +211,10 @@ defmodule Phoenix.Component.Declarative do
     Module.put_attribute(module, :on_definition, __MODULE__)
     Module.put_attribute(module, :before_compile, __MODULE__)
 
-    if prefix_matches == [] do
+    if matches == [] and prefix_matches == [] do
       []
     else
-      prefix_matches ++ [quote(do: {_, false})]
+      matches ++ prefix_matches ++ [quote(do: {_, false})]
     end
   end
 

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -28,14 +28,14 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
   end
 
   defmodule CustomGlobals do
-    use Phoenix.Component, globals: ~w(customattr), global_prefixes: ~w(myprefix-)
+    use Phoenix.Component, globals: ~w(custom-attr), global_prefixes: ~w(myprefix-)
   end
 
   test "custom __global__?" do
     assert CustomGlobals.__global__?("myprefix-a")
     refute CustomGlobals.__global__?("otherprefix-a")
 
-    assert CustomGlobals.__global__?("customattr")
+    assert CustomGlobals.__global__?("custom-attr")
   end
 
   defmodule RemoteFunctionComponentWithAttrs do

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -27,6 +27,15 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     assert Phoenix.Component.Declarative.__global__?("phx-click")
   end
 
+  defmodule CustomGlobals do
+    use Phoenix.Component, global_prefixes: ~w(myprefix-)
+  end
+
+  test "custom __global__?" do
+    assert CustomGlobals.__global__?("myprefix-a")
+    refute CustomGlobals.__global__?("otherprefix-a")
+  end
+
   defmodule RemoteFunctionComponentWithAttrs do
     use Phoenix.Component
 

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -28,12 +28,14 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
   end
 
   defmodule CustomGlobals do
-    use Phoenix.Component, global_prefixes: ~w(myprefix-)
+    use Phoenix.Component, globals: ~w(customattr), global_prefixes: ~w(myprefix-)
   end
 
   test "custom __global__?" do
     assert CustomGlobals.__global__?("myprefix-a")
     refute CustomGlobals.__global__?("otherprefix-a")
+
+    assert CustomGlobals.__global__?("customattr")
   end
 
   defmodule RemoteFunctionComponentWithAttrs do


### PR DESCRIPTION
Adds option like:

```elixir
use Phoenix.Component, globals: ~w(custom-attr)`
```

This is useful if you're working with web components with custom attribute names as described in [this ElixirConf video](https://www.youtube.com/watch?v=xXWyOy9XdA8). It would also be useful when working with new or experimental HTML attributes that aren't already in the `@globals` list that is hardcoded into `Phoenix.Component.Declarative`.