### PR TITLE
RFC: Support multiple JS.push events in LiveViewTest

### DIFF
--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -317,10 +317,18 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
             # but we take care to only send the `value` and any `extra` values
             # (collected from phx-value or form inputs) once with the first event.
             #
-            # (I can't quite reckon when you might be able to send phx-value-x values
-            # and uploads from a phx-click and also trigger JS events, but this
-            # method retains any previous behaviour: traditional events come in as [event] and
-            # multi-js-push come in as [js_push, js_push, ...].)
+            # > I can't quite reckon when you might be able to send phx-value-x values
+            # > and uploads from a phx-click and also trigger JS events, but this
+            # > method retains any current behaviour, even if aberrant.
+            #
+            # > This means that the `phx-target` and `phx-value` below will
+            # > be attached to the first event.
+            #
+            # > <button phx-target={@myself}
+            # >         phx-value-x="also-sent"
+            # >         phx-click={JS.push("e", ...) |> JS.push("e", target: @myself, ...)}>
+            # >   both to self
+            # > </button>
             event_or_js
             |> maybe_js_event()
             |> List.wrap()

--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -317,12 +317,12 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
             |> maybe_js_event()
             |> List.wrap()
             |> Enum.map(fn {event, js_values, js_target_selector} ->
-              dom_values = Map.merge(dom_values, js_values)
+              event_values = Map.merge(dom_values, js_values)
 
               {values, uploads} =
                 case value do
-                  %Upload{} = upload -> {dom_values, upload}
-                  other -> {DOM.deep_merge(dom_values, stringify(other, & &1)), nil}
+                  %Upload{} = upload -> {event_values, upload}
+                  other -> {DOM.deep_merge(event_values, stringify(other, & &1)), nil}
                 end
 
               js_targets = DOM.targets_from_selector(root, js_target_selector)

--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -366,8 +366,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
       end
 
     case result do
-      [{%ClientProxy{} = _view, cids, _event, _values, _upload} | _] = events
-      when is_list(cids) ->
+      [{%ClientProxy{} = _view, _cids, _event, _values, _upload} | _] = events ->
         last_event = length(events) - 1
 
         diffs =

--- a/test/phoenix_live_view/integrations/event_test.exs
+++ b/test/phoenix_live_view/integrations/event_test.exs
@@ -17,7 +17,7 @@ defmodule Phoenix.LiveView.EventTest do
     test "LiveViewTest supports sending multiple push events in one render call", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/events-multi-js")
 
-      assert element(view, "[phx-click]")
+      assert element(view, "#add-one-and-ten")
              |> render_click() =~ "count: 11"
     end
   end

--- a/test/phoenix_live_view/integrations/event_test.exs
+++ b/test/phoenix_live_view/integrations/event_test.exs
@@ -13,6 +13,15 @@ defmodule Phoenix.LiveView.EventTest do
     {:ok, conn: Plug.Test.init_test_session(build_conn(), config[:session] || %{})}
   end
 
+  describe "multiple push_event" do
+    test "LiveViewTest supports sending multiple push events in one render call", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/events-multi-js")
+
+      assert element(view, "[phx-click]")
+             |> render_click() =~ "count: 11"
+    end
+  end
+
   describe "push_event" do
     test "sends updates with general assigns diff", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/events")

--- a/test/phoenix_live_view/integrations/event_test.exs
+++ b/test/phoenix_live_view/integrations/event_test.exs
@@ -13,12 +13,44 @@ defmodule Phoenix.LiveView.EventTest do
     {:ok, conn: Plug.Test.init_test_session(build_conn(), config[:session] || %{})}
   end
 
-  describe "multiple push_event" do
-    test "LiveViewTest supports sending multiple push events in one render call", %{conn: conn} do
+  describe "LiveViewTest supports multiple JS.push events" do
+    test "from one click", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/events-multi-js")
 
       assert element(view, "#add-one-and-ten")
              |> render_click() =~ "count: 11"
+    end
+
+    test "with repiles", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/events-multi-js")
+
+      assert element(view, "#reply-values")
+             |> render_click()
+
+      assert_reply(view, %{value: 1})
+      assert_reply(view, %{value: 2})
+    end
+
+    test "from a component to itself", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/events-multi-js-in-component")
+
+      html =
+        element(view, "#child_1 #push-to-self-component")
+        |> render_click()
+
+      assert html =~ "child_1 count: 11"
+      assert html =~ "child_2 count: 0"
+    end
+
+    test "from a component to other targets", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/events-multi-js-in-component")
+
+      html =
+        element(view, "#child_1 #push-between-components")
+        |> render_click()
+
+      assert html =~ "child_1 count: 1"
+      assert html =~ "child_2 count: 2"
     end
   end
 

--- a/test/phoenix_live_view/integrations/event_test.exs
+++ b/test/phoenix_live_view/integrations/event_test.exs
@@ -35,7 +35,7 @@ defmodule Phoenix.LiveView.EventTest do
       {:ok, view, _html} = live(conn, "/events-multi-js-in-component")
 
       html =
-        element(view, "#child_1 #push-to-self-component")
+        element(view, "#child_1 #push-to-self")
         |> render_click()
 
       assert html =~ "child_1 count: 11"
@@ -46,11 +46,12 @@ defmodule Phoenix.LiveView.EventTest do
       {:ok, view, _html} = live(conn, "/events-multi-js-in-component")
 
       html =
-        element(view, "#child_1 #push-between-components")
+        element(view, "#child_1 #push-to-other-targets")
         |> render_click()
 
       assert html =~ "child_1 count: 1"
       assert html =~ "child_2 count: 2"
+      assert html =~ "root count: -1"
     end
   end
 

--- a/test/phoenix_live_view/integrations/event_test.exs
+++ b/test/phoenix_live_view/integrations/event_test.exs
@@ -13,48 +13,6 @@ defmodule Phoenix.LiveView.EventTest do
     {:ok, conn: Plug.Test.init_test_session(build_conn(), config[:session] || %{})}
   end
 
-  describe "LiveViewTest supports multiple JS.push events" do
-    test "from one click", %{conn: conn} do
-      {:ok, view, _html} = live(conn, "/events-multi-js")
-
-      assert element(view, "#add-one-and-ten")
-             |> render_click() =~ "count: 11"
-    end
-
-    test "with repiles", %{conn: conn} do
-      {:ok, view, _html} = live(conn, "/events-multi-js")
-
-      assert element(view, "#reply-values")
-             |> render_click()
-
-      assert_reply(view, %{value: 1})
-      assert_reply(view, %{value: 2})
-    end
-
-    test "from a component to itself", %{conn: conn} do
-      {:ok, view, _html} = live(conn, "/events-multi-js-in-component")
-
-      html =
-        element(view, "#child_1 #push-to-self")
-        |> render_click()
-
-      assert html =~ "child_1 count: 11"
-      assert html =~ "child_2 count: 0"
-    end
-
-    test "from a component to other targets", %{conn: conn} do
-      {:ok, view, _html} = live(conn, "/events-multi-js-in-component")
-
-      html =
-        element(view, "#child_1 #push-to-other-targets")
-        |> render_click()
-
-      assert html =~ "child_1 count: 1"
-      assert html =~ "child_2 count: 2"
-      assert html =~ "root count: -1"
-    end
-  end
-
   describe "push_event" do
     test "sends updates with general assigns diff", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/events")
@@ -169,6 +127,48 @@ defmodule Phoenix.LiveView.EventTest do
       |> render_click(%{reply: "123"})
 
       refute_received _
+    end
+  end
+
+  describe "LiveViewTest supports multiple JS.push events" do
+    test "from one click", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/events-multi-js")
+
+      assert element(view, "#add-one-and-ten")
+             |> render_click() =~ "count: 11"
+    end
+
+    test "with repiles", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/events-multi-js")
+
+      assert element(view, "#reply-values")
+             |> render_click()
+
+      assert_reply(view, %{value: 1})
+      assert_reply(view, %{value: 2})
+    end
+
+    test "from a component to itself", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/events-multi-js-in-component")
+
+      html =
+        element(view, "#child_1 #push-to-self")
+        |> render_click()
+
+      assert html =~ "child_1 count: 11"
+      assert html =~ "child_2 count: 0"
+    end
+
+    test "from a component to other targets", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/events-multi-js-in-component")
+
+      html =
+        element(view, "#child_1 #push-to-other-targets")
+        |> render_click()
+
+      assert html =~ "child_1 count: 1"
+      assert html =~ "child_2 count: 2"
+      assert html =~ "root count: -1"
     end
   end
 end

--- a/test/support/live_views/events.ex
+++ b/test/support/live_views/events.ex
@@ -30,10 +30,10 @@ defmodule Phoenix.LiveViewTest.EventsMultiJSLive do
 
   def render(assigns) do
     ~H"""
-    <span phx-click={
-      JS.push("inc", value: %{inc: 1})
-      |> JS.push("inc", value: %{inc: 10})
-    }>push-button</span>
+    <span id="add-one-and-ten"
+      phx-click={JS.push("inc", value: %{inc: 1}) |> JS.push("inc", value: %{inc: 10})}>
+      Add 1 and 10
+    </span>
     count: <%= @count %>
     """
   end

--- a/test/support/live_views/events.ex
+++ b/test/support/live_views/events.ex
@@ -24,6 +24,33 @@ defmodule Phoenix.LiveViewTest.EventsLive do
   def handle_info({:run, func}, socket), do: func.(socket)
 end
 
+defmodule Phoenix.LiveViewTest.EventsMultiJSLive do
+  use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
+  alias Phoenix.LiveView.JS
+
+  def render(assigns) do
+    ~H"""
+    <span phx-click={
+      JS.push("inc", value: %{inc: 1})
+      |> JS.push("inc", value: %{inc: 10})
+    }>push-button</span>
+    count: <%= @count %>
+    """
+  end
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, events: [], count: 0)}
+  end
+
+  def handle_event("inc", %{"inc" => v}, socket) do
+    {:noreply, update(socket, :count, &(&1 + v))}
+  end
+
+  def handle_call({:run, func}, _, socket), do: func.(socket)
+
+  def handle_info({:run, func}, socket), do: func.(socket)
+end
+
 defmodule Phoenix.LiveViewTest.EventsInMountLive do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
 

