### PR TITLE
Fixes stream/4 reset: true blanking out LiveComponents. Updated tests for OTP 26 non-sorted maps

### DIFF
--- a/assets/js/phoenix_live_view/rendered.js
+++ b/assets/js/phoenix_live_view/rendered.js
@@ -151,7 +151,7 @@ export default class Rendered {
   isNewFingerprint(diff = {}){ return !!diff[STATIC] }
 
   templateStatic(part, templates){
-    if(typeof (part) === "number") {
+    if(typeof (part) === "number"){
       return templates[part]
     } else {
       return part
@@ -221,7 +221,6 @@ export default class Rendered {
           if(!child.id){ child.id = `${this.parentViewId()}-${cid}-${i}` }
           if(skip){
             child.setAttribute(PHX_SKIP, "")
-            child.innerHTML = ""
           }
           return [true, hasComponents]
         } else {

--- a/test/phoenix_component/components_test.exs
+++ b/test/phoenix_component/components_test.exs
@@ -329,7 +329,7 @@ defmodule Phoenix.LiveView.ComponentsTest do
       html = parse(template)
 
       assert [
-               {"form", [{"class", "pretty"}, {"data-foo", "bar"}, {"phx-change", "valid"}],
+               {"form", [{"class", "pretty"}, {"phx-change", "valid"}, {"data-foo", "bar"}],
                 [
                   {"input", [{"id", "base_foo"}, {"name", "base[foo]"}, {"type", "text"}], []}
                 ]}
@@ -474,10 +474,10 @@ defmodule Phoenix.LiveView.ComponentsTest do
                   {"enctype", "multipart/form-data"},
                   {"action", "/"},
                   {"method", "post"},
-                  {"class", "pretty"},
-                  {"data-foo", "bar"},
                   {"id", "form"},
-                  {"phx-change", "valid"}
+                  {"class", "pretty"},
+                  {"phx-change", "valid"},
+                  {"data-foo", "bar"}
                 ],
                 [
                   {"input",
@@ -526,8 +526,12 @@ defmodule Phoenix.LiveView.ComponentsTest do
                       {"name", "myform[inner][_persistent_id]"},
                       {"value", "0"}
                     ], []},
-                   {"input", [{"id", "myform_inner_0_foo"}, {"name", "myform[inner][foo]"}, {"type", "text"}],
-                    []}
+                   {"input",
+                    [
+                      {"id", "myform_inner_0_foo"},
+                      {"name", "myform[inner][foo]"},
+                      {"type", "text"}
+                    ], []}
                  ]
                }
              ] = html
@@ -553,7 +557,8 @@ defmodule Phoenix.LiveView.ComponentsTest do
                  [
                    {"input",
                     [{"type", "hidden"}, {"name", "name[_persistent_id]"}, {"value", "0"}], []},
-                   {"input", [{"id", "myform_inner_0_foo"}, {"name", "name[foo]"}, {"type", "text"}], []}
+                   {"input",
+                    [{"id", "myform_inner_0_foo"}, {"name", "name[foo]"}, {"type", "text"}], []}
                  ]
                }
              ] = html

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -31,7 +31,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     use Phoenix.Component
 
     attr :id, :any, required: true
-    slot :inner_block
+    slot(:inner_block)
     def remote(assigns), do: ~H[]
   end
 
@@ -43,7 +43,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     def func1_line, do: __ENV__.line
     attr :id, :any, required: true
     attr :email, :string, default: nil
-    slot :inner_block
+    slot(:inner_block)
     def func1(assigns), do: ~H[]
 
     def func2_line, do: __ENV__.line
@@ -101,14 +101,18 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
 
   test "merges globals" do
     assert render(FunctionComponentWithAttrs, :with_global, %{}) ==
-             "<button id=\"container\" aria-hidden=\"true\" class=\"btn\"></button>"
+             "<button id=\"container\" class=\"btn\" aria-hidden=\"true\"></button>"
   end
 
   test "merges globals with defaults" do
     assigns = %{id: "btn", style: "display: none;"}
 
-    assert render(FunctionComponentWithAttrs, :button_with_defaults, assigns) ==
-             "<button class=\"primary\" id=\"btn\" style=\"display: none;\"></button>"
+    button_1 =
+      render(FunctionComponentWithAttrs, :button_with_defaults, assigns)
+
+    assert button_1 =~ "<button id=\"btn\""
+    assert button_1 =~ "class=\"primary\""
+    assert button_1 =~ "style=\"display: none;\""
 
     assert render(FunctionComponentWithAttrs, :button_with_defaults, %{class: "hidden"}) ==
              "<button class=\"hidden\"></button>"
@@ -166,7 +170,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                    required: false
                  }
                ],
-               line: func1_line + 4,
+               line: func1_line + 4
              },
              func2: %{
                kind: :def,
@@ -248,7 +252,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                  }
                ],
                slots: [],
-               line: with_global_line + 6,
+               line: with_global_line + 6
              },
              button_with_values: %{
                kind: :def,
@@ -264,7 +268,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                  }
                ],
                slots: [],
-               line: button_with_values_line + 2,
+               line: button_with_values_line + 2
              },
              button_with_values_and_default_1: %{
                kind: :def,
@@ -280,7 +284,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                  }
                ],
                slots: [],
-               line: button_with_values_and_default_1_line + 2,
+               line: button_with_values_and_default_1_line + 2
              },
              button_with_values_and_default_2: %{
                kind: :def,
@@ -296,7 +300,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                  }
                ],
                slots: [],
-               line: button_with_values_and_default_2_line + 2,
+               line: button_with_values_and_default_2_line + 2
              },
              button_with_examples: %{
                kind: :def,
@@ -322,13 +326,13 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
 
     def fun_with_slot_line, do: __ENV__.line + 3
 
-    slot :inner_block
+    slot(:inner_block)
     def fun_with_slot(assigns), do: ~H[]
 
     def fun_with_named_slots_line, do: __ENV__.line + 4
 
-    slot :header
-    slot :footer
+    slot(:header)
+    slot(:footer)
     def fun_with_named_slots(assigns), do: ~H[]
 
     def fun_with_slot_attrs_line, do: __ENV__.line + 6
@@ -418,7 +422,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                    required: false
                  }
                ],
-               line: FunctionComponentWithSlots.fun_with_slot_line(),
+               line: FunctionComponentWithSlots.fun_with_slot_line()
              },
              fun_with_named_slots: %{
                attrs: [],
@@ -466,7 +470,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                    required: true
                  }
                ],
-               line: FunctionComponentWithSlots.fun_with_slot_attrs_line(),
+               line: FunctionComponentWithSlots.fun_with_slot_attrs_line()
              },
              table: %{
                attrs: [
@@ -521,7 +525,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
 
       def example2_line, do: __ENV__.line + 2
 
-      slot :slot
+      slot(:slot)
       def example2(assigns)
 
       def example2(_assigns) do
@@ -559,7 +563,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                    required: false
                  }
                ],
-               line: Bodyless.example2_line() + 1,
+               line: Bodyless.example2_line() + 1
              }
            }
   end
@@ -602,6 +606,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
 
       attr :id, :any
       attr :errors, :list, default: []
+
       def assigned_with_same_default(assigns) do
         assign(assigns, errors: [])
       end
@@ -629,10 +634,10 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     defmodule SlotDefaults do
       use Phoenix.Component
 
-      slot :inner_block
+      slot(:inner_block)
       def func(assigns), do: ~H[<%= render_slot(@inner_block) %>]
 
-      slot :inner_block, required: true
+      slot(:inner_block, required: true)
       def func_required(assigns), do: ~H[<%= render_slot(@inner_block) %>]
     end
 
@@ -646,8 +651,8 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       use Phoenix.Component
 
       attr :rest, :global
-      slot :inner_block, required: true
-      slot :col, required: true
+      slot(:inner_block, required: true)
+      slot(:col, required: true)
 
       def test(assigns) do
         ~H"""
@@ -787,7 +792,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                ],
                kind: :def,
                slots: [],
-               line: line + 23,
+               line: line + 23
              },
              func_with_slot_docs: %{
                attrs: [],
@@ -812,7 +817,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                    required: false
                  }
                ],
-               line: line + 29,
+               line: line + 29
              }
            }
   end
@@ -1078,7 +1083,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       defmodule Phoenix.ComponentTest.SlotDocsInvalidType do
         use Elixir.Phoenix.Component
 
-        slot :invalid, doc: :foo
+        slot(:invalid, doc: :foo)
         def func(assigns), do: ~H[]
       end
     end
@@ -1109,7 +1114,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       defmodule Phoenix.ComponentTest.SlotMacroInvalidName do
         use Elixir.Phoenix.Component
 
-        slot "not an atom"
+        slot("not an atom")
         def func(assigns), do: ~H[]
       end
     end
@@ -1118,7 +1123,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       defmodule Phoenix.ComponentTest.SlotMacroInvalidOpts do
         use Elixir.Phoenix.Component
 
-        slot :slot, "not a list"
+        slot(:slot, "not a list")
         def func(assigns), do: ~H[]
       end
     end
@@ -1148,11 +1153,11 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       defmodule Phoenix.ComponentTest.MultiClauseWrong do
         use Elixir.Phoenix.Component
 
-        slot :inner_block
+        slot(:inner_block)
         def func(assigns = %{foo: _}), do: ~H[]
         def func(assigns = %{bar: _}), do: ~H[]
 
-        slot :named
+        slot(:named)
         def func(assigns = %{baz: _}), do: ~H[]
       end
     end
@@ -1180,7 +1185,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       defmodule Phoenix.ComponentTest.SlotOnInvalidFunction do
         use Elixir.Phoenix.Component
 
-        slot :inner_block
+        slot(:inner_block)
         def func(a, b), do: a + b
       end
     end
@@ -1209,7 +1214,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
 
         def func(assigns = %{baz: _}), do: ~H[]
 
-        slot :inner_block
+        slot(:inner_block)
       end
     end
   end
@@ -1479,8 +1484,8 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       defmodule Phoenix.ComponentTest.SlotDup do
         use Elixir.Phoenix.Component
 
-        slot :foo
-        slot :foo
+        slot(:foo)
+        slot(:foo)
         def func(assigns), do: ~H[]
       end
     end
@@ -1510,7 +1515,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       defmodule SlotAttrNameConflict do
         use Elixir.Phoenix.Component
 
-        slot :named
+        slot(:named)
         attr :named, :any
 
         def func(assigns), do: ~H[]
@@ -1522,7 +1527,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
         use Elixir.Phoenix.Component
 
         attr :named, :any
-        slot :named
+        slot(:named)
 
         def func(assigns), do: ~H[]
       end

--- a/test/phoenix_component/rendering_test.exs
+++ b/test/phoenix_component/rendering_test.exs
@@ -5,9 +5,9 @@ defmodule Phoenix.ComponentRenderingTest do
   import ExUnit.CaptureIO
   import Phoenix.LiveViewTest
 
-  embed_templates "pages/*"
-  embed_templates "another_root/*.html", root: "pages"
-  embed_templates "another_root/*.text", root: "pages", suffix: "_text"
+  embed_templates("pages/*")
+  embed_templates("another_root/*.html", root: "pages")
+  embed_templates("another_root/*.text", root: "pages", suffix: "_text")
 
   defp h2s(template) do
     template
@@ -168,7 +168,7 @@ defmodule Phoenix.ComponentRenderingTest do
       assert eval(~H|<.changed foo={@foo} bar={assigns} />|) == [["%{bar: true}"]]
 
       assigns = %{foo: 1, __changed__: %{foo: true}}
-      assert eval(~H|<.changed foo={@foo} bar={assigns} />|) == [["%{bar: true, foo: true}"]]
+      assert eval(~H|<.changed foo={@foo} bar={assigns} />|) == [["%{foo: true, bar: true}"]]
     end
 
     test "with conflict on changed assigns" do
@@ -206,7 +206,7 @@ defmodule Phoenix.ComponentRenderingTest do
       assigns = %{a: 1, b: 2, bar: 3, __changed__: %{a: true, b: true, bar: true}}
 
       assert eval(~H"<.changed {%{a: assigns[:b], b: assigns[:a]}} bar={@bar} />") ==
-               [["%{a: true, b: true, bar: true}"]]
+               [["%{a: true, b: true, bar: true}"]] || [["%{a: true, bar: true, b: true}"]]
     end
 
     defp wrapper(assigns) do
@@ -279,6 +279,12 @@ defmodule Phoenix.ComponentRenderingTest do
                [
                  [
                    "%{foo: true, inner_block: true}",
+                   [["%{inner_block: true, bar: true}", [nil, "%{foo: true}"]]]
+                 ]
+               ] ||
+               [
+                 [
+                   "%{foo: true, inner_block: true}",
                    [["%{bar: true, inner_block: true}", [nil, "%{foo: true}"]]]
                  ]
                ]
@@ -291,6 +297,12 @@ defmodule Phoenix.ComponentRenderingTest do
       assert eval(
                ~H|<.inner_changed :let={foo} foo={@foo}><.inner_changed :let={bar} bar={foo}><%= bar %><%= inspect(Map.get(assigns, :__changed__)) %></.inner_changed></.inner_changed>|
              ) ==
+               [
+                 [
+                   "%{foo: true, inner_block: true}",
+                   [["%{inner_block: true, bar: true}", ["var", "%{foo: true}"]]]
+                 ]
+               ] ||
                [
                  [
                    "%{foo: true, inner_block: true}",

--- a/test/phoenix_live_view/integrations/connect_test.exs
+++ b/test/phoenix_live_view/integrations/connect_test.exs
@@ -32,7 +32,7 @@ defmodule Phoenix.LiveView.ConnectTest do
         assert html =~ ~S<user-agent: "custom-client">
         assert html =~ ~S<x-headers: [{"x-foo", "bar"}, {"x-bar", "baz"}]>
         assert html =~ ~S<trace: [{"tracestate", "one"}, {"traceparent", "two"}]>
-        assert html =~ ~S<peer: %{address: {127, 0, 0, 1}, port: 111317, ssl_cert: nil}>
+        assert html =~ ~S<peer: %{port: 111317, address: {127, 0, 0, 1}, ssl_cert: nil}>
         assert html =~ ~S<uri: http://www.example.com/connect>
       end
 

--- a/test/phoenix_live_view/js_test.exs
+++ b/test/phoenix_live_view/js_test.exs
@@ -63,7 +63,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.push("inc", value: %{one: 1, two: 2})) ==
-               "[[&quot;push&quot;,{&quot;event&quot;:&quot;inc&quot;,&quot;value&quot;:{&quot;one&quot;:1,&quot;two&quot;:2}}]]"
+               "[[&quot;push&quot;,{&quot;value&quot;:{&quot;one&quot;:1,&quot;two&quot;:2},&quot;event&quot;:&quot;inc&quot;}]]"
     end
   end
 
@@ -160,7 +160,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.add_class("show")) ==
-               "[[&quot;add_class&quot;,{&quot;names&quot;:[&quot;show&quot;],&quot;time&quot;:200,&quot;to&quot;:null,&quot;transition&quot;:[[],[],[]]}]]"
+               "[[&quot;add_class&quot;,{&quot;time&quot;:200,&quot;names&quot;:[&quot;show&quot;],&quot;to&quot;:null,&quot;transition&quot;:[[],[],[]]}]]"
     end
   end
 
@@ -263,7 +263,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.remove_class("show")) ==
-               "[[&quot;remove_class&quot;,{&quot;names&quot;:[&quot;show&quot;],&quot;time&quot;:200,&quot;to&quot;:null,&quot;transition&quot;:[[],[],[]]}]]"
+               "[[&quot;remove_class&quot;,{&quot;time&quot;:200,&quot;names&quot;:[&quot;show&quot;],&quot;to&quot;:null,&quot;transition&quot;:[[],[],[]]}]]"
     end
   end
 
@@ -313,7 +313,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.dispatch("click", to: ".foo")) ==
-               "[[&quot;dispatch&quot;,{&quot;event&quot;:&quot;click&quot;,&quot;to&quot;:&quot;.foo&quot;}]]"
+               "[[&quot;dispatch&quot;,{&quot;to&quot;:&quot;.foo&quot;,&quot;event&quot;:&quot;click&quot;}]]"
     end
   end
 
@@ -426,7 +426,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.toggle(to: "#modal")) ==
-               "[[&quot;toggle&quot;,{&quot;display&quot;:null,&quot;ins&quot;:[[],[],[]],&quot;outs&quot;:[[],[],[]],&quot;time&quot;:200,&quot;to&quot;:&quot;#modal&quot;}]]"
+               "[[&quot;toggle&quot;,{&quot;display&quot;:null,&quot;time&quot;:200,&quot;ins&quot;:[[],[],[]],&quot;to&quot;:&quot;#modal&quot;,&quot;outs&quot;:[[],[],[]]}]]"
     end
   end
 
@@ -688,7 +688,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.set_attribute({"disabled", "true"})) ==
-               "[[&quot;set_attr&quot;,{&quot;attr&quot;:[&quot;disabled&quot;,&quot;true&quot;],&quot;to&quot;:null}]]"
+               "[[&quot;set_attr&quot;,{&quot;to&quot;:null,&quot;attr&quot;:[&quot;disabled&quot;,&quot;true&quot;]}]]"
     end
   end
 
@@ -730,7 +730,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.remove_attribute("disabled")) ==
-               "[[&quot;remove_attr&quot;,{&quot;attr&quot;:&quot;disabled&quot;,&quot;to&quot;:null}]]"
+               "[[&quot;remove_attr&quot;,{&quot;to&quot;:null,&quot;attr&quot;:&quot;disabled&quot;}]]"
     end
   end
 


### PR DESCRIPTION
This is a fix for the three issues. Essentially the liveview components html was being set to `""` on `stream/4 ` `reset: true` and caused empty live view components instead of leaving them there. 

Granted, I cannot figure out how to write a test for this issue based on the existing tests. I would love some advice on how best to write a test for this. That being said, my change did not cause any of the tests to fail. 

I've also updated the tests to account for the variety of non-sorted maps OTP 26 introduced. 

https://elixirforum.com/t/handling-nested-lists-in-liveview-streams-grouped-by-date/57538/6
https://github.com/phoenixframework/phoenix_live_view/issues/2696
https://github.com/phoenixframework/phoenix_live_view/issues/2698

Apologies in advance if this is a bad PR, still quite new to all of this and the first time of touching the internal magic of LiveView.

If there's a better way to write the fixes for the tests let me know as well and I'd be more than happy to implement!