### PR TITLE
Move global attribute doc higher as a list item

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -815,6 +815,11 @@ defmodule Phoenix.Component.Declarative do
   defp build_attrs_docs(attrs) do
     [
       "## Attributes\n",
+      if Enum.any?(attrs, &(&1.type == :global)) do
+        "\n* Global attributes are accepted."
+      else
+        ""
+      end,
       for attr <- attrs, attr.doc != false, attr.type != :global, into: [] do
         [
           "\n* ",
@@ -825,11 +830,6 @@ defmodule Phoenix.Component.Declarative do
           build_attr_doc_and_default(attr, "  "),
           build_attr_values_or_examples(attr)
         ]
-      end,
-      if Enum.any?(attrs, &(&1.type == :global)) do
-        "\nGlobal attributes are accepted."
-      else
-        ""
       end
     ]
   end

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -848,7 +848,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       fun_attr_global: """
       ## Attributes
 
-      Global attributes are accepted.
+      * Global attributes are accepted.
       """,
       fun_attr_struct: """
       ## Attributes


### PR DESCRIPTION
Make "Global attributes are accepted." less obstructed by turning it into a list item, to the top of the list.

![image](https://user-images.githubusercontent.com/102391810/229555539-c0d6d4c6-6b61-4282-b7bc-64541b421eeb.png)

Reasoning: Although global attributes supposedly go to the end of the list (opinionated), knowing they are accepted right away helps better understanding of the component behaviour.