### PR TITLE
Fixup example in docs for `stream_insert/4`

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1619,7 +1619,7 @@ defmodule Phoenix.LiveView do
   existing item and move it to the end of a collection, issue a `stream_delete`, followed
   by a `stream_insert`. For example:
 
-     socket = get_song!(id)
+      song = get_song!(id)
 
       socket
       |> stream_delete(:songs, song)


### PR DESCRIPTION
The example for [updating items](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#stream_insert/4-updating-items) looks off

