### PR TITLE
Add 'inert' to the list of global HTML attributes

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -33,6 +33,7 @@ defmodule Phoenix.Component.Declarative do
     height
     hidden
     id
+    inert
     inputmode
     is
     itemid


### PR DESCRIPTION
Add [inert](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert) according to [the list of global HTML attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#inert).