### PR TITLE
document heex :for does not support multiple generators

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -720,7 +720,7 @@ defmodule Phoenix.Component do
   <.error :for={msg <- @errors} :if={msg != nil} message={msg} />
   ```
 
-  Note that unlike Elixir's regular `for`, Heex's `:for` does not support multiple
+  Note that unlike Elixir's regular `for`, HEEx' `:for` does not support multiple
   generators in one expression.
 
   ## Code formatting

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -720,6 +720,9 @@ defmodule Phoenix.Component do
   <.error :for={msg <- @errors} :if={msg != nil} message={msg} />
   ```
 
+  Note that unlike Elixir's regular `for`, Heex's `:for` does not support multiple
+  generators in one expression.
+
   ## Code formatting
 
   You can automatically format HEEx templates (.heex) and `~H` sigils


### PR DESCRIPTION
Unsure if this is an oversight or intentional or just something with no nice solution.

Given `:for={a <- 0..10, b <- 0..a}`, we get `syntax error before: ','` because `Code.string_to_quoted` cant handle it.

https://github.com/phoenixframework/phoenix_live_view/blob/b02d7c255f7939c08ad46ac39bc6bbcaa52178bb/lib/phoenix_live_view/tag_engine.ex#L729

https://github.com/phoenixframework/phoenix_live_view/blob/b02d7c255f7939c08ad46ac39bc6bbcaa52178bb/lib/phoenix_live_view/tag_engine.ex#L831-L833

I think it's at least *possible* to construct `"for #{expr}, do: nil"` to send to the parser, then adjust  `validate_quoted_special_attr!` to handle multiple for-generator forms *and* adjust the `handle_special_expr` code to de/reconstruct the parsed expression and replace the `do: nil` with the correct body.