### PR TITLE
Support form submitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.18.17
+
+### Enhancements
+  * Support [`submitter`](https://developer.mozilla.org/en-US/docs/Web/API/SubmitEvent/submitter) on form submit events.
+
 ## 0.18.16 (2023-02-23)
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ $ npm install --save --prefix assets mdn-polyfills url-search-params-polyfill fo
 
 Note: The `shim-keyboard-event-key` polyfill is also required for [MS Edge 12-18](https://caniuse.com/#feat=keyboardevent-key).
 
+Note: The `event-submitter-polyfill` package is also required for [MS Edge 12-80 &amp; Safari &lt; 15.4](https://caniuse.com/mdn-api_submitevent_submitter).
+
 ```
 // assets/js/app.js
 import "mdn-polyfills/Object.assign"
@@ -153,6 +155,7 @@ import "classlist-polyfill"
 import "new-event-polyfill"
 import "@webcomponents/template"
 import "shim-keyboard-event-key"
+import "event-submitter-polyfill"
 import "core-js/features/set"
 import "core-js/features/url"
 

--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -47,7 +47,8 @@ let JS = {
         if(_target){ pushOpts._target = _target }
         targetView.pushInput(sourceEl, targetCtx, newCid, event || phxEvent, pushOpts, callback)
       } else if(eventType === "submit"){
-        targetView.submitForm(sourceEl, targetCtx, event || phxEvent, pushOpts)
+        let {submitter} = args
+        targetView.submitForm(sourceEl, targetCtx, event || phxEvent, submitter, pushOpts)
       } else {
         targetView.pushEvent(eventType, sourceEl, targetCtx, event || phxEvent, data, pushOpts)
       }

--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -822,7 +822,7 @@ export default class LiveSocket {
       e.preventDefault()
       e.target.disabled = true
       this.withinOwners(e.target, view => {
-        JS.exec("submit", phxEvent, view, e.target, ["push", {}])
+        JS.exec("submit", phxEvent, view, e.target, ["push", {submitter: e.submitter}])
       })
     }, false)
 

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -250,6 +250,32 @@ describe("View + DOM", function(){
       view.submitForm(form, form, {target: form})
     })
 
+    test("payload includes submitter when provided", function(){
+      let liveSocket = new LiveSocket("/live", Socket)
+      let el = liveViewDOM()
+      let form = el.querySelector("form")
+      let btn = document.createElement("button")
+      btn.setAttribute("type", "submit")
+      btn.setAttribute("name", "btnName")
+      btn.setAttribute("value", "btnValue")
+      form.appendChild(btn)
+
+      let view = simulateJoinedView(el, liveSocket)
+      let channelStub = {
+        push(_evt, payload, _timeout){
+          expect(payload.type).toBe("form")
+          expect(payload.event).toBeDefined()
+          expect(payload.value).toBe("increment=1&note=2&btnName=btnValue")
+          return {
+            receive(){ return this }
+          }
+        }
+      }
+
+      view.channel = channelStub
+      view.submitForm(form, form, {target: form}, btn)
+    })
+
     test("disables elements after submission", function(){
       let liveSocket = new LiveSocket("/live", Socket)
       let el = liveViewDOM()


### PR DESCRIPTION
Adds support for [`SubmitEvent.submitter`](https://developer.mozilla.org/en-US/docs/Web/API/SubmitEvent/submitter), which as of February 2023 is [supported by 91.49%](https://caniuse.com/mdn-api_submitevent_submitter) of browsers.

Additionally there is [`event-submitter-polyfill`](https://www.npmjs.com/package/event-submitter-polyfill) which is called out in the README for older browsers.

Closes #2148, related to #184, related to #511