### PR TITLE
Better error msg on missing default id in streams

### DIFF
--- a/lib/phoenix_live_view/live_stream.ex
+++ b/lib/phoenix_live_view/live_stream.ex
@@ -32,7 +32,7 @@ defmodule Phoenix.LiveView.LiveStream do
     raise ArgumentError, """
     expected stream :#{dom_prefix} to be a struct or map with :id key, got: #{inspect(other)}
 
-    If you would like to generate custom DOM id's based on other keys, use the :dom_id option.
+    If you would like to generate custom DOM id's based on other keys, use stream_configure/3 with the :dom_id option beforehand.
     """
   end
 


### PR DESCRIPTION
Since are configured separately with `configure_stream/3`, the warning message about a missing `:id` key when using the default DOM id should explain that a bit more precisely. Just a small thing.