### PR TITLE
Support nested JS commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Enhancements
   * Support ordered inputs within `inputs_for`, to pair with Ecto's new `sort_param` and `drop_param` casting
   * Send form phx-value's on form events
+  * Support nested JS commands, e.g. `JS.set_attribute({"phx-click", JS.remove_attribute("aria-seletec")})`
 
 ### Deprecations
   * Deprecate passing `:dom_id` to `stream/4` in favor of `stream_configure/3`

--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -221,6 +221,7 @@ let JS = {
 
     DOM.putSticky(el, "attrs", currentEl => {
       newRemoves.forEach(attr => currentEl.removeAttribute(attr))
+      if (val.constructor === Array) {val = JSON.stringify(val)}
       newSets.forEach(([attr, val]) => currentEl.setAttribute(attr, val))
       return [newSets, newRemoves]
     })

--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -221,8 +221,10 @@ let JS = {
 
     DOM.putSticky(el, "attrs", currentEl => {
       newRemoves.forEach(attr => currentEl.removeAttribute(attr))
-      if (val.constructor === Array) {val = JSON.stringify(val)}
-      newSets.forEach(([attr, val]) => currentEl.setAttribute(attr, val))
+      newSets.forEach(([attr, val]) => {
+        if (val.constructor === Array) {val = JSON.stringify(val)}
+        currentEl.setAttribute(attr, val)
+      })
       return [newSets, newRemoves]
     })
   },

--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -135,7 +135,16 @@ defmodule Phoenix.LiveView.JS do
 
   defimpl Phoenix.HTML.Safe, for: Phoenix.LiveView.JS do
     def to_iodata(%Phoenix.LiveView.JS{} = js) do
-      Phoenix.HTML.Engine.html_escape(Phoenix.json_library().encode!(js.ops))
+      js
+      |> traverse()
+      |> Phoenix.json_library.encode!()
+      |> Phoenix.HTML.Engine.html_escape()
+    end
+    defp traverse(%Phoenix.LiveView.JS{ops: [[a, %{attr: [b, %Phoenix.LiveView.JS{} = c]}]]} = js) do
+      traverse(%{js | ops: [[a, %{attr: [b, traverse(c)]}]]})
+    end
+    defp traverse(%Phoenix.LiveView.JS{} = js) do
+      js.ops
     end
   end
 

--- a/test/phoenix_live_view/js_test.exs
+++ b/test/phoenix_live_view/js_test.exs
@@ -689,6 +689,8 @@ defmodule Phoenix.LiveView.JSTest do
     test "encoding" do
       assert js_to_string(JS.set_attribute({"disabled", "true"})) ==
                "[[&quot;set_attr&quot;,{&quot;attr&quot;:[&quot;disabled&quot;,&quot;true&quot;],&quot;to&quot;:null}]]"
+      assert js_to_string(JS.set_attribute({"phx-click", JS.set_attribute({"aria-expanded", "true"})})) ==
+                "[[&quot;set_attr&quot;,{&quot;attr&quot;:[&quot;phx-click&quot;,[[&quot;set_attr&quot;,{&quot;attr&quot;:[&quot;aria-expanded&quot;,&quot;true&quot;],&quot;to&quot;:null}]]]}]]"
     end
   end
 


### PR DESCRIPTION
This PR adds support for nested JS commands by traversing them in `Phoenix.HTML.Safe.to_iodata/1` and encoding them in `setOrRemoveAttrs/3`.

Resolve #2619