### PR TITLE
Ensure that a `streams` struct is assigned, before configuration

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1632,7 +1632,7 @@ defmodule Phoenix.LiveView do
   def stream_configure(%Socket{} = socket, name, opts) when is_list(opts) do
     new_socket = ensure_streams(socket)
 
-    case socket.assigns.streams do
+    case new_socket.assigns.streams do
       %{^name => %LiveStream{}} ->
         raise ArgumentError, "cannot configure stream :#{name} after it has been streamed"
 


### PR DESCRIPTION
The new `stream_configure/3` function was not properly using the result of a call to `ensure_streams/1`

This was resulting in an error `(KeyError) key :streams not found %{...}`, during any call to `stream_configure/3`