### PR TITLE
Allow `values` before `default` in `attr`

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -411,18 +411,20 @@ defmodule Phoenix.Component.Declarative do
   defp attr_slot(name, nil), do: "#{inspect(name)}"
   defp attr_slot(name, slot), do: "#{inspect(name)} in slot #{inspect(slot)}"
 
-  defp validate_attr_default!(slot, name, _type, [default: default, values: values], line, file) do
-    unless default in values do
-      compile_error!(line, file, """
-      expected the default value for attr #{attr_slot(name, slot)} to be one of #{inspect(values)}, \
-      got: #{inspect(default)}
-      """)
-    end
-  end
+  defp validate_attr_default!(slot, name, type, opts, line, file) do
+    case {opts[:default], opts[:values]} do
+      {default, nil} ->
+        unless valid_value?(type, default) do
+          bad_default!(slot, name, type, default, line, file)
+        end
 
-  defp validate_attr_default!(slot, name, type, [default: default], line, file) do
-    unless valid_value?(type, default) do
-      bad_default!(slot, name, type, default, line, file)
+      {default, values} ->
+        unless default in values do
+          compile_error!(line, file, """
+          expected the default value for attr #{attr_slot(name, slot)} to be one of #{inspect(values)}, \
+          got: #{inspect(default)}
+          """)
+        end
     end
   end
 

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -67,6 +67,14 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     attr :text, :string, values: ["Save", "Cancel"]
     def button_with_values(assigns), do: ~H[<button><%= @text %></button>]
 
+    def button_with_values_and_default_1_line, do: __ENV__.line
+    attr :text, :string, values: ["Save", "Cancel"], default: "Save"
+    def button_with_values_and_default_1(assigns), do: ~H[<button><%= @text %></button>]
+
+    def button_with_values_and_default_2_line, do: __ENV__.line
+    attr :text, :string, default: "Save", values: ["Save", "Cancel"]
+    def button_with_values_and_default_2(assigns), do: ~H[<button><%= @text %></button>]
+
     def button_with_examples_line, do: __ENV__.line
     attr :text, :string, examples: ["Save", "Cancel"]
     def button_with_examples(assigns), do: ~H[<button><%= @text %></button>]
@@ -116,6 +124,8 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     with_global_line = FunctionComponentWithAttrs.with_global_line()
     button_with_defaults_line = FunctionComponentWithAttrs.button_with_defaults_line()
     button_with_values_line = FunctionComponentWithAttrs.button_with_values_line()
+    button_with_values_and_default_1_line = FunctionComponentWithAttrs.button_with_values_and_default_1_line()
+    button_with_values_and_default_2_line = FunctionComponentWithAttrs.button_with_values_and_default_2_line()
     button_with_examples_line = FunctionComponentWithAttrs.button_with_examples_line()
 
     assert FunctionComponentWithAttrs.__components__() == %{
@@ -245,6 +255,36 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                ],
                slots: []
              },
+             button_with_values_and_default_1: %{
+              kind: :def,
+              attrs: [
+                %{
+                  line: button_with_values_and_default_1_line + 1,
+                  name: :text,
+                  opts: [values: ["Save", "Cancel"], default: "Save"],
+                  required: false,
+                  doc: nil,
+                  slot: nil,
+                  type: :string
+                }
+              ],
+              slots: []
+            },
+            button_with_values_and_default_2: %{
+              kind: :def,
+              attrs: [
+                %{
+                  line: button_with_values_and_default_2_line + 1,
+                  name: :text,
+                  opts: [default: "Save", values: ["Save", "Cancel"]],
+                  required: false,
+                  doc: nil,
+                  slot: nil,
+                  type: :string
+                }
+              ],
+              slots: []
+            },
              button_with_examples: %{
                kind: :def,
                attrs: [


### PR DESCRIPTION
This fixes a compilation error when the attributes are "wrongly" ordered.
(Also added two test cases for both orderings.)

Example:
```elixir
  attr :variant, :string, values: ["normal", "outline"], default: "normal"
```

results in 

```
== Compilation error in file some_file.ex ==
** (FunctionClauseError) no function clause matching in Phoenix.Component.Declarative.validate_attr_default!/6    
    
    The following arguments were given to Phoenix.Component.Declarative.validate_attr_default!/6:
    
        # 1
        nil
    
        # 2
        :variant
    
        # 3
        :string
    
        # 4
        [values: ["normal", "outline"], default: "normal"]
    
        # 5
        18
    
        # 6
        "path/to/some_file.ex"
    
    Attempted function clauses (showing 2 out of 2):
    
        defp validate_attr_default!(slot, name, _type, [default: default, values: values], line, file)
        defp validate_attr_default!(slot, name, type, [default: default], line, file)
    
    (phoenix_live_view 0.18.1) lib/phoenix_component/declarative.ex:414: Phoenix.Component.Declarative.validate_attr_default!/6
    (phoenix_live_view 0.18.1) lib/phoenix_component/declarative.ex:349: Phoenix.Component.Declarative.__attr__!/6
```