### PR TITLE
Fix syntax error typos in docs

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -205,12 +205,12 @@ defmodule Phoenix.LiveComponent do
         use Phoenix.LiveComponent
 
         def render(assigns) do
-          ~H"\""
+          ~H"""
           <form phx-submit="..." phx-target={@myself}>
             <input name="title"><%= @card.title %></input>
             ...
           </form>
-          "\""
+          """
         end
 
         ...
@@ -357,11 +357,11 @@ defmodule Phoenix.LiveComponent do
         use Phoenix.LiveComponent
 
         def render(assigns) do
-          ~H"\""
+          ~H"""
           <button class="css-framework-class" phx-click="click">
             <%= @text %>
           </button>
-          "\""
+          """
         end
 
         def handle_event("click", _, socket) do
@@ -373,11 +373,11 @@ defmodule Phoenix.LiveComponent do
   Instead, it is much simpler to create a function component:
 
       def my_button(%{text: _, click: _} = assigns) do
-        ~H"\""
+        ~H"""
         <button class="css-framework-class" phx-click={@click}>
           <%= @text %>
         </button>
-        "\""
+        """
       end
 
   If you keep components mostly as an application concern with


### PR DESCRIPTION
These make the docs look a bit funny:

<img width="462" alt="Screen Shot 2022-09-29 at 1 41 32 pm" src="https://user-images.githubusercontent.com/543859/192948134-d24ad6e3-54b8-4785-aec4-07b018e0217f.png">

(this was reported by someone else on Slack but they didn't have the time to fix it, and it doesn't look like anyone else has yet)