### PR TITLE
fix typo in phoenix component default slot docs

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -316,7 +316,7 @@ defmodule Phoenix.Component do
   ### The default slot
 
   The example above uses the default slot, accessible as an assign named `@inner_block`, to render
-  HEEx content via the `render_slot/2` function.
+  HEEx content via the `render_slot/1` function.
 
   If the values rendered in the slot need to be dynamic, you can pass a second value back to the
   HEEx content by calling `render_slot/2`:


### PR DESCRIPTION
I noticed a small typo when I was recently reading “The default slot” section in the Phoenix.Component docs and it causes me a tiny confusion whether I skip something in the reading or not. Great docs so far though!