### PR TITLE
Validating :map attributes

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1522,7 +1522,7 @@ defmodule Phoenix.Component do
 
   * You specify a literal attribute (such as `value="string"` or `value`, but not `value={expr}`)
   and the type does not match. The following types currently support literal validation:
-  `:string`, `:atom`, `:boolean`, `:integer`, `:float`, and `:list`.
+  `:string`, `:atom`, `:boolean`, `:integer`, `:float`, `:map` and `:list`.
 
   * You specify a literal attribute and it is not a member of the `:values` list.
 

--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -1236,6 +1236,7 @@ defmodule Phoenix.LiveView.HTMLEngine do
 
   defp attr_type({:<<>>, _, _} = value), do: {:string, value}
   defp attr_type(value) when is_list(value), do: {:list, value}
+  defp attr_type(value = {:%{}, _, _}), do: {:map, value}
   defp attr_type(value) when is_binary(value), do: {:string, value}
   defp attr_type(value) when is_integer(value), do: {:integer, value}
   defp attr_type(value) when is_float(value), do: {:float, value}

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -124,8 +124,13 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     with_global_line = FunctionComponentWithAttrs.with_global_line()
     button_with_defaults_line = FunctionComponentWithAttrs.button_with_defaults_line()
     button_with_values_line = FunctionComponentWithAttrs.button_with_values_line()
-    button_with_values_and_default_1_line = FunctionComponentWithAttrs.button_with_values_and_default_1_line()
-    button_with_values_and_default_2_line = FunctionComponentWithAttrs.button_with_values_and_default_2_line()
+
+    button_with_values_and_default_1_line =
+      FunctionComponentWithAttrs.button_with_values_and_default_1_line()
+
+    button_with_values_and_default_2_line =
+      FunctionComponentWithAttrs.button_with_values_and_default_2_line()
+
     button_with_examples_line = FunctionComponentWithAttrs.button_with_examples_line()
 
     assert FunctionComponentWithAttrs.__components__() == %{
@@ -256,35 +261,35 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                slots: []
              },
              button_with_values_and_default_1: %{
-              kind: :def,
-              attrs: [
-                %{
-                  line: button_with_values_and_default_1_line + 1,
-                  name: :text,
-                  opts: [values: ["Save", "Cancel"], default: "Save"],
-                  required: false,
-                  doc: nil,
-                  slot: nil,
-                  type: :string
-                }
-              ],
-              slots: []
-            },
-            button_with_values_and_default_2: %{
-              kind: :def,
-              attrs: [
-                %{
-                  line: button_with_values_and_default_2_line + 1,
-                  name: :text,
-                  opts: [default: "Save", values: ["Save", "Cancel"]],
-                  required: false,
-                  doc: nil,
-                  slot: nil,
-                  type: :string
-                }
-              ],
-              slots: []
-            },
+               kind: :def,
+               attrs: [
+                 %{
+                   line: button_with_values_and_default_1_line + 1,
+                   name: :text,
+                   opts: [values: ["Save", "Cancel"], default: "Save"],
+                   required: false,
+                   doc: nil,
+                   slot: nil,
+                   type: :string
+                 }
+               ],
+               slots: []
+             },
+             button_with_values_and_default_2: %{
+               kind: :def,
+               attrs: [
+                 %{
+                   line: button_with_values_and_default_2_line + 1,
+                   name: :text,
+                   opts: [default: "Save", values: ["Save", "Cancel"]],
+                   required: false,
+                   doc: nil,
+                   slot: nil,
+                   type: :string
+                 }
+               ],
+               slots: []
+             },
              button_with_examples: %{
                kind: :def,
                attrs: [
@@ -814,6 +819,11 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       ## Attributes
 
       * `attr` (`:float`)
+      """,
+      fun_attr_map: """
+      ## Attributes
+
+      * `attr` (`:map`)
       """,
       fun_attr_list: """
       ## Attributes

--- a/test/phoenix_component/verify_test.exs
+++ b/test/phoenix_component/verify_test.exs
@@ -131,6 +131,7 @@ defmodule Phoenix.ComponentVerifyTest do
           attr :boolean, :boolean
           attr :integer, :integer
           attr :float, :float
+          attr :map, :map
           attr :list, :list
           attr :global, :global
 
@@ -154,6 +155,7 @@ defmodule Phoenix.ComponentVerifyTest do
             <.func any={true} />
             <.func any={1} />
             <.func any={1.0} />
+            <.func any={%{}} />
             <.func any={[]} />
             <.func any={nil} />
             """
@@ -168,6 +170,7 @@ defmodule Phoenix.ComponentVerifyTest do
             <.func string={true} />
             <.func string={1} />
             <.func string={1.0} />
+            <.func string={%{}} />
             <.func string={[]} />
             <.func string={nil} />
             """
@@ -182,6 +185,7 @@ defmodule Phoenix.ComponentVerifyTest do
             <.func atom={true} />
             <.func atom={1} />
             <.func atom={1.0} />
+            <.func atom={%{}} />
             <.func atom={[]} />
             <.func atom={nil} />
             """
@@ -196,6 +200,7 @@ defmodule Phoenix.ComponentVerifyTest do
             <.func boolean={true} />
             <.func boolean={1} />
             <.func boolean={1.0} />
+            <.func boolean={%{}} />
             <.func boolean={[]} />
             <.func boolean={nil} />
             """
@@ -210,6 +215,7 @@ defmodule Phoenix.ComponentVerifyTest do
             <.func integer={true} />
             <.func integer={1} />
             <.func integer={1.0} />
+            <.func integer={%{}} />
             <.func integer={[]} />
             <.func integer={nil} />
             """
@@ -224,8 +230,24 @@ defmodule Phoenix.ComponentVerifyTest do
             <.func float={true} />
             <.func float={1} />
             <.func float={1.0} />
+            <.func float={%{}} />
             <.func float={[]} />
             <.func float={nil} />
+            """
+          end
+
+          def render_map_line, do: __ENV__.line + 4
+
+          def map_render(assigns) do
+            ~H"""
+            <.func map="map" />
+            <.func map={:map} />
+            <.func map={true} />
+            <.func map={1} />
+            <.func map={1.0} />
+            <.func map={%{}} />
+            <.func map={[]} />
+            <.func map={nil} />
             """
           end
 
@@ -238,6 +260,7 @@ defmodule Phoenix.ComponentVerifyTest do
             <.func list={true} />
             <.func list={1} />
             <.func list={1.0} />
+            <.func list={%{}} />
             <.func list={[]} />
             <.func list={nil} />
             """
@@ -261,8 +284,9 @@ defmodule Phoenix.ComponentVerifyTest do
           {true, 2},
           {1, 3},
           {1.0, 4},
-          {[], 5},
-          {nil, 6}
+          {%{}, 5},
+          {[], 6},
+          {nil, 7}
         ] do
       assert warnings =~ """
              attribute "string" in component \
@@ -278,7 +302,8 @@ defmodule Phoenix.ComponentVerifyTest do
           {"atom", 0},
           {1, 3},
           {1.0, 4},
-          {[], 5}
+          {%{}, 5},
+          {[], 6}
         ] do
       assert warnings =~ """
              attribute "atom" in component \
@@ -295,8 +320,9 @@ defmodule Phoenix.ComponentVerifyTest do
           {:boolean, 1},
           {1, 3},
           {1.0, 4},
-          {[], 5},
-          {nil, 6}
+          {%{}, 5},
+          {[], 6},
+          {nil, 7}
         ] do
       assert warnings =~ """
              attribute "boolean" in component \
@@ -313,8 +339,9 @@ defmodule Phoenix.ComponentVerifyTest do
           {:integer, 1},
           {true, 2},
           {1.0, 4},
-          {[], 5},
-          {nil, 6}
+          {%{}, 5},
+          {[], 6},
+          {nil, 7}
         ] do
       assert warnings =~ """
              attribute "integer" in component \
@@ -331,13 +358,33 @@ defmodule Phoenix.ComponentVerifyTest do
           {:float, 1},
           {true, 2},
           {1, 3},
-          {[], 5},
-          {nil, 6}
+          {%{}, 5},
+          {[], 6},
+          {nil, 7}
         ] do
       assert warnings =~ """
              attribute "float" in component \
              Phoenix.ComponentVerifyTest.TypeAttrs.func/1 \
              must be a :float, got: #{inspect(value)}
