### PR TITLE
fix(live_socket_client): Set main correctly

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -371,7 +371,7 @@ export default class LiveSocket {
         let view = this.newRootView(rootEl)
         view.setHref(this.getHref())
         view.join()
-        if(rootEl.hasAttribute(PHX_MAIN)){ this.main = view }
+        if(rootEl.hasAttribute(PHX_MAIN) != null){ this.main = view }
       }
       rootsFound = true
     })


### PR DESCRIPTION
Early tonight I created a new Phoenix project, immediately I generated a new LiveView resource using `mix phx.gen.live`.

When saving a new entry in this resource using the default modal provided by the generator I ran into this error:
```js
Cannot read properties of null, reading `el`
```

Error comes from this line https://github.com/phoenixframework/phoenix_live_view/blob/master/assets/js/phoenix_live_view/live_socket.js#L388

After debugging it, I realized that `this.main` is not set correctly because of this condition https://github.com/phoenixframework/phoenix_live_view/blob/master/assets/js/phoenix_live_view/live_socket.js#L374

The attribute exists but it returns an empty string, which is a falsy value.

This is not caught by the tests because they all use `data-phx-main="true"`, I couldn't find where in the Elixir code this attribute is set, just my lack of experience :D

I verified this fixes the issue in my application, after updating the compiled source code the modal submit button correctly changes its style, the page is not fully reloaded and the flash message is displayed.