### PR TITLE
Fix typos

### DIFF
--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -436,7 +436,7 @@ describe("View + DOM", function(){
       expect(childIds()).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9])
 
       // Make sure we don't have a memory leak when doing updates
-      let initalCount = countChildNodes()
+      let initialCount = countChildNodes()
       updateDynamics(view,
         [["1", "1"], ["2", "2"], ["3", "3"]]
       )
@@ -450,7 +450,7 @@ describe("View + DOM", function(){
         [["1", "1"], ["2", "2"], ["3", "3"]]
       )
 
-      expect(countChildNodes()).toBe(initalCount)
+      expect(countChildNodes()).toBe(initialCount)
     })
 
     test("prepend", async () => {
@@ -500,7 +500,7 @@ describe("View + DOM", function(){
       expect(childIds()).toEqual([8, 9, 6, 7, 4, 5, 2, 3, 1])
 
       // Make sure we don't have a memory leak when doing updates
-      let initalCount = countChildNodes()
+      let initialCount = countChildNodes()
       updateDynamics(view,
         [["1", "1"], ["2", "2"], ["3", "3"]]
       )
@@ -514,7 +514,7 @@ describe("View + DOM", function(){
         [["1", "1"], ["2", "2"], ["3", "3"]]
       )
 
-      expect(countChildNodes()).toBe(initalCount)
+      expect(countChildNodes()).toBe(initialCount)
     })
 
     test("ignore", async () => {

--- a/guides/server/deployments.md
+++ b/guides/server/deployments.md
@@ -2,7 +2,7 @@
 
 One of the questions that arise from LiveView stateful model is what considerations are necessary when deploying a new version of LiveView.
 
-First off, whenever LiveView disconnects, it will automatically attempt to reconnect to the server using exponential back-off. This means it will try immediately, then wait 2s and try again, then 5s and so on. If you are deploying, this typically means the next reconnection will immediatelly succeed and your load balancer will automatically redirect to the new servers.
+First off, whenever LiveView disconnects, it will automatically attempt to reconnect to the server using exponential back-off. This means it will try immediately, then wait 2s and try again, then 5s and so on. If you are deploying, this typically means the next reconnection will immediately succeed and your load balancer will automatically redirect to the new servers.
 
 However, your LiveView _may_ still have state that will be lost in this transition. How to deal with it? The good news is that there are a series of practices you can follow that will not only help with deployments but it will improve your application in general.
 

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -607,7 +607,7 @@ defmodule Phoenix.Component do
   The expression inside `{...}` must be either a keyword list or a map containing
   the key-value pairs representing the dynamic attributes.
 
-  You can pair this notation `assigns_to_attributes/2` to strip out any internal
+  You can pair this notation with `assigns_to_attributes/2` to strip out any internal
   LiveView attributes and user-defined assigns from being expanded into the HTML tag:
 
   ```heex
@@ -2068,7 +2068,7 @@ defmodule Phoenix.Component do
   </.form>
   ```
 
-  In the example above, we use passed a changeset to `for` and captured
+  In the example above, we passed a changeset to `for` and captured
   the value using `:let={f}`. This approach is ok outside of LiveViews,
   as there are no change tracking optimizations to consider.
 

--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -475,7 +475,7 @@ defmodule Phoenix.LiveView.Engine do
 
         # The reason we can safely ignore assigns here is because
         # each branch in the live/render constructs are their own
-        # rendered struct and, if the rendered has a new fingerpint,
+        # rendered struct and, if the rendered has a new fingerprint,
         # then change tracking is fully disabled.
         #
         # For example, take this code:


### PR DESCRIPTION
This fixes a few typos that I found while reading the docs. I also ran the [typos](https://github.com/crate-ci/typos) code spell checker which spotted some more.