### PR TITLE
Add execDynamicMounted view function

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -324,6 +324,11 @@ export default class View {
     DOM.all(this.el, `[${this.binding(PHX_MOUNTED)}]`, el => this.maybeMounted(el))
   }
 
+  execDynamicMounted(el) {
+    this.maybeAddNewHook(el)
+    this.maybeMounted(el)
+  }
+
   applyJoinPatch(live_patch, html, streams, events){
     this.attachTrueDocEl()
     let patch = new DOMPatch(this, this.el, this.id, html, streams, null)


### PR DESCRIPTION
This pull request adds a new function called `execDynamicMounted` to `view.js`, so that users can call it to manually run `phx-hook` and `phx-mounted` in components.

Our current use case is to receive a reference to the user's `liveSocket` and then call `liveSocket.main.execDynamicMounted(element)` after manually adding it to the DOM. This behavior works as expected.

I would like to ask some guidance about the best API design for this (check if we can make it a static function and export it separately), or how to create a test for it.

Fixes #2563