### PR TITLE
Fix heading level for "Embedding external template files"

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -462,7 +462,7 @@ defmodule Phoenix.Component do
 
   You can learn more about slots and the `slot/3` macro [in its documentation](`slot/3`).
 
-  ### Embedding external template files
+  ## Embedding external template files
 
   The `embed_templates/1` macro can be used to embed `.html.heex` files
   as function components. The directory path is based on the current


### PR DESCRIPTION
This section has an h3 heading which makes it appear under "Slots" despite not being directly related to it. Because of this the heading is also not displayed in the sidebar.