### PR TITLE
Fix Phoenix.LiveViewTest.page_title/1 to allow for <title> within <svg>

### DIFF
--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -1368,7 +1368,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
   defp put_cid(payload, cid), do: Map.put(payload, "cid", cid)
 
   defp root_page_title(root_html) do
-    case DOM.maybe_one(root_html, "title") do
+    case DOM.maybe_one(root_html, "head > title") do
       {:ok, {"title", _, [text]}} -> text
       {:error, _kind, _desc} -> nil
     end

--- a/test/support/live_views/elements.ex
+++ b/test/support/live_views/elements.ex
@@ -153,6 +153,9 @@ defmodule Phoenix.LiveViewTest.ElementsLive do
     <form id="trigger-form-value" action="/not_found" method="POST" phx-submit="form-submit-trigger"
           phx-trigger-action={@trigger_action}>
     </form>
+
+    <%# @page_title assign is unique %>
+    <svg><title>SVG with title</title></svg>
     """
   end
 


### PR DESCRIPTION
From [hexdocs.pm/phoenix_live_view/live-layouts.html#updating-document-title](https://hexdocs.pm/phoenix_live_view/live-layouts.html#updating-document-title)

> Because the root layout from the Plug pipeline is rendered outside of LiveView, the contents cannot be dynamically changed. The one exception is the <title> of the HTML document. Phoenix LiveView special cases the @page_title assign to allow dynamically updating the title of the page, which is useful when using live navigation, or annotating the browser tab with a notification.

The current implementation of `Phoenix.LiveViewTest.page_title/1` searches only for a single <title> tag.

The assumption that only one `<title>` tag exists on the page does not hold if the page also includes a title tag within an `<svg>` element. The `page_title/1` function returns `nil` but the HTML for the page title tag contains the expected value.

`<svg><title>Brief, accessible title</title>...</svg> ` is a valid pattern. https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title

Updating the CSS selector from `title` to `head > title` seems to match the [mozilla documentation for the document title tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title).

Superficially similar to #1496