### PR TITLE
Docs: Reduce ambiguity in live_session example code

### DIFF
--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -176,13 +176,15 @@ defmodule Phoenix.LiveView.Router do
   pipe through it:
 
       live_session :admin, on_mount: MyAppWeb.AdminLiveAuth do
-        # Regular routes
-        pipe_through [MyAppWeb.AdminPlugAuth]
-        get "/admin/health"
+        scope "/" do
+          # Regular routes
+          pipe_through [MyAppWeb.AdminPlugAuth]
+          get "/admin/health", AdminHealthController, :index
 
-        # Live routes
-        live "/admin", AdminDashboardLive, :index
-        live "/admin/posts", AdminPostLive, :index
+          # Live routes
+          live "/admin", AdminDashboardLive, :index
+          live "/admin/posts", AdminPostLive, :index
+        end
       end
 
   The opposite is also true, if you have regular http routes and you want to


### PR DESCRIPTION
I was going through the docs and spotted some possibly ambiguous code in the examples. This PR updates the code example to try and avoid confusion around plug pipelines, scopes, and live sessions.

I added a wrapping `scope` for the `pipe_through` call so developers do not assume `live_session` will implicitly generate a scope to restrict `MyAppWeb.AdminPlugAuth` to the admin live session routes.

The old example code will apply `MyAppWeb.AdminPlugAuth` to any routes defined after the `live_session :admin` block which may be unexpected for some developers. It's easy to see the wrapping `live_session` block and assume the plug pipeline will be restricted to that `do/end` block. If, for example, a developer copy/pasted the example and then cut/pasted the `live_session :default` block below the `live_session :admin` block the admin plug would apply to any HTTP calls to the `:default` routes. Including the wrapping scope hopefully makes it more obvious that the `pipe_through` call should be wrapped in an admin scope for cases like the one in this example.

Also clean up the controller `get` call example by including the `plug` and `plug_opts` parameters.

I'm also happy to make further updates if a different scope setup is preferred for the example docs such as scoping to `"/admin"` or something. I figured `"/"` keeps the focus on the live session code where something like `"/admin"` would trigger more changes in the example code and draw focus away from the purpose of the example.