### PR TITLE
Remove more previously deprecated functionality from live_img_preview (#2608)

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2725,26 +2725,16 @@ defmodule Phoenix.Component do
 
   attr.(:rest, :global, [])
 
-  def live_img_preview(%{entry: %Phoenix.LiveView.UploadEntry{ref: ref} = entry} = assigns) do
-    rest =
-      assigns
-      |> assigns_to_attributes([:entry])
-      |> Keyword.put_new_lazy(:id, fn -> "phx-preview-#{ref}" end)
-
-    assigns = assign(assigns, entry: entry, ref: ref, rest: rest)
-
+  def live_img_preview(assigns) do
     ~H"""
     <img
+      id={"phx-preview-#{@entry.ref}"}
       data-phx-upload-ref={@entry.upload_ref}
-      data-phx-entry-ref={@ref}
+      data-phx-entry-ref={@entry.ref}
       data-phx-hook="Phoenix.LiveImgPreview"
       data-phx-update="ignore"
       {@rest} />
     """
-  end
-
-  def live_img_preview(_assigns) do
-    raise ArgumentError, "missing required :entry attribute to <.live_img_preview/>"
   end
 
   @doc """


### PR DESCRIPTION
Now that attr. is used for the live_img_preview component (from 19b7784dfef956a2daff1b4e6e264d98325ca440) additional code in the live_img_preview appears unnecessary and to be causing #2608 . The validation that there is an entry assign is performed automatically by attr.