### PR TITLE
Relax regex used during js navigation (redirect)

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -739,7 +739,7 @@ export default class LiveSocket {
   historyRedirect(href, linkState, flash){
     // convert to full href if only path prefix
     if(!this.isConnected()){ return Browser.redirect(href, flash) }
-    if(/^\/+.*$/.test(href)){
+    if(/^\/$|^\/[^\/]+.*$/.test(href)){
       let {protocol, host} = window.location
       href = `${protocol}//${host}${href}`
     }

--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -739,7 +739,7 @@ export default class LiveSocket {
   historyRedirect(href, linkState, flash){
     // convert to full href if only path prefix
     if(!this.isConnected()){ return Browser.redirect(href, flash) }
-    if(/^\/[^\/]+.*$/.test(href)){
+    if(/^\/+.*$/.test(href)){
       let {protocol, host} = window.location
       href = `${protocol}//${host}${href}`
     }


### PR DESCRIPTION
There seems to be a bug when navigating to the sites root via `JS.navigate/1`, and maybe other functions that use `LiveSocket.historyRedirect`

Can be reproduced by performing `JS.navigate("/")`  

The LV server process crashes with this CaseClauseError:

```
** (CaseClauseError) no case clause matching: %Phoenix.LiveView.Route{path: [], view: ComponentsWeb.HomeLive.Index, action: :index, opts: [action: :index, router: ComponentsWeb.Router], live_session: %{extra: %{on_mount: [%{function: &ComponentsWeb.InitAssigns.on_mount/4, id: {ComponentsWeb.InitAssigns, :default}, stage: :mount}], session: %{}}, name: :default, vsn: 1668894584134865752}, params: %{}, uri: %URI{scheme: nil, userinfo: nil, host: nil, port: nil, path: "/", query: nil, fragment: nil}}
    (phoenix_live_view 0.18.3) lib/phoenix_live_view/channel.ex:990: Phoenix.LiveView.Channel.verified_mount/8
    (phoenix_live_view 0.18.3) lib/phoenix_live_view/channel.ex:59: Phoenix.LiveView.Channel.handle_info/2
```
My investigation has concluded it is because `scheme` and `host` are not being supplied with the `uri`, due to a regex in the JS code.

A workaround is to supply something innocuous to the URL like `/?`, which is `accepted` by the regex performed on the supplied href. 

I am not completely sure what the purpose of the regex is (what a surprise :P) ,  pretty sure it is only there to ensure this function is not called with an external URL. The proposed improvement solves the problem but is surely not as strict

There is probably a better way that does not involve a regex at all? 

fixes #2334

