### PR TITLE
file_input/4 can set an entry's relative path

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1088,6 +1088,7 @@ defmodule Phoenix.LiveViewTest do
     * `:content` - the binary content of the file
     * `:size` - the byte size of the content
     * `:type` - the MIME type of the file
+    * `:relative_path` - for simulating webkitdirectory metadata
 
   ## Examples
 

--- a/lib/phoenix_live_view/test/structs.ex
+++ b/lib/phoenix_live_view/test/structs.ex
@@ -90,9 +90,12 @@ defmodule Phoenix.LiveViewTest.Upload do
       Map.get(entry, :content) ||
         raise ArgumentError, "the :content of the binary entry file data is required."
 
+    relative_path = Map.get(entry, :relative_path)
+
     %{
       "name" => name,
       "content" => content,
+      "relative_path" => relative_path,
       "ref" => to_string(System.unique_integer([:positive])),
       "size" => entry[:size] || byte_size(content),
       "type" => entry[:type] || MIME.from_path(name)

--- a/test/phoenix_live_view/upload/directory_test.exs
+++ b/test/phoenix_live_view/upload/directory_test.exs
@@ -1,0 +1,41 @@
+defmodule Phoenix.LiveView.DirectoryTest do
+  use ExUnit.Case, async: false
+
+  @endpoint Phoenix.LiveViewTest.Endpoint
+
+  import Phoenix.LiveViewTest
+
+  alias Phoenix.LiveViewTest.UploadLive
+
+  def mount_lv(setup) when is_function(setup, 1) do
+    conn = Plug.Test.init_test_session(Phoenix.ConnTest.build_conn(), %{})
+    {:ok, lv, _} = live_isolated(conn, UploadLive, session: %{})
+    :ok = GenServer.call(lv.pid, {:setup, setup})
+    {:ok, lv}
+  end
+
+  test "can set relative path from file_input/4 helper" do
+    {:ok, lv} =
+      mount_lv(fn socket ->
+        Phoenix.LiveView.allow_upload(socket, :avatar,
+          max_entries: 2,
+          chunk_size: 20,
+          accept: :any,
+          external: fn _entry, socket ->
+            {:ok, %{uploader: "S3"}, socket}
+          end
+        )
+      end)
+
+    avatar =
+      file_input(lv, "form", :avatar, [
+        %{
+          name: "foo1.jpeg",
+          content: String.duplicate("ok", 100),
+          relative_path: "some/path/to/foo1.jpeg"
+        }
+      ])
+
+    assert render_upload(avatar, "foo1.jpeg", 1) =~ "relative path:some/path/to/foo1.jpeg"
+  end
+end

--- a/test/support/live_views/upload_live.ex
+++ b/test/support/live_views/upload_live.ex
@@ -16,6 +16,7 @@ defmodule Phoenix.LiveViewTest.UploadLive do
         <%= for msg <- upload_errors(@uploads.avatar, entry) do %>
           error:<%= inspect(msg) %>
         <% end %>
+        relative path:<%= entry.client_relative_path %>
       <% end %>
       <.live_file_input upload={@uploads.avatar} />
       <button type="submit">save</button>


### PR DESCRIPTION
Fixes https://github.com/phoenixframework/phoenix_live_view/issues/2628

Allow the `file_input` test helper to set an upload entry's relative path. This is normally set by browsers when using [the webkitdirectory attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/webkitdirectory) on a file input, in order to upload an entire directory in one go.

Note that while testing this PR on main, I found [a regression](https://github.com/phoenixframework/phoenix_live_view/issues/2631) that removes support for the `webkitdirectory` attribute in production code.