### PR TITLE
Improve Router.live_session/3 docs

### DIFF
--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -128,9 +128,8 @@ defmodule Phoenix.LiveView.Router do
   `live_redirect` from the client with navigation purely over the existing
   websocket connection. This allows live routes defined in the router to
   mount a new root LiveView without additional HTTP requests to the server.
-  If there is no live session defined in the router, all live routes are
-  considered part of one global implicit live session.
-  
+  For backwards compatibility reasons, all live routes defined outside
+  of any live session are considered part of an unnamed live session.
 
   ## Security Considerations
 

--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -128,6 +128,9 @@ defmodule Phoenix.LiveView.Router do
   `live_redirect` from the client with navigation purely over the existing
   websocket connection. This allows live routes defined in the router to
   mount a new root LiveView without additional HTTP requests to the server.
+  If there is no live session defined in the router, all live routes are
+  considered part of one global implicit live session.
+  
 
   ## Security Considerations
 


### PR DESCRIPTION
I got quite confused about the fact that my two live routes defined in a router without any `live_session` were able to live redirect between each other without an additional HTTP request.

I think this docs improvement could help further readers/users.

Also, I can add similar sentence to the https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#link/1 docs if you think it could help even more.