### PR TITLE
fix regression in liveview tests with newer phoenix_html

### DIFF
--- a/lib/phoenix_live_view/test/dom.ex
+++ b/lib/phoenix_live_view/test/dom.ex
@@ -154,7 +154,7 @@ defmodule Phoenix.LiveViewTest.DOM do
       static = if static in [nil, ""], do: nil, else: static
       found = {id, session, static}
 
-      if main == "true" do
+      if main not in [nil, "", "false"] do
         acc ++ [found]
       else
         [found | acc]


### PR DESCRIPTION
See: https://github.com/phoenixframework/phoenix_live_view/issues/2455

This PR patches `Phoenix.LiveViewTest.DOM.find_live_views/1` to accept other values than just `"true"` for the main LiveView.  This is because with the new `phoenix_html` changes the value is no longer `"true"`.

I don't know if this is the best way to address this issue, but thought I'd at least prepare this PR just in case