### PR TITLE
Add params for the form component

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1937,6 +1937,13 @@ defmodule Phoenix.Component do
     """
   )
 
+  attr.(:params, :any,
+    doc: """
+    Parameters associated to this form.
+    Can be used to supply input values when the data source is an atom.
+    """
+  )
+
   attr.(:rest, :global,
     include: ~w(autocomplete name rel enctype novalidate target),
     doc: "Additional HTML attributes to add to the form tag."

--- a/test/phoenix_component/components_test.exs
+++ b/test/phoenix_component/components_test.exs
@@ -422,6 +422,38 @@ defmodule Phoenix.LiveView.ComponentsTest do
                 ]}
              ] = html
     end
+
+    test "generates form with input values supplied by params" do
+      params = %{"foo" => "my", "bar" => "form"}
+      assigns = %{params: params}
+
+      template = ~H"""
+      <.form :let={f} for={:myform} params={@params}>
+        <%= text_input f, :foo %>
+        <%= textarea f, :bar %>
+      </.form>
+      """
+
+      html = parse(template)
+
+      assert [
+               {"form", [],
+                [
+                  {"input",
+                   [
+                     {"id", "myform_foo"},
+                     {"name", "myform[foo]"},
+                     {"type", "text"},
+                     {"value", "my"}
+                   ], []},
+                  {"textarea",
+                   [
+                     {"id", "myform_bar"},
+                     {"name", "myform[bar]"}
+                   ], ["\nform"]}
+                ]}
+             ] = html
+    end
   end
 
   describe "live_file_input/1" do


### PR DESCRIPTION
This allows for the params parameter to be send trough to `form_for`, neat when the data source is an atom so you don't have to manually set the value of each input field in your form.
I'm not sure i nailed the doc thought. 

Ref. https://github.com/phoenixframework/phoenix_live_view/issues/2388