### PR TITLE
Update assigns_to_attributes/2 documentation

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -726,14 +726,14 @@ defmodule Phoenix.Component do
   would like to add to the element, such as class, data attributes, etc:
 
   ```heex
-  <.my_link href="/" id={@id} new_window={true} class="my-class">Home</.my_link>
+  <.my_link to="/" id={@id} new_window={true} class="my-class">Home</.my_link>
   ```
 
   We could support the dynamic attributes with the following component:
 
       def my_link(assigns) do
         target = if assigns[:new_window], do: "_blank", else: false
-        extra = assigns_to_attributes(assigns, [:new_window])
+        extra = assigns_to_attributes(assigns, [:new_window, :to])
 
         assigns =
           assigns
@@ -741,7 +741,7 @@ defmodule Phoenix.Component do
           |> assign(:extra, extra)
 
         ~H"""
-        <a href={@href} target={@target} {@extra}>
+        <a href={@to} target={@target} {@extra}>
           <%= render_slot(@inner_block) %>
         </a>
         """


### PR DESCRIPTION
Currently the example in the documentation actually double renders the `href` attribute, as it is statically declared as well as passed in the `@extra` assign as dynamic attributes.

This merely updates it so that the component takes a `to` assign (similar to the old fashioned `link/2` function from `phoenix_html`), and so that the example is is "technically" correct.

I don't think the browser cares at all about the double attribute, but when I noticed it while reading it had me scratching my head for a moment wondering if it automatically de-duped attributes or not.

I had also thought about removed the static href declaration entirely, but i figured since it's necessary for a valid anchor tag, you'd want it to error if the assign isn't present.

Thanks!
