### PR TITLE
add handle_async as callback to live component behaviour

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -522,5 +522,12 @@ defmodule Phoenix.LiveComponent do
             ) ::
               {:noreply, Socket.t()} | {:reply, map, Socket.t()}
 
-  @optional_callbacks mount: 1, update_many: 1, update: 2, handle_event: 3
+  @callback handle_async(
+              name :: atom,
+              async_fun_result :: {:ok, term} | {:exit, term},
+              socket :: Socket.t()
+            ) ::
+              {:noreply, Socket.t()}
+
+  @optional_callbacks mount: 1, update_many: 1, update: 2, handle_event: 3, handle_async: 3
 end


### PR DESCRIPTION
When working with start_async inside a live component, I get the following error

```elixir
warning: got "@impl Phoenix.LiveComponent" for function handle_async/3 but this behaviour does not specify such callback. The known callbacks are:

  * Phoenix.LiveComponent.handle_event/3 (function)
  * Phoenix.LiveComponent.mount/1 (function)
  * Phoenix.LiveComponent.render/1 (function)
  * Phoenix.LiveComponent.update/2 (function)
  * Phoenix.LiveComponent.update_many/1 (function)
```

As the code itself works just fine, I assume that it's just the behaviour callback missing, so this PR adds it.