### PR TITLE
Document JS.push's phx-value and phx-target behaviour

### DIFF
--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -80,6 +80,19 @@ defmodule Phoenix.LiveView.JS do
         |> JS.add_class("warmer", to: ".thermo")
       }>+</button>
 
+  Any `phx-value-*` attributes will also be included in the payload, their
+  values will be overwritten by values given directly to `push/1`. Any
+  `phx-target` attribute will also be used, and overwritten.
+
+      <button
+        phx-click={JS.push("inc", value: %{limit: 40})}
+        phx-value-room="bedroom"
+        phx-value-limit="this value will be 40"
+        phx-target={@myself}
+      >+</button>
+
+  Push command
+
   ## Custom JS events with `JS.dispatch/1` and `window.addEventListener`
 
   `dispatch/1` can be used to dispatch custom JavaScript events to
@@ -135,11 +148,14 @@ defmodule Phoenix.LiveView.JS do
 
   ## Options
 
-    * `:target` - The selector or component ID to push to
-    * `:loading` - The selector to apply the phx loading classes to
+    * `:target` - The selector or component ID to push to. This value will
+      overwrite any `phx-target` attribute present on the element.
+    * `:loading` - The selector to apply the phx loading classes to.
     * `:page_loading` - Boolean to trigger the phx:page-loading-start and
-      phx:page-loading-stop events for this push. Defaults to `false`
-    * `:value` - The map of values to send to the server
+      phx:page-loading-stop events for this push. Defaults to `false`.
+    * `:value` - The map of values to send to the server. These values will be
+      merged over any `phx-value-*` attributes that are present on the element.
+      All keys will be treated as strings when merging.
 
   ## Examples
 

--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -91,8 +91,6 @@ defmodule Phoenix.LiveView.JS do
         phx-target={@myself}
       >+</button>
 
-  Push command
-
   ## Custom JS events with `JS.dispatch/1` and `window.addEventListener`
 
   `dispatch/1` can be used to dispatch custom JavaScript events to


### PR DESCRIPTION
`JS.push` will include any `phx-value-*` values from the source element and will also target any `phx-target` on the element if given. These values are overwritten by any value or target given to the actual function.

There are some quirks with forms however, where they never attach any `phx-value` attributes, and they have a particular quirk with `phx-target` where `phx-change=JS.push` requires *both* `phx-target` and `target: t` for the message to be correctly sent.

As such, I have left forms behaviour undocumented as I'm unsure what the intent is.

See reproduction of form behaviour and examples of generic buttons:

<details>
<summary>code</summary>

