### PR TITLE
Respect to_form :as option in form field access

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2094,7 +2094,6 @@ defmodule Phoenix.Component do
   attr.(:for, :any, required: true, doc: "An existing form or the form source data.")
 
   attr.(:action, :string,
-    default: nil,
     doc: """
     The action to submit the form on.
     This attribute must be given if you intend to submit the form to a URL without LiveView.
@@ -2102,7 +2101,6 @@ defmodule Phoenix.Component do
   )
 
   attr.(:as, :atom,
-    default: nil,
     doc: """
     The server side parameter in which all params for this form
     will be collected. For example, setting `as: :user_params` means

--- a/test/phoenix_component/components_test.exs
+++ b/test/phoenix_component/components_test.exs
@@ -292,6 +292,25 @@ defmodule Phoenix.LiveView.ComponentsTest do
              ] = html
     end
 
+    test "generates form with prebuilt form and :as" do
+      assigns = %{form: to_form(%{}, as: :data)}
+
+      template = ~H"""
+      <.form :let={f} for={@form}>
+        <input id={f[:foo].id} name={f[:foo].name} type="text" />
+      </.form>
+      """
+
+      html = parse(template)
+
+      assert [
+               {"form", [],
+                [
+                  {"input", [{"id", "data_foo"}, {"name", "data[foo]"}, {"type", "text"}], []}
+                ]}
+             ] = html
+    end
+
     test "generates form with prebuilt form and options" do
       assigns = %{form: to_form(%{})}
 


### PR DESCRIPTION
Currently the default `as: nil` overrides `:as` from `to_form`.