### PR TITLE
Formatter - treat .link component as inline

### DIFF
--- a/lib/phoenix_live_view/html_formatter.ex
+++ b/lib/phoenix_live_view/html_formatter.ex
@@ -204,10 +204,14 @@ defmodule Phoenix.LiveView.HTMLFormatter do
   # force a line break. This list has been taken from here:
   #
   # https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements#list_of_inline_elements
-  @inline_elements ~w(a abbr acronym audio b bdi bdo big br button canvas cite
+  @inline_tags ~w(a abbr acronym audio b bdi bdo big br button canvas cite
   code data datalist del dfn em embed i iframe img input ins kbd label map
   mark meter noscript object output picture progress q ruby s samp select slot
   small span strong sub sup svg template textarea time u tt var video wbr)
+
+  @inline_components ~w(.link)
+
+  @inline_elements @inline_tags ++ @inline_components
 
   # Default line length to be used in case nothing is specified in the `.formatter.exs` options.
   @default_line_length 98

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -2041,6 +2041,15 @@ if Version.match?(System.version(), ">= 1.13.0") do
       """)
     end
 
+    test "treats .link component as inline" do
+      assert_formatter_doesnt_change(
+        """
+        <.link class="font-semibold" navigate={~p"/open/file?autosave=true"}>Browse them here</.link>.
+        """,
+        heex_line_length: 72
+      )
+    end
+
     # TODO: Remove this `if` after Elixir versions before than 1.14 are no
     # longer supported.
     if function_exported?(EEx, :tokenize, 2) do


### PR DESCRIPTION
Since that's LV common component it is usually wrapper for `a` element, we don't want extra spaces because of formatting.