### PR TITLE
Handling patching and navigating via JS commands in events during tests.

### DIFF
--- a/test/phoenix_live_view/integrations/elements_test.exs
+++ b/test/phoenix_live_view/integrations/elements_test.exs
@@ -885,6 +885,18 @@ defmodule Phoenix.LiveView.ElementsTest do
       assert view |> element("#button-js-click-value") |> render_click()
       assert last_event(view) == "<div id=\"last-event\">button-click: %{\"one\" => 1}</div>"
     end
+
+    test "patch", %{live: view} do
+      assert view |> element("#button-js-patch") |> render_click()
+
+      assert last_event(view) ==
+               "<div id=\"last-event\">handle_params: %{\"from\" => \"patch\"}</div>"
+    end
+
+    test "navigate", %{live: view} do
+      assert view |> element("#button-js-navigate") |> render_click()
+      assert_redirect(view, "/example")
+    end
   end
 
   describe "child component / JS commands" do

--- a/test/support/live_views/elements.ex
+++ b/test/support/live_views/elements.ex
@@ -34,6 +34,8 @@ defmodule Phoenix.LiveViewTest.ElementsLive do
 
     <button id="button-js-click" phx-click={JS.push("button-click")}>This is a JS button</button>
     <button id="button-js-click-value" phx-click={JS.push("button-click", value: %{one: 1})}>This is a JS button with a value</button>
+    <button id="button-js-patch" phx-click={JS.patch("/elements?from=patch")}>This is a JS button which will patch</button>
+    <button id="button-js-navigate" phx-click={JS.navigate("/example")}>This is a JS button which will navigate</button>
     <button id="button-disabled-click" phx-click="button-click" disabled>This is a button</button>
     <span id="span-click-no-value" phx-click="span-click">This is a span</span>
     <span id="span-click-value" phx-click="span-click" value="123" phx-value-extra="&lt;456&gt;">This is a span</span>


### PR DESCRIPTION
Shortcut patch / navigation events to their current implementations before handling pushes / events as before.

Fixes #2566 