### PR TITLE
[Docs] improve clarity of HEEx docs section

### DIFF
--- a/guides/server/assigns-eex.md
+++ b/guides/server/assigns-eex.md
@@ -1,4 +1,4 @@
-# Socket state and HEEx templates
+# Assigns and HEEx templates
 
 All of the data in a LiveView is stored in the socket, which is a server 
 side struct called `Phoenix.LiveView.Socket`. Your own data is stored

--- a/guides/server/assigns-eex.md
+++ b/guides/server/assigns-eex.md
@@ -1,8 +1,9 @@
 # Socket state and HEEx templates
 
-All of the data in a LiveView is stored in the socket, in a server 
-side struct in `Phoenix.LiveView.Socket` called `assigns`. Socket state 
-is never shared with the client beyond what your template renders.
+All of the data in a LiveView is stored in the socket, which is a server 
+side struct called `Phoenix.LiveView.Socket`. Your own data is stored
+under the `assigns` key of said struct. The server data is never shared
+with the client beyond what your template renders.
 
 Phoenix template language is called HEEx (HTML+EEx). EEx is Embedded 
 Elixir, an Elixir string template engine. Those templates

--- a/guides/server/assigns-eex.md
+++ b/guides/server/assigns-eex.md
@@ -1,18 +1,19 @@
-# Assigns and HEEx templates
+# Socket state and HEEx templates
 
-All of the data in a LiveView is stored in the socket as assigns, which
-is a server side struct in `Phoenix.LiveView.Socket`. Socket state is
-never shared with the client beyond what your template renders.
+All of the data in a LiveView is stored in the socket, in a server 
+side struct in `Phoenix.LiveView.Socket` called `assigns`. Socket state 
+is never shared with the client beyond what your template renders.
+
+Phoenix template language is called HEEx (HTML+EEx). EEx is Embedded 
+Elixir, an Elixir string template engine. Those templates
+are either files with the `.heex` extension or they are created
+directly in source files via the `~H` sigil. You can learn more about
+the HEEx syntax by checking the docs for [the `~H` sigil](`Phoenix.Component.sigil_H/2`).
 
 The `Phoenix.Component.assign/2` and `Phoenix.Component.assign/3`
 functions help store those values. Those values can be accessed
 in the LiveView as `socket.assigns.name` but they are accessed
-inside LiveView templates as `@name`.
-
-Phoenix template language is called HEEx (HTML+EEx). Those templates
-are either files with the `.heex` extension or they are created
-directly in source files via the `~H` sigil. You can learn more about
-the HEEx syntax by checking the docs for [the `~H` sigil](`Phoenix.Component.sigil_H/2`).
+inside HEEx templates as `@name`.
 
 In this section, we are going to cover how LiveView minimizes
 the payload over the wire by understanding the interplay between


### PR DESCRIPTION
This is a proposed change to increase the clarity of the section, rearranging sections so all needed definitions hae already been explained, to make this sentence say 
> Those values can be accessed in the LiveView as `socket.assigns.name` but they are accessed inside HEEx templates as `@name`.

instead of 

> Those values can be accessed in the LiveView as `socket.assigns.name` but they are accessed inside LiveView templates as `@name`.

Also, I believe that "socket state" is a more widely understood term for what the assigns object does, so changed the section title accordingly.