### PR TITLE
Fix changelog mentioning live_upload_preview instead of live_img_preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ## Bug Fixes
   * Fix phx-loading class being applied to dead views
-  * Fix `<.live_upload_preview />` causing invalid attribute errors on uploads
+  * Fix `<.live_img_preview />` causing invalid attribute errors on uploads
   * Do not fire phx events when element is disabled
 
 ## Enhancements


### PR DESCRIPTION
I've noticed that in changelog it mentioned `live_upload_preview` where it should be `live_img_preview`