### PR TITLE
Fixes typo in LiveView docs.

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -83,7 +83,7 @@ defmodule Phoenix.LiveView do
         # In Phoenix v1.6+ apps, the line below should be: use MyAppWeb, :live_view
         use Phoenix.LiveView
 
-        def render(assigns) do
+        def render(socket) do
           ~H"""
           Current temperature: <%= @temperature %>
           """


### PR DESCRIPTION
I noticed this while reading through the LiveView docs, and it confused me for a few minutes.