### PR TITLE
Fix issue with sticky remove transitions on push_navigate

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -324,6 +324,10 @@ let DOM = {
     return node.getAttribute && node.getAttribute(PHX_STICKY) !== null
   },
 
+  isChildOfAny(el, nodes){
+    return !!nodes.find(node => node.contains(el))
+  },
+
   firstPhxChild(el){
     return this.isPhxChild(el) ? el : this.all(el, `[${PHX_PARENT_ID}]`)[0]
   },

--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -400,7 +400,7 @@ export default class LiveSocket {
 
     this.main = this.newRootView(newMainEl, flash, liveReferer)
     this.main.setRedirect(href)
-    this.transitionRemoves()
+    this.transitionRemoves(null, true)
     this.main.join((joinCount, onDone) => {
       if(joinCount === 1 && this.commitPendingLink(linkRef)){
         this.requestDOMUpdate(() => {
@@ -414,9 +414,14 @@ export default class LiveSocket {
     })
   }
 
-  transitionRemoves(elements){
+  transitionRemoves(elements, skipSticky){
     let removeAttr = this.binding("remove")
     elements = elements || DOM.all(document, `[${removeAttr}]`)
+
+    if(skipSticky){
+      const stickies = DOM.findPhxSticky(document) || []
+      elements = elements.filter(el => !DOM.isChildOfAny(el, stickies))
+    }
     elements.forEach(el => {
       this.execJS(el, el.getAttribute(removeAttr), "remove")
     })


### PR DESCRIPTION
Fixes #2756

@chrismccord Grabbed this one for me as it seemed very simple to fix

Let me know what you think. Glad to iterate towards a better patch
I don't like passing null to `this.transitionRemoves` but it should be ok.