### PR TITLE
Accept global_prefixes option for LiveComponent

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -441,7 +441,7 @@ defmodule Phoenix.LiveComponent do
       @before_compile Phoenix.LiveView.Renderer
 
       # Phoenix.Component must come last so its @before_compile runs last
-      use Phoenix.Component, opts
+      use Phoenix.Component, Keyword.take(unquote(opts), [:global_prefixes])
 
       @doc false
       def __live__, do: %{kind: :component, module: __MODULE__}

--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -434,14 +434,14 @@ defmodule Phoenix.LiveComponent do
 
   alias Phoenix.LiveView.Socket
 
-  defmacro __using__(_) do
+  defmacro __using__(opts \\ []) do
     quote do
       import Phoenix.LiveView
       @behaviour Phoenix.LiveComponent
       @before_compile Phoenix.LiveView.Renderer
 
       # Phoenix.Component must come last so its @before_compile runs last
-      use Phoenix.Component
+      use Phoenix.Component, opts
 
       @doc false
       def __live__, do: %{kind: :component, module: __MODULE__}

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -479,7 +479,7 @@ defmodule Phoenix.LiveView do
       @before_compile Phoenix.LiveView
 
       # Phoenix.Component must come last so its @before_compile runs last
-      use Phoenix.Component, Keyword.take(unquote(opts), [:global_prefixes])
+      use Phoenix.Component, Keyword.take(opts, [:global_prefixes])
     end
   end
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -479,7 +479,7 @@ defmodule Phoenix.LiveView do
       @before_compile Phoenix.LiveView
 
       # Phoenix.Component must come last so its @before_compile runs last
-      use Phoenix.Component
+      use Phoenix.Component, Keyword.take(unquote(opts), [:global_prefixes])
     end
   end
 


### PR DESCRIPTION
This allows `use Phoenix.LiveComponent, global_prefixes: ~w(x-)` on the caller.

@chrismccord this appears to fix the issue I was seeing with `x-bind:disabled` failing compile checks. The caller in this situation was a LiveComponent so there was no way to set `global_prefixes` on the caller without this change.