### PR TITLE
Consider form input only if name attribute is defined

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -1049,7 +1049,7 @@ export default class View {
   pushFormRecovery(form, newCid, callback){
     this.liveSocket.withinOwners(form, (view, targetCtx) => {
       let input = Array.from(form.elements).find(el => {
-        return DOM.isFormInput(el) && el.type !== "hidden" && !el.hasAttribute(this.binding("change"))
+        return DOM.isFormInput(el) && el.name && el.type !== "hidden" && !el.hasAttribute(this.binding("change"))
       })
       let phxEvent = form.getAttribute(this.binding(PHX_AUTO_RECOVER)) || form.getAttribute(this.binding("change"))
 


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix_live_view/issues/2583

An input tag without a name was considered as the form's sourceEl.
If a phx-target was specified for such an input tag, the form's change event was dispatched to a different component than the form's phx-target.
If it doesn't have a name attribute it won't be part of the FormData and should not be considered a form input like in this PR.