### PR TITLE
Pass `live/4` `:private` values to `socket.private` on mount

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -1145,8 +1145,6 @@ defmodule Phoenix.LiveView.Channel do
     Map.merge(route_private, private)
   end
 
-  defp maybe_merge_route_private(_route_private, private), do: private
-
   defp sync_with_parent(parent, assign_new) do
     try do
       GenServer.call(parent, {@prefix, :child_mount, self(), assign_new})

--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -73,7 +73,7 @@ defmodule Phoenix.LiveView.Router do
     * `:metadata` - a map to optional feed metadata used on telemetry events and route info,
       for example: `%{route_name: :foo, access: :user}`.
 
-    * `:private` - an optional map of private data to put in the plug connection.
+    * `:private` - an optional map of private data to put in the plug connection,
       for example: `%{route_name: :foo, access: :user}`.
 
   ## Examples
@@ -365,6 +365,7 @@ defmodule Phoenix.LiveView.Router do
       opts
       |> Keyword.put(:router, router)
       |> Keyword.put(:action, action)
+      |> Keyword.put(:private, private)
 
     {as_helper, as_action} = inferred_as(live_view, opts[:as], action)
 

--- a/test/phoenix_live_view/integrations/live_view_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test.exs
@@ -251,6 +251,13 @@ defmodule Phoenix.LiveView.LiveViewTest do
     end
   end
 
+  describe "private" do
+    test "pass router live private to socket mount", %{conn: conn} do
+      {:ok, view, _} = live(conn, "/thermo-private")
+      assert render(view) =~ "Private is: 1"
+    end
+  end
+
   describe "messaging callbacks" do
     test "handle_event with no change in socket", %{conn: conn} do
       {:ok, view, html} = live(conn, "/thermo")

--- a/test/support/live_views/general.ex
+++ b/test/support/live_views/general.ex
@@ -20,6 +20,9 @@ defmodule Phoenix.LiveViewTest.ThermostatLive do
         <i><%= user.name %> <%= user.email %></i>
       <% end %>
     <% end %>
+    <%= if @private do %>
+      Private is: <%= @private %>
+    <% end %>
     """
   end
 
@@ -44,7 +47,7 @@ defmodule Phoenix.LiveViewTest.ThermostatLive do
     users = session["users"] || []
     val = if connected?(socket), do: 1, else: 0
 
-    {:ok, assign(socket, val: val, nest: nest, users: users, greeting: nil)}
+    {:ok, assign(socket, val: val, nest: nest, users: users, greeting: nil, private: socket.private[:val])}
   end
 
   def handle_params(params, _url, socket) do

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -27,6 +27,7 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/thermo", ThermostatLive
     live "/thermo/:id", ThermostatLive
     live "/thermo-container", ThermostatLive, container: {:span, style: "thermo-flex<script>"}
+    live "/thermo-private", ThermostatLive, private: %{val: 1}
     live "/", ThermostatLive, as: :live_root
     live "/clock", ClockLive
     live "/redir", RedirLive


### PR DESCRIPTION
An attempt to close #2136

I faced a very similar use case on https://github.com/BeaconCMS/beacon as explained by @barkerja where some live routes are defined at compile-time and having those private values from the router in mount would be really useful.