### PR TITLE
Add `<.inputs_for />`

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2015,6 +2015,96 @@ defmodule Phoenix.Component do
   defp form_method(method) when is_binary(method), do: {"post", method}
 
   @doc """
+  Renders nested form inputs for associations or embeds.
+
+  [INSERT LVATTRDOCS]
+
+  This function is built on top of `Phoenix.HTML.Form.inputs_for/3`.
+
+  For more information about  options and how to build inputs, see `Phoenix.HTML.Form`.
+
+  ## Examples
+
+  ```heex
+  <.form
+    :let={f}
+    for={@changeset}
+    phx-change="change_name"
+  >
+    <.inputs_for :let={f_nested} field={{:f, :nested}}>
+      <%= text_input f_nested, :name %>
+    </.inputs_for>
+  </.form>
+  ```
+  """
+  attr.(:field, :any,
+    required: true,
+    doc: "A %Phoenix.HTML.Form{}/field name tuple, for example: {f, :email}."
+  )
+
+  attr.(:id, :string,
+    doc: """
+    The id to be used in the form, defaults to the concatenation of the given
+    field to the parent form id.
+    """
+  )
+
+  attr.(:as, :atom,
+    doc: """
+    The name to be used in the form, defaults to the concatenation of the given
+    field to the parent form name.
+    """
+  )
+
+  attr.(:default, :any, doc: "The value to use if none is available.")
+
+  attr.(:prepend, :list,
+    doc: """
+    The values to prepend when rendering. This only applies if the field value
+    is a list and no parameters were sent through the form.
+    """
+  )
+
+  attr.(:append, :list,
+    doc: """
+    The values to append when rendering. This only applies if the field value
+    is a list and no parameters were sent through the form.
+    """
+  )
+
+  attr.(:skip_hidden, :boolean,
+    default: false,
+    doc: """
+    Skip the automatic rendering of hidden fields to allow for more tight control
+    over the generated markup. You can access `form.hidden` or use
+    `Phoenix.HTML.Form.hidden_inputs_for/1` to generate them manually.
+    """
+  )
+
+  slot.(:inner_block, required: true, doc: "The content rendered for each nested form.")
+
+  def inputs_for(assigns) do
+    {form, field} = assigns[:field] || raise ArgumentError, "missing :field assign to inputs_for"
+
+    opts =
+      assigns
+      |> Map.take([:id, :as, :default, :append, :prepend])
+      |> Enum.reject(fn {_, v} -> v == nil end)
+
+    assigns =
+      assigns
+      |> assign(:field, nil)
+      |> assign(:inputs, Phoenix.HTML.Form.inputs_for(form, field, opts))
+
+    ~H"""
+    <%= for finner <- @inputs do %>
+      <%= unless @skip_hidden, do: Phoenix.HTML.Form.hidden_inputs_for(finner) %>
+      <%= render_slot(@inner_block, finner) %>
+    <% end %>
+    """
+  end
+
+  @doc """
   Generates a link for live and href navigation.
 
   [INSERT LVATTRDOCS]

--- a/test/phoenix_component/components_test.exs
+++ b/test/phoenix_component/components_test.exs
@@ -456,6 +456,153 @@ defmodule Phoenix.LiveView.ComponentsTest do
     end
   end
 
+  describe "inputs_for" do
+    test "raises when missing required assigns" do
+      assert_raise ArgumentError, ~r/missing :field assign/, fn ->
+        assigns = %{}
+
+        template = ~H"""
+        <.form :let={_f}  for={:myform}>
+          <.inputs_for :let={finner}>
+            <%= text_input finner, :foo %>
+          </.inputs_for>
+        </.form>
+        """
+
+        parse(template)
+      end
+    end
+
+    test "generates nested inputs with no options" do
+      assigns = %{}
+
+      template = ~H"""
+        <.form :let={f}  for={:myform}>
+          <.inputs_for :let={finner} field={{f, :inner}}>
+            <%= text_input finner, :foo %>
+          </.inputs_for>
+        </.form>
+      """
+
+      html = parse(template)
+
+      assert [
+               {"form", [],
+                [
+                  {"input",
+                   [
+                     {"id", "myform_inner_foo"},
+                     {"name", "myform[inner][foo]"},
+                     {"type", "text"}
+                   ], []}
+                ]}
+             ] = html
+    end
+
+    test "with naming options" do
+      assigns = %{}
+
+      template = ~H"""
+        <.form :let={f}  for={:myform}>
+          <.inputs_for :let={finner} field={{f, :inner}} id="test" as={:name}>
+            <%= text_input finner, :foo %>
+          </.inputs_for>
+        </.form>
+      """
+
+      html = parse(template)
+
+      assert [
+               {"form", [],
+                [
+                  {"input",
+                   [
+                     {"id", "test_foo"},
+                     {"name", "name[foo]"},
+                     {"type", "text"}
+                   ], []}
+                ]}
+             ] = html
+    end
+
+    test "with default map option" do
+      assigns = %{}
+
+      template = ~H"""
+        <.form :let={f}  for={:myform}>
+          <.inputs_for :let={finner} field={{f, :inner}} default={%{foo: "123"}}>
+            <%= text_input finner, :foo %>
+          </.inputs_for>
+        </.form>
+      """
+
+      html = parse(template)
+
+      assert [
+               {"form", [],
+                [
+                  {"input",
+                   [
+                     {"id", "myform_inner_foo"},
+                     {"name", "myform[inner][foo]"},
+                     {"type", "text"},
+                     {"value", "123"}
+                   ], []}
+                ]}
+             ] = html
+    end
+
+    test "with default list and list related options" do
+      assigns = %{}
+
+      template = ~H"""
+        <.form :let={f}  for={:myform}>
+          <.inputs_for
+            :let={finner}
+            field={{f, :inner}}
+            default={[%{foo: "456"}]}
+            prepend={[%{foo: "123"}]}
+            append={[%{foo: "789"}]}
+          >
+            <%= text_input finner, :foo %>
+          </.inputs_for>
+        </.form>
+      """
+
+      html = parse(template)
+
+      assert [
+               {"form", [],
+                [
+                  {
+                    "input",
+                    [
+                      {"id", "myform_inner_0_foo"},
+                      {"name", "myform[inner][0][foo]"},
+                      {"type", "text"},
+                      {"value", "123"}
+                    ],
+                    []
+                  },
+                  {"input",
+                   [
+                     {"id", "myform_inner_1_foo"},
+                     {"name", "myform[inner][1][foo]"},
+                     {"type", "text"},
+                     {"value", "456"}
+                   ], []},
+                  {"input",
+                   [
+                     {"id", "myform_inner_2_foo"},
+                     {"name", "myform[inner][2][foo]"},
+                     {"type", "text"},
+                     {"value", "789"}
+                   ], []}
+                ]}
+             ] = html
+    end
+  end
+
   describe "live_file_input/1" do
     test "renders attributes" do
       assigns = %{


### PR DESCRIPTION
I've seen so many people try to use `<%= for finner <- inputs_for(f, :inner) do %>` without accompanying `hidden_inputs_for(finner)` that I think it makes sense to have a function component mimicing `inputs_for/4`, which also did add the hidden inputs automatically in the past - before `inputs_for/3` was added to improve LV change tracking.

Feel free to rip out once the forms overhaul is happening.