### PR TITLE
Update security model documentation

### DIFF
--- a/guides/server/security-model.md
+++ b/guides/server/security-model.md
@@ -64,7 +64,7 @@ which allows you to encapsulate this logic and execute it on every mount,
 as you would with plug:
 
     defmodule MyAppWeb.UserLiveAuth do
-      import Phoenix.Component, only: [assign_new: 3]
+      import Phoenix.Component
       import Phoenix.LiveView
 
       def on_mount(:default, _params, %{"user_id" => user_id} = _session, socket) do

--- a/guides/server/security-model.md
+++ b/guides/server/security-model.md
@@ -64,6 +64,7 @@ which allows you to encapsulate this logic and execute it on every mount,
 as you would with plug:
 
     defmodule MyAppWeb.UserLiveAuth do
+      import Phoenix.Component, only: [assign_new: 3]
       import Phoenix.LiveView
 
       def on_mount(:default, _params, %{"user_id" => user_id} = _session, socket) do


### PR DESCRIPTION
I was following this documentation but unfortunately the `assign_new` function and its friends have recently moved to `Phoenix.Component`. The `only:` is unnecessary but it feels a bit awkward (maybe?) to bring in everything from `Component` into this `on_mount`.

Hoping this is techically correct 🤞 I can also just `import Phoenix.Component` upon request 😛 (or let a maintainer do it)