### PR TITLE
FIX remove existing items in stream if reset=true

### DIFF
--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -110,9 +110,7 @@ export default class DOMPatch {
         })
         if(reset !== undefined){
           DOM.all(container, `[${PHX_STREAM_REF}="${ref}"]`, child => {
-            if(!inserts[child.id]){
-              this.removeStreamChildElement(child)
-            }
+            this.removeStreamChildElement(child)
           })
         }
         deleteIds.forEach(id => {


### PR DESCRIPTION
When using `stream(socket, :elements, elements, reset: true)`, elements that allready existed in the stream were not deleted from the DOM before the new elements are inserted. If the elements have a different order than before, this ordering was not mapped to the DOM.
By removing the filter for already existing elements to delete them all, the given order of the elements is retained.

Fixes #2767, fixes #2826