### PR TITLE
Add preprocess_tokens/1 callback

### DIFF
--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -48,6 +48,9 @@ defmodule Phoenix.LiveView.HTMLEngine do
   def classify_type(name), do: {:tag, name}
 
   @impl true
+  def preprocess_tokens(tokens), do: tokens
+
+  @impl true
   for void <- ~w(area base br col hr img input link meta param command keygen source) do
     def void?(unquote(void)), do: true
   end

--- a/lib/phoenix_live_view/tag_engine.ex
+++ b/lib/phoenix_live_view/tag_engine.ex
@@ -41,6 +41,17 @@ defmodule Phoenix.LiveView.TagEngine do
   @callback void?(name :: binary()) :: boolean()
 
   @doc """
+  Returns a list of tokens to be rendered.
+
+  This function allows HTML engines to perform initial transformations on
+  nodes within the template AST before it is processed for rendering. You
+  can just implement as `def preprocess_tokens(tokens), do: tokens` if you
+  want to ignore this.
+  """
+  @type token :: {atom(), binary(), list(tuple()), map()}
+  @callback preprocess_tokens(tokens :: [token()]) :: [token()]
+
+  @doc """
   Renders a component defined by the given function.
 
   This function is rarely invoked directly by users. Instead, it is used by `~H`
@@ -174,7 +185,10 @@ defmodule Phoenix.LiveView.TagEngine do
 
   @impl true
   def handle_body(%{tokens: tokens, file: file, cont: cont} = state) do
-    tokens = Tokenizer.finalize(tokens, file, cont, state.source)
+    tokens =
+      tokens
+      |> Tokenizer.finalize(file, cont, state.source)
+      |> state.tag_handler.preprocess_tokens()
 
     token_state =
       state


### PR DESCRIPTION
This pull request introduces a `preprocess_tokens/1` callback to the `Phoenix.LiveView.TagEngine` behaviour for transforming a HEEx template's AST before rendering. The changes here build off of the work done by @feliperenan to open up the tokenizer for customization and is necessary to support some custom template syntax we'd like to add to LiveView Native ([related PR here](https://github.com/liveview-native/live_view_native/pull/16)).

The implementation for `Phoenix.LiveView.HTMLEngine` simply returns the passed tokens in their unmodified state, so this doesn't affect how LiveView templates are compiled or rendered.

Linking [this thread](https://github.com/liveview-native/liveview-client-swiftui/pull/787#discussion_r1170453190) for context as per @bcardarella 