### PR TITLE
Fix auto-uploading when changing an existing input

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -875,7 +875,7 @@ export default class View {
     }
     this.pushWithReply(refGenerator, "event", event, resp => {
       DOM.showError(inputEl, this.liveSocket.binding(PHX_FEEDBACK_FOR))
-      if(DOM.isUploadInput(inputEl) && inputEl.getAttribute("data-phx-auto-upload") !== null){
+      if(DOM.isUploadInput(inputEl) && inputEl.dataset.phxAutoUpload !== null){
         if(LiveUploader.filesAwaitingPreflight(inputEl).length > 0){
           let [ref, _els] = refGenerator()
           this.uploadFiles(inputEl.form, targetCtx, ref, cid, (_uploads) => {


### PR DESCRIPTION
When uploading a file using auto-upload, if a file input is already populated, changing the input will not result in the auto-upload triggering.

When calling `inputEl.getAttribute("data-phx-auto-upload")` the first time, it returns a non-null value. When the input is changed, it returns a null value.

When using `inputEl.dataset.phxAutoUpload` the value is correctly non-null regardless of if the file input has been previously populated.

This closes #2271