### PR TITLE
Document socket session options at runtime

### DIFF
--- a/lib/phoenix_live_view/socket.ex
+++ b/lib/phoenix_live_view/socket.ex
@@ -30,6 +30,18 @@ defmodule Phoenix.LiveView.Socket do
 
       socket "/live", MyAppWeb.UserSocket,
         websocket: [connect_info: [session: @session_options]]
+
+  If you require session options to be set at runtime, you can use 
+  an MFA tuple. The function it designates must return a keyword list.
+
+      socket "/live", MyAppWeb.UserSocket,
+        websocket: [connect_info: [session: {__MODULE__, :runtime_opts, []}]]
+
+      # ...  
+    
+      def runtime_opts() do
+        Keyword.put(@session_options, :domain, host())
+      end
   """
   use Phoenix.Socket
 


### PR DESCRIPTION
Hello,

This is a small docs update in reference to the following patch: https://github.com/RiverFinancial/phoenix/commit/bb9a0a4030c61bfb51a4de2b91677b3652926afa
Apologies if this is documented elsewhere, I've been struggling to find it.

Thanks
