### PR TITLE
Add docs about request method to live/4

### DIFF
--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -17,6 +17,11 @@ defmodule Phoenix.LiveView.Router do
 
       live_path(@socket, ThermostatLive)
 
+  > #### HTTP requests {: .info}
+  >
+  > The HTTP request method that a route defined by the `live/4` macro
+  > responds to is `GET`.
+
   ## Actions and live navigation
 
   It is common for a LiveView to have multiple states and multiple URLs.


### PR DESCRIPTION
I think this is quite important info, so it'd be awesome to have it in the docs. 🙃 

This is the rendered docs:

<img width="846" alt="CleanShot 2023-07-26 at 17 11 27@2x" src="https://github.com/phoenixframework/phoenix_live_view/assets/3890250/f07487e7-1da6-4d98-a812-2239dd6b6534">
