### PR TITLE
Unload socket before redirecting

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -379,7 +379,7 @@ export default class LiveSocket {
   }
 
   redirect(to, flash){
-    this.disconnect()
+    this.unload();
     Browser.redirect(to, flash)
   }
 

--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -379,7 +379,7 @@ export default class LiveSocket {
   }
 
   redirect(to, flash){
-    this.unload();
+    this.unload()
     Browser.redirect(to, flash)
   }
 


### PR DESCRIPTION
I've encountered similar issue to https://github.com/phoenixframework/phoenix_live_view/issues/2311 and https://github.com/phoenixframework/phoenix_live_view/issues/2276. When I was redirecting from live view to dead view, I was seeing a "disconnected" flash error.

Using `unload` instead of `disconnect` fixes the issue.