### PR TITLE
Adds live_view macro update required to move to latest 0.18

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -69,6 +69,20 @@ def router do
 end
 ```
 
+In that same file, update your live_view layout configuration:
+
+```diff
+# lib/my_app_web.ex
+
+def live_view do
+  use Phoenix.LiveView,
+-    layout: {MyAppWeb.LayoutView, "live.html"}
++    layout: {MyAppWeb.LayoutView, :live}
+
+  unquote(view_helpers())
+end
+```
+
 Then add the `Phoenix.LiveView.Router.fetch_live_flash/2` plug to your browser pipeline, in place of `:fetch_flash`:
 
 ```diff


### PR DESCRIPTION
I was having issues updating a project from 0.17 to 0.18. I kept running into this error:

```
[error] #PID<0.6924.0> running MyAppWeb.Endpoint (connection #PID<0.6922.0>, stream id 1) terminated
Server: localhost:4040 (http)
Request: GET /
** (exit) an exception was raised:
    ** (CaseClauseError) no case clause matching: "live"
        (phoenix_live_view 0.18.13) lib/phoenix_live_view/utils.ex:186: Phoenix.LiveView.Utils.to_rendered/2
        (phoenix_live_view 0.18.13) lib/phoenix_live_view/static.ex:251: Phoenix.LiveView.Static.to_rendered_content_tag/4
        (phoenix_live_view 0.18.13) lib/phoenix_live_view/static.ex:135: Phoenix.LiveView.Static.render/3
        (phoenix_live_view 0.18.13) lib/phoenix_live_view/controller.ex:39: Phoenix.LiveView.Controller.live_render/3
        (phoenix 1.6.15) lib/phoenix/router.ex:354: Phoenix.Router.__call__/2
        (my_app 0.1.0) lib/my_app_web/endpoint.ex:1: MyAppWeb.Endpoint.plug_builder_call/2
        (my_app 0.1.0) lib/plug/debugger.ex:136: MyAppWeb.Endpoint."call (overridable 3)"/2
        (my_app 0.1.0) lib/my_app_web/endpoint.ex:1: MyAppWeb.Endpoint.call/2
        (phoenix 1.6.15) lib/phoenix/endpoint/cowboy2_handler.ex:54: Phoenix.Endpoint.Cowboy2Handler.init/4
        (cowboy 2.9.0) /.../my_app/deps/cowboy/src/cowboy_handler.erl:37: :cowboy_handler.execute/2
        (cowboy 2.9.0) /.../my_app/deps/cowboy/src/cowboy_stream_h.erl:306: :cowboy_stream_h.execute/3
        (cowboy 2.9.0) /.../my_app/deps/cowboy/src/cowboy_stream_h.erl:295: :cowboy_stream_h.request_process/3
        (stdlib 4.2) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
```

I was able to fix by doing what's described in the PR delta.

Note: there were deprecation warnings in the boot logs that would have tipped me off to this. It took me a hilarious bit of time to notice those 🤦🏻. They looked like this:

```
warning: passing a string as a layout template in use options is deprecated, please pass {MyAppWeb.LayoutView, :live} instead of {MyAppWeb.LayoutView, "live.html"}
  (phoenix_live_view 0.18.13) lib/phoenix_live_view/utils.ex:161: Phoenix.LiveView.Utils.normalize_layout/2
  (phoenix_live_view 0.18.13) lib/phoenix_live_view.ex:496: Phoenix.LiveView."MACRO-__before_compile__"/2
  (elixir 1.14.3) src/elixir_dispatch.erl:224: :elixir_dispatch.expand_macro_fun/7
  (elixir 1.14.3) src/elixir_dispatch.erl:211: :elixir_dispatch.expand_require/6
  (elixir 1.14.3) src/elixir_dispatch.erl:135: :elixir_dispatch.dispatch_require/7
  (elixir 1.14.3) src/elixir_module.erl:412: :elixir_module.expand_callback/6
```

That those were warnings/deprecations makes me think it should have still worked but I didn't go digging that far yet :D 