### PR TITLE
Fix transition bug for `JS.add_class` / `JS.remove_class` / `JS.transition`

### DIFF
--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -191,12 +191,19 @@ let JS = {
   },
 
   addOrRemoveClasses(el, adds, removes, transition, time, view){
-    let [transition_run, transition_start, transition_end] = transition || [[], [], []]
-    if(transition_run.length > 0){
-      let onStart = () => this.addOrRemoveClasses(el, transition_start.concat(transition_run), [])
-      let onDone = () => this.addOrRemoveClasses(el, adds.concat(transition_end), removes.concat(transition_run).concat(transition_start))
+    let [transitionRun, transitionStart, transitionEnd] = transition || [[], [], []]
+    if(transitionRun.length > 0){
+      let onStart = () => {
+        this.addOrRemoveClasses(el, transitionStart, [].concat(transitionRun).concat(transitionEnd))
+        window.requestAnimationFrame(() => {
+          this.addOrRemoveClasses(el, transitionRun, [])
+          window.requestAnimationFrame(() => this.addOrRemoveClasses(el, transitionEnd, transitionStart))
+        })
+      }
+      let onDone = () => this.addOrRemoveClasses(el, adds.concat(transitionEnd), removes.concat(transitionRun).concat(transitionStart))
       return view.transition(time, onStart, onDone)
     }
+
     window.requestAnimationFrame(() => {
       let [prevAdds, prevRemoves] = DOM.getSticky(el, "classes", [[], []])
       let keepAdds = adds.filter(name => prevAdds.indexOf(name) < 0 && !el.classList.contains(name))


### PR DESCRIPTION
This PR is trying to close #2484.

To reproduce the problem, you can run <https://github.com/plastic-forks/live-view-transition-inconsistency/blob/main/live_view.exs>.
To see the solution, you can run <https://github.com/plastic-forks/live-view-transition-inconsistency/blob/main/live_view-fixed.exs> which uses the fixed `phoenix_live_view.min.js`.