### PR TITLE
Prevent app failure due to missing `<title>` tag

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -140,8 +140,12 @@ let DOM = {
 
   putTitle(str){
     let titleEl = document.querySelector("title")
-    let {prefix, suffix} = titleEl.dataset
-    document.title = `${prefix || ""}${str}${suffix || ""}`
+    if(titleEl){
+      let {prefix, suffix} = titleEl.dataset
+      document.title = `${prefix || ""}${str}${suffix || ""}`
+    } else {
+      document.title = str
+    }
   },
 
   debounce(el, event, phxDebounce, defaultDebounce, phxThrottle, defaultThrottle, asyncFilter, callback){


### PR DESCRIPTION
Browsers are capable of rendering pages with no title but LV breaks if it's missing.