### PR TITLE
Fix documentation for router hooks

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -575,6 +575,7 @@ defmodule Phoenix.LiveView do
         Ensures common `assigns` are applied to all LiveViews attaching this hook.
         "\""
         import Phoenix.LiveView
+        import Phoenix.Component
 
         def on_mount(:default, _params, _session, socket) do
           {:cont, assign(socket, :page_title, "DemoWeb")}


### PR DESCRIPTION
`assign` (used in line 581) is not imported from `Phoenix.LiveView` since 0.18, instead this is available in `Phoenix.Component`.