### PR TITLE
[Doc] Correct the usage example in the function doc of stream/4

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1693,12 +1693,12 @@ defmodule Phoenix.LiveView do
       items to maintain the limit. For example, to limit the stream to the last 10 items
       in the UI while appending new items, pass a negative value:
 
-          stream(socket, :posts, posts, at: -1, limit: -10)
+          stream(socket, :songs, songs, at: -1, limit: -10)
 
       Likewise, to limit the stream to the first 10 items, while prepending new items,
       pass a positive value:
 
-          stream(socket, :posts, posts, at: 0, limit: 10)
+          stream(socket, :songs, songs, at: 0, limit: 10)
 
   Once a stream is defined, a new `@streams` assign is available containing
   the name of the defined streams. For example, in the above definition, the


### PR DESCRIPTION
According to the explanation below, 

```
Once a stream is defined, a new `@streams` assign is available containing
the name of the defined streams. For example, in the above definition, the
stream may be referenced as `@streams.songs` in your template. Stream items
are temporary and freed from socket state immediately after the `render/1`
function is invoked (or a template is rendered from disk).
```  

the example should be written as follows.
```elixir
stream(socket, :songs, songs, at: -1, limit: -10)
# ...
stream(socket, :songs, songs, at: 0, limit: 10)
```
