### PR TITLE
Allow inputs/buttons with id="submit" when using phx-trigger-action

### DIFF
--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -284,7 +284,7 @@ export default class DOMPatch {
 
     if(externalFormTriggered){
       liveSocket.unload()
-      externalFormTriggered.submit()
+      Object.getPrototypeOf(externalFormTriggered).submit.call(externalFormTriggered)
     }
     return true
   }

--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -284,6 +284,8 @@ export default class DOMPatch {
 
     if(externalFormTriggered){
       liveSocket.unload()
+      // use prototype's submit in case there's a form control with name or id of "submit"
+      // https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit
       Object.getPrototypeOf(externalFormTriggered).submit.call(externalFormTriggered)
     }
     return true


### PR DESCRIPTION
From MDN: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit

> A form control (such as a submit button) with a `name` or `id` of `submit` will mask the form's submit method. Trying to call `myForm.submit();` throws an error "submit is not a function" because in this case `submit` refers to the form control which has a `name` or `id` of submit.

We can fix this by bypassing the form's `submit` method and instead using the `submit` method from the form's prototype.