### PR TITLE
Specify doc type as component for async_result/1

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2960,6 +2960,7 @@ defmodule Phoenix.Component do
   </.async_result>
   ```
   """
+  @doc type: :component
   attr.(:assign, AsyncResult, required: true)
   slot.(:loading, doc: "rendered while the assign is loading")
 


### PR DESCRIPTION
I was looking for the `async_result/1` docs and was surprised to find it under the section Functions rather than Components in the [`Phoenix.Component` module docs](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#async_result/1). After investigating, it seems like that's because there's a missing `@doc` attribute with `type` metadata i.e. `@doc type: :component`.
