### PR TITLE
`<img>` globals

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -81,6 +81,7 @@ defmodule Phoenix.Component.Declarative do
     onvolumechange
     onwaiting
     accesskey
+    alt
     autocapitalize
     autocomplete
     autofocus
@@ -92,6 +93,7 @@ defmodule Phoenix.Component.Declarative do
     draggable
     enterkeyhint
     exportparts
+    height
     hidden
     id
     inputmode
@@ -120,6 +122,7 @@ defmodule Phoenix.Component.Declarative do
     action
     placeholder
     pattern
+    width
   )
 
   @doc false

--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -88,6 +88,8 @@ defmodule Phoenix.Component.Declarative do
     class
     contenteditable
     contextmenu
+    crossorigin
+    decoding
     dir
     download
     draggable
@@ -98,18 +100,24 @@ defmodule Phoenix.Component.Declarative do
     id
     inputmode
     is
+    ismap
     itemid
     itemprop
     itemref
     itemscope
     itemtype
     lang
+    loading
     nonce
     part
+    referrerpolicy
     rel
     role
+    sizes
     slot
     spellcheck
+    src
+    srcset
     style
     tabindex
     target
@@ -122,6 +130,7 @@ defmodule Phoenix.Component.Declarative do
     action
     placeholder
     pattern
+    usemap
     width
   )
 


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img. I left out experimental and deprecated attributes.