### PR TITLE
Clarify return values of :external upload functions

### DIFF
--- a/guides/client/uploads-external.md
+++ b/guides/client/uploads-external.md
@@ -46,7 +46,9 @@ Configure your uploader on `c:Phoenix.LiveView.mount/3`:
 Supply the `:external` option to
 `Phoenix.LiveView.allow_upload/3`. It requires a 2-arity
 function that generates a signed URL where the client will
-push the bytes for the upload entry.
+push the bytes for the upload entry. This function must
+return either `{:ok, meta, socket}` or `{:error, meta, socket}`,
+where `meta` must me a map.
 
 For example, if you were using a context that provided a
 [`start_session`](https://developers.google.com/youtube/v3/guides/using_resumable_upload_protocol##Start_Resumable_Session)

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -900,7 +900,9 @@ defmodule Phoenix.LiveView do
       upload channel when a new chunk has not been received. Defaults `10_000`.
 
     * `:external` - The 2-arity function for generating metadata for external
-      client uploaders. See the Uploads section for example usage.
+      client uploaders. This function must return either `{:ok, meta, socket}`
+      or `{:error, meta, socket}` where meta is a map. See the Uploads section
+      for example usage.
 
     * `:progress` - The optional 3-arity function for receiving progress events
 


### PR DESCRIPTION
I recently ran into an issue where I wanted to return an error from my presign_url function when doing external uploads, and the only way I figured out how to do so was to find where it was executed inside of the upload channel.

This could certainly be more clear how it wires into an actual live view, but at the bare minimum explains the two return values that won't crash the channel.