### PR TITLE
Fix Phoenix.ChannelTest.connect/3 warning

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1143,7 +1143,7 @@ defmodule Phoenix.LiveViewTest do
   defmacro file_input(view, form_selector, name, entries) do
     quote bind_quoted: [view: view, selector: form_selector, name: name, entries: entries] do
       require Phoenix.ChannelTest
-      builder = fn -> Phoenix.ChannelTest.connect(Phoenix.LiveView.Socket, %{}, %{}) end
+      builder = fn -> Phoenix.ChannelTest.connect(Phoenix.LiveView.Socket, %{}) end
       Phoenix.LiveViewTest.__file_input__(view, selector, name, entries, builder)
     end
   end


### PR DESCRIPTION
brought about by: https://github.com/phoenixframework/phoenix/pull/5488

Removing the 3rd argument is backwards compatible since `connect_info` still defaults to `%{}`.