### PR TITLE
Docs - Adds information on how we can force a nested LiveView to be re-mounted

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -257,7 +257,8 @@ defmodule Phoenix.LiveView do
 
   When rendering a child LiveView, the `:id` option is required to uniquely
   identify the child. A child LiveView will only ever be rendered and mounted
-  a single time, provided its ID remains unchanged.
+  a single time, provided its ID remains unchanged. To force a child to re-mount 
+  with new session data, a new ID must be provided.
 
   Given that a LiveView runs on its own process, it is an excellent tool for creating
   completely isolated UI elements, but it is a slightly expensive abstraction if


### PR DESCRIPTION
This information has been removed in the past, but is very useful when we need to know a way to force a nested LiveView re-mount. I don't know if that information was transferred elsewhere. But I think this will save us to spend time trying to figure out how we can do this.

https://github.com/phoenixframework/phoenix_live_view/blob/e4c6f7140d5b8c383e584671a63c14e85e9c26e9/lib/phoenix_live_view.ex#L371-L379