### PR TITLE
Add `phx-keydown-*` and `phx-keyup-*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Enhancements
   * Support ordered inputs within `inputs_for`, to pair with Ecto's new `sort_param` and `drop_param` casting
   * Send form phx-value's on form events
+  * Support for `ctrl`, `meta`, `shift` modifiers on key events. E.g: `phx-keydown-control-a={JS.set_attribute({"aria-select", "true"}, to: "div")}`
 
 ### Deprecations
   * Deprecate passing `:dom_id` to `stream/4` in favor of `stream_configure/3`

--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -521,8 +521,16 @@ export default class LiveSocket {
     this.bind({keyup: "keyup", keydown: "keydown"}, (e, type, view, targetEl, phxEvent, eventTarget) => {
       let matchKey = targetEl.getAttribute(this.binding(PHX_KEY))
       let pressedKey = e.key && e.key.toLowerCase() // chrome clicked autocompletes send a keydown without key
-      if(matchKey && matchKey.toLowerCase() !== pressedKey){ return }
-
+      let binding = this.binding(e.type)
+      let keys = []
+      if (e.ctrlKey){keys.push("control")}
+      if (e.metaKey){keys.push("meta")}
+      if (e.shiftKey){keys.push("shift")}
+      if (keys.includes(pressedKey) === false){keys.push(pressedKey)}
+      let phxKey = [binding].concat(keys).join("-")
+      let hasPhxKey = targetEl.getAttributeNames().includes(phxKey)
+      phxEvent = hasPhxKey ? targetEl.getAttribute(phxKey) : phxEvent
+      if (hasPhxKey === false && matchKey && matchKey.toLowerCase() !== pressedKey) {return}
       let data = {key: e.key, ...this.eventMeta(type, e, targetEl)}
       JS.exec(type, phxEvent, view, targetEl, ["push", {data}])
     })

--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -652,7 +652,8 @@ export default class LiveSocket {
 
   bindKey(eventName){
     let key = this.binding(eventName)
-    window.addEventListener(eventName, e => {
+    let windowBinding = this.binding(`window-${eventName}`)
+    this.on(eventName, e => {
       let target = e.target
       let matchKey = target.getAttribute(this.binding(PHX_KEY))
       let pressedKey = e.key && e.key.toLowerCase() // chrome clicked autocompletes send a keydown without key
@@ -672,6 +673,16 @@ export default class LiveSocket {
           this.withinOwners(target, view => {
             let data = {key: e.key, ...this.eventMeta(eventName, e, target)}
             JS.exec(eventName, phxEvent, view, target, ["push", {data}])
+          })
+        })
+      } else {
+        DOM.all(document, `[${windowBinding}]`, el => {
+          let phxEvent = el.getAttribute(windowBinding)
+          this.debounce(el, e, browserEventName, () => {
+            this.withinOwners(el, view => {
+              let data = {key: e.key, ...this.eventMeta(eventName, e, target)}
+              JS.exec(eventName, phxEvent, view, target, ["push", {data}])
+            })
           })
         })
       }

--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -97,7 +97,7 @@ values will be sent as part of the payload. For example:
 ## Key Events
 
 The `onkeydown`, and `onkeyup` events are supported via the `phx-keydown`,
-and `phx-keyup` bindings. Each binding supports a `phx-key` attribute, which triggers
+`phx-keyup`, `phx-keyup-*`, and `phx-keydown-*` bindings. Each binding supports a `phx-key` attribute, which triggers
 the event for the specific key press. If no `phx-key` is provided, the event is triggered
 for any key press. When pushed, the value sent to the server will contain the `"key"`
 that was pressed, plus any user-defined metadata. For example, pressing the


### PR DESCRIPTION
This PR adds explicit key event attributes to support multiple key events per element and their modifiers.

```
<div phx-keyup=“keydown” phx-key=“a” phx-keydown-control-a={JS.set_attribute({"aria-select", "true"}, to: "div")></div>
```

Resolve #2617 