### PR TITLE
Add viewport check to click away

### DIFF
--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -26,6 +26,16 @@ let JS = {
     return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length > 0)
   },
 
+  isInViewport(el){
+    const rect = el.getBoundingClientRect()
+    return (
+      rect.top >= 0 &&
+        rect.left >= 0 &&
+        rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+        rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+    )
+  },
+
   // private
 
   // commands

--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -661,7 +661,7 @@ export default class LiveSocket {
       if(!(el.isSameNode(clickStartedAt) || el.contains(clickStartedAt))){
         this.withinOwners(e.target, view => {
           let phxEvent = el.getAttribute(phxClickAway)
-          if(JS.isVisible(el)){
+          if(JS.isVisible(el) && JS.isInViewport(el)){
             JS.exec("click", phxEvent, view, el, ["push", {data: this.eventMeta("click", e, e.target)}])
           }
         })


### PR DESCRIPTION
Augments the `phx-click-away` feature to account for elements outside the viewport (see https://codepen.io/sevensidedmarble/pen/LYqmGzp?editors=1111) and [associated issue](https://github.com/phoenixframework/phoenix_live_view/issues/2929) for more details. Closes #2929.