### PR TITLE
`Phoenix.LiveView.Logger`: merge lifecycle, view, and event into one line

### DIFF
--- a/lib/phoenix_live_view/logger.ex
+++ b/lib/phoenix_live_view/logger.ex
@@ -116,9 +116,7 @@ defmodule Phoenix.LiveView.Logger do
     if level && connected?(socket) do
       Logger.log(level, fn ->
         [
-          "HANDLE PARAMS",
-          ?\n,
-          "  View: ",
+          "HANDLE PARAMS in ",
           inspect(socket.view),
           ?\n,
           "  Parameters: ",
@@ -157,13 +155,10 @@ defmodule Phoenix.LiveView.Logger do
     if level do
       Logger.log(level, fn ->
         [
-          "HANDLE EVENT",
-          ?\n,
-          "  View: ",
-          inspect(socket.view),
-          ?\n,
-          "  Event: ",
+          "HANDLE EVENT ",
           inspect(event),
+          " in ",
+          inspect(socket.view),
           ?\n,
           "  Parameters: ",
           inspect(filter_values(params))
@@ -201,16 +196,12 @@ defmodule Phoenix.LiveView.Logger do
     if level do
       Logger.log(level, fn ->
         [
-          "HANDLE EVENT",
-          ?\n,
+          "HANDLE EVENT ",
+          inspect(event),
+          " in ",
+          inspect(socket.view),
           "  Component: ",
           inspect(component),
-          ?\n,
-          "  View: ",
-          inspect(socket.view),
-          ?\n,
-          "  Event: ",
-          inspect(event),
           ?\n,
           "  Parameters: ",
           inspect(filter_values(params))

--- a/test/phoenix_live_view/integrations/telemetry_test.exs
+++ b/test/phoenix_live_view/integrations/telemetry_test.exs
@@ -47,7 +47,7 @@ defmodule Phoenix.LiveView.TelemtryTest do
       refute log =~ "MOUNT Phoenix.LiveViewTest.ThermostatLive"
       refute log =~ "Replied in "
 
-      refute log =~ "HANDLE PARAMS"
+      refute log =~ "HANDLE PARAMS in Phoenix.LiveViewTest.ThermostatLive"
       refute log =~ "Replied in "
     end
 
@@ -108,8 +108,7 @@ defmodule Phoenix.LiveView.TelemtryTest do
       assert log =~ "  Session: %{\"current_user_id\" => \"1\"}"
       assert log =~ "Replied in"
 
-      assert log =~ "HANDLE PARAMS"
-      assert log =~ "  View: Phoenix.LiveViewTest.ThermostatLive"
+      assert log =~ "HANDLE PARAMS in Phoenix.LiveViewTest.ThermostatLive"
       assert log =~ "  Parameters: %{\"foo\" => \"bar\"}"
       assert log =~ "Replied in"
     end
@@ -164,9 +163,7 @@ defmodule Phoenix.LiveView.TelemtryTest do
           assert metadata.params == %{"temp" => "20"}
         end)
 
-      assert log =~ "HANDLE EVENT"
-      assert log =~ "  View: Phoenix.LiveViewTest.ThermostatLive"
-      assert log =~ "  Event: \"save\""
+      assert log =~ "HANDLE EVENT \"save\" in Phoenix.LiveViewTest.ThermostatLive"
       assert log =~ "  Parameters: %{\"temp\" => \"20\"}"
       assert log =~ "Replied in"
     end
@@ -223,10 +220,8 @@ defmodule Phoenix.LiveView.TelemtryTest do
           assert metadata.params == %{"op" => "upcase"}
         end)
 
-      assert log =~ "HANDLE EVENT"
+      assert log =~ "HANDLE EVENT \"transform\" in Phoenix.LiveViewTest.WithComponentLive"
       assert log =~ "  Component: Phoenix.LiveViewTest.StatefulComponent"
-      assert log =~ "  View: Phoenix.LiveViewTest.WithComponentLive"
-      assert log =~ "  Event: \"transform\""
       assert log =~ "  Parameters: %{\"op\" => \"upcase\"}"
       assert log =~ "Replied in"
     end


### PR DESCRIPTION
This PR updates the formatting used by `Phoenix.LiveView.Logger` to write fewer lines per telemetry event logged. This change applies to both Live Views and Live Components. The same data is logged as before but in a more space efficient way 🙂 

Before:
```
HANDLE EVENT
  View: FooLive
  Event: "validate"
  Parameters: %{"foo" => "bar"}
Replied in 250µs
```

After:
```
HANDLE EVENT "validate" in FooLive
  Parameters: %{"foo" => "bar"}
Replied in 250µs
```