### PR TITLE
Don't unload if the click occured inside of a contenteditable

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -75,6 +75,7 @@ let DOM = {
 
     if(e.defaultPrevented || href === null || this.wantsNewTab(e)){ return false }
     if(href.startsWith("mailto:") || href.startsWith("tel:")){ return false }
+    if(e.target.isContentEditable){ return false }
 
     try {
       url = new URL(href)


### PR DESCRIPTION
If a link is inside of a `<div contenteditable="true">`, clicking on it will simply focus the `contenteditable`, not navigate to the link, however live_socket behaves as if we are about to navigate to that link and unloads the socket.

(see issue #2670)