### PR TITLE
Elaborate on New vs Existing Assigns in `update/2`

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -45,7 +45,7 @@ defmodule Phoenix.LiveComponent do
   `c:mount/1` is called once, when the component is first added to the page. `c:mount/1`
   receives the `socket` as argument. Then `c:update/2` is invoked with all of the
   assigns given to [`live_component/1`](`Phoenix.Component.live_component/1`).
-  If `c:update/2` is not defined all assigns are simply merged into the socket. The assigns received by the [`update/2`](`c:Phoenix.LiveComponent.update/2`) callback will only include the _new_ assigns passed from this function. Pre-existing assigns may be found in `socket.assigns`.
+  If `c:update/2` is not defined all assigns are simply merged into the socket. The assigns received as the first argument of the [`update/2`](`c:Phoenix.LiveComponent.update/2`) callback will only include the _new_ assigns passed from this function. Pre-existing assigns may be found in `socket.assigns`.
 
   After the component is updated, `c:render/1` is called with all assigns.
   On first render, we get:

--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -45,7 +45,8 @@ defmodule Phoenix.LiveComponent do
   `c:mount/1` is called once, when the component is first added to the page. `c:mount/1`
   receives the `socket` as argument. Then `c:update/2` is invoked with all of the
   assigns given to [`live_component/1`](`Phoenix.Component.live_component/1`).
-  If `c:update/2` is not defined all assigns are simply merged into the socket.
+  If `c:update/2` is not defined all assigns are simply merged into the socket. The assigns received by the [`update/2`](`c:Phoenix.LiveComponent.update/2`) callback will only include the _new_ assigns passed from this function. Pre-existing assigns may be found in `socket.assigns`.
+
   After the component is updated, `c:render/1` is called with all assigns.
   On first render, we get:
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1294,7 +1294,7 @@ defmodule Phoenix.LiveView do
   [`preload/1`](`c:Phoenix.LiveComponent.preload/1`) then
   [`update/2`](`c:Phoenix.LiveComponent.update/2`) is invoked with the new assigns.
   If [`update/2`](`c:Phoenix.LiveComponent.update/2`) is not defined
-  all assigns are simply merged into the socket. The assigns received by the [`update/2`](`c:Phoenix.LiveComponent.update/2`) callback will only include the _new_ assigns passed from this function. Pre-existing assigns may be found in `socket.assigns`.
+  all assigns are simply merged into the socket. The assigns received as the first argument of the [`update/2`](`c:Phoenix.LiveComponent.update/2`) callback will only include the _new_ assigns passed from this function. Pre-existing assigns may be found in `socket.assigns`.
 
   While a component may always be updated from the parent by updating some
   parent assigns which will re-render the child, thus invoking

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1294,7 +1294,7 @@ defmodule Phoenix.LiveView do
   [`preload/1`](`c:Phoenix.LiveComponent.preload/1`) then
   [`update/2`](`c:Phoenix.LiveComponent.update/2`) is invoked with the new assigns.
   If [`update/2`](`c:Phoenix.LiveComponent.update/2`) is not defined
-  all assigns are simply merged into the socket.
+  all assigns are simply merged into the socket. The assigns received by the [`update/2`](`c:Phoenix.LiveComponent.update/2`) callback will only include the _new_ assigns passed from this function. Pre-existing assigns may be found in `socket.assigns`.
 
   While a component may always be updated from the parent by updating some
   parent assigns which will re-render the child, thus invoking


### PR DESCRIPTION
When I was working on a LiveComponent which persists multiple assigns to the socket, it wasn't clear from the docs that only the new assign(s) would appear in the first arg of `update/2`. Nor was it clear how to access existing assigns. It makes sense in hindsight, but I want to clarify how the callback works a bit with this PR.