### PR TITLE
[Docs] Fix link typo

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1579,7 +1579,7 @@ defmodule Phoenix.LiveView do
   the server from overwhelming the client with new results while also opening up
   powerful features like virtualized infinite scrolling. See a complete
   bidirectional infinite scrolling example with stream limits in the
-  [scroll events guide](bindings.md##scroll-events-and-infinite-stream-pagination)
+  [scroll events guide](bindings.md#scroll-events-and-infinite-stream-pagination)
 
   When a stream exceeds the limit on the client, the existing items will be removed
   based on the


### PR DESCRIPTION
In [stream/4](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#stream/4) docs, in subsection **Limiting a stream**, there's a link to **scroll events guide**.

The current link is
```
https://hexdocs.pm/phoenix_live_view/bindings.html##scroll-events-and-infinite-stream-pagination
```

And it should be
```
https://hexdocs.pm/phoenix_live_view/bindings.html#scroll-events-and-infinite-stream-pagination
```

(Double ##)