### PR TITLE
Sanitize phx-change attribute in formsForRecovery (#2252)

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -1092,7 +1092,10 @@ export default class View {
         .filter(form => form.elements.length > 0)
         .filter(form => form.getAttribute(this.binding(PHX_AUTO_RECOVER)) !== "ignore")
         .map(form => {
-          let newForm = template.content.querySelector(`form[id="${form.id}"][${phxChange}="${form.getAttribute(phxChange)}"]`)
+          // attribute given via JS module needs to be escaped as it contains the symbols []",
+          // which result in an invalid css selector otherwise.
+          const phxChangeValue = form.getAttribute(phxChange).replaceAll(/([\[\]"])/g, '\\$1')
+          let newForm = template.content.querySelector(`form[id="${form.id}"][${phxChange}="${phxChangeValue}"]`)
           if(newForm){
             return [form, newForm, this.targetComponentID(newForm)]
           } else {

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -225,6 +225,13 @@ describe("View + DOM", function(){
     view = new View(liveViewDOM(html), liveSocket)
     view.joinCount = 2
     expect(view.formsForRecovery().length).toBe(0)
+
+    html = "<form id='my-form' phx-change='[[\"push\",{\"event\":\"update\",\"target\":1}]]'><input name=\"foo\" /></form>"
+    view = new View(liveViewDOM(html), liveSocket)
+    view.joinCount = 1
+    const newForms = view.formsForRecovery(html)
+    expect(newForms.length).toBe(1)
+    expect(newForms[0][0].getAttribute('phx-change')).toBe('[[\"push\",{\"event\":\"update\",\"target\":1}]]')
   })
 
   describe("submitForm", function(){


### PR DESCRIPTION
When using the `JS` module to set `phx-change`, the call to `formsForRecovery` on frontend will fail due to not passing the attribute value correctly into a css selector.

Escaping is necessary for the css selector to become valid.

`CSS.escape` would be a more foolproof approach but jest does not support it in node env in which it runs. Not sure if it supports it in jsdom.

In that case, our best bet would be to stub `CSS.escape` and spy on it.

If that is the preferred approach here, I would be happy to do it some time tomorrow.

Resolves #2252 