### PR TITLE
Slot without do-block attr warning fix

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -812,7 +812,7 @@ defmodule Phoenix.Component.Declarative do
           build_attr_values_or_examples(attr)
         ]
       end,
-      if Enum.any?(attrs, & &1.type == :global) do
+      if Enum.any?(attrs, &(&1.type == :global)) do
         "\nGlobal attributes are accepted."
       else
         ""
@@ -1167,6 +1167,22 @@ defmodule Phoenix.Component.Declarative do
 
                 # undefined slot attr
                 %{} ->
+                  cond do
+                    attr_name == :inner_block or
+                        (has_global? and __global__?(caller_module, Atom.to_string(attr_name))) ->
+                      :ok
+
+                    attrs == [] ->
+                      :ok
+
+                    true ->
+                      message =
+                        "undefined attribute \"#{attr_name}\" in slot \"#{slot_name}\" " <>
+                          "for component #{component_fa(call)}"
+
+                      warn(message, call.file, line)
+                  end
+
                   if attr_name == :inner_block or
                        (has_global? and __global__?(caller_module, Atom.to_string(attr_name))) do
                     :ok

--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -1182,17 +1182,6 @@ defmodule Phoenix.Component.Declarative do
 
                       warn(message, call.file, line)
                   end
-
-                  if attr_name == :inner_block or
-                       (has_global? and __global__?(caller_module, Atom.to_string(attr_name))) do
-                    :ok
-                  else
-                    message =
-                      "undefined attribute \"#{attr_name}\" in slot \"#{slot_name}\" " <>
-                        "for component #{component_fa(call)}"
-
-                    warn(message, call.file, line)
-                  end
               end
             end
         end

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -1155,6 +1155,30 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     end
   end
 
+  test "does not raise for basic slot (no do-block) when slot attr type is not supported" do
+    defmodule BasicSlotAttrTypeNotSupported do
+      use Phoenix.Component
+
+      slot :item
+
+      def list(assigns) do
+        ~H"""
+        <div>
+          <%= render_slot(@item) %>
+        </div>
+        """
+      end
+
+      def use_list(assigns) do
+        ~H"""
+          <.list>
+            <:item class="test"></:item>
+          </.list>
+        """
+      end
+    end
+  end
+
   test "raise if slot attr type is not supported" do
     msg = ~r"invalid type :not_a_type for attr :foo in slot :named"
 

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -1155,30 +1155,6 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     end
   end
 
-  test "does not raise for basic slot (no do-block) when slot attr type is not supported" do
-    defmodule BasicSlotAttrTypeNotSupported do
-      use Phoenix.Component
-
-      slot :item
-
-      def list(assigns) do
-        ~H"""
-        <div>
-          <%= render_slot(@item) %>
-        </div>
-        """
-      end
-
-      def use_list(assigns) do
-        ~H"""
-          <.list>
-            <:item class="test"></:item>
-          </.list>
-        """
-      end
-    end
-  end
-
   test "raise if slot attr type is not supported" do
     msg = ~r"invalid type :not_a_type for attr :foo in slot :named"
 

--- a/test/phoenix_component/verify_test.exs
+++ b/test/phoenix_component/verify_test.exs
@@ -468,6 +468,35 @@ defmodule Phoenix.ComponentVerifyTest do
            """
   end
 
+  test "does not warn for unknown attribute in slot without do-block" do
+    warnings =
+      capture_io(:stderr, fn ->
+        defmodule SlotWithoutDoBlock do
+          use Phoenix.Component
+
+          slot :item
+
+          def func_slot_wo_do_block(assigns) do
+            ~H"""
+            <div>
+              <%= render_slot(@item) %>
+            </div>
+            """
+          end
+
+          def render(assigns) do
+            ~H"""
+            <.func_slot_wo_do_block>
+              <:item class="test"></:item>
+            </.func_slot_wo_do_block>
+            """
+          end
+        end
+      end)
+
+    assert warnings == ""
+  end
+
   test "validates slot attr values" do
     warnings =
       capture_io(:stderr, fn ->
@@ -909,7 +938,9 @@ defmodule Phoenix.ComponentVerifyTest do
 
           def func(assigns), do: ~H[]
 
-          slot :named
+          slot :named do
+            attr :attr, :string
+          end
 
           def func_undefined_slot_attrs(assigns), do: ~H[]
 


### PR DESCRIPTION
I like to run my mix projects with `warnings_as_errors: true` by default, and I've been experiencing `"undefined attribute \"#{attr_name}\" in slot \"#{slot_name}\" for component #{component_fa(call)}"` compiler warnings similarly described in this comment, https://github.com/phoenixframework/phoenix_live_view/issues/2265#issuecomment-1303252142, in this issue, https://github.com/phoenixframework/phoenix_live_view/issues/2265.  This PR updates `declarative.ex` to match expectations as described by @josevalim in https://github.com/phoenixframework/phoenix_live_view/issues/2265#issuecomment-1272110925 in the same issue.