### PR TITLE
Add scoped JS selector support

### DIFF
--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -224,7 +224,19 @@ let JS = {
   },
 
   filterToEls(sourceEl, {to}){
-    return to ? DOM.all(document, to) : [sourceEl]
+    if(Array.isArray(to)){
+      let [elSelector, scopeSelector] = to
+      let scopeEl = sourceEl.closest(scopeSelector)
+      // It's not possible to select the scope root with a query. A null element
+      // selector indicates we should use the scope element itself.
+      if(elSelector === null){
+        return scopeEl ? [scopeEl] : []
+      } else {
+        return scopeEl ? DOM.all(scopeEl, elSelector) : []
+      }
+    } else {
+      return to ? DOM.all(document, to) : [sourceEl]
+    }
   },
 
   defaultDisplay(el){

--- a/assets/test/js_test.js
+++ b/assets/test/js_test.js
@@ -511,6 +511,58 @@ describe("JS", () => {
       expect(modal.getAttribute("aria-expanded")).toEqual(null)
     })
 
+    test("with defaults and selector + scope", () => {
+      let view = setupView(`
+      <div id="out-of-scope" class="modal"></div>
+      <div id="scope">
+        <div id="in-scope" class="modal">
+          <div id="set" phx-click='[["set_attr", {"to": [".modal", "#scope"], "attr": ["aria-expanded", "true"]}]]'></div>
+          <div id="remove" phx-click='[["remove_attr", {"to": [".modal", "#scope"], "attr": "aria-expanded"}]]'></div>
+        </div>
+      </div>
+      `)
+
+      let targetModal = document.querySelector("#in-scope")
+      let otherModal = document.querySelector("#out-of-scope")
+      let set = document.querySelector("#set")
+      let remove = document.querySelector("#remove")
+
+      expect(targetModal.getAttribute("aria-expanded")).toEqual(null)
+      expect(otherModal.getAttribute("aria-expanded")).toEqual(null)
+      JS.exec("click", set.getAttribute("phx-click"), view, set)
+      expect(targetModal.getAttribute("aria-expanded")).toEqual("true")
+      expect(otherModal.getAttribute("aria-expanded")).toEqual(null)
+
+      JS.exec("click", remove.getAttribute("phx-click"), view, remove)
+      expect(targetModal.getAttribute("aria-expanded")).toEqual(null)
+      expect(otherModal.getAttribute("aria-expanded")).toEqual(null)
+    })
+
+    test("with defaults and null target + scope", () => {
+      let view = setupView(`
+      <div id="out-of-scope" class="modal"></div>
+      <div id="in-scope" class="modal">
+        <div id="set" phx-click='[["set_attr", {"to": [null, ".modal"], "attr": ["aria-expanded", "true"]}]]'></div>
+        <div id="remove" phx-click='[["remove_attr", {"to": [null, ".modal"], "attr": "aria-expanded"}]]'></div>
+      </div>
+      `)
+
+      let targetModal = document.querySelector("#in-scope")
+      let otherModal = document.querySelector("#out-of-scope")
+      let set = document.querySelector("#set")
+      let remove = document.querySelector("#remove")
+
+      expect(targetModal.getAttribute("aria-expanded")).toEqual(null)
+      expect(otherModal.getAttribute("aria-expanded")).toEqual(null)
+      JS.exec("click", set.getAttribute("phx-click"), view, set)
+      expect(targetModal.getAttribute("aria-expanded")).toEqual("true")
+      expect(otherModal.getAttribute("aria-expanded")).toEqual(null)
+
+      JS.exec("click", remove.getAttribute("phx-click"), view, remove)
+      expect(targetModal.getAttribute("aria-expanded")).toEqual(null)
+      expect(otherModal.getAttribute("aria-expanded")).toEqual(null)
+    })
+
     test("with no selector", () => {
       let view = setupView(`
       <div id="set" phx-click='[["set_attr", {"to": null, "attr": ["aria-expanded", "true"]}]]'></div>

--- a/test/phoenix_live_view/js_test.exs
+++ b/test/phoenix_live_view/js_test.exs
@@ -277,6 +277,20 @@ defmodule Phoenix.LiveView.JSTest do
              }
     end
 
+    test "with scoped to" do
+      assert JS.dispatch("click", to: {"target", "scope"}) == %JS{
+               ops: [["dispatch", %{to: ["target", "scope"], event: "click"}]]
+             }
+
+      assert JS.dispatch("click", to: {nil, "scope"}) == %JS{
+               ops: [["dispatch", %{to: [nil, "scope"], event: "click"}]]
+             }
+
+      assert_raise ArgumentError, ~r/tuple must have two elements/, fn ->
+        JS.dispatch("click", to: {})
+      end
+    end
+
     test "raises with unknown options" do
       assert_raise ArgumentError, ~r/invalid option for dispatch/, fn ->
         JS.dispatch("click", to: ".foo", bad: :opt)


### PR DESCRIPTION
> Extends LiveView.JS's `:to` option to accept a two element tuple, where the first element is the traditional target selector (or nil) and the second element is a "scope selector".
> 
> The scope selector is applied to the emitting element via `Element.closest()`, finding the nearest matching parent, then the target selector is applied from the scope element, selecting all matching children.
> 
> Additionally `nil` may be given as the target selector to select the scope element itself, turning this into a "parent selector" interface too.

It can be useful to limit the selector search space for JS commands, without having to give every instance a unique dom ID, meaning components can "self restrict" their internal commands to their own peer nodes.

AlpineJS does this by defining a `x-data` attribute, which defines a context, but this option (defining a `phx-js-root` "scope attribute" and always looking up to see if we're inside one) isn't really practical for LV as we don't have the same ability to "break out" of the scope like alpine, so nested components could find themselves "locked in" by unknown parent components.

This means we need a two part selector, one do find the scope root -- which is *always* a parent of the emitting element -- and a second for the targets. It felt more natural to combine this under the `to` option rather than adding an additional `scope`/`parent`/`inside` option. I went with a tuple `{target, scope}`, because a list may imply "apply to all these selectors", and a tuple is less syntax and more defined than a map. Since we can't JSON encode tuples, they are converted to two element lists in the `ops` field for processing on the javascript side (they may be better described by a map however).

The tuple could be extended to support `{target, scope: "scope", opt: x}`, where `{string, string}` is an alias for `{string, scope: string}`.

Additionally, since the "target selector" always looks "inside" the scope element, it's impossible to target the scope element itself, which is useful to set component-wide attributes. In this case `nil` can be used as the target selector to target the scope element (sort of synonymous to the current `to: nil` behaviour).