### PR TITLE
Process case when "from" is missing for proxy callback

### DIFF
--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -456,11 +456,8 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
 
       :error ->
         case Map.fetch(state.dropped_replies, ref) do
-          {:ok, :missing_from} ->
-            {:noreply, %{state | dropped_replies: Map.delete(state.dropped_replies, ref)}}
-
           {:ok, from} ->
-            GenServer.reply(from, {:ok, nil})
+            from  && GenServer.reply(from, {:ok, nil})
             {:noreply, %{state | dropped_replies: Map.delete(state.dropped_replies, ref)}}
 
           :error ->
@@ -670,12 +667,12 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
         state = %{state | html: new_html}
         payload = %{"cids" => will_destroy_cids}
 
-        push_with_callback(state, view, "cids_will_destroy", :missing_from, payload, fn _, state ->
+        push_with_callback(state, view, "cids_will_destroy", nil, payload, fn _, state ->
           still_there_cids = DOM.component_ids(view.id, state.html)
           payload = %{"cids" => Enum.reject(will_destroy_cids, &(&1 in still_there_cids))}
 
           state =
-            push_with_callback(state, view, "cids_destroyed", :missing_from, payload, fn reply, state ->
+            push_with_callback(state, view, "cids_destroyed", nil, payload, fn reply, state ->
               cids = reply.payload.cids
               {:noreply, update_in(state.views[topic].rendered, &DOM.drop_cids(&1, cids))}
             end)

--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -457,7 +457,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
       :error ->
         case Map.fetch(state.dropped_replies, ref) do
           {:ok, from} ->
-            from  && GenServer.reply(from, {:ok, nil})
+            from && GenServer.reply(from, {:ok, nil})
             {:noreply, %{state | dropped_replies: Map.delete(state.dropped_replies, ref)}}
 
           :error ->

--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -456,6 +456,9 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
 
       :error ->
         case Map.fetch(state.dropped_replies, ref) do
+          {:ok, :missing_from} ->
+            {:noreply, %{state | dropped_replies: Map.delete(state.dropped_replies, ref)}}
+
           {:ok, from} ->
             GenServer.reply(from, {:ok, nil})
             {:noreply, %{state | dropped_replies: Map.delete(state.dropped_replies, ref)}}
@@ -667,12 +670,12 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
         state = %{state | html: new_html}
         payload = %{"cids" => will_destroy_cids}
 
-        push_with_callback(state, view, "cids_will_destroy", nil, payload, fn _, state ->
+        push_with_callback(state, view, "cids_will_destroy", :missing_from, payload, fn _, state ->
           still_there_cids = DOM.component_ids(view.id, state.html)
           payload = %{"cids" => Enum.reject(will_destroy_cids, &(&1 in still_there_cids))}
 
           state =
-            push_with_callback(state, view, "cids_destroyed", nil, payload, fn reply, state ->
+            push_with_callback(state, view, "cids_destroyed", :missing_from, payload, fn reply, state ->
               cids = reply.payload.cids
               {:noreply, update_in(state.views[topic].rendered, &DOM.drop_cids(&1, cids))}
             end)


### PR DESCRIPTION
Fixes https://github.com/phoenixframework/phoenix_live_view/issues/2693

I processed a situation, where "from" value is invalid for using by `GenServer.reply/2`.
I have also explicitly used `:missing_from` for such cases.
Should I replace it back with `nil`, or create a module attribute, like `@missing_from :missing_from`?

I was not able to reliably reproduce the issue, so did not create any tests for it.