### PR TITLE
Prepend without reordered

### DIFF
--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -164,7 +164,6 @@ export default class DOMPatch {
           return el
         },
         onNodeAdded: (el) => {
-          if(el.getAttribute){ this.maybeReOrderStream(el) }
 
           // hack to fix Safari handling of img srcset and video tags
           if(el instanceof HTMLImageElement && el.srcset){
@@ -223,7 +222,6 @@ export default class DOMPatch {
             externalFormTriggered = el
           }
           updates.push(el)
-          this.maybeReOrderStream(el)
         },
         onBeforeElUpdated: (fromEl, toEl) => {
           DOM.maybeAddPrivateHooks(toEl, phxViewportTop, phxViewportBottom)
@@ -339,31 +337,6 @@ export default class DOMPatch {
   getStreamInsert(el){
     let insert = el.id ? this.streamInserts[el.id] : {}
     return insert || {}
-  }
-
-  maybeReOrderStream(el){
-    let {ref, streamAt, limit} = this.getStreamInsert(el)
-    if(streamAt === undefined){ return }
-
-    // we need to the PHX_STREAM_REF here as well as addChild is invoked only for parents
-    DOM.putSticky(el, PHX_STREAM_REF, el => el.setAttribute(PHX_STREAM_REF, ref))
-
-    if(streamAt === 0){
-      el.parentElement.insertBefore(el, el.parentElement.firstElementChild)
-    } else if(streamAt > 0){
-      let children = Array.from(el.parentElement.children)
-      let oldIndex = children.indexOf(el)
-      if(streamAt >= children.length - 1){
-        el.parentElement.appendChild(el)
-      } else {
-        let sibling = children[streamAt]
-        if(oldIndex > streamAt){
-          el.parentElement.insertBefore(el, sibling)
-        } else {
-          el.parentElement.insertBefore(el, sibling.nextElementSibling)
-        }
-      }
-    }
   }
 
   transitionPendingRemoves(){

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1646,17 +1646,12 @@ defmodule Phoenix.LiveView do
 
       stream_insert(socket, :songs, %Song{id: 2, title: "Song 2"}, at: 0)
 
-  Or updating an existing song, while also moving it to the top of the collection:
-
-      stream_insert(socket, :songs, %Song{id: 1, title: "Song 1 updated"}, at: 0)
-
   ## Updating Items
 
   As shown, an existing item on the client can be updated by issuing a `stream_insert` for
-  the existing item. When the client updates an existing item with an "append" operation
-  (passing the `at: -1` option), the item will remain in the same location as it was
-  previously, and will not be moved to the end of the parent children. To both update an
-  existing item and move it to the end of a collection, issue a `stream_delete`, followed
+  the existing item. When the client updates an existing item , the item will remain in the
+  same location as it was previously, and will not be moved on the stream list. To both update
+  an existing item and move it from a collection, issue a `stream_delete`, followed
   by a `stream_insert`. For example:
 
       song = get_song!(id)


### PR DESCRIPTION
# Problem

Let's suppose we have a stream for a todo list. Each items are ordered by `updated_at` desc (more recently update on the top)
On this todo list multiple users could work together at the same time using all the power of LV with Phoenix.PubSub.

We want a feature "when a user update a todo list item, it updates the list for all connected users"

There 2 cases for users that will be notified by a PubSub event (e.g. `{:item_updated, item}`):

* stream_insert `at: 0`

The dom element will be reordered for everyone included people that have already loaded the element in their dom. Its annoying, let's suppose you update an item on the 5th pages. It will "disappear" to be moved at the 1st place of the list.

* stream_insert `at: -1`

If you have already loaded the dom element in your list, it will updated it without moving it. It's nice BUT if you haven't load the item it will be append to your list. We don't want that because our list MUST be ordered by updated_at desc

# Solution

If we never reordered the dom we fix the problem. 

For people that want exactly the behaviour we removed, they can use `stream_delete/3` right before `stream_insert` as the have to do for reordered in append. So in fact the idea is to have the same behavior for append, prepend or insert at specific position
