### PR TITLE
docgen: fix rendering of integer lists & omit "and"/"or" for examples/values with only one item

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -877,9 +877,9 @@ defmodule Phoenix.Component.Declarative do
     case Keyword.fetch(opts, :include) do
       {:ok, [_ | _] = inc} ->
         if doc do
-          [build_doc(doc, indent, true), "Supports all globals plus: `", inspect(inc), "`."]
+          [build_doc(doc, indent, true), "Supports all globals plus: ", build_literal(inc), "."]
         else
-          ["Supports all globals plus: `", inspect(inc), "`."]
+          ["Supports all globals plus: ", build_literal(inc), "."]
         end
 
       _ ->
@@ -891,9 +891,9 @@ defmodule Phoenix.Component.Declarative do
     case Keyword.fetch(opts, :default) do
       {:ok, default} ->
         if doc do
-          [build_doc(doc, indent, true), "Defaults to `", inspect(default), "`."]
+          [build_doc(doc, indent, true), "Defaults to ", build_literal(default), "."]
         else
-          ["Defaults to `", inspect(default), "`."]
+          ["Defaults to ", build_literal(default), "."]
         end
 
       :error ->
@@ -941,10 +941,18 @@ defmodule Phoenix.Component.Declarative do
     []
   end
 
+  defp build_literals_list([literal], _condition) do
+    [build_literal(literal)]
+  end
+
   defp build_literals_list(literals, condition) do
     literals
-    |> Enum.map_intersperse(", ", &[?`, inspect(&1), ?`])
+    |> Enum.map_intersperse(", ", &build_literal/1)
     |> List.insert_at(-2, [condition, " "])
+  end
+
+  defp build_literal(literal) do
+    [?`, inspect(literal, charlists: :as_list), ?`]
   end
 
   defp build_hyphen(%{doc: doc}) when is_binary(doc) do

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -962,6 +962,8 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
 
       * `attr1` (`:atom`) - Must be one of `:foo`, `:bar`, or `:baz`.
       * `attr2` (`:atom`) - Examples include `:foo`, `:bar`, and `:baz`.
+      * `attr3` (`:list`) - Must be one of `[60, 40]`.
+      * `attr4` (`:list`) - Examples include `[60, 40]`.
       """
     }
 

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -163,6 +163,8 @@ defmodule Phoenix.LiveViewTest.FunctionComponentWithAttrs do
 
   attr :attr1, :atom, values: [:foo, :bar, :baz]
   attr :attr2, :atom, examples: [:foo, :bar, :baz]
+  attr :attr3, :list, values: [[60, 40]]
+  attr :attr4, :list, examples: [[60, 40]]
 
   def fun_attr_values_examples(assigns), do: ~H[]
 end


### PR DESCRIPTION
See https://github.com/phoenixframework/phoenix_live_view/issues/2277