### PR TITLE
Add InfiniteScroll hook after patch, fixes #2667

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -389,6 +389,9 @@ export default class View {
 
     patch.after("added", el => {
       this.liveSocket.triggerDOM("onNodeAdded", [el])
+      let phxViewportTop = this.binding(PHX_VIEWPORT_TOP)
+      let phxViewportBottom = this.binding(PHX_VIEWPORT_BOTTOM)
+      DOM.maybeAddPrivateHooks(el, phxViewportTop, phxViewportBottom)
       this.maybeAddNewHook(el)
       if(el.getAttribute){ this.maybeMounted(el) }
     })


### PR DESCRIPTION
This PR fixes the InfiniteScroll hook (phx-viewport-top/bottom) not being applied after a LiveView patch navigation.

As I'm not really into the LiveView Javascript code, I'm not sure if that is the correct way to fix this, so please feel free to close this PR if it's wrong :)

Fixes #2667
Fixes #2896