### PR TITLE
Changed 'render' to 'renders' because 'renders' agrees with the singular 'a process'

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1,7 +1,7 @@
 defmodule Phoenix.LiveView do
   @moduledoc ~S'''
   A LiveView is a process that receives events, updates
-  its state, and render updates to a page as diffs.
+  its state, and renders updates to a page as diffs.
 
   The LiveView programming model is declarative: instead of
   saying "once event X happens, change Y on the page",


### PR DESCRIPTION
noticed a typo; this is my first PR, so please feel free to contact me if needed 