### PR TITLE
Tokenizer - add tests for local and remote components

### DIFF
--- a/test/phoenix_live_view/tokenizer_test.exs
+++ b/test/phoenix_live_view/tokenizer_test.exs
@@ -807,6 +807,69 @@ defmodule Phoenix.LiveView.TokenizerTest do
     end
   end
 
+  describe "local component" do
+    test "self-closing" do
+      assert tokenize("""
+             <.live_component module={MyApp.WeatherComponent} id="thermostat" city="Kraków" />
+             """) == [
+               {:local_component, "live_component",
+                 [
+                   {"module", {:expr, "MyApp.WeatherComponent", %{line: 1, column: 26}}, %{line: 1, column: 18}},
+                   {"id", {:string, "thermostat", %{delimiter: 34}}, %{line: 1, column: 50}},
+                   {"city", {:string, "Kraków", %{delimiter: 34}}, %{line: 1, column: 66}}
+                 ],
+                 %{line: 1, closing: :self, column: 1, tag_name: ".live_component", inner_location: {1, 82}}
+               },
+               {:text, "\n", %{line_end: 2, column_end: 1}}
+             ]
+    end
+
+    test "traverses until </.link>" do
+      assert tokenize("""
+             <.link href="/">Regular anchor link</.link>
+             """) == [
+               {:local_component, "link", [{"href", {:string, "/", %{delimiter: 34}}, %{line: 1, column: 8}}], %{line: 1, column: 1, tag_name: ".link", inner_location: {1, 17}}},
+               {:text, "Regular anchor link", %{line_end: 1, column_end: 36}},
+               {:close, :local_component, "link", %{line: 1, column: 36, tag_name: ".link", inner_location: {1, 36}}},
+               {:text, "\n", %{line_end: 2, column_end: 1}}
+             ]
+    end
+  end
+
+  describe "remote component" do
+    test "self-closing" do
+      assert tokenize("""
+             <MyAppWeb.CoreComponents.flash kind={:info} flash={@flash} />
+             """) == [
+               {
+                 :remote_component,
+                 "MyAppWeb.CoreComponents.flash",
+                 [{"kind", {:expr, ":info", %{column: 38, line: 1}}, %{column: 32, line: 1}}, {"flash", {:expr, "@flash", %{column: 52, line: 1}}, %{column: 45, line: 1}}],
+                 %{closing: :self, column: 1, inner_location: {1, 62}, line: 1, tag_name: "MyAppWeb.CoreComponents.flash"}
+               },
+               {:text, "\n", %{column_end: 1, line_end: 2}}
+             ]
+    end
+
+    test "traverses until </MyAppWeb.CoreComponents.modal>" do
+      assert tokenize("""
+             <MyAppWeb.CoreComponents.modal id="confirm" on_cancel={JS.navigate(~p"/posts")}>
+               This is another modal.
+             </MyAppWeb.CoreComponents.modal>
+             """) == [
+               {
+                 :remote_component,
+                 "MyAppWeb.CoreComponents.modal",
+                 [{"id", {:string, "confirm", %{delimiter: 34}}, %{line: 1, column: 32}}, {"on_cancel", {:expr, "JS.navigate(~p\"/posts\")", %{line: 1, column: 56}}, %{line: 1, column: 45}}],
+                 %{line: 1, column: 1, tag_name: "MyAppWeb.CoreComponents.modal", inner_location: {1, 81}}
+               },
+               {:text, "\n  This is another modal.\n", %{line_end: 3, column_end: 1}},
+               {:close, :remote_component, "MyAppWeb.CoreComponents.modal", %{line: 3, column: 1, tag_name: "MyAppWeb.CoreComponents.modal", inner_location: {3, 1}}},
+               {:text, "\n", %{line_end: 4, column_end: 1}}
+             ]
+    end
+  end
+
   test "mixing text and tags" do
     tokens =
       tokenize("""


### PR DESCRIPTION
I was investigating a bug and realized there's no test for components in the tokenizer. Seems like it would be helpful to add those tests.