### PR TITLE
Add note about not enforcing stream limit on first mount.

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1602,6 +1602,10 @@ defmodule Phoenix.LiveView do
   positive limit will prune items from the end of the container, while a negative
   limit will prune items from the beginning of the container.
 
+  Note that on the first `mount/3` render (when no websocket connection was established yet),
+  the limit set is not enforced. In this situation, one should pass the desired amount of
+  items to the stream to avoid confusions.
+
   ## Required DOM attributes
 
   For stream items to be trackable on the client, the following requirements

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1602,9 +1602,10 @@ defmodule Phoenix.LiveView do
   positive limit will prune items from the end of the container, while a negative
   limit will prune items from the beginning of the container.
 
-  Note that on the first `mount/3` render (when no websocket connection was established yet),
-  the limit set is not enforced. In this situation, one should pass the desired amount of
-  items to the stream to avoid confusions.
+  Note that the limit is not enforced on the first `mount/3` render (when no websocket
+  connection was established yet), as it means more data than necessary has been
+  loaded. In such cases, you should only load and pass the desired amount of items
+  to the stream.
 
   ## Required DOM attributes
 


### PR DESCRIPTION
# Comment
From our slack discussion, here is a PR to warn folks about stream limits not being enforced on the first render.
Let me know if you see any issues.

Cheers.