### PR TITLE
Support multiple x <- y, a <- b in :for expressions

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -720,8 +720,9 @@ defmodule Phoenix.Component do
   <.error :for={msg <- @errors} :if={msg != nil} message={msg} />
   ```
 
-  Note that unlike Elixir's regular `for`, HEEx' `:for` does not support multiple
-  generators in one expression.
+  Unlike Elixir's regular `for`, HEEx' `:for` does not support any options such
+  as `:into` or embedded filter expressions. Multiple generators (`x <- y`) are
+  supported.
 
   ## Code formatting
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1575,6 +1575,8 @@ defmodule Phoenix.LiveView do
 
   Now `stream_insert/3` and `stream_delete/3` may be issued and new rows will
   be inserted or deleted from the client.
+
+  Note that streams must the first generator given to `:for`.
   """
   def stream(socket, name, items, opts \\ []) do
     opts = Keyword.merge(opts, id: Phoenix.LiveView.Utils.random_id())


### PR DESCRIPTION
Ref https://github.com/phoenixframework/phoenix_live_view/pull/2540.

Support syntax such as

```html
<div :for={user <- @users, tags <- user.tags}>
```

*Only* extends support for additional `x <- y` generator expressions, "for options" and lone "filter expressions" remain unsupported.