### PR TITLE
Allow select html tags to apply diff changes on focus

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -371,8 +371,8 @@ let DOM = {
   },
 
   mergeFocusedInput(target, source){
-    // skip selects because FF will reset highlighted index for any setAttribute
-    if(!(target instanceof HTMLSelectElement)){ DOM.mergeAttrs(target, source, {exclude: ["value"]}) }
+    DOM.mergeAttrs(target, source, {exclude: ["value"]})
+
     if(source.readOnly){
       target.setAttribute("readonly", true)
     } else {


### PR DESCRIPTION
When a select input has the focus, such as when an user is changing a values of a select, then we want to apply the changes that come from the server. This was initially disabled specifically for FF as Brian's comment but that might not be an issue anymore. We just installed a new version of FF and it works ok now.

context: We started this investigation as we have a form with a regular `phx-change` validation with a required constraint and the css classes on errors were not applying on the select. We saw that the server was sending those changes but the js part was not applying those because of condition on the `mergeFocusedInput`.

We initially tried to just apply a new `id` to the select (based on the select value) but that did not work nice as the `phx-no-feedback` class was not being removed as phoenix was considering that select as a new element.

| before | after |
| --- | --- |
| ![current-version](https://github.com/phoenixframework/phoenix_live_view/assets/317960/78290825-ac97-48d6-8d5c-38c72568b479) | ![with-fix-version](https://github.com/phoenixframework/phoenix_live_view/assets/317960/a7ff5d3d-c784-4cbd-85bc-090f832b9a12)
7bd90a3d) |
