### PR TITLE
Fix wantsNewTab with uppercase target

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -61,7 +61,7 @@ let DOM = {
   wantsNewTab(e){
     let wantsNewTab = e.ctrlKey || e.shiftKey || e.metaKey || (e.button && e.button === 1)
     let isDownload = (e.target instanceof HTMLAnchorElement && e.target.hasAttribute("download"))
-    let isTargetBlank = e.target.getAttribute("target") === "_blank"
+    let isTargetBlank = e.target.hasAttribute("target") && e.target.getAttribute("target").toLowerCase() === "_blank"
     return wantsNewTab || isTargetBlank || isDownload
   },
 

--- a/assets/test/dom_test.js
+++ b/assets/test/dom_test.js
@@ -16,6 +16,19 @@ describe("DOM", () => {
     curTitle && curTitle.remove()
   })
 
+  describe ("wantsNewTab", () => {
+    test("case insensitive target", () => {
+      let event = e("https://test.local")
+      expect(DOM.wantsNewTab(event)).toBe(false)
+      // lowercase
+      event.target.setAttribute("target", "_blank")
+      expect(DOM.wantsNewTab(event)).toBe(true)
+      // uppercase
+      event.target.setAttribute("target", "_BLANK")
+      expect(DOM.wantsNewTab(event)).toBe(true)
+    })
+  })
+
   describe("isNewPageClick", () => {
     test("identical locations", () => {
       let currentLoc


### PR DESCRIPTION
Hi there,

I recently chased down a bug in our repo where clicking on a link in a modal which opened a new tab caused the live socket to disconnect, and the modal could not be dismissed. It turned out that I had copy-pasted from a stack overflow answer about making a link open in a new tab which had `target=_BLANK`, where currently the code only checks for the lowercase `target=_blank`.

Sorry to jump straight to a PR with no issue, but it seemed like the same amount of work to write an issue as to submit a PR.

Thanks!

edit: A link to the spec, specifying that that the target value should be a case-insensitive match: https://html.spec.whatwg.org/multipage/document-sequences.html#valid-navigable-target-name-or-keyword