### PR TITLE
Fix @doc generation for :global attribute type (fixes #2709)

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -817,7 +817,7 @@ defmodule Phoenix.Component.Declarative do
   defp build_attrs_docs(attrs) do
     [
       "## Attributes\n",
-      for attr <- attrs, attr.doc != false && attr.type !== :global, into: [] do
+      for attr <- attrs, attr.doc != false && attr.type != :global, into: [] do
         [
           "\n* ",
           build_attr_name(attr),

--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -904,7 +904,6 @@ defmodule Phoenix.Component.Declarative do
 
   defp build_attr_doc_and_default(%{doc: doc, type: :global, opts: opts}, indent) do
     [
-      # always included
       "\n* Global attributes are accepted.",
       if(doc, do: [" ", build_doc(doc, indent, false)], else: []),
       case Keyword.get(opts, :include) do

--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -817,20 +817,21 @@ defmodule Phoenix.Component.Declarative do
   defp build_attrs_docs(attrs) do
     [
       "## Attributes\n",
-      for attr <- attrs, attr.doc != false, into: [] do
-        if attr.type == :global do
-          build_attr_doc_and_default(attr, "  ")
-        else
-          [
-            "\n* ",
-            build_attr_name(attr),
-            build_attr_type(attr),
-            build_attr_required(attr),
-            build_hyphen(attr),
-            build_attr_doc_and_default(attr, "  "),
-            build_attr_values_or_examples(attr)
-          ]
-        end
+      for attr <- attrs, attr.doc != false && attr.type !== :global, into: [] do
+        [
+          "\n* ",
+          build_attr_name(attr),
+          build_attr_type(attr),
+          build_attr_required(attr),
+          build_hyphen(attr),
+          build_attr_doc_and_default(attr, "  "),
+          build_attr_values_or_examples(attr)
+        ]
+      end,
+      # global always goes at the end
+      case Enum.find(attrs, &(&1.type === :global)) do
+        nil -> []
+        attr -> build_attr_doc_and_default(attr, "  ")
       end
     ]
   end

--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -817,7 +817,7 @@ defmodule Phoenix.Component.Declarative do
   defp build_attrs_docs(attrs) do
     [
       "## Attributes\n",
-      for attr <- attrs, attr.doc != false && attr.type != :global, into: [] do
+      for attr <- attrs, attr.doc != false and attr.type != :global do
         [
           "\n* ",
           build_attr_name(attr),

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -870,17 +870,23 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       fun_attr_global_doc_include: """
       ## Attributes
 
-      * Global attributes are accepted. These are passed to the innner input field. Supports all globals plus: `["value"]`.
+      * Global attributes are accepted. These are passed to the inner input field. Supports all globals plus: `["value"]`.
       """,
       fun_attr_global_doc: """
       ## Attributes
 
-      * Global attributes are accepted. These are passed to the innner input field.
+      * Global attributes are accepted. These are passed to the inner input field.
       """,
       fun_attr_global_include: """
       ## Attributes
 
       * Global attributes are accepted. Supports all globals plus: `["value"]`.
+      """,
+      fun_attr_global_and_regular: """
+      ## Attributes
+
+      * `name` (`:string`) - The form input name.
+      * Global attributes are accepted. These are passed to the inner input field.
       """,
       fun_attr_struct: """
       ## Attributes
@@ -1035,7 +1041,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     assert Enum.find_value(abstract_code, fn
              {:function, line, :fun_doc_false, 1, _} -> line
              _ -> nil
-           end) == 114
+           end) == 118
   end
 
   test "does not override signature of Elixir functions" do

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -867,6 +867,21 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
 
       * Global attributes are accepted.
       """,
+      fun_attr_global_doc_include: """
+      ## Attributes
+
+      * Global attributes are accepted. These are passed to the innner input field. Supports all globals plus: `["value"]`.
+      """,
+      fun_attr_global_doc: """
+      ## Attributes
+
+      * Global attributes are accepted. These are passed to the innner input field.
+      """,
+      fun_attr_global_include: """
+      ## Attributes
+
+      * Global attributes are accepted. Supports all globals plus: `["value"]`.
+      """,
       fun_attr_struct: """
       ## Attributes
 

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -1035,7 +1035,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     assert Enum.find_value(abstract_code, fn
              {:function, line, :fun_doc_false, 1, _} -> line
              _ -> nil
-           end) == 105
+           end) == 114
   end
 
   test "does not override signature of Elixir functions" do

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -51,6 +51,15 @@ defmodule Phoenix.LiveViewTest.FunctionComponentWithAttrs do
   attr :attr, :global
   def fun_attr_global(assigns), do: ~H[]
 
+  attr :rest, :global, doc: "These are passed to the innner input field"
+  def fun_attr_global_doc(assigns), do: ~H[]
+
+  attr :rest, :global, doc: "These are passed to the innner input field", include: ~w(value)
+  def fun_attr_global_doc_include(assigns), do: ~H[]
+
+  attr :rest, :global, include: ~w(value)
+  def fun_attr_global_include(assigns), do: ~H[]
+
   attr :attr, Struct
   def fun_attr_struct(assigns), do: ~H[]
 

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -51,14 +51,18 @@ defmodule Phoenix.LiveViewTest.FunctionComponentWithAttrs do
   attr :attr, :global
   def fun_attr_global(assigns), do: ~H[]
 
-  attr :rest, :global, doc: "These are passed to the innner input field"
+  attr :rest, :global, doc: "These are passed to the inner input field"
   def fun_attr_global_doc(assigns), do: ~H[]
 
-  attr :rest, :global, doc: "These are passed to the innner input field", include: ~w(value)
+  attr :rest, :global, doc: "These are passed to the inner input field", include: ~w(value)
   def fun_attr_global_doc_include(assigns), do: ~H[]
 
   attr :rest, :global, include: ~w(value)
   def fun_attr_global_include(assigns), do: ~H[]
+
+  attr :name, :string, doc: "The form input name"
+  attr :rest, :global, doc: "These are passed to the inner input field"
+  def fun_attr_global_and_regular(assigns), do: ~H[]
 
   attr :attr, Struct
   def fun_attr_struct(assigns), do: ~H[]


### PR DESCRIPTION
The codebase contains code that clearly shows there was intent to support both `doc` and `include` options for an attribute of type `:global`, but after adding some test coverage, it became evident it wasn't being reached.

After coverage was added and the bug was fixed, I took the liberty to refactor the code a bit.

Fixes #2709 