### PR TITLE
[fix] add missing bracket to stream_configure

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1633,7 +1633,7 @@ defmodule Phoenix.LiveView do
           stream(socket, :songs, songs)
 
           socket
-          |> stream_configure(:songs, dom_id: &("songs-#{&1.id}")
+          |> stream_configure(:songs, dom_id: &("songs-#{&1.id}"))
           |> stream(:songs, songs)
 
   A stream must be configured before items are inserted, and once configured,
@@ -1641,7 +1641,7 @@ defmodule Phoenix.LiveView do
   single time in a LiveComponent, use the `mount/1` callback. For example:
 
       def mount(socket) do
-        {:ok, stream_configure(socket, :songs, dom_id: &("songs-#{&1.id}")}
+        {:ok, stream_configure(socket, :songs, dom_id: &("songs-#{&1.id}"))}
       end
 
       def update(assigns, socket) do


### PR DESCRIPTION
Fix a missing bracket in the documentation for `stream_configure`.