### PR TITLE
Docs: Explain sockets as a server-only data struct

### DIFF
--- a/guides/server/assigns-eex.md
+++ b/guides/server/assigns-eex.md
@@ -1,6 +1,11 @@
 # Assigns and HEEx templates
 
 All of the data in a LiveView is stored in the socket as assigns.
+The socket state is a server side struct in  `Phoenix.LiveView.Socket`
+and `Phoenix.Socket` which maintains state through a GenServer,
+there is one process per socket connection, the socket is never
+shared with the client.
+
 The `Phoenix.Component.assign/2` and `Phoenix.Component.assign/3`
 functions help store those values. Those values can be accessed
 in the LiveView as `socket.assigns.name` but they are accessed

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -37,6 +37,12 @@ defmodule Phoenix.LiveView do
   Any time a stateful view changes or updates its socket assigns, it is
   automatically re-rendered and the updates are pushed to the client.
 
+  Socket assigns are values kept on the server side by
+  `Phoenix.Socket`, this is different from the common pattern of sending
+  the connection state to the client in the form of a token or cookie,
+  typically used in HTTP requests. Under the hood there is a GenServer that
+  creates a process for each socket connection through `Phoenix.LiveView.Socket`.
+
   You begin by rendering a LiveView typically from your router.
   When LiveView is first rendered, the `c:mount/3` callback is invoked
   with the current params, the current session and the LiveView socket.


### PR DESCRIPTION
I was curious and went looking for this info in the source code, so I assume it might be nice to include in the docs. 

I also was not sure if `the socket` was something that stayed on the server only, or if it had information shared with the client, this is in contrast with using `conn` which does share information with the client.