### PR TITLE
Fix formatting error in `bindings.md`

### DIFF
--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -22,7 +22,7 @@ callback, for example:
 | [Key Events](#key-events) | `phx-keydown`, `phx-keyup`, `phx-window-keydown`, `phx-window-keyup`, `phx-key` |
 | [DOM Patching](dom-patching.md) | `phx-mounted`, `phx-update`, `phx-remove` |
 | [JS Interop](js-interop.md#client-hooks) | `phx-hook` |
-| [Lifecycle Events](#lifecycle-events) | `phx-mounted` | `phx-disconnected` | `phx-connected`|
+| [Lifecycle Events](#lifecycle-events) | `phx-mounted`, `phx-disconnected`, `phx-connected` |
 | [Rate Limiting](#rate-limiting-events-with-debounce-and-throttle) | `phx-debounce`, `phx-throttle` |
 | [Static tracking](`Phoenix.LiveView.static_changed?/1`) | `phx-track-static` |
 


### PR DESCRIPTION
This causes the generated hexdocs to break the table at this point - there's more columns than the table is expecting

Currently it looks like this:

<img width="850" alt="Screen Shot 2022-10-06 at 2 20 54 pm" src="https://user-images.githubusercontent.com/543859/194229059-0d89ad62-c0e7-49a4-8164-039018b8acd8.png">
