### PR TITLE
Update phoenix_component.ex

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2249,7 +2249,7 @@ defmodule Phoenix.Component do
         |> cast(attrs, [:title])
         |> cast_embed(:emails,
           with: &email_changeset/2,
-          sort_param: :emails_order,
+          sort_param: :emails_sort,
           drop_param: :emails_drop
         )
       end


### PR DESCRIPTION
Documentation fix: Fix sort_param name in changeset from   emails_order to email_sort in the changeset

In the heex example list[emails_sort][] is used, to be consistent I have renamed the sort_param to emails_sort in the changeset as well.