### PR TITLE
Improve LiveComponent update callback example

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -137,7 +137,7 @@ defmodule Phoenix.LiveComponent do
   callback:
 
       def update(assigns, socket) do
-        user = Repo.get!(User, assigns.id)
+        user = Repo.get(User, assigns.id)
         {:ok, assign(socket, :user, user)}
       end
 


### PR DESCRIPTION
Based on the issue discussed here: https://elixirforum.com/t/rendering-404s-through-liveview/30018/8?u=tfwright

I am not sure if at one point the error potentially raised by the original example code would have been caught by `Plug`, but when using the current version it will cause the LV process to crash without further handling which would arguably be required, especially if the id is coming from the URL. The use of `get` seems less misleading in the absence of further context about how this component is being used.

Another option would be to leave the original code but add a link with a note about error handling with LV: https://hexdocs.pm/phoenix_live_view/error-handling.html#exceptions-on-events-handle_info-handle_event-etc