### PR TITLE
Set `data-phx-stream` attribute on appended stream items in test cases

### DIFF
--- a/lib/phoenix_live_view/test/dom.ex
+++ b/lib/phoenix_live_view/test/dom.ex
@@ -432,6 +432,10 @@ defmodule Phoenix.LiveViewTest.DOM do
         new_children =
           Enum.reduce(stream_inserts, children, fn {id, {ref, insert_at, _limit}}, acc ->
             old_index = Enum.find_index(acc, &(attribute(&1, "id") == id))
+
+            not_appended? =
+              is_nil(Enum.find_index(updated_appended, &(attribute(&1, "id") == id)))
+
             existing? = Enum.find_index(updated_existing_children, &(attribute(&1, "id") == id))
             deleted? = MapSet.member?(stream_deletes, id)
 
@@ -442,8 +446,8 @@ defmodule Phoenix.LiveViewTest.DOM do
               end
 
             cond do
-              # skip added children that aren't ours
-              parent_id(html_tree, id) != container_id ->
+              # skip added children that aren't ours if they are not being appended
+              not_appended? and parent_id(html_tree, id) != container_id ->
                 acc
 
               # do not append existing child if already present, only update in place
@@ -586,7 +590,7 @@ defmodule Phoenix.LiveViewTest.DOM do
     |> parse_sorted!()
   end
 
-  @doc"""
+  @doc """
   Parses HTML into Floki format with sorted attributes.
   """
   def parse_sorted!(value) do

--- a/test/phoenix_live_view/integrations/stream_test.exs
+++ b/test/phoenix_live_view/integrations/stream_test.exs
@@ -104,6 +104,20 @@ defmodule Phoenix.LiveView.StreamTest do
     assert lv |> render() |> users_in_dom("admins") == [{"admins-2", "updated"}]
   end
 
+  test "should properly reset after a steam has been set after mount", %{conn: conn} do
+    {:ok, lv, _} = live(conn, "/stream")
+    assert lv |> element("#users div") |> has_element?()
+
+    lv |> render_hook("reset-users", %{})
+    refute lv |> element("#users div") |> has_element?()
+
+    lv |> render_hook("stream-users", %{})
+    assert lv |> element("#users div") |> has_element?()
+
+    lv |> render_hook("reset-users", %{})
+    refute lv |> element("#users div") |> has_element?()
+  end
+
   test "stream reset on patch", %{conn: conn} do
     {:ok, lv, _html} = live(conn, "/healthy/fruits")
 

--- a/test/support/live_views/streams.ex
+++ b/test/support/live_views/streams.ex
@@ -35,11 +35,16 @@ defmodule Phoenix.LiveViewTest.StreamLive do
     """
   end
 
+  @users [
+    %{id: 1, name: "chris"},
+    %{id: 2, name: "callan"}
+  ]
+
   def mount(_params, _session, socket) do
     {:ok,
      socket
      |> assign(:invalid_consume, false)
-     |> stream(:users, [user(1, "chris"), user(2, "callan")])
+     |> stream(:users, @users)
      |> stream(:admins, [user(1, "chris-admin"), user(2, "callan-admin")])}
   end
 
@@ -72,6 +77,14 @@ defmodule Phoenix.LiveViewTest.StreamLive do
      socket
      |> stream_delete_by_dom_id(:users, dom_id)
      |> stream_insert(:users, user, at: at)}
+  end
+
+  def handle_event("reset-users", _, socket) do
+    {:noreply, stream(socket, :users, [], reset: true)}
+  end
+
+  def handle_event("stream-users", _, socket) do
+    {:noreply, stream(socket, :users, @users)}
   end
 
   def handle_event("admin-delete", %{"id" => dom_id}, socket) do

--- a/test/support/live_views/streams.ex
+++ b/test/support/live_views/streams.ex
@@ -10,6 +10,7 @@ defmodule Phoenix.LiveViewTest.StreamLive do
     <div :for={{id, _user} <- Enum.map(@streams.users, &(&1))} id={id} />
     """
   end
+
   def render(assigns) do
     ~H"""
     <div id="users" phx-update="stream">


### PR DESCRIPTION
This should fix #2816. 

Let me know if there is a better way to solve this. After poking around and investigating #2816, I found that the reason why streams wouldn't properly reset was actually because the `data-phx-stream` attribute wasn't set. 

Because the reset functionality in tests depended on this, it meant if you streamed more content after adding stuff, it could never be reset again. Instead, I added a check so that items that are being appended will make sure to have their `data-phx-stream` attribute set to the correct stream ref.