### PR TITLE
Fix exception thrown when slots have global attr

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -120,7 +120,12 @@ defmodule Phoenix.Component.Declarative do
 
   @doc false
   def __global__?(module, name, global_attr \\ nil) when is_atom(module) and is_binary(name) do
-    includes = global_attr && Keyword.get(global_attr.opts, :include, [])
+    includes =
+      if global_attr do
+        Keyword.get(global_attr.opts, :include, [])
+      else
+        []
+      end
 
     if function_exported?(module, :__global__?, 1) do
       module.__global__?(name) or __global__?(name) or name in includes

--- a/test/phoenix_component/verify_test.exs
+++ b/test/phoenix_component/verify_test.exs
@@ -903,7 +903,9 @@ defmodule Phoenix.ComponentVerifyTest do
 
           def func(assigns), do: ~H[]
 
-          slot :named
+          slot :named do
+            attr :rest, :global
+          end
 
           def func_undefined_slot_attrs(assigns), do: ~H[]
 


### PR DESCRIPTION
Before this change `includes` defaulted to nil, which caused an exception (`Enumerable not implemented for nil of type Atom`) to raise during compilation if you had a slot with a global attr defined.