### PR TITLE
fix for non-inputs being tracked as in #2648

### DIFF
--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -229,8 +229,8 @@ export default class DOMPatch {
           // input handling
           DOM.copyPrivates(toEl, fromEl)
 
-          let isFocusedFormEl = focused && fromEl.isSameNode(focused) && DOM.isFormInput(fromEl)
-          if(isFocusedFormEl && fromEl.type !== "hidden"){
+          let isFocusedFormEl = focused && fromEl.isSameNode(focused)
+          if(isFocusedFormEl && DOM.isFormInput(fromEl) && fromEl.type !== "hidden"){
             this.trackBefore("updated", fromEl, toEl)
             DOM.mergeFocusedInput(fromEl, toEl)
             DOM.syncAttrsToProps(fromEl)
@@ -246,7 +246,7 @@ export default class DOMPatch {
             DOM.maybeAddPrivateHooks(toEl, phxViewportTop, phxViewportBottom)
             DOM.syncAttrsToProps(toEl)
             DOM.applyStickyOperations(toEl)
-            if(toEl.getAttribute("name")){
+            if(toEl.getAttribute("name") && DOM.isFormInput(toEl)){
               trackedInputs.push(toEl)
             }
             this.trackBefore("updated", fromEl, toEl)


### PR DESCRIPTION
re. issue #2648 it seems that the fix at https://github.com/phoenixframework/phoenix_live_view/commit/3da40b587e5ba8367f65478d71e5c099929b9da0 was missing one place where inputs were being tracked