### PR TITLE
relax key requirements for start_async

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -82,8 +82,8 @@ defmodule Phoenix.LiveView do
 
   The `assign_async/3` function takes a name, a list of keys which will be assigned
   asynchronously, and a function. This function will be wrapped in a `task` by
-  `assign_async`, making it easy for you to return the result. This function must 
-  return an `{:ok, assigns}` or `{:error, reason}` tuple, where `assigns` is a map 
+  `assign_async`, making it easy for you to return the result. This function must
+  return an `{:ok, assigns}` or `{:error, reason}` tuple, where `assigns` is a map
   of the keys passed to `assign_async`.
   If the function returns anything else, an error is raised.
 
@@ -101,8 +101,8 @@ defmodule Phoenix.LiveView do
       end
 
   The state of the async operation is stored in the socket assigns within an
-  `Phoenix.LiveView.AsyncResult`. It carries the loading and failed states, as 
-  well as the result. For example, if we wanted to show the loading states in 
+  `Phoenix.LiveView.AsyncResult`. It carries the loading and failed states, as
+  well as the result. For example, if we wanted to show the loading states in
   the UI for the `:org`, our template could conditionally render the states:
 
   ```heex
@@ -1849,8 +1849,7 @@ defmodule Phoenix.LiveView do
 
   See the moduledoc for more information.
   """
-  def start_async(%Socket{} = socket, name, func)
-      when is_atom(name) and is_function(func, 0) do
+  def start_async(%Socket{} = socket, name, func) when is_function(func, 0) do
     Async.start_async(socket, name, func)
   end
 

--- a/lib/phoenix_live_view/async.ex
+++ b/lib/phoenix_live_view/async.ex
@@ -3,8 +3,7 @@ defmodule Phoenix.LiveView.Async do
 
   alias Phoenix.LiveView.{AsyncResult, Socket, Channel}
 
-  def start_async(%Socket{} = socket, key, func)
-      when is_atom(key) and is_function(func, 0) do
+  def start_async(%Socket{} = socket, key, func) when is_function(func, 0) do
     run_async_task(socket, key, func, :start)
   end
 

--- a/test/phoenix_live_view/integrations/start_async_test.exs
+++ b/test/phoenix_live_view/integrations/start_async_test.exs
@@ -67,6 +67,12 @@ defmodule Phoenix.LiveView.StartAsyncTest do
       assert render(lv)
       assert_receive {:exit, _pid, :boom}, 1000
     end
+
+    test "complex key task", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, "/start_async?test=complex_key")
+
+      assert render_async(lv) =~ "result: :complex_key"
+    end
   end
 
   describe "LiveComponent start_async" do
@@ -122,6 +128,12 @@ defmodule Phoenix.LiveView.StartAsyncTest do
 
       assert render(lv) =~ "lc: :loading"
       assert render_async(lv, 200) =~ "lc: :renewed"
+    end
+
+    test "complex key task", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, "/start_async?test=lc_complex_key")
+
+      assert render_async(lv) =~ "lc: :complex_key"
     end
   end
 end

--- a/test/support/live_views/general.ex
+++ b/test/support/live_views/general.ex
@@ -572,6 +572,13 @@ defmodule Phoenix.LiveViewTest.StartAsyncLive do
      end)}
   end
 
+  def mount(%{"test" => "complex_key"}, _session, socket) do
+    {:ok,
+     socket
+     |> assign(result: :loading)
+     |> start_async({:result_task, :foo}, fn -> :complex_key end)}
+  end
+
   def handle_async(:result_task, {:ok, result}, socket) do
     {:noreply, assign(socket, result: result)}
   end
@@ -582,6 +589,10 @@ defmodule Phoenix.LiveViewTest.StartAsyncLive do
 
   def handle_async(:result_task, {:exit, reason}, socket) do
     {:noreply, assign(socket, result: {:exit, reason})}
+  end
+
+  def handle_async({:result_task, _}, {:ok, result}, socket) do
+    {:noreply, assign(socket, result: result)}
   end
 
   def handle_info(:boom, _socket), do: exit(:boom)
@@ -656,6 +667,13 @@ defmodule Phoenix.LiveViewTest.StartAsyncLive.LC do
      end)}
   end
 
+  def update(%{test: "complex_key"}, socket) do
+    {:ok,
+     socket
+     |> assign(result: :loading)
+     |> start_async({:result_task, :foo}, fn -> :complex_key end)}
+  end
+
   def update(%{action: :cancel}, socket) do
     {:ok, cancel_async(socket, :result_task)}
   end
@@ -678,5 +696,9 @@ defmodule Phoenix.LiveViewTest.StartAsyncLive.LC do
 
   def handle_async(:result_task, {:exit, reason}, socket) do
     {:noreply, assign(socket, result: {:exit, reason})}
+  end
+
+  def handle_async({:result_task, _}, {:ok, result}, socket) do
+    {:noreply, assign(socket, result: result)}
   end
 end


### PR DESCRIPTION
I'm in the process of migrating a LV that currently starts async tasks using Task.async to `start_async`, but stumbled across the requirement for the key to be an atom. When starting tasks dynamically, e.g. one task for a list of users, I'd like to name these tasks with more complex keys like `{:user, USER_ID}`. Currently one would need to create new atoms (that's a no go), but still would not be able to pattern match in `handle_async`.

I created this PR to allow arbitrary keys when using `start_async` and it seems to work just fine. Code like this is possible now:

```elixir
defmodule MyLiveView do
  use Phoenix.LiveView

  def mount(_params, _session, socket) do
    users = [1, 2, 3]

    socket = Enum.reduce(users, socket, fn user, socket ->
      start_async(socket, {:user_details, user}, fn ->
        # do something specific for the user
      end)
    end)

    {:ok, assign(socket, :user_details, %{})}
  end

  def handle_async({:user_details, id}, {:ok, result}, socket) do
    {:noreply, update(socket, :user_details, &Map.put(&1, id, result))}
  end
end
```

Do you see any problems with relaxing the key requirements here? Maybe there is another solution that works equally well that I just didn't see.