```elixir
Application.put_env(:sample, Example.Endpoint,
  http: [ip: {127, 0, 0, 1}, port: 5001],
  server: true,
  live_view: [signing_salt: "aaaaaaaa"],
  secret_key_base: String.duplicate("a", 64)
)

Mix.install([
  {:plug_cowboy, "~> 2.5"},
  {:jason, "~> 1.0"},
  {:phoenix, "~> 1.7.2", override: true},
  {:phoenix_live_view, "~> 0.18.18"}
])

defmodule Example.ErrorView do
  def render(template, _), do: Phoenix.Controller.status_message_from_template(template)
end

defmodule Example.Component do
  use Phoenix.LiveComponent
  alias Phoenix.LiveView.JS

  def render(assigns) do
    ~H"""
    <div id={@id}>
      <h2>
      Count: <%= @count %>
      </h2>
    </div>
    """
  end

  def handle_event("inc", %{}, socket) do
    {:noreply, update(socket, :count, &(&1 + 1))}
  end
end

defmodule Example.HomeLive do
  use Phoenix.LiveView, layout: {__MODULE__, :live}
  alias Phoenix.LiveView.JS

  def mount(_params, _session, socket) do
    {:ok, assign(socket, :events, [])}
  end

  def render("live.html", assigns) do
    ~H"""
    <script src="https://cdn.jsdelivr.net/npm/phoenix@1.7.2/priv/static/phoenix.min.js"></script>
    <script src="https://cdn.jsdelivr.net/npm/phoenix_live_view@0.18.18/priv/static/phoenix_live_view.min.js"></script>
    <script>
      let liveSocket = new window.LiveView.LiveSocket("/live", window.Phoenix.Socket)
      liveSocket.connect()
    </script>
    <style>
      html {
        width: 1000px;
        margin: 1rem auto;
      }
      main {
        display: grid;
        grid-template-columns: 1fr 1fr;
        grid-column-gap: 1em;
      }
      * { font-size: 1rem; }
      div { margin-bottom: 2rem; }
      button, form {
        padding: 1ex 2ex;
        border: 1px solid black;
      }
    </style>
    <%= @inner_content %>
    """
  end

  def render(assigns) do
    ~H"""
    <main>
    <section>
      <div>
        <h1>Button</h1>
        <p>
          This button has phx-click=JS.push. The push event has its own values,
          and the button has some additional phx-value attributes.
        </p>
        <p>
          JS push sends the `value` map and any phx-value attributes. The js value
          overwrites the phx-values.
        </p>
        <button
          phx-click={JS.push("event", value: %{js: "world", override: "js"})}
          phx-value-from-attr="hello"
          phx-value-override="html"
        >
          Push
        </button>
      </div>

      <div>
        <h1>Button inside tag</h1>
        <p>
          This button is inside a form. It behaves identically to the previous
          example.
        </p>
        <form phx-change="fake" phx-submit="fake">
          <input type="text" name="username" value="plain input"/>
          <button
            type="button"
            phx-click={JS.push("event", value: %{js: "world", override: "js"})}
            phx-value-from-attr="hello"
            phx-value-override="html">
            Push
          </button>
        </form>
      </div>

      <div>
        <h1>Form with phx-click</h1>
        <p>
          This form sends an event on click. It attaches any `phx-value`
          attributes from the form element to the event. input values are NOT included.
        </p>
        <form
          phx-change="fake"
          phx-submit="fake"
          phx-value-from-attr="hello"
          phx-click={JS.push("event", value: %{js: "world"})}
        >
          <input type="text" name="username" value="plain input"/>
          <input type="text" name="password" phx-value="hunter2" value="input with phx-value"/>
        </form>
      </div>

      <div>
        <h1>Form with phx-change=JS.push</h1>
        <p>
          This form sends an event on change. No phx-value values are
          included. Form input values ARE included.
        </p>

        <form
          phx-change={JS.push("event", value: %{js: "world"})}
          phx-submit="fake"
          phx-value-from-attr="hello"
        >
          <input type="text" name="username" value="plain input"/>
          <input type="text" name="password" phx-value="hunter2" value="input with phx-value"/>
        </form>
      </div>

      <div>
        <h1>JS.exec's a push on another element</h1>
        <p>
          This button runs JS.exec against another element. phx-values on
          the target element are included, values on the source element are
          not.
        </p>

        <button
          phx-click={JS.exec("data-js", to: "#target-1")}
          phx-value-old="so old"
        >
          button
        </button>
        <div
          id="target-1"
          data-js={JS.push("event", value: %{js: "world", override: "js"})}
          phx-value-from-attr="hello"
          phx-value-override="html">
        </div>
      </div>

      <div>
        <h1>Push with target</h1>
        <.live_component module={Example.Component} id={:my_component} count={0}/>

        <p>
            This button pushes to a component via js.target
        </p>

        <button
          phx-click={JS.push("inc", target: "#my_component")}
        >
          target: "#my_component"
        </button>

        <p>
            This button pushes to a component via phx-target
        </p>
        <button
          phx-click={JS.push("inc")}
          phx-target="#my_component"
        >
          phx-target="#my_component"
        </button>

        <p>
            This button pushes to a component via both, the JS value is used.
        </p>
        <button
          phx-click={JS.push("inc", target: "#my_component")}
          phx-target="#fake-component"
        >
          target: "#my_component",
          phx-target="#fake-component"
        </button>

      </div>

      <div>
        <h1>Push with target</h1>
        <.live_component module={Example.Component} id={:my_component_2} count={0}/>

        <p>
          This form has BOTH phx-change={JS.push(inc, target)} phx-target and
          changes increment the counter.
        </p>
        <form
          phx-change={JS.push("inc", target: "#my_component_2")}
          phx-target="#my_component_2">
          <input type="text" name="username" value="plain input"/>
        </form>

        <p>
          This form has phx-change={JS.push(inc, target)}, the target is
          ignored and the message is sent to the parent view (and crashes).
        </p>
        <form
          phx-change={JS.push("inc", target: "#my_component_2")}>
          <input type="text" name="username" value="plain input"/>
        </form>

        <p>
          This form has phx-change={JS.push(inc)} phx-target. phx-target is
          ignored and the message is sent to the parent view (and crashes).
        </p>
        <form
          phx-change={JS.push("inc")} phx-target="#my_component_2">
          <input type="text" name="username" value="plain input"/>
        </form>

        <p>
          This form has phx-change={JS.push(inc)} but has phx-target on the
          input. The message is sent to the parent view (and crashes).
        </p>
        <form
          phx-change={JS.push("inc")}>
          <input type="text" name="username" value="plain input"  phx-target="#my_component_2"/>
        </form>
      </div>
    </section>
    <section>
      <h1>Event log (newest first)</h1>
      <pre :for={e <- @events}><%= inspect(e, pretty: true, width: 30) %></pre>
    </section>
    </main>
    """
  end

  def handle_event("event", params, socket) do
    {:noreply, update(socket, :events, fn e -> [params | e] end)}
  end

  def handle_event("fake", params, socket) do
    {:noreply,
     update(socket, :events, fn e -> [Map.put(params, "source", "phx-change/submit") | e] end)}
  end
end

defmodule Example.Router do
  use Phoenix.Router
  import Phoenix.LiveView.Router

  pipeline :browser do
    plug(:accepts, ["html"])
  end

  scope "/", Example do
    pipe_through(:browser)

    live("/", HomeLive, :index)
  end
end

defmodule Example.Endpoint do
  use Phoenix.Endpoint, otp_app: :sample
  socket("/live", Phoenix.LiveView.Socket)
  plug(Example.Router)
end

{:ok, _} = Supervisor.start_link([Example.Endpoint], strategy: :one_for_one)
Process.sleep(:infinity)
```` 

</details>