### PR TITLE
Display errors on file uploads 

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2794,7 +2794,7 @@ defmodule Phoenix.Component do
 
   defp join_refs(entries), do: Enum.join(entries, ",")
 
-  defp valid_upload?(%{entries: [_ | _], errors: []}), do: true
+  defp valid_upload?(%{entries: [_ | _]}), do: true
   defp valid_upload?(%{}), do: false
 
   @doc """

--- a/lib/phoenix_live_view/upload_config.ex
+++ b/lib/phoenix_live_view/upload_config.ex
@@ -507,13 +507,7 @@ defmodule Phoenix.LiveView.UploadConfig do
     if too_many_files?(new_conf) do
       {:error, put_error(new_conf, new_conf.ref, @too_many_files)}
     else
-      case new_conf do
-        %UploadConfig{errors: []} = new_conf ->
-          {:ok, new_conf}
-
-        %UploadConfig{errors: [_ | _]} = new_conf ->
-          {:error, new_conf}
-      end
+      {:ok, new_conf }
     end
   end
 

--- a/test/phoenix_live_view/upload/config_test.exs
+++ b/test/phoenix_live_view/upload/config_test.exs
@@ -254,12 +254,12 @@ defmodule Phoenix.LiveView.UploadConfigTest do
     test "returns error when entry with greater than max_file_size provided" do
       socket = LiveView.allow_upload(build_socket(), :avatar, accept: :any)
       entry = build_client_entry(:avatar, %{"size" => 8_000_001})
-      assert {:error, avatar} = UploadConfig.put_entries(socket.assigns.uploads.avatar, [entry])
+      assert {:ok, avatar} = UploadConfig.put_entries(socket.assigns.uploads.avatar, [entry])
       assert avatar.errors == [{entry["ref"], :too_large}]
 
       socket = LiveView.allow_upload(build_socket(), :avatar, accept: :any, max_file_size: 1024)
       entry = build_client_entry(:avatar, %{"size" => 2048})
-      assert {:error, avatar} = UploadConfig.put_entries(socket.assigns.uploads.avatar, [entry])
+      assert {:ok, avatar} = UploadConfig.put_entries(socket.assigns.uploads.avatar, [entry])
       assert avatar.errors == [{entry["ref"], :too_large}]
     end
 
@@ -312,7 +312,7 @@ defmodule Phoenix.LiveView.UploadConfigTest do
       hero_config = socket.assigns.uploads.hero
       entry = build_client_entry(:avatar, %{"name" => "file.gif"})
 
-      assert {:error, %UploadConfig{} = hero_config} =
+      {:ok, %UploadConfig{} = hero_config} =
                UploadConfig.put_entries(hero_config, [entry])
 
       assert hero_config.errors == [{entry["ref"], :not_accepted}]
@@ -320,7 +320,7 @@ defmodule Phoenix.LiveView.UploadConfigTest do
       hero_config = drop_entry(hero_config, entry["ref"])
       entry = build_client_entry(:avatar, %{"name" => "file.gif", "type" => "image/png"})
 
-      assert {:error, %UploadConfig{} = hero_config} =
+      assert {:ok, %UploadConfig{} = hero_config} =
                UploadConfig.put_entries(hero_config, [entry])
 
       assert hero_config.errors == [{entry["ref"], :not_accepted}]
@@ -328,7 +328,7 @@ defmodule Phoenix.LiveView.UploadConfigTest do
       hero_config = drop_entry(hero_config, entry["ref"])
       entry = build_client_entry(:avatar, %{"name" => "file", "type" => "image/png"})
 
-      assert {:error, %UploadConfig{} = hero_config} =
+      assert {:ok, %UploadConfig{} = hero_config} =
                UploadConfig.put_entries(hero_config, [entry])
 
       assert hero_config.errors == [{entry["ref"], :not_accepted}]
@@ -353,7 +353,7 @@ defmodule Phoenix.LiveView.UploadConfigTest do
 
       hero_config = socket.assigns.uploads.hero
       entry = build_client_entry(:avatar, %{"name" => "photo", "type" => "image/gif"})
-      assert {:error, hero_config} = UploadConfig.put_entries(hero_config, [entry])
+      assert {:ok, hero_config} = UploadConfig.put_entries(hero_config, [entry])
       assert hero_config.errors == [{entry["ref"], :not_accepted}]
 
       hero_config = drop_entry(hero_config, entry["ref"])
@@ -361,7 +361,7 @@ defmodule Phoenix.LiveView.UploadConfigTest do
       entry =
         build_client_entry(:avatar, %{"name" => "photo.jpg", "type" => "application/x-httpd-php"})
 
-      assert {:error, hero_config} = UploadConfig.put_entries(hero_config, [entry])
+      assert {:ok, hero_config} = UploadConfig.put_entries(hero_config, [entry])
       assert hero_config.errors == [{entry["ref"], :not_accepted}]
     end
 


### PR DESCRIPTION
Fixes #2664 phoenixframework/phoenix_live_view

This is to resolve issue: https://github.com/phoenixframework/phoenix_live_view/issues/2664

Using the setup suggested by the issue above I have the altered the liveview code to display all errors (and not just the first one). All the test cases seem to work whilst manually testing but this has expectedly broken (3) tests. However I am not entirely sure the test assertions are all correct as the same tests done manually work, and these 3 tests only break on the mocks. 

`test/phoenix_live_view/upload/external_test.exs:108`

```
  3) test preflight with error return (Phoenix.LiveView.UploadExternalTest)
     test/phoenix_live_view/upload/external_test.exs:108
     ** (exit) exited in: GenServer.call(#PID<0.2289.0>, {:allowed_ack, "phx-F4G79lTAzoBu9CNE", %{chunk_size: 20, max_entries: 2, max_file_size: 8000000}, [%{"content" => "okokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokok", "name" => "foo.jpeg", "ref" => "9061", "relative_path" => nil, "size" => 200, "type" => "image/jpeg"}, %{"content" => "okokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokok", "name" => "bad.jpeg", "ref" => "9093", "relative_path" => nil, "size" => 200, "type" => "image/jpeg"}], %{}}, 5000)
         ** (EXIT) an exception was raised:
             ** (KeyError) key "9061" not found in: %{}
                 :erlang.map_get("9061", %{})
                 (phoenix_live_view 0.19.5) lib/phoenix_live_view/test/upload_client.ex:57: anonymous fn/4 in Phoenix.LiveViewTest.UploadClient.handle_call/3
                 (elixir 1.13.1) lib/enum.ex:2396: Enum."-reduce/3-lists^foldl/2-0-"/3
                 (phoenix_live_view 0.19.5) lib/phoenix_live_view/test/upload_client.ex:55: Phoenix.LiveViewTest.UploadClient.handle_call/3
                 (stdlib 3.17) gen_server.erl:721: :gen_server.try_handle_call/4
                 (stdlib 3.17) gen_server.erl:750: :gen_server.handle_msg/6
                 (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
     code: assert {:error, [[^ref, %{reason: "bad name"}]]} = render_upload(avatar, "foo.jpeg", 1)
     stacktrace:
       (elixir 1.13.1) lib/gen_server.ex:1030: GenServer.call/3
       (phoenix_live_view 0.19.5) lib/phoenix_live_view/test/live_view_test.ex:1824: Phoenix.LiveViewTest.render_upload/3
       test/phoenix_live_view/upload/external_test.exs:116: (test)
```

Would love some advice to get this over the line 🙏🏻  Thank you :) 

P.s. sorry for the long delay on this I have been very time poor this month 😞 