### PR TITLE
Fix JS.exec `:to` documention

### DIFF
--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -735,7 +735,7 @@ defmodule Phoenix.LiveView.JS do
 
   ## Options
 
-    * `:to` - The optional DOM selector to push focus to.
+    * `:to` - The optional DOM selector to fetch the attribute from.
       Defaults to the current element.
 
   ## Examples


### PR DESCRIPTION
copy paste relic