### PR TITLE
Guides: replace `live_patch` with `<.link>`, mention `phx-page-loading` with other loading states

### DIFF
--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -377,3 +377,6 @@ container:
   - `"phx-error"` - applied when an error occurs on the server. Note, this
     class will be applied in conjunction with `"phx-loading"` if connection
     to the server is lost.
+
+For navigation related loading states (both automatic and manual), see `phx-page-loading` as described in
+[JavaScript interoperability: Live navigation events](js-interop.html#live-navigation-events).

--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -76,8 +76,8 @@ their own events too.
 
 ### Live navigation events
 
-For live page navigation via `live_redirect` and `live_patch`, their server-side
-equivalents `push_redirect` and `push_patch`, as well as form
+For live page navigation via `<.link navigate={...}>` and `<.link patch={...}>`,
+their server-side equivalents `push_redirect` and `push_patch`, as well as form
 submits via `phx-submit`, the JavaScript events `"phx:page-loading-start"` and
 `"phx:page-loading-stop"` are dispatched on window. Additionally, any `phx-`
 event may dispatch page loading events by annotating the DOM element with


### PR DESCRIPTION
Update `live_*` for `<.link>`.

Adds mention of `phx-page-loading` near other "loading states" docs so it can be found a bit more organically. Unsure if that's the correct syntax to link between guides once it's generated.

