### PR TITLE
Copy FileList on drop event when max_entries: 1

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -549,7 +549,7 @@ export default class LiveSocket {
       let files = Array.from(e.dataTransfer.files || [])
       if(!dropTarget || dropTarget.disabled || files.length === 0 || !(dropTarget.files instanceof FileList)){ return }
 
-      LiveUploader.trackFiles(dropTarget, files)
+      LiveUploader.trackFiles(dropTarget, files, e.dataTransfer)
       dropTarget.dispatchEvent(new Event("input", {bubbles: true}))
     })
     this.on(PHX_TRACK_UPLOADS, e => {

--- a/assets/js/phoenix_live_view/live_uploader.js
+++ b/assets/js/phoenix_live_view/live_uploader.js
@@ -66,12 +66,14 @@ export default class LiveUploader {
     DOM.putPrivate(inputEl, "files", DOM.private(inputEl, "files").filter(f => !Object.is(f, file)))
   }
 
-  static trackFiles(inputEl, files){
+  static trackFiles(inputEl, files, dataTransfer){
     if(inputEl.getAttribute("multiple") !== null){
       let newFiles = files.filter(file => !this.activeFiles(inputEl).find(f => Object.is(f, file)))
       DOM.putPrivate(inputEl, "files", this.activeFiles(inputEl).concat(newFiles))
       inputEl.value = null
     } else {
+      // Reset inputEl files to align output with programmatic changes (i.e. drag and drop)
+      if(dataTransfer && dataTransfer.files.length > 0){ inputEl.files = dataTransfer.files }
       DOM.putPrivate(inputEl, "files", files)
     }
   }


### PR DESCRIPTION
The files property of an input element is an immutable [FileList][1] object that can only be replaced with another FileList. While we are not allowed to make a new FileList object directly (there is no public constructor), the [DataTransfer][2] object provided by the HTML Drag and Drop API also has a files property of the same type.

For future reference, the DataTransfer API could be used to unify more of the upload paths- the [public constructor][3] is generally available.

For completeness, this change has one undesirable effect: if a user drops multiple files, the text next to the file input will eventually get out-of-sync with the number of pending uploads. This may be solvable in a future update.

Tested on Mac OS Chrome 108, Firefox 108, and Safari 16.2.

[1]: https://developer.mozilla.org/en-US/docs/Web/API/FileList
[2]: https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer
[3]: https://caniuse.com/mdn-api_datatransfer_datatransfer

Closes #2392