+               test/phoenix_component/verify_test.exs:#{line + offset}: (file)
+             """
+    end
+
+    line = get_line(__MODULE__.TypeAttrs, :render_map_line)
+
+    for {value, offset} <- [
+          {"map", 0},
+          {:map, 1},
+          {true, 2},
+          {1, 3},
+          {1.0, 4},
+          {[], 6},
+          {nil, 7}
+        ] do
+      assert warnings =~ """
+             attribute "map" in component \
+             Phoenix.ComponentVerifyTest.TypeAttrs.func/1 \
+             must be a :map, got: #{inspect(value)}
                test/phoenix_component/verify_test.exs:#{line + offset}: (file)
              """
     end
@@ -350,7 +397,8 @@ defmodule Phoenix.ComponentVerifyTest do
           {true, 2},
           {1, 3},
           {1.0, 4},
-          {nil, 6}
+          {%{}, 5},
+          {nil, 7}
         ] do
       assert warnings =~ """
              attribute "list" in component \

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -42,6 +42,9 @@ defmodule Phoenix.LiveViewTest.FunctionComponentWithAttrs do
   attr :attr, :float
   def fun_attr_float(assigns), do: ~H[]
 
+  attr :attr, :map
+  def fun_attr_map(assigns), do: ~H[]
+
   attr :attr, :list
   def fun_attr_list(assigns), do: ~H[]
 


### PR DESCRIPTION
Related to #2226 

Seems that in the current code in master, the `:map` type was already supported, just was not used for value validation.

I don't know if it was on purpose, because I had to do some special handling on this type (see my addition in  `html_engine.ex`)