### PR TITLE
fix negative tabindex handling when determining focusability

### DIFF
--- a/assets/js/phoenix_live_view/aria.js
+++ b/assets/js/phoenix_live_view/aria.js
@@ -17,7 +17,7 @@ let ARIA = {
       (el instanceof HTMLAreaElement && el.href !== undefined) ||
       (!el.disabled && (this.anyOf(el, [HTMLInputElement, HTMLSelectElement, HTMLTextAreaElement, HTMLButtonElement]))) ||
       (el instanceof HTMLIFrameElement) ||
-      (el.tabIndex > 0 || (!interactiveOnly && el.tabIndex === 0 && el.getAttribute("tabindex") !== null && el.getAttribute("aria-hidden") !== "true"))
+      (el.tabIndex > 0 || (!interactiveOnly && el.getAttribute("tabindex") !== null && el.getAttribute("aria-hidden") !== "true"))
     )
   },
 


### PR DESCRIPTION
This PR solves [this](https://github.com/phoenixframework/phoenix_live_view/issues/2917) issue. Basically, it seems the code was taking tabindex to mean something it doesn't. Negative tabindexes are programatically focusable, and they should be treated as such by isFocusable.

There's a secondary issue here which is that this code also seems to be considering all elements with positive tabindexes interactive, which is not what a positive tabindex means. I've chosen not to change that as it is outside the scope of my original issue, but I do think the `el.tabIndex > 0` check should be removed as it is, in my opinion, a bug.