### PR TITLE
Turn global attribute into list item

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -827,7 +827,7 @@ defmodule Phoenix.Component.Declarative do
         ]
       end,
       if Enum.any?(attrs, &(&1.type == :global)) do
-        "\nGlobal attributes are accepted."
+        "\n* Global attributes are accepted."
       else
         ""
       end

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -848,7 +848,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       fun_attr_global: """
       ## Attributes
 
-      Global attributes are accepted.
+      * Global attributes are accepted.
       """,
       fun_attr_struct: """
       ## Attributes


### PR DESCRIPTION
Make "Global attributes are accepted." less obstructed by turning it into a list item, to the bottom of the list.

![image](https://user-images.githubusercontent.com/102391810/229555539-c0d6d4c6-6b61-4282-b7bc-64541b421eeb.png)

