### PR TITLE
Include `.formatter.exs` in hex package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -136,7 +136,7 @@ defmodule Phoenix.LiveView.MixProject do
       },
       files:
         ~w(assets/js lib priv) ++
-          ~w(CHANGELOG.md LICENSE.md mix.exs package.json README.md)
+          ~w(CHANGELOG.md LICENSE.md mix.exs package.json README.md .formatter.exs)
     ]
   end
 


### PR DESCRIPTION
The `.formatter.exs` file contains an `export` option but the file isn't included in the package. For apps using Phoenix 1.6, the formatter wants to convert `slot :inner_block, required: true` to `slot(:inner_block, required: true)`.