--- a/test/support/live_views/events.ex
+++ b/test/support/live_views/events.ex
@@ -32,21 +32,25 @@ defmodule Phoenix.LiveViewTest.EventsMultiJSLive do
     ~H"""
     count: <%= @count %>
 
-    <span id="add-one-and-ten"
+    <button
+      id="add-one-and-ten"
       phx-click={
-      JS.push("inc", value: %{inc: 1})
-      |> JS.push("inc", value: %{inc: 10})
-      }>
+        JS.push("inc", value: %{inc: 1})
+        |> JS.push("inc", value: %{inc: 10})
+      }
+    >
       Add 1 and 10
-    </span>
+    </button>
 
-    <span id="reply-values"
+    <button
+      id="reply-values"
       phx-click={
-      JS.push("reply", value: %{int: 1})
-      |> JS.push("reply", value: %{int: 2})
-      }>
+        JS.push("reply", value: %{int: 1})
+        |> JS.push("reply", value: %{int: 2})
+      }
+    >
       Reply with 1 and 2
-    </span>
+    </button>
     """
   end
 
@@ -85,20 +89,24 @@ defmodule Phoenix.LiveViewTest.EventsInComponentMultiJSLive do
     def render(assigns) do
       ~H"""
       <div id={@id}>
-        <button id="push-to-self"
-                phx-click={
-                  JS.push("inc", target: "#child_1", value: %{inc: 1})
-                |> JS.push("inc", target: "#child_1", value: %{inc: 10})}>
-          both to self
+        <button
+          id="push-to-self"
+          phx-click={
+            JS.push("inc", target: "#child_1", value: %{inc: 1})
+            |> JS.push("inc", target: "#child_1", value: %{inc: 10})}
+        >
+          Both to self
         </button>
 
-        <button id="push-to-other-targets"
-                phx-click={
-                JS.push("inc", target: "#child_2", value: %{inc: 2})
-                |> JS.push("inc", target: "#child_1", value: %{inc: 1})
-                |> JS.push("inc", value: %{inc: -1})
-                }>
-          one to either
+        <button
+          id="push-to-other-targets"
+          phx-click={
+            JS.push("inc", target: "#child_2", value: %{inc: 2})
+            |> JS.push("inc", target: "#child_1", value: %{inc: 1})
+            |> JS.push("inc", value: %{inc: -1})
+          }
+        >
+          One to everyone
         </button>
 
         <%= @id %> count: <%= @count %>

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -100,6 +100,7 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/events", EventsLive
     live "/events-in-mount", EventsInMountLive
     live "/events-in-component", EventsInComponentLive
+    live "/events-multi-js", EventsMultiJSLive
 
     # integration components
     live "/component_in_live", ComponentInLive.Root

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -101,6 +101,7 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/events-in-mount", EventsInMountLive
     live "/events-in-component", EventsInComponentLive
     live "/events-multi-js", EventsMultiJSLive
+    live "/events-multi-js-in-component", EventsInComponentMultiJSLive
 
     # integration components
     live "/component_in_live", ComponentInLive.Root


### PR DESCRIPTION
Currently LiveViewTest can't test views or components with something like:

```html
<button phx-click={JS.push("event_a") |> JS.push("event_b")}/>
```

This PR adds support for that by collecting all events and passing them through a reducer.

This PR retains the slightly unexpected current behaviour of merging `phx-value-x` attributes into `JS.push` data but only for the first `JS.push` event. It also preserves the current behaviour of using `phx-target` if present for `JS.push`, for all events.