### PR TITLE
Update docs to use button tag instead of div

### DIFF
--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -63,22 +63,22 @@ defmodule Phoenix.LiveView.JS do
   with the event, apply loading states to external elements, etc. For example,
   given this basic `phx-click` event:
 
-      <div phx-click="inc">+</div>
+      <button phx-click="inc">+</button>
 
   Imagine you need to target your current component, and apply a loading state
   to the parent container while the client awaits the server acknowledgement:
 
       alias Phoenix.LiveView.JS
 
-      <div phx-click={JS.push("inc", loading: ".thermo", target: @myself)}>+</div>
+      <button phx-click={JS.push("inc", loading: ".thermo", target: @myself)}>+</button>
 
   Push commands also compose with all other utilities. For example,
   to add a class when pushing:
 
-      <div phx-click={
+      <button phx-click={
         JS.push("inc", loading: ".thermo", target: @myself)
         |> JS.add_class("warmer", to: ".thermo")
-      }>+</div>
+      }>+</button>
 
   ## Custom JS events with `JS.dispatch/1` and `window.addEventListener`
 


### PR DESCRIPTION
I found a few spots in the docs that use `phx-click` on a `div`, and I think it'd probably be better to demonstrate the proper way you should use `phx-click`: ie., it should probably be on an element with the proper aria role.