### PR TITLE
Allow Phoenix.LiveViewTest.live_redirect to navigate to nested paths

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1705,7 +1705,7 @@ defmodule Phoenix.LiveViewTest do
 
     url =
       case Keyword.fetch!(opts, :to) do
-        "/" <> path -> URI.merge(root.uri, path)
+        "/" <> _ = path -> URI.merge(root.uri, path)
         url -> url
       end
 

--- a/test/phoenix_live_view/integrations/navigation_test.exs
+++ b/test/phoenix_live_view/integrations/navigation_test.exs
@@ -177,6 +177,9 @@ defmodule Phoenix.LiveView.NavigationTest do
         assert {"class", "thermo"} in attrs
         assert str =~ "The temp is"
       end
+
+      assert {:ok, thermo_live3, _html} = live_redirect(thermo_live2, to: "/thermo-live-session/nested-thermo")
+      assert {:ok, _thermo_live4, _html} = live_redirect(thermo_live3, to: "/thermo-live-session/nested-thermo")
     end
 
     test "refused with mismatched live session", %{conn: conn} do

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -139,6 +139,7 @@ defmodule Phoenix.LiveViewTest.Router do
     # live_session
     live_session :test do
       live "/thermo-live-session", ThermostatLive
+      live "/thermo-live-session/nested-thermo", ThermostatLive
       live "/clock-live-session", ClockLive
       live "/classlist", ClassListLive
     end


### PR DESCRIPTION
This fixes the problem described in #2798.