### PR TITLE
Adding modifier key support to phx-key

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -107,7 +107,9 @@ import {
   closure,
   debug,
   isObject,
-  maybe
+  maybe,
+  parsePhxKey,
+  hasSpecificKeyBeenPressed
 } from "./utils"
 
 import Browser from "./browser"
@@ -523,12 +525,11 @@ export default class LiveSocket {
     this.bindClicks()
     if(!dead){ this.bindForms() }
     this.bind({keyup: "keyup", keydown: "keydown"}, (e, type, view, targetEl, phxEvent, eventTarget) => {
-      let matchKey = targetEl.getAttribute(this.binding(PHX_KEY))
-      let pressedKey = e.key && e.key.toLowerCase() // chrome clicked autocompletes send a keydown without key
-      if(matchKey && matchKey.toLowerCase() !== pressedKey){ return }
-
-      let data = {key: e.key, ...this.eventMeta(type, e, targetEl)}
-      JS.exec(type, phxEvent, view, targetEl, ["push", {data}])
+      let matchKey = parsePhxKey(targetEl.getAttribute(this.binding(PHX_KEY)))
+      if (hasSpecificKeyBeenPressed(e, matchKey)) {
+        let data = {phx_key: matchKey, key: e.key, ...this.eventMeta(type, e, targetEl)}
+        JS.exec(type, phxEvent, view, targetEl, ["push", {data}])
+      }
     })
     this.bind({blur: "focusout", focus: "focusin"}, (e, type, view, targetEl, phxEvent, eventTarget) => {
       if(!eventTarget){

--- a/assets/js/phoenix_live_view/utils.js
+++ b/assets/js/phoenix_live_view/utils.js
@@ -61,3 +61,73 @@ export let channelUploader = function (entries, onError, resp, liveSocket){
     entryUploader.upload()
   })
 }
+
+export let parsePhxKey = (key) => {
+  if(!key){ return [] }
+  return key.match(/[^.\]]+(?=[^\]]*$)/g) || []
+}
+
+// Thanks to Alpine.js https://github.com/alpinejs/alpine/blob/main/packages/alpinejs/src/utils/on.js#L108 
+export let hasSpecificKeyBeenPressed = (e, keys) => {
+
+  // If no key is defined, its a press
+  if (keys.length === 0) return true
+
+  // If one is passed, AND it matches the key pressed, we'll call it a press.
+  if (keys.length === 1 && keyToModifiers(e.key).includes(keys[0])) return true
+
+  // The user is listening for key combinations.
+  const systemKeyModifiers = ['ctrl', 'shift', 'alt', 'meta', 'cmd', 'super']
+  const selectedSystemKeyModifiers = systemKeyModifiers.filter(modifier => keys.includes(modifier))
+
+  keys = keys.filter(i => ! selectedSystemKeyModifiers.includes(i))
+  if (selectedSystemKeyModifiers.length > 0) {
+      const activelyPressedKeyModifiers = selectedSystemKeyModifiers.filter(modifier => {
+          // Alias "cmd" and "super" to "meta"
+          if (modifier === 'cmd' || modifier === 'super') modifier = 'meta'
+
+          return e[`${modifier}Key`]
+      })
+
+      // If all the modifiers selected are pressed, ...
+      if (activelyPressedKeyModifiers.length === selectedSystemKeyModifiers.length) {
+          // AND the remaining key is pressed as well. It's a press.
+          if (keyToModifiers(e.key).includes(keys[0])) return true
+      }
+  }
+
+  return false
+}
+
+function kebabCase(subject) {
+  if ([' ','_'].includes(subject)) return subject
+  return subject.replace(/([a-z])([A-Z])/g, '$1-$2').replace(/[_\s]/, '-').toLowerCase()
+}
+
+// Thanks to Alpine.js https://github.com/alpinejs/alpine/blob/main/packages/alpinejs/src/utils/on.js#L154
+export let keyToModifiers = (key) => {
+  if (!key) return []
+  key = kebabCase(key)
+  let modifierToKeyMap = {
+      'ctrl': 'control',
+      'slash': '/',
+      'space': ' ',
+      'spacebar': ' ',
+      'cmd': 'meta',
+      'esc': 'escape',
+      'up': 'arrow-up',
+      'down': 'arrow-down',
+      'left': 'arrow-left',
+      'right': 'arrow-right',
+      'period': '.',
+      'equal': '=',
+      'minus': '-',
+      'underscore': '_',
+  }
+
+  modifierToKeyMap[key] = key
+
+  return Object.keys(modifierToKeyMap).map(modifier => {
+      if (modifierToKeyMap[modifier] === key) return modifier
+  }).filter(modifier => modifier)
+}

--- a/assets/js/phoenix_live_view/utils.js
+++ b/assets/js/phoenix_live_view/utils.js
@@ -66,36 +66,54 @@ export let parsePhxKey = (key) => {
   if(!key){ return [] }
   return key.match(/[^.\]]+(?=[^\]]*$)/g) || []
 }
+// The following is thanks to Alpine.js https://github.com/alpinejs/alpine/blob/main/packages/alpinejs/src/utils/on.js
+// # MIT License
 
-// Thanks to Alpine.js https://github.com/alpinejs/alpine/blob/main/packages/alpinejs/src/utils/on.js#L108 
+// Copyright © 2019-2021 Caleb Porzio and contributors
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 export let hasSpecificKeyBeenPressed = (e, keys) => {
-
   // If no key is defined, its a press
   if (keys.length === 0) return true
 
   // If one is passed, AND it matches the key pressed, we'll call it a press.
-  if (keys.length === 1 && keyToModifiers(e.key).includes(keys[0])) return true
+    if (keys.length === 1 && keyToModifiers(e.key).includes(keys[0])) return true
 
   // The user is listening for key combinations.
-  const systemKeyModifiers = ['ctrl', 'shift', 'alt', 'meta', 'cmd', 'super']
+    const systemKeyModifiers = ['ctrl', 'shift', 'alt', 'meta', 'cmd', 'super']
   const selectedSystemKeyModifiers = systemKeyModifiers.filter(modifier => keys.includes(modifier))
 
   keys = keys.filter(i => ! selectedSystemKeyModifiers.includes(i))
   if (selectedSystemKeyModifiers.length > 0) {
-      const activelyPressedKeyModifiers = selectedSystemKeyModifiers.filter(modifier => {
-          // Alias "cmd" and "super" to "meta"
-          if (modifier === 'cmd' || modifier === 'super') modifier = 'meta'
+    const activelyPressedKeyModifiers = selectedSystemKeyModifiers.filter(modifier => {
+      // Alias "cmd" and "super" to "meta"
+      if (modifier === 'cmd' || modifier === 'super') modifier = 'meta'
 
-          return e[`${modifier}Key`]
-      })
+      return e[`${modifier}Key`]
+    })
 
-      // If all the modifiers selected are pressed, ...
+    // If all the modifiers selected are pressed, ...
       if (activelyPressedKeyModifiers.length === selectedSystemKeyModifiers.length) {
-          // AND the remaining key is pressed as well. It's a press.
+        // AND the remaining key is pressed as well. It's a press.
           if (keyToModifiers(e.key).includes(keys[0])) return true
       }
   }
-
   return false
 }
 
@@ -104,30 +122,29 @@ function kebabCase(subject) {
   return subject.replace(/([a-z])([A-Z])/g, '$1-$2').replace(/[_\s]/, '-').toLowerCase()
 }
 
-// Thanks to Alpine.js https://github.com/alpinejs/alpine/blob/main/packages/alpinejs/src/utils/on.js#L154
 export let keyToModifiers = (key) => {
   if (!key) return []
   key = kebabCase(key)
   let modifierToKeyMap = {
-      'ctrl': 'control',
-      'slash': '/',
-      'space': ' ',
-      'spacebar': ' ',
-      'cmd': 'meta',
-      'esc': 'escape',
-      'up': 'arrow-up',
-      'down': 'arrow-down',
-      'left': 'arrow-left',
-      'right': 'arrow-right',
-      'period': '.',
-      'equal': '=',
-      'minus': '-',
-      'underscore': '_',
+    'ctrl': 'control',
+    'slash': '/',
+    'space': ' ',
+    'spacebar': ' ',
+    'cmd': 'meta',
+    'esc': 'escape',
+    'up': 'arrow-up',
+    'down': 'arrow-down',
+    'left': 'arrow-left',
+    'right': 'arrow-right',
+    'period': '.',
+    'equal': '=',
+    'minus': '-',
+    'underscore': '_',
   }
 
   modifierToKeyMap[key] = key
 
   return Object.keys(modifierToKeyMap).map(modifier => {
-      if (modifierToKeyMap[modifier] === key) return modifier
+    if (modifierToKeyMap[modifier] === key) return modifier
   }).filter(modifier => modifier)
 }

--- a/assets/test/utils_test.js
+++ b/assets/test/utils_test.js
@@ -1,5 +1,5 @@
 import {Socket} from "phoenix"
-import { closestPhxBinding } from "phoenix_live_view/utils"
+import { closestPhxBinding, parsePhxKey, hasSpecificKeyBeenPressed } from "phoenix_live_view/utils"
 import LiveSocket from "phoenix_live_view/live_socket"
 import { simulateJoinedView, liveViewDOM } from "./test_helpers"
 
@@ -33,5 +33,37 @@ describe("utils", () => {
       expect(closestPhxBinding(element, "phx-click")).toBe(null)
     })
   })
-})
 
+  describe("phx-key", () => {
+    test("parsePhxKey", () => {
+      expect(parsePhxKey("k")).toEqual(["k"])
+      expect(parsePhxKey("meta.k")).toEqual(["meta", "k"])
+      expect(parsePhxKey("alt.k")).toEqual(["alt", "k"])
+      expect(parsePhxKey("ctrl.period")).toEqual(["ctrl", "period"])
+      expect(parsePhxKey("shift.ctrl.slash")).toEqual(["shift", "ctrl", "slash"])
+      expect(parsePhxKey("esc")).toEqual(["esc"])
+    })
+
+    test("hasSpecificKeyBeenPressed", () => {
+      expect(hasSpecificKeyBeenPressed({key: "k"}, parsePhxKey("k"))).toEqual(true)
+      expect(hasSpecificKeyBeenPressed({key: "j"}, parsePhxKey("k"))).toEqual(false)
+
+      expect(hasSpecificKeyBeenPressed({key: "k", metaKey: true}, parsePhxKey("meta.k"))).toEqual(true)
+      expect(hasSpecificKeyBeenPressed({key: "k", metaKey: true}, parsePhxKey("cmd.k"))).toEqual(true)
+      expect(hasSpecificKeyBeenPressed({key: "k", metaKey: true}, parsePhxKey("super.k"))).toEqual(true)
+
+      expect(hasSpecificKeyBeenPressed({key: "k", metaKey: false}, parsePhxKey("meta.k"))).toEqual(false)
+      expect(hasSpecificKeyBeenPressed({key: "k", metaKey: false}, parsePhxKey("cmd.k"))).toEqual(false)
+      expect(hasSpecificKeyBeenPressed({key: "k", metaKey: false}, parsePhxKey("super.k"))).toEqual(false)
+
+      expect(hasSpecificKeyBeenPressed({key: "k", altKey: true}, parsePhxKey("alt.k"))).toEqual(true)
+      expect(hasSpecificKeyBeenPressed({key: "k", altKey: false}, parsePhxKey("alt.k"))).toEqual(false)
+
+      expect(hasSpecificKeyBeenPressed({key: ".", ctrlKey: true}, parsePhxKey("ctrl.period"))).toEqual(true)
+      expect(hasSpecificKeyBeenPressed({key: ",", ctrlKey: false}, parsePhxKey("ctrl.period"))).toEqual(false)
+
+      expect(hasSpecificKeyBeenPressed({key: "/", ctrlKey: true, shiftKey: true}, parsePhxKey("shift.ctrl.slash"))).toEqual(true)
+      expect(hasSpecificKeyBeenPressed({key: "Escape"}, parsePhxKey("esc"))).toEqual(true)
+    })
+  })
+})

--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -104,7 +104,7 @@ for any key press. When pushed, the value sent to the server will contain the `"
 that was pressed, plus any user-defined metadata. For example, pressing the
 Escape key looks like this:
 
-    %{"key" => "Escape"}
+    %{"key" => "Escape", "phx_key" => "esc"}
 
 To capture additional user-defined metadata, the `metadata` option for keydown events
 may be provided to the `LiveSocket` constructor. For example:
@@ -122,10 +122,50 @@ may be provided to the `LiveSocket` constructor. For example:
       }
     })
 
-To determine which key has been pressed you should use `key` value. The
-available options can be found on
-[MDN](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values)
-or via the [Key Event Viewer](https://w3c.github.io/uievents/tools/key-event-viewer.html).
+You can also use the `phx-key` value to listen for more complex combinations, for example
+here is a `phx-key` value that listens for when the `Shift` key is held and `Enter` is
+pressed:
+
+```heex
+<div class="container"
+    phx-keydown="new_line"
+    phx-key="shift.enter">
+  ...
+</div>
+```
+
+You can directly use any valid key names exposed via KeyboardEvent.key as modifiers by 
+converting them to kebab-case.
+
+```heex
+<div class="container"
+    phx-keydown="new_line"
+    phx-key="page-down">
+  ...
+</div>
+```
+
+For easy reference, here is a list of common keys you may want to listen for.
+
+| Modifier    | Keyboard Key |
+| ----------- | ------------ |
+| .shift	  | Shift        |
+| .enter      | Enter        |
+| .space	  | Space        |
+| .ctrl	      | Ctrl         |
+| .cmd        | Cmd          |
+| .meta       | Cmd/Windows  |
+| .alt        | Alt          |
+| .up         | Up           |
+| .down       | Down         |
+| .left       | Left         |
+| .right      | Right        |
+| .escape     | Escape       |
+| .tab        | Tab          |
+| .caps-lock  | Caps Lock    |
+| .equal      | Equal, =     |
+| .period     | Period, .    |
+| .slash      | /            |
 
 *Note*: it is possible for certain browser features like autofill to trigger key events
 with no `"key"` field present in the value map sent to the server. For this reason, we

--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -149,9 +149,9 @@ For easy reference, here is a list of common keys you may want to listen for.
 
 | Modifier    | Keyboard Key |
 | ----------- | ------------ |
-| .shift	  | Shift        |
+| .shift      | Shift        |
 | .enter      | Enter        |
-| .space	  | Space        |
+| .space      | Space        |
 | .ctrl	      | Ctrl         |
 | .cmd        | Cmd          |
 | .meta       | Cmd/Windows  |


### PR DESCRIPTION
This is heavily based on and influnced by Alpine.js
https://alpinejs.dev/directives/on#keyboard-events 

Read more here https://github.com/phoenixframework/phoenix_live_view/compare/js/modifier-keys?expand=1#diff-111702fc118e0ad46017e414f1b7574231f826fcbf3e31bfdadcd504c06f49c2R125-R168

We are still backwards compatible with the old way of doing phx-key (or we should be) and we get nice features like `meta.k` or `shift.enter` with minimal work! 

I still need to add some key based integration tests. 