### PR TITLE
Store submitted state on inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bug Fixes
   * Fix undefined _target param when using `JS.push` for form changes
+  * Fix `phx-no-feedback` missing from inputs added after a form submit
 
 ## 0.18.3 (2022-10-26)
 

--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -231,7 +231,7 @@ let DOM = {
     let input = field && container.querySelector(`[id="${field}"], [name="${field}"], [name="${field}[]"]`)
     if(!input){ return }
 
-    if(!(this.private(input, PHX_HAS_FOCUSED) || this.private(input.form, PHX_HAS_SUBMITTED))){
+    if(!(this.private(input, PHX_HAS_FOCUSED) || this.private(input, PHX_HAS_SUBMITTED))){
       el.classList.add(PHX_NO_FEEDBACK_CLASS)
     }
   },

--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -1125,6 +1125,7 @@ export default class View {
     DOM.putPrivate(form, PHX_HAS_SUBMITTED, true)
     let phxFeedback = this.liveSocket.binding(PHX_FEEDBACK_FOR)
     let inputs = Array.from(form.elements)
+    inputs.forEach(input => DOM.putPrivate(input, PHX_HAS_SUBMITTED, true))
     this.liveSocket.blurActiveElement(this)
     this.pushFormSubmit(form, targetCtx, phxEvent, opts, () => {
       inputs.forEach(input => DOM.showError(input, phxFeedback))

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -260,6 +260,9 @@ describe("View + DOM", function(){
 
       view.submitForm(form, form, {target: form})
       expect(DOM.private(form, "phx-has-submitted")).toBeTruthy()
+      Array.from(form.elements).forEach(input => {
+        expect(DOM.private(input, "phx-has-submitted")).toBeTruthy()
+      })
       expect(form.classList.contains("phx-submit-loading")).toBeTruthy()
       expect(form.querySelector("button").dataset.phxDisabled).toBeTruthy()
       expect(form.querySelector("input").dataset.phxReadonly).toBeTruthy()


### PR DESCRIPTION
Tracking form submitted state on each input allows new inputs to be added after a form submit without immediately showing their errors.

Closes #2350