### PR TITLE
Add live_component update telemetry event

### DIFF
--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -664,8 +664,7 @@ defmodule Phoenix.LiveView.Diff do
         telemetry_metadata = %{
           socket: socket,
           component: component,
-          assigns_sockets: assigns_sockets,
-          update_many?: update_many?
+          assigns_sockets: assigns_sockets
         }
 
         sockets =

--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -662,19 +662,12 @@ defmodule Phoenix.LiveView.Diff do
         metadata = Enum.reverse(metadata)
         update_many? = function_exported?(component, :update_many, 1)
 
-        component_data=
-          assigns_sockets
-          |> Enum.zip(metadata)
-          |> Enum.map(fn {{assigns, socket}, {cid, _id, new?}} ->
-            %{
-              assigns: assigns,
-              socket: socket,
-              cid: cid,
-              new?: new?
-            }
-          end)
-
-        telemetry_metadata = %{socket: socket, component: component, component_data: component_data, update_many?: update_many?}
+        telemetry_metadata = %{
+          socket: socket,
+          component: component,
+          assigns_sockets: assigns_sockets,
+          update_many?: update_many?
+        }
 
         sockets =
           :telemetry.span([:phoenix, :live_component, :update], telemetry_metadata, fn ->
@@ -687,9 +680,7 @@ defmodule Phoenix.LiveView.Diff do
                 end)
               end
 
-            component_data = sockets |> Enum.zip(component_data) |> Enum.map(fn {socket, data} -> %{data | socket: socket} end)
-            
-            {sockets, Map.put(telemetry_metadata, :component_data, component_data)}
+            {sockets, Map.put(telemetry_metadata, :sockets, sockets)}
           end)
 
         triplet = zip_components(sockets, metadata, component, cids, {pending, diffs, components})

--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -629,6 +629,7 @@ defmodule Phoenix.LiveView.Diff do
     {{pending, diffs, components}, seen_ids} =
       Enum.reduce(pending, acc, fn {component, entries}, acc ->
         {{pending, diffs, components}, seen_ids} = acc
+        update_many? = function_exported?(component, :update_many, 1)
         entries = maybe_preload_components(component, Enum.reverse(entries))
 
         {assigns_sockets, metadata, components, seen_ids} =
@@ -659,8 +660,6 @@ defmodule Phoenix.LiveView.Diff do
           end)
 
         assigns_sockets = Enum.reverse(assigns_sockets)
-        metadata = Enum.reverse(metadata)
-        update_many? = function_exported?(component, :update_many, 1)
 
         telemetry_metadata = %{
           socket: socket,
@@ -683,6 +682,7 @@ defmodule Phoenix.LiveView.Diff do
             {sockets, Map.put(telemetry_metadata, :sockets, sockets)}
           end)
 
+        metadata = Enum.reverse(metadata)
         triplet = zip_components(sockets, metadata, component, cids, {pending, diffs, components})
         {triplet, seen_ids}
       end)

--- a/test/phoenix_live_view/integrations/telemetry_test.exs
+++ b/test/phoenix_live_view/integrations/telemetry_test.exs
@@ -263,7 +263,6 @@ defmodule Phoenix.LiveView.TelemtryTest do
 
       assert metadata.socket
       assert metadata.component == Phoenix.LiveViewTest.StatefulComponent
-      refute metadata.update_many?
 
       assert [
                {

--- a/test/phoenix_live_view/integrations/telemetry_test.exs
+++ b/test/phoenix_live_view/integrations/telemetry_test.exs
@@ -266,30 +266,27 @@ defmodule Phoenix.LiveView.TelemtryTest do
       refute metadata.update_many?
 
       assert [
-               %{
-                 cid: cid,
-                 assigns: %{id: _id, name: name},
-                 socket: component_socket,
-                 new?: true
+               {
+                 %{id: _id, name: name},
+                 %{assigns: %{myself: cid}} = component_socket
                },
                _
-             ] = metadata.component_data
-
-      assert is_integer(cid)
+             ] = metadata.assigns_sockets
 
       assert_receive {:event, [:phoenix, :live_component, :update, :stop], %{duration: _},
                       metadata}
 
       assert metadata.socket
       assert metadata.component == Phoenix.LiveViewTest.StatefulComponent
-      assert [%{socket: updated_component_socket}, _] = metadata.component_data
+      assert [updated_component_socket, _] = metadata.sockets
 
       assert updated_component_socket != component_socket
+      assert %{myself: ^cid} = updated_component_socket.assigns
 
       render_click(view, "disable", %{"name" => name})
 
       assert_receive {:event, [:phoenix, :live_component, :update, :start], %{system_time: _},
-                      %{component_data: [%{new?: false, assigns: %{name: ^name, disabled: true}} | _]}}
+                      %{assigns_sockets: [{%{name: ^name, disabled: true}, _} | _]}}
     end
   end
 

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -323,6 +323,10 @@ defmodule Phoenix.LiveViewTest.WithMultipleTargets do
   def handle_event("transform", %{"op" => _op}, socket) do
     {:noreply, assign(socket, :message, "Parent was updated")}
   end
+
+  def handle_event("disable", %{"name" => name}, socket) do
+    {:noreply, assign(socket, :disabled, Enum.uniq([name | socket.assigns.disabled]))}
+  end
 end
 
 defmodule Phoenix.LiveViewTest.WithLogOverride do


### PR DESCRIPTION
The second part of what was discussed on [this thread](https://elixirforum.com/t/more-telemetry-events-for-liveview/59388). This together with #2907 will already give good hooks for traces to be able to correlate nested component renders.

For this one, I decided to group cid, socket, assigns and whether the component is new or not in a list of maps to make life easier for whoever is consuming this.

I took the opportunity to do a slightly refactor to make the "shape" of `assigns_sockets` uniform regardless of whether the component have `update_many` exported or not. This was done simply by just adding `{new_assigns, socket}` to the assigns_sockets in the inner reduce and then calling update after inside a `map` call.