### PR TITLE
Added dynamic hook methods to LiveSocket

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -351,16 +351,16 @@ export default class LiveSocket {
   * @param {string} name 
   * @param {Object} hook 
   */
-  addHook(name, hook) {
+  addHook(name, hook){
     this.hooks[name] = hook
     // go through and find relevant elements which should have `mount` callbacks called
     document.querySelectorAll(`[phx-hook=${name}]`).forEach(el => {
-      this.main.maybeAddNewHook(el);
+      this.main.maybeAddNewHook(el)
     })
   }
 
-  removeHook(name) {
-    delete this.hooks[name];
+  removeHook(name){
+    delete this.hooks[name]
   }
 
   getHookCallbacks(name){
@@ -741,7 +741,7 @@ export default class LiveSocket {
     }, false)
   }
 
-  maybeScroll(scroll) {
+  maybeScroll(scroll){
     if(typeof(scroll) === "number"){
       requestAnimationFrame(() => {
         window.scrollTo(0, scroll)

--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -351,12 +351,16 @@ export default class LiveSocket {
   * @param {string} name 
   * @param {Object} hook 
   */
-  addHookDynamically(name, hook) {
+  addHook(name, hook) {
     this.hooks[name] = hook
     // go through and find relevant elements which should have `mount` callbacks called
     document.querySelectorAll(`[phx-hook=${name}]`).forEach(el => {
       this.main.maybeAddNewHook(el);
     })
+  }
+
+  removeHook(name) {
+    delete this.hooks[name];
   }
 
   getHookCallbacks(name){

--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -347,6 +347,18 @@ export default class LiveSocket {
     }, afterMs)
   }
 
+  /**
+  * @param {string} name 
+  * @param {Object} hook 
+  */
+  addHookDynamically(name, hook) {
+    this.hooks[name] = hook
+    // go through and find relevant elements which should have `mount` callbacks called
+    document.querySelectorAll(`[phx-hook=${name}]`).forEach(el => {
+      this.main.maybeAddNewHook(el);
+    })
+  }
+
   getHookCallbacks(name){
     return name && name.startsWith("Phoenix.") ? Hooks[name.split(".")[1]] : this.hooks[name]
   }

--- a/assets/test/live_socket_test.js
+++ b/assets/test/live_socket_test.js
@@ -237,4 +237,22 @@ describe("LiveSocket", () => {
 
     expect(getItemCalls).toEqual(1)
   })
+
+  test("addHook / removeHook dynamically", async () => {
+    let liveSocket = new LiveSocket("/live", Socket)
+
+    expect(Object.keys(liveSocket.hooks).length).toEqual(0)
+
+    const testHook = {mounted(){}}
+
+    liveSocket.addHook("test", testHook)
+
+    expect(Object.keys(liveSocket.hooks).length).toEqual(1)
+    expect(liveSocket.hooks["test"]).toBeTruthy()
+
+    liveSocket.removeHook("test")
+
+    expect(Object.keys(liveSocket.hooks).length).toEqual(0)
+    expect(liveSocket.hooks["test"]).toBeUndefined()
+  })
 })


### PR DESCRIPTION
This PR adds 2 new methods to the JS client's `LiveSocket` 

- `addHook` 
  This allows for dynamically adding new hooks to the LiveSocket, after initialisation.
- `removeHook`
  This allows for removal of hooks dynamically

## The Why

I've been experimenting with co-locating JS hooks with the Liveviews which call them (so outside of the traditional `/assets` folder) 

This means that hooks are not known at first render and initialisation of the `LiveSocket`

These methods therefore are needed to provide a way of lazily adding/removing hooks at runtime!

## An example using this 

In my toy project https://github.com/C-Sinclair/hook_beast, you'll see the `addHook` function in action ([this line specifically](https://github.com/C-Sinclair/hook_beast/blob/67a492c053413f16ecaeb602d93baf87e26f22b4/lib/hook_beast.ex#L17))