### PR TITLE
Fix warnings

### DIFF
--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -2,7 +2,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
   use ExUnit.Case, async: true
 
   import Phoenix.Component
-  alias Phoenix.LiveView.Tokenizer.{ParseError, HTML}
+  alias Phoenix.LiveView.Tokenizer.ParseError
 
   defp eval(string, assigns \\ %{}, opts \\ []) do
     opts =


### PR DESCRIPTION
Remove an unused/non-existing module from html_engine_test.