### PR TITLE
[Doc] Correct the usage example in the function doc of to_form/2

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1397,7 +1397,7 @@ defmodule Phoenix.Component do
   changesets. `:errors` a keyword of tuples in the shape
   of `{error_message, options_list}`. Here is an example:
 
-      to_form(%{"search" => nil}, errors: [search: [{"Can't be blank", []}]])
+      to_form(%{"search" => nil}, errors: [search: {"Can't be blank", []}])
 
   If an existing `Phoenix.HTML.Form` struct is given, the
   options above will override its existing values if given.


### PR DESCRIPTION
Remove unnecessary list.

The original example causes the following error.

```elixir
to_form(%{"search" => nil}, errors: [search: [{"Can't be blank", []}]])
```

```
** (FunctionClauseError) no function clause matching in FalconWeb.ErrorHelpers.translate_error/1
```
