### PR TITLE
Update sample code for on_mount authentication

### DIFF
--- a/guides/server/security-model.md
+++ b/guides/server/security-model.md
@@ -70,11 +70,13 @@ as you would with plug:
     defmodule MyAppWeb.UserLiveAuth do
       import Phoenix.Component
       import Phoenix.LiveView
+      alias MyAppWeb.Accounts # from `mix gen.phx.auth`
 
-      def on_mount(:default, _params, %{"user_id" => user_id} = _session, socket) do
-        socket = assign_new(socket, :current_user, fn ->
-          Accounts.get_user!(user_id)
-        end)
+      def on_mount(:default, _params, %{"user_token" => user_token} = _session, socket) do
+        socket =
+          assign_new(socket, :current_user, fn ->
+            Accounts.get_user_by_session_token(user_token)
+          end)
 
         if socket.assigns.current_user.confirmed_at do
           {:cont, socket}


### PR DESCRIPTION
This fails `%{"user_id" => user_id} = _session` because session does not contain `user_id`, however it does contain `user_token`.

I'm using:
```elixir
  defp deps do
    [
      {:phoenix, "~> 1.6.13"},
      {:phoenix_html, "~> 3.0"},
      {:phoenix_live_reload, "~> 1.2", only: :dev},
      {:phoenix_live_view, "~> 0.18.3"},
      {:plug_cowboy, "~> 2.5"},
    ]
  end
```