### PR TITLE
Make note on errors in changesets more explicit in Component docs

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1390,7 +1390,9 @@ defmodule Phoenix.Component do
   Then the remaining options are merged with the existing
   form options.
 
-  Errors will not be displayed in a form if the changeset :action is nil or :ignore. Refer to [a note on :errors for more information](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#form/1-a-note-on-errors).
+  Errors in a form are only displayed if the changeset's `action`
+  field is set (and it is not set to `:ignore`). Refer to
+  [a note on :errors for more information](#form/1-a-note-on-errors).
   """
   def to_form(data_or_params, options \\ [])
 

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1389,6 +1389,8 @@ defmodule Phoenix.Component do
   options above will override its existing values if given.
   Then the remaining options are merged with the existing
   form options.
+
+  Errors will not be displayed in a form if the changeset :action is nil or :ignore. Refer to [a note on :errors for more information](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#form/1-a-note-on-errors).
   """
   def to_form(data_or_params, options \\ [])
 


### PR DESCRIPTION
I had a discussion with two other people about how we all were stuck on getting form validations to show in the new form world.

I noticed there's now a section on covering this but I think it should be included in the `to_form` documentation since 3 of us missed it I imagine others might as well.