### PR TITLE
Remove references to the deprecated preload callback

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -237,7 +237,7 @@ defmodule Phoenix.LiveComponent do
   ## Managing state
 
   Now that we have learned how to define and use components, as well as
-  how to use `c:preload/1` as a data loading optimization, it is important
+  how to use `c:update_many/2` as a data loading optimization, it is important
   to talk about how to manage state in components.
 
   Generally speaking, you want to avoid both the parent LiveView and the
@@ -347,7 +347,7 @@ defmodule Phoenix.LiveComponent do
 
   Now, each CardComponent will load its own card. Of course, doing so
   per card could be expensive and lead to N queries, where N is the
-  number of cards, so we can use the `c:preload/1` callback to make it
+  number of cards, so we can use the `c:update_many/2` callback to make it
   efficient.
 
   Once the card components are started, they can each manage their own
@@ -366,7 +366,7 @@ defmodule Phoenix.LiveComponent do
       end
 
   With `Phoenix.LiveView.send_update/3`, the `CardComponent` given by `id`
-  will be invoked, triggering both preload and update callbacks, which will
+  will be invoked, triggering the update or update_many callback, which will
   load the most up to date data from the database.
 
   ## Cost of live components

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1429,14 +1429,15 @@ defmodule Phoenix.LiveView do
   the live component. If you pass the module, then the `:id` that identifies
   the component must be passed as part of the assigns.
 
-  When the component receives the update, first the optional
-  [`preload/1`](`c:Phoenix.LiveComponent.preload/1`) then
-  [`update/2`](`c:Phoenix.LiveComponent.update/2`) is invoked with the new assigns.
-  If [`update/2`](`c:Phoenix.LiveComponent.update/2`) is not defined
-  all assigns are simply merged into the socket. The assigns received as the
-  first argument of the [`update/2`](`c:Phoenix.LiveComponent.update/2`)
-  callback will only include the _new_ assigns passed from this function.
-  Pre-existing assigns may be found in `socket.assigns`.
+  When the component receives the update,
+  [`update_many/2`](`c:Phoenix.LiveComponent.update_many/2`) will be invoked if
+  it is defined, otherwise [`update/2`](`c:Phoenix.LiveComponent.update/2`) is
+  invoked with the new assigns.  If
+  [`update/2`](`c:Phoenix.LiveComponent.update/2`) is not defined all assigns
+  are simply merged into the socket. The assigns received as the first argument
+  of the [`update/2`](`c:Phoenix.LiveComponent.update/2`) callback will only
+  include the _new_ assigns passed from this function.  Pre-existing assigns may
+  be found in `socket.assigns`.
 
   While a component may always be updated from the parent by updating some
   parent assigns which will re-render the child, thus invoking


### PR DESCRIPTION
Update_many is used in favor of preload which has been deprecated.