### PR TITLE
Only extract `value` meta when element is not a form, closes #2680

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -849,7 +849,7 @@ export default class View {
       let name = el.attributes[i].name
       if(name.startsWith(prefix)){ meta[name.replace(prefix, "")] = el.getAttribute(name) }
     }
-    if(el.value !== undefined){
+    if(el.tagName !== "FORM" && el.value !== undefined){
       if(!meta){ meta = {} }
       meta.value = el.value
 


### PR DESCRIPTION
`extractMeta` receives a "root element".

When this element is an input, we want to retrieve the current value.

When the element is a form, `form.key` will look up any inputs in the form with the name "key". If an input has the name "value", then we would retrieve the input element *as the value*, instead of getting the value of an input.

We explicitly avoid getting the value of a form to avoid this edgecase.

At time of writing, the value attribute is valid on button, data, input, li, meter, option, progress and param tags.