### PR TITLE
Check for reset element when resetting form (#2505)

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -860,10 +860,12 @@ export default class LiveSocket {
       let form = e.target
       DOM.resetForm(form, this.binding(PHX_FEEDBACK_FOR))
       let input = Array.from(form.elements).find(el => el.type === "reset")
-      // wait until next tick to get updated input value
-      window.requestAnimationFrame(() => {
-        input.dispatchEvent(new Event("input", {bubbles: true, cancelable: false}))
-      })
+      if(input){
+        // wait until next tick to get updated input value
+        window.requestAnimationFrame(() => {
+          input.dispatchEvent(new Event("input", {bubbles: true, cancelable: false}))
+        })
+      }
     })
   }
 


### PR DESCRIPTION
A form may be reset directly by `HTMLFormElement.prototype.reset()` meaning it may not always contain a `<button type="reset"/>` element. Only dispatch to the reset element if it exists.