### PR TITLE
Ensure phx-click-away bindings are handled in the view or component they're defined.

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -636,7 +636,7 @@ export default class LiveSocket {
     let phxClickAway = this.binding("click-away")
     DOM.all(document, `[${phxClickAway}]`, el => {
       if(!(el.isSameNode(clickStartedAt) || el.contains(clickStartedAt))){
-        this.withinOwners(e.target, view => {
+        this.withinOwners(el, view => {
           let phxEvent = el.getAttribute(phxClickAway)
           if(JS.isVisible(el)){
             JS.exec("click", phxEvent, view, el, ["push", {data: this.eventMeta("click", e, e.target)}])


### PR DESCRIPTION
I ran into this bug with nested LiveViews. If you're in a LiveView that is inside the root and click anywhere, this can trigger `phx-click-away` events to fire from the root view but be handled in the nested view that may not have handlers defined, causing the app to crash.