### PR TITLE
Proposal: add support to embed .eex templates

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1401,14 +1401,15 @@ defmodule Phoenix.Component do
         def about_page(assigns)
       end
 
-  Multiple invocations of `embed_templates` is also supported.
+  Note that multiple invocations of `embed_templates` is supported,
+  and the following extensions are supported: .html.heex, .eex
   """
   defmacro embed_templates(pattern, opts \\ []) do
     quote do
       Phoenix.Template.compile_all(
         &Phoenix.Component.__embed__/1,
         Path.expand(unquote(opts)[:root] || __DIR__, __DIR__),
-        unquote(pattern) <> ".html"
+        unquote(pattern)
       )
     end
   end
@@ -1439,7 +1440,14 @@ defmodule Phoenix.Component do
   end
 
   @doc false
-  def __embed__(path), do: path |> Path.basename() |> Path.rootname() |> Path.rootname()
+  def __embed__(path) do
+    if Path.extname(path) in [".heex", ".eex"] do
+      [template | _] = Path.basename(path) |> Path.rootname() |> String.split(".")
+      template
+    else
+      raise ArgumentError, "expected template file ending in .html.eex or .eex, received: #{path}"
+    end
+  end
 
   @doc ~S'''
   Declares a function component slot.

--- a/test/phoenix_component/rendering_test.exs
+++ b/test/phoenix_component/rendering_test.exs
@@ -7,6 +7,7 @@ defmodule Phoenix.ComponentRenderingTest do
 
   embed_templates "pages/*"
   embed_templates "another_root/*", root: "pages"
+  embed_templates "templates/*"
 
   defp h2s(template) do
     template
@@ -47,6 +48,10 @@ defmodule Phoenix.ComponentRenderingTest do
 
       # attr'd bodyless definition
       assert render_component(&welcome_page/1) == "Welcome chris"
+    end
+
+    test "embed eex files" do
+      assert sitemap(%{}) =~ "sitemap"
     end
   end
 

--- a/test/phoenix_component/templates/sitemap.xml.eex
+++ b/test/phoenix_component/templates/sitemap.xml.eex
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+  </sitemap>
+</sitemapindex>


### PR DESCRIPTION
Commit https://github.com/phoenixframework/phoenix_live_view/commit/7e7e8eee854659e45d4c367d7ea902c19f40e88d is forcing `embed_templates/2` to compile only `.html*` template files, but I'm wondering if it could support `.eex` files too.

My use case is generating a Sitemap XML file, which is based on a `sitemap.xml.eex` template file. The alternative, in the case `embed_templates/2` won't support .eex, is to call `Phoenix.Template.compile_all/3`:

```elixir
defmodule MyAppWeb.SitemapXML do
  require Phoenix.Template

  Phoenix.Template.compile_all(
    fn path -> path |> Path.basename() |> Path.rootname(".xml.eex") end,
    __DIR__,
    "sitemap_xml/*"
  )
end
```

I think that's reasonable considering that `Phoenix.Template` list `eex` as a default engine:

```
iex> Phoenix.Template.engines()
%{
  eex: Phoenix.Template.EExEngine,
  exs: Phoenix.Template.ExsEngine,
  heex: Phoenix.LiveView.HTMLEngine,
  leex: Phoenix.LiveView.Engine
}
```

Wdyt?