### PR TITLE
Force assign unchanged defaults

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1252,8 +1252,8 @@ defmodule Phoenix.Component do
 
   def assign(%{__changed__: changed} = assigns, key, value) do
     case assigns do
-      # force assign the key if the attribute was declared with same default as being assigned
-      %{^key => ^value, __defaults__: %{^key => ^value}} ->
+      # force assign the key if the attribute was declared with default
+      %{^key => ^value, __defaults__: %{^key => _}} ->
         Phoenix.LiveView.Utils.force_assign(assigns, changed, key, value)
 
       %{^key => ^value} ->

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1252,6 +1252,10 @@ defmodule Phoenix.Component do
 
   def assign(%{__changed__: changed} = assigns, key, value) do
     case assigns do
+      # force assign the key if the attribute was declared with same default as being assigned
+      %{^key => ^value, __defaults__: %{^key => ^value}} ->
+        Phoenix.LiveView.Utils.force_assign(assigns, changed, key, value)
+
       %{^key => ^value} ->
         assigns
 
@@ -2137,6 +2141,7 @@ defmodule Phoenix.Component do
   def form(assigns) do
     # Extract options and then to the same call as form_for
     action = assigns[:action]
+
     form_for =
       case assigns[:for] do
         nil -> %{}

--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -3,7 +3,15 @@ defmodule Phoenix.Component.Declarative do
 
   ## Reserved assigns
 
-  @reserved_assigns [:__changed__, :__slot__, :inner_block, :myself, :flash, :socket]
+  @reserved_assigns [
+    :__changed__,
+    :__slot__,
+    :__defaults__,
+    :inner_block,
+    :myself,
+    :flash,
+    :socket
+  ]
 
   @doc false
   def __reserved__, do: @reserved_assigns
@@ -613,7 +621,15 @@ defmodule Phoenix.Component.Declarative do
             {name, []}
           end
 
-        defaults = attr_defaults ++ slot_defaults
+        defaults =
+          case attr_defaults do
+            [] ->
+              attr_defaults ++ slot_defaults
+
+            [_ | _] ->
+              tracked_defaults = Macro.escape(Map.new(attr_defaults))
+              [{:__defaults__, tracked_defaults}] ++ attr_defaults ++ slot_defaults
+          end
 
         {global_name, global_default} =
           case Enum.find(attrs, fn attr -> attr.type == :global end) do
@@ -812,7 +828,7 @@ defmodule Phoenix.Component.Declarative do
           build_attr_values_or_examples(attr)
         ]
       end,
-      if Enum.any?(attrs, & &1.type == :global) do
+      if Enum.any?(attrs, &(&1.type == :global)) do
         "\nGlobal attributes are accepted."
       else
         ""

--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -628,7 +628,7 @@ defmodule Phoenix.Component.Declarative do
 
             [_ | _] ->
               tracked_defaults = Macro.escape(Map.new(attr_defaults))
-              [{:__defaults__, tracked_defaults}] ++ attr_defaults ++ slot_defaults
+              [{:__defaults__, tracked_defaults} | attr_defaults] ++ slot_defaults
           end
 
         {global_name, global_default} =

--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -627,7 +627,7 @@ defmodule Phoenix.Component.Declarative do
               attr_defaults ++ slot_defaults
 
             [_ | _] ->
-              tracked_defaults = Macro.escape(Map.new(attr_defaults))
+              tracked_defaults = Macro.escape(Map.new(attr_defaults, fn {key, _} -> {key, []} end))
               [{:__defaults__, tracked_defaults} | attr_defaults] ++ slot_defaults
           end
 

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -584,6 +584,12 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
 
       attr :value, :string
       def no_default(assigns), do: ~H[<%= inspect @value %>]
+
+      attr :id, :any
+      attr :errors, :list, default: []
+      def assigned_with_same_default(assigns) do
+        assign(assigns, errors: [])
+      end
     end
 
     assert render(AttrDefaults, :add, %{}) == "3"
@@ -593,6 +599,9 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     assert_raise KeyError, ~r":value not found", fn ->
       render(AttrDefaults, :no_default, %{})
     end
+
+    assigns = AttrDefaults.assigned_with_same_default(%{__changed__: %{}})
+    assert Phoenix.Component.changed?(assigns, :errors)
   end
 
   test "provides slot defaults" do


### PR DESCRIPTION
We are good on the `update` and `assign_new` front because they do not consider the value equality.