### PR TITLE
Fix forms with phx-page-loading not dispatching events (fixes #2596)

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -853,7 +853,7 @@ export default class LiveSocket {
             if(!DOM.isTextualInput(input)){
               this.setActiveElement(input)
             }
-            const form_page_loading = input.form.getAttribute(this.binding(PHX_PAGE_LOADING)) !== null
+            const form_page_loading = input.form && input.form.getAttribute(this.binding(PHX_PAGE_LOADING)) !== null
             JS.exec("change", phxEvent, view, input, ["push", {_target: e.target.name, dispatcher: dispatcher, page_loading: form_page_loading}])
           })
         })

--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -99,6 +99,7 @@ import {
   RELOAD_JITTER_MIN,
   RELOAD_JITTER_MAX,
   PHX_REF,
+  PHX_PAGE_LOADING
 } from "./constants"
 
 import {
@@ -852,7 +853,8 @@ export default class LiveSocket {
             if(!DOM.isTextualInput(input)){
               this.setActiveElement(input)
             }
-            JS.exec("change", phxEvent, view, input, ["push", {_target: e.target.name, dispatcher: dispatcher}])
+            const form_page_loading = input.form.getAttribute(this.binding(PHX_PAGE_LOADING)) !== null
+            JS.exec("change", phxEvent, view, input, ["push", {_target: e.target.name, dispatcher: dispatcher, page_loading: form_page_loading}])
           })
         })
       }, false)


### PR DESCRIPTION
When a form input changes and triggers a phx-change event, only the input was checked for a `phx-page-loading` attribute. We now also check the inputs parent form.