### PR TITLE
Emit live_view render telemetry span events

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -913,31 +913,36 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   defp render_diff(state, socket, force?) do
-    :telemetry.span([:phoenix, :live_view, :render], %{socket: socket, force?: force?}, fn ->
-      changed? = Utils.changed?(socket)
+    changed? = Utils.changed?(socket)
 
-      {socket, diff, components} =
-        if force? or changed? do
-          rendered = Utils.to_rendered(socket, socket.view)
-          {socket, diff, components} = Diff.render(socket, rendered, state.components)
+    {socket, diff, components} =
+      if force? or changed? do
+        :telemetry.span(
+          [:phoenix, :live_view, :render],
+          %{socket: socket, force?: force?, changed?: changed?},
+          fn ->
+            rendered = Utils.to_rendered(socket, socket.view)
+            {socket, diff, components} = Diff.render(socket, rendered, state.components)
 
-          socket =
-            socket
-            |> Lifecycle.after_render()
-            |> Utils.clear_changed()
+            socket =
+              socket
+              |> Lifecycle.after_render()
+              |> Utils.clear_changed()
 
-          {socket, diff, components}
-        else
-          {socket, %{}, state.components}
-        end
+            {
+              {socket, diff, components},
+              %{socket: socket, force?: force?, changed?: changed?}
+            }
+          end
+        )
+      else
+        {socket, %{}, state.components}
+      end
 
-      diff = Diff.render_private(socket, diff)
-      new_socket = Utils.clear_temp(socket)
-      {
-        {:diff, diff, %{state | socket: new_socket, components: components}},
-        %{socket: new_socket, diff: diff, force?: force?, changed?: changed?}
-      }
-    end)
+    diff = Diff.render_private(socket, diff)
+    new_socket = Utils.clear_temp(socket)
+
+    {:diff, diff, %{state | socket: new_socket, components: components}}
   end
 
   defp reply(state, {ref, extra}, status, payload) do

--- a/test/phoenix_live_view/integrations/telemetry_test.exs
+++ b/test/phoenix_live_view/integrations/telemetry_test.exs
@@ -202,22 +202,17 @@ defmodule Phoenix.LiveView.TelemetryTest do
 
       assert metadata.socket.transport_pid
       assert metadata.force?
+      assert metadata.changed?
 
       assert_receive {:event, [:phoenix, :live_view, :render, :stop], %{duration: _}, metadata}
 
       assert metadata.socket.transport_pid
-      # Includes a full render diff
-      assert %{0 => _, :s => _} = metadata.diff
       assert metadata.force?
       assert metadata.changed?
 
       render_submit(view, :save, %{temp: 20})
 
-      # Returns a partial diff on the second render
-      assert_receive {:event, [:phoenix, :live_view, :render, :stop], %{duration: _}, metadata}
-      assert %{} = metadata.diff
-      refute Enum.empty?(metadata.diff)
-      refute Map.has_key?(metadata.diff, :s)
+      assert_receive {:event, [:phoenix, :live_view, :render, :stop], %{duration: _}, _}
     end
   end
 


### PR DESCRIPTION
As discussed in [this thread](https://elixirforum.com/t/more-telemetry-events-for-liveview/59388) this PR introduces a new telemetry span for the LiveView render cycle.

The update/update_many span will be added in another PR.

I haven't added any docs on that yet, wanted to start with the core code changes to allow us to continue with the discussion. If we think this makes sense I can put some effort in the  docs for this new telemetry events.

I included force? and changed? metadata because is low hanging fruit and it can be interesting (maybe to count how many forced renders are there for each live view.

I also included the diffs, so one could, for example, count how many non-forced events that params have changed resulted in empty diffs.

By wrapping the calls to `Diff.render`, we make sure that on the context of OpenTelemetry all spans/events caused by LiveComponent update/update_many callbacks will end up as child spans (either directly or indirectly) of this single render span, which could be really useful to flagging out N+1 problematic scenarios.