### PR TITLE
Correctly pick first non-hidden input in pushFormRecovery

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -1073,7 +1073,7 @@ export default class View {
       let inputs = Array.from(form.elements).filter(el => DOM.isFormInput(el) && el.name && !el.hasAttribute(phxChange))
       if(inputs.length === 0){ return }
 
-      let input = inputs.find(el => el.type !== "hidden") || input[0]
+      let input = inputs.find(el => el.type !== "hidden") || inputs[0]
       let phxEvent = form.getAttribute(this.binding(PHX_AUTO_RECOVER)) || form.getAttribute(this.binding("change"))
       JS.exec("change", phxEvent, view, input, ["push", {_target: input.name, newCid: newCid, callback: callback}])
     })


### PR DESCRIPTION
I have a form using phx-change with a single hidden input in (the input's value is updated by a hook), and getting `ReferenceError: Cannot access 'input' before initialization` on reconnects. I think this should fix it

I'm not sure on what the best way to write a test for this is - I can't see an existing one for pushFormRecovery and couldn't figure out the proper way to trigger/assert the function