### PR TITLE
Issue #2735 Fix AST for functions with attrs

### DIFF
--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -987,7 +987,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     end
   end
 
-  test "BEAM ast for function has the correct line number" do
+  test "BEAM ast for component function has the correct line number" do
     module = Phoenix.LiveViewTest.FunctionComponentWithAttrs
 
     # find the ast with code from ExDoc.Language.Erlang.get_abstract_code/1
@@ -1001,9 +1001,9 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
              end) == 24
 
       assert Enum.find_value(abstract_code, fn
-               {:function, line, :fun_doc_injection, 1, _} -> line
+               {:function, line, :fun_doc_false, 1, _} -> line
                _ -> nil
-             end) == 101
+             end) == 105
     end
   end
 

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -987,6 +987,26 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     end
   end
 
+  test "BEAM ast for function has the correct line number" do
+    module = Phoenix.LiveViewTest.FunctionComponentWithAttrs
+
+    # find the ast with code from ExDoc.Language.Erlang.get_abstract_code/1
+    with {^module, binary, _file} <- :code.get_object_code(module),
+         {:ok, {_, [{:abstract_code, {_vsn, abstract_code}}]}} <-
+            :beam_lib.chunks(binary, [:abstract_code]) do
+
+      assert Enum.find_value(abstract_code, fn
+               {:function, line, :identity, 1, _} -> line
+               _ -> nil
+             end) == 24
+
+      assert Enum.find_value(abstract_code, fn
+               {:function, line, :fun_doc_injection, 1, _} -> line
+               _ -> nil
+             end) == 101
+    end
+  end
+
   test "does not override signature of Elixir functions" do
     {:docs_v1, _, :elixir, "text/markdown", _, _, docs} =
       Code.fetch_docs(Phoenix.LiveViewTest.FunctionComponentWithAttrs)


### PR DESCRIPTION
Issue #2735 

Opening this as a draft because I only have the failing unit test. I will probably need help understanding the inner workings of how the code is compiled with the wrong line number. 

The second assert fails because it gets 17 when it expects 105. Line 17 is where the module is defined. Line 105 is where the function `fun_doc_false` is defined.