### PR TITLE
Add file extension example to file upload

### DIFF
--- a/guides/server/uploads.md
+++ b/guides/server/uploads.md
@@ -180,8 +180,9 @@ upload data alongside the form data:
 @impl Phoenix.LiveView
 def handle_event("save", _params, socket) do
   uploaded_files =
-    consume_uploaded_entries(socket, :avatar, fn %{path: path}, _entry ->
-      dest = Path.join([:code.priv_dir(:my_app), "static", "uploads", Path.basename(path)])
+    consume_uploaded_entries(socket, :avatar, fn %{path: path}, entry ->
+      ext = "." <> get_entry_extension(entry)
+      dest = Path.join([:code.priv_dir(:my_app), "static", "uploads", Path.basename(path <> ext)])
       # The `static/uploads` directory must exist for `File.cp!/2`
       # and MyAppWeb.static_paths/0 should contain uploads to work,.
       File.cp!(path, dest)
@@ -189,6 +190,11 @@ def handle_event("save", _params, socket) do
     end)
 
   {:noreply, update(socket, :uploaded_files, &(&1 ++ uploaded_files))}
+end
+
+defp get_entry_extension(entry) do
+  [ext | _] = MIME.extensions(entry.client_type)
+  ext
 end
 ```
 
@@ -229,13 +235,19 @@ defmodule MyAppWeb.UploadLive do
   @impl Phoenix.LiveView
   def handle_event("save", _params, socket) do
     uploaded_files =
-      consume_uploaded_entries(socket, :avatar, fn %{path: path}, _entry ->
-        dest = Path.join([:code.priv_dir(:my_app), "static", "uploads", Path.basename(path)])
+      consume_uploaded_entries(socket, :avatar, fn %{path: path}, entry ->
+        ext = "." <> get_entry_extension(entry)
+        dest = Path.join([:code.priv_dir(:my_app), "static", "uploads", Path.basename(path <> ext)])
         File.cp!(path, dest)
         {:ok, ~p"/uploads/#{Path.basename(dest)}"}
       end)
 
     {:noreply, update(socket, :uploaded_files, &(&1 ++ uploaded_files))}
+  end
+
+  defp get_entry_extension(entry) do
+    [ext | _] = MIME.extensions(entry.client_type)
+    ext
   end
 
   defp error_to_string(:too_large), do: "Too large"

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -873,12 +873,18 @@ defmodule Phoenix.LiveView do
 
       def handle_event("save", _params, socket) do
         uploaded_files =
-          consume_uploaded_entries(socket, :avatar, fn %{path: path}, _entry ->
-            dest = Path.join("priv/static/uploads", Path.basename(path))
+          consume_uploaded_entries(socket, :avatar, fn %{path: path}, entry ->
+            ext = "." <> get_entry_extension(entry)
+            dest = Path.join("priv/static/uploads", Path.basename(path <> ext))
             File.cp!(path, dest)
-            {:ok, Routes.static_path(socket, "/uploads/#{Path.basename(dest)}")}
+            {:ok, ~p"/uploads/#{Path.basename(dest)}"}
           end)
         {:noreply, update(socket, :uploaded_files, &(&1 ++ uploaded_files))}
+      end
+
+      defp get_entry_extension(entry) do
+        [ext | _] = MIME.extensions(entry.client_type)
+        ext
       end
   """
   defdelegate consume_uploaded_entries(socket, name, func), to: Phoenix.LiveView.Upload
@@ -906,9 +912,10 @@ defmodule Phoenix.LiveView do
           {[_|_] = entries, []} ->
             uploaded_files = for entry <- entries do
               consume_uploaded_entry(socket, entry, fn %{path: path} ->
-                dest = Path.join("priv/static/uploads", Path.basename(path))
+                ext = "." <> get_entry_extension(entry)
+                dest = Path.join("priv/static/uploads", Path.basename(path <> ext))
                 File.cp!(path, dest)
-                {:ok, Routes.static_path(socket, "/uploads/#{Path.basename(dest)}")}
+                {:ok, ~p"/uploads/#{Path.basename(dest)}"}
               end)
             end
             {:noreply, update(socket, :uploaded_files, &(&1 ++ uploaded_files))}
@@ -916,6 +923,11 @@ defmodule Phoenix.LiveView do
           _ ->
             {:noreply, socket}
         end
+      end
+
+      defp get_entry_extension(entry) do
+        [ext | _] = MIME.extensions(entry.client_type)
+        ext
       end
   """
   defdelegate consume_uploaded_entry(socket, entry, func), to: Phoenix.LiveView.Upload


### PR DESCRIPTION
I was working on a file upload functionality today and I noticed my SVG images weren't being rendered (other images were working fine, though).

I started watching the [Phoenix LiveView Uploads Deep Dive](https://www.youtube.com/watch?v=PffpT2eslH8) to see if there was something I was missing and I noticed one thing: Chris was passing the file extension to `dest` there.

I gave it a try to see if this would fix the SVG rendering issue and it did work. So, I'm wondering if there's something I'm missing here or if we should always add the file extension to the path.

I'm adding it to the docs but feel free to close this PR if not having the extension is intentional and/or I'm doing something wrong.