### PR TITLE
Remove fragment part from query on redirects

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -752,7 +752,7 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   defp patch_params_and_action!(socket, %{to: to}) do
-    destructure [path, query], :binary.split(to, "?")
+    destructure [path, query], :binary.split(to, ["?", "#"], [:global])
     to = %{socket.host_uri | path: path, query: query}
 
     case Route.live_link_info!(socket, socket.private.root_view, to) do

--- a/test/phoenix_live_view/integrations/params_test.exs
+++ b/test/phoenix_live_view/integrations/params_test.exs
@@ -331,6 +331,13 @@ defmodule Phoenix.LiveView.ParamsTest do
       assert_receive {:handle_params, "http://www.example.com/counter/123?from=rehandled_params",
                       %{val: 1}, %{"from" => "rehandled_params", "id" => "123"}}
     end
+
+    test "remove fragment from query", %{conn: conn} do
+      {:ok, counter_live, _html} = live(conn, "/counter/123")
+
+      send(counter_live.pid, {:push_patch, "/counter/123?query=value#fragment"})
+      assert render(counter_live) =~ rendered_to_string(~s|%{"id" => "123", "query" => "value"}|)
+    end
   end
 
   describe "push_navigate" do


### PR DESCRIPTION
I was recently updating my project from 0.17.5 and noticed that the fragment never gets stripped from a URI on redirects, so it ends up appended to the last of the query params, breaking some of my tests. I must be the last person on Earth to be using fragments, but they're part of the spec, so this should be supported :)

I added a unit test, but I'm not sure it's adequate or in the right place, so please let me know if there's something that needs changing.