### PR TITLE
Fix life-cycle diagram to contain preload/1 on change

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -183,14 +183,16 @@ defmodule Phoenix.LiveComponent do
   ```mermaid
   flowchart LR
     *((start)):::event-.->P
-    WE([wait for parent changes]):::event-.->U
-    W([wait for events]):::event-.->H
+    WE([wait for<br>parent changes]):::event-.->P
+    W([wait for<br>events]):::event-.->H
 
-    subgraph w[" "]
+    subgraph j__transparent[" "]
 
       subgraph i[" "]
         direction TB
-        P(preload/1):::callback-->M
+        P(preload/1):::callback-->C{ever<br>mounted?}:::diamond
+        C --> |yes| U
+        C --> |no| M
         M(mount/1):::callback-->U
       end
 
@@ -199,8 +201,7 @@ defmodule Phoenix.LiveComponent do
       subgraph j[" "]
         direction TB
         A --> |yes| R
-        H(handle_event/3):::callback-->A{any changes?}:::diamond
-
+        H(handle_event/3):::callback-->A{any<br>changes?}:::diamond
       end
 
       A --> |no| W

--- a/mix.exs
+++ b/mix.exs
@@ -72,30 +72,34 @@ defmodule Phoenix.LiveView.MixProject do
   defp before_closing_body_tag(:html) do
     """
     <script type="module">
-    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10.0.2/dist/mermaid.esm.min.mjs';
     mermaid.initialize({
       securityLevel: 'loose',
       theme: 'base'
     });
     </script>
     <style>
-    pre > code.mermaid text.flowchartTitleText {
+    code.mermaid text.flowchartTitleText {
       fill: var(--textBody) !important;
     }
-    pre > code.mermaid g.cluster > rect {
+    code.mermaid g.cluster > rect {
       fill: var(--background) !important;
       stroke: var(--neutralBackground) !important;
     }
-    pre > code.mermaid g.edgePaths > path {
+    code.mermaid g.cluster[id$="__transparent"] > rect {
+      fill-opacity: 0 !important;
+      stroke: none !important;
+    }
+    code.mermaid g.edgePaths > path {
       stroke: var(--textBody) !important;
     }
-    pre > code.mermaid g.edgeLabels span.edgeLabel:not(:empty) {
+    code.mermaid g.edgeLabels span.edgeLabel:not(:empty) {
       background-color: var(--textBody) !important;
       padding: 3px 5px !important;
       border-radius:25%;
       color: var(--background) !important;
     }
-    pre > code.mermaid .marker {
+    code.mermaid .marker {
       fill: var(--textBody) !important;
       stroke: var(--textBody) !important;
     }


### PR DESCRIPTION
As these paragraphs point out 

(quote) 

So on first render, the following callbacks will be invoked:

```
preload(list_of_assigns) -> mount(socket) -> update(assigns, socket) -> render(assigns)
```

On subsequent renders, these callbacks will be invoked:

```
preload(list_of_assigns) -> update(assigns, socket) -> render(assigns)
```

(end quote)

the diagram needs to reflect those arrows.

Additionally, I added a transparent styling to a pure layout types of sub-graphs.

![image](https://user-images.githubusercontent.com/102391810/224315893-0725334a-0ed1-440b-ab10-79e5a3546a04.png)
![image](https://user-images.githubusercontent.com/102391810/224316003-84962f3a-8049-46ee-9260-ce67672198c6.png)
