### PR TITLE
Fix form_defaults in LiveViewTest for empty textareas when using fast_html instead of Floki's default HTML Parser

### DIFF
--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -1129,8 +1129,8 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
     end)
   end
 
-  defp form_defaults({"textarea", _, [value]}, name, acc) do
-    Plug.Conn.Query.decode_pair({name, String.replace_prefix(value, "\n", "")}, acc)
+  defp form_defaults({"textarea", _, children}, name, acc) when length(children) <= 1 do
+    Plug.Conn.Query.decode_pair({name, String.replace_prefix("#{children}", "\n", "")}, acc)
   end
 
   defp form_defaults({"input", _, _} = node, name, acc) do

--- a/test/phoenix_live_view/integrations/elements_test.exs
+++ b/test/phoenix_live_view/integrations/elements_test.exs
@@ -533,6 +533,7 @@ defmodule Phoenix.LiveView.ElementsTest do
       # Text area
       assert form =~ ~s|"textarea" => "Text"|
       assert form =~ ~s|"textarea_nl" => "Text"|
+      assert form =~ ~s|"textarea_empty" => ""|
 
       # Ignore everything with no name, disabled, or submits
       refute form =~ "no-name"

--- a/test/support/live_views/elements.ex
+++ b/test/support/live_views/elements.ex
@@ -114,6 +114,7 @@ defmodule Phoenix.LiveViewTest.ElementsLive do
         <option value="3" selected>Three</option>
       </select>
       <textarea name="hello[textarea]">Text</textarea>
+      <textarea name="hello[textarea_empty]"></textarea>
       <!-- Mimic textarea from Phoenix.HTML -->
       <textarea name="hello[textarea_nl]">
     Text</textarea>


### PR DESCRIPTION
This PR fixes the bug described in #2457, which occurrs when running tests while using `fast_html` instead of Floki's default `mochiweb` parser.

Since this parser follow the [whatg spec](https://dom.spec.whatwg.org/) more closely, empty textareas nodes do not have any value (so: `[]` instead of `[""]`), which caused a `FunctionClauseError` when LiveViewTest parses the HTML Tree, for example on `render_change`.

This PR attempts to fix this by checking if there's only zero or one children in the `textarea` and then interpolates the `children` as the `value`, essentially making the default value be `""`.