### PR TITLE
Apply sticky operations to focused inputs (#2511)

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -349,6 +349,7 @@ let DOM = {
     } else {
       target.removeAttribute("readonly")
     }
+    DOM.applyStickyOperations(target)
   },
 
   hasSelectionRange(el){


### PR DESCRIPTION
Fixes https://github.com/phoenixframework/phoenix_live_view/issues/2511

Focused inputs are handled specially and while focused, they would lose any changes applied by JS operations. These changes would be correctly restored when any re-render occurred after the element was defocused. We now apply the operations after performing our regular element merge.