### PR TITLE
 Add 'disabled' to accepted file input attributes

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2751,7 +2751,7 @@ defmodule Phoenix.Component do
       "the optional override for the accept attribute. Defaults to :accept specified by allow_upload"
   )
 
-  attr.(:rest, :global, include: ~w(webkitdirectory required))
+  attr.(:rest, :global, include: ~w(webkitdirectory required disabled))
 
   def live_file_input(%{upload: upload} = assigns) do
     assigns = assign_new(assigns, :accept, fn -> upload.accept != :any && upload.accept end)


### PR DESCRIPTION
This code is working currently in my project, the input is actually becoming disabled when I write it like this:
```elixir
<.live_file_input
  upload={@uploads.image}
  disabled={not @can_be_saved}
/>
```
The problem is that I got the compilation warning that says the following:
```
warning: undefined attribute "disabled" for component Phoenix.Component.live_file_input/1
  lib/quiz_arena_web/live/quiz_live/steps/questions.html.heex:127: (file)
```

The warning appears after I switched to the newest live_view:
```elixir
{:phoenix_live_view, "~> 0.19.1"}
```