### PR TITLE
Include writer failure in upload errors

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1037,6 +1037,7 @@ defmodule Phoenix.Component do
   * `:too_large` - The entry exceeds the `:max_file_size` constraint
   * `:not_accepted` - The entry does not match the `:accept` MIME types
   * `:external_client_failure` - When external upload fails
+  * `{:writer_failure, reason}` - When the custom writer fails with `reason`
 
   ## Examples
 

--- a/lib/phoenix_live_view/test/upload_client.ex
+++ b/lib/phoenix_live_view/test/upload_client.ex
@@ -167,6 +167,9 @@ defmodule Phoenix.LiveViewTest.UploadClient do
       %Phoenix.Socket.Reply{ref: ^ref, status: :ok} ->
         :ok = ClientProxy.report_upload_progress(proxy_pid, from, element, entry.ref, stats.new_percent, state.cid)
         update_entry_start(state, entry, stats.new_start)
+      %Phoenix.Socket.Reply{ref: ^ref, status: :error} ->
+        :ok = ClientProxy.report_upload_progress(proxy_pid, from, element, entry.ref, %{"error" => "failure"}, state.cid)
+        update_entry_start(state, entry, stats.new_start)
     after
       get_chunk_timeout(state) -> exit(:timeout)
     end

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -132,7 +132,11 @@ defmodule Phoenix.LiveView.Upload do
       when is_binary(reason) do
     conf = get_upload_by_ref!(socket, config_ref)
 
-    put_upload_error(socket, conf.name, entry_ref, :external_client_failure)
+    if conf.external do
+      put_upload_error(socket, conf.name, entry_ref, :external_client_failure)
+    else
+      socket
+    end
   end
 
   @doc """

--- a/lib/phoenix_live_view/upload_channel.ex
+++ b/lib/phoenix_live_view/upload_channel.ex
@@ -110,7 +110,9 @@ defmodule Phoenix.LiveView.UploadChannel do
               {:error, _reason, new_socket} -> new_socket
             end
 
-          {:reply, {:error, %{reason: :io_error}}, new_socket}
+          Channel.report_writer_error(socket.assigns.live_view_pid, reason)
+
+          {:reply, {:error, %{reason: :writer_error}}, new_socket}
       end
     else
       reply = %{reason: :file_size_limit_exceeded, limit: max_file_size}

--- a/test/phoenix_live_view/upload/channel_test.exs
+++ b/test/phoenix_live_view/upload/channel_test.exs
@@ -25,6 +25,10 @@ defmodule Phoenix.LiveView.UploadChannelTest do
     end
 
     @impl true
+    def write_chunk("error_with:" <> reason, test_name) do
+      {:error, reason, test_name}
+    end
+
     def write_chunk(data, test_name) do
       send(test_name, {:write_chunk, data})
       {:ok, test_name}
@@ -745,6 +749,29 @@ defmodule Phoenix.LiveView.UploadChannelTest do
         assert_receive {:write_chunk, _chunk1}
         refute_receive {:write_chunk, _}
         assert_receive {:close, :cancel}
+      end
+
+      @tag allow: [
+             max_entries: 1,
+             chunk_size: 50,
+             accept: :any,
+             writer: &__MODULE__.build_writer/3
+           ]
+
+      test "writer with error", %{lv: lv} do
+        Process.register(self(), :test_writer)
+
+        content = "error_with:oops"
+
+        avatar =
+          file_input(lv, "form", :avatar, [
+            %{name: "foo.jpeg", content: content}
+          ])
+
+        assert render_upload(avatar, "foo.jpeg") =~
+                 ~s/entry_error:{:writer_failure, &quot;oops&quot;}/
+
+        assert_receive {:close, {:error, "oops"}}
       end
     end
   end


### PR DESCRIPTION
Allows custom writer errors to be consumed in `upload_errors`.