### PR TITLE
Fix documentation example for intersperse

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2642,7 +2642,7 @@ defmodule Phoenix.Component do
     <:separator>
       <span class="sep">|</span>
     </:separator>
-    <%= item.name %>
+    <%= item %>
   </.intersperse>
   ```
 


### PR DESCRIPTION
The enum passed doesn't seem to work as it's a plain list and so it raises (KeyError) key :name not found in: "home".