### PR TITLE
Minor typo in update_many documentation

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -158,7 +158,7 @@ defmodule Phoenix.LiveComponent do
           |> Repo.all()
           |> Map.new()
 
-        Enum.map(assigns_sockets, fn {assigns, sockets} ->
+        Enum.map(assigns_sockets, fn {assigns, socket} ->
           assign(socket, :user, users[assigns.id])
         end)
       end


### PR DESCRIPTION
Funny enough, I was preparing a presentation about phoenix performance and my N+1 example was almost exactly the same here and when I realised it I tried copying the code and then realised the minor typo.