### PR TITLE
docs: clarify <.async_result/> rendering precedence of stale result over loading and failed states

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2936,6 +2936,8 @@ defmodule Phoenix.Component do
 
   @doc """
   Renders an async assign with slots for the different loading states.
+  The result state takes precedence over subsequent loading and failed
+  states.
 
   *Note*: The inner block receives the result of the async assign as a :let.
   The let is only accessible to the inner block and is not in scope to the
@@ -2954,18 +2956,28 @@ defmodule Phoenix.Component do
     <% end %>
   </.async_result>
   ```
+
+  To display loading and failed states again on subsequent `assign_async` calls,
+  reset the assign to a result-free `%AsyncResult{}`:
+
+  ```elixir
+  {:noreply,
+    socket
+    |> assign_async(:page, :data, &reload_data/0)
+    |> assign(:page, AsyncResult.loading())}
+  ```
   """
   attr.(:assign, AsyncResult, required: true)
-  slot.(:loading, doc: "rendered while the assign is loading")
+  slot.(:loading, doc: "rendered while the assign is loading for the first time")
 
   slot.(:failed,
     doc:
-      "rendered when an error or exit is caught or assign_async returns `{:error, reason}`. Receives the error as a :let."
+      "rendered when an error or exit is caught or assign_async returns `{:error, reason}` for the first time. Receives the error as a `:let`"
   )
 
   slot.(:inner_block,
     doc:
-      "rendered when the assign is loaded successfully via AsyncResult.ok/2. Receives the result as a :let"
+      "rendered when the assign is loaded successfully via `AsyncResult.ok/2`. Receives the result as a `:let`"
   )
 
   def async_result(%{assign: async_assign} = assigns) do


### PR DESCRIPTION
> **Note**
> Edit: its a feature, not a bug. So I'll just clarify the docs

---

## Problem

`<.async_result />` component displays the stale result instead of the `<:loading/>` slot after calling `assign_async/2` more than once

### Root cause

- The `async_result` component prioritizes rendering the result (or stale result) if the `ok?` key is `true` 
- `AsyncResult.loading(existing, keys)` doesn't reset the `ok?` key to `false`.

Therefore the loading state is never shown after re-calling `assign_async`.

### Use case

Loading a heavy report based on a filter form. The current behaviour of showing only the first loading leads to a bad experience because the user will just see the stale data until the new data replaces abruptly.

```elixir
  def handle_event("filter",  params, socket) do
    case Filter.validate(params) do 
      {:error, changeset} ->
        {:noreply, assign(socket, form: to_form(changeset)}
      {:ok, _struct} ->
        {:noreply, push_patch(socket, to: Routes.resource_path(socket, :index, params))}
      end
   end

  def handle_params(params, _url, socket) do
    {:noreply,
     assign_async(socket, :report, fn ->
       {:ok, %{report: load_heavy_report(params)}}
     end)}
  end
```

## Solution

This PR implements the simplest one:
- treat this behaviour as a bug
- prioritize showing the `loading` state over the stale entry

## Alternatives

### Display _both_ the stale result and loading state

And let users hide what they need with `:if` special attribute. The most flexible design I guess 🤔 

```heex
<.async_result assign={@report} >
  <:loading :if={not @report.ok?}>
    I will only be rendered on the first `async_assign` call
  </:loading>
  <div :if={not @report.loading}>
      I'm not rendered if the report doesn't load
  </div>
</.async_result>
```

### Reset `AsyncResult` attribute `:ok?` back to `false`

After calling `assign_async` more than once.

Which I think is an inferior solution since the "show both stale and loading" use cases wouldn't be supported.

### Keep and document the current behaviour

I've been able to support this use case by calling `|> update(:report, &(%{&1 | ok?: false})`. Could also have written and maintained my own special flavour of `async_result` in `CoreComponents`. But I'd rather have this use case supported by the framework
