### PR TITLE
Copy for admonition for users about the location of phx-update="stream"

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1565,6 +1565,11 @@ defmodule Phoenix.LiveView do
        along with a unique DOM id.
     2. Each stream item must include its DOM id on the item's element.
 
+> #### Info {: .info}
+>
+> Not placing `phx-update="stream"` on the **immediate parent** for **each stream**
+> will result in unexpected behavior when calling `stream_insert` or `stream_delete`.
+
   When consuming a stream in a template, the DOM id and item is passed as a tuple,
   allowing convenient inclusion of the DOM id for each item. For example:
 


### PR DESCRIPTION
Add an admonition about the perils of not having phx-update="stream" on the immediate parent of a stream.