### PR TITLE
Use layout defined in live_session during disconnected render

### DIFF
--- a/lib/phoenix_live_view/plug.ex
+++ b/lib/phoenix_live_view/plug.ex
@@ -43,7 +43,7 @@ defmodule Phoenix.LiveView.Plug do
 
   defp put_layout_from_router(conn, extra) do
     case Map.fetch(extra, :layout) do
-      {:ok, layout} ->  Plug.Conn.put_private(conn, :phoenix_live_layout, layout)
+      {:ok, layout} -> Plug.Conn.put_private(conn, :phoenix_live_layout, layout)
       :error -> conn
     end
   end

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -62,6 +62,14 @@ defmodule Phoenix.LiveView.Static do
     _ -> %{}
   end
 
+  defp maybe_get_live_layout(%{extra: %{layout: layout}}) do
+    layout
+  end
+
+  defp maybe_get_live_layout(_) do
+    false
+  end
+
   @doc """
   Renders a live view without spawning a LiveView server.
 
@@ -80,6 +88,7 @@ defmodule Phoenix.LiveView.Static do
     conn_session = maybe_get_session(conn)
     {to_sign_session, mount_session} = load_session(conn_session, opts)
     live_session = live_session(conn)
+    live_layout = maybe_get_live_layout(live_session)
     config = load_live!(view, :view)
     lifecycle = lifecycle(config, live_session)
     {tag, extended_attrs} = container(config, opts)
@@ -100,6 +109,7 @@ defmodule Phoenix.LiveView.Static do
           conn_session: conn_session,
           lifecycle: lifecycle,
           root_view: view,
+          phoenix_live_layout: live_layout,
           __changed__: %{}
         },
         action,

--- a/test/phoenix_live_view/router_test.exs
+++ b/test/phoenix_live_view/router_test.exs
@@ -254,16 +254,32 @@ defmodule Phoenix.LiveView.RouterTest do
                Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
 
       assert route.live_session.extra == %{
-        layout: {Phoenix.LiveViewTest.LayoutView, :live_override}
-      }
+               layout: {Phoenix.LiveViewTest.LayoutView, :live_override}
+             }
 
       {:ok, view, html} = live(conn, path)
 
       assert html =~
-        ~r|<div[^>]+>LIVEOVERRIDESTART\-123\-The value is: 123\-LIVEOVERRIDEEND|
+               ~r|<div[^>]+>LIVEOVERRIDESTART\-123\-The value is: 123\-LIVEOVERRIDEEND|
 
       assert render(view) =~
-        ~r|<div[^>]+>LIVEOVERRIDESTART\-123\-The value is: 123\-LIVEOVERRIDEEND|
+               ~r|<div[^>]+>LIVEOVERRIDESTART\-123\-The value is: 123\-LIVEOVERRIDEEND|
+    end
+
+    test "with layout override on disconnected render", %{conn: conn} do
+      path = "/dashboard-live-session-layout"
+
+      assert {:internal, route} =
+               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
+
+      assert route.live_session.extra == %{
+               layout: {Phoenix.LiveViewTest.LayoutView, :live_override}
+             }
+
+      conn = get(conn, path)
+
+      assert html_response(conn, 200) =~
+               ~r|<div[^>]+>LIVEOVERRIDESTART\-123\-The value is: 123\-LIVEOVERRIDEEND|
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/phoenixframework/phoenix_live_view/issues/2376