### PR TITLE
Convert relative paths to full paths in pushHistoryPatch

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -748,7 +748,11 @@ export default class LiveSocket {
 
   pushHistoryPatch(href, linkState, targetEl){
     if(!this.isConnected()){ return Browser.redirect(href) }
-
+    // Convert relative path to full path (as in historyRedirect)
+    if(/^\/$|^\/[^\/]+.*$/.test(href)){
+      let {protocol, host} = window.location
+      href = `${protocol}//${host}${href}`
+    }
     this.withPageLoading({to: href, kind: "patch"}, done => {
       this.main.pushLinkPatch(href, targetEl, linkRef => {
         this.historyPatch(href, linkState, linkRef)


### PR DESCRIPTION
While investigating #2665 I noticed that `pushHistoryPatch` was passing the given href to `pushLinkPatch` as-is, meaning that attempting to patch to a relative path would fail if the path belonged to a route under a host scope, since a relative path doesn't include a host.

This MR copies the relative path to full path conversion code from `historyRedirect` into `pushHistoryPatch`, fixing the issue.