### PR TITLE
Document HTML attrs dasherization breaking change in CHANGESET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
   * Remove previously deprecated `<%= live_img_preview(entry) %>`. Use `<.live_img_preview entry={entry} />` instead
   * Remove previously deprecated `<%= live_file_input(upload) %>`. Use `<.live_file_input upload={upload} />` instead
   * Remove previously deprecated `<%= live_component(Component) %>`. Use `<.live_component module={Component} id=\"hello\" />` instead
+  * Don't convert underscores to dashes automatically when rendering HTML attributes. Use dashes or underscores where appropriate instead.
 
 ### Enhancements
   * Support stream resets with bulk insert operations


### PR DESCRIPTION
In #2546 HTML attributes stopped being dasherized. This is a breaking change that was released on Phoenix LiveView 0.19.0 but not documented in the CHANGESET. 

As [suggested](https://github.com/phoenixframework/phoenix_live_view/issues/2545#issuecomment-1810330291) by @jose this PR updates the CHANGELOG to document this change so it won't caught others as a surprise.