### PR TITLE
Fix typo in Phoenix.Component @moduledoc

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -716,7 +716,7 @@ defmodule Phoenix.Component do
 
   ```heex
   <.table id="my-table" rows={@users}>
-    <:col :for={header <- @headers} let={user}>
+    <:col :for={header <- @headers} :let={user}>
       <td><%= user[:header] %></td>
     </:col>
   <table>


### PR DESCRIPTION
Code example is missing `:` for `:let`