### PR TITLE
[docs] Remove unused import from Gettext for I18n code sample

### DIFF
--- a/guides/server/using-gettext.md
+++ b/guides/server/using-gettext.md
@@ -25,8 +25,6 @@ You can also use the `on_mount` (`Phoenix.LiveView.on_mount/1`) hook to
 automatically restore the locale for every LiveView in your application:
 
     defmodule MyAppWeb.RestoreLocale do
-      import Phoenix.LiveView
-
       def on_mount(:default, _params, %{"locale" => locale} = _session, socket) do
         Gettext.put_locale(MyApp.Gettext, locale)
         {:cont, socket}


### PR DESCRIPTION
Fixes the warning

```
unused import Phoenix.LiveView
```

In the given example, the `RestoreLocale` hook is integrated for all live views by default, so it follows after the `use Phoenix.LiveView`.