### PR TITLE
Fix HTMLFormatter for textarea

### DIFF
--- a/lib/phoenix_live_view/html_formatter.ex
+++ b/lib/phoenix_live_view/html_formatter.ex
@@ -479,7 +479,7 @@ defmodule Phoenix.LiveView.HTMLFormatter do
          source
        ) do
     {mode, block} =
-      if (tag_name in ["pre", "textarea"] or contains_special_attrs?(attrs)) and buffer != [] do
+      if tag_name in ["pre", "textarea"] or contains_special_attrs?(attrs) do
         content = content_from_source(source, open_meta.inner_location, close_meta.inner_location)
         {:preserve, [{:text, content, %{newlines: 0}}]}
       else

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -1666,9 +1666,12 @@ if Version.match?(System.version(), ">= 1.13.0") do
       <textarea />
       """)
 
-      assert_formatter_doesnt_change("""
-      <textarea></textarea>
-      """)
+      assert_formatter_doesnt_change(
+        """
+        <textarea></textarea>
+        """,
+        line_length: 5
+      )
     end
 
     test "keeps right format for inline elements within block elements" do


### PR DESCRIPTION
Resolves #2838 

`HTMLFormatter` is adding a newline between `<textarea>` tags, which adds unexpected whitespace to the rendered output.  This can be reproduced by setting the line length on the following test:
```elixir
assert_formatter_doesnt_change(
  """
  <textarea></textarea>
  """,
  line_length: 5
)
```

The culprit is a check for `buffer != []` which fails the test when present but passes when the check is removed.