### PR TITLE
Fix assert_patch default timeout

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1278,7 +1278,9 @@ defmodule Phoenix.LiveViewTest do
     path
   end
 
-  def assert_patch(view, to) when is_binary(to), do: assert_patch(view, to, 100)
+  def assert_patch(view, to) when is_binary(to) do
+    assert_patch(view, to, Application.fetch_env!(:ex_unit, :assert_receive_timeout))
+  end
 
   @doc """
   Asserts a live patch will happen to a given path within `timeout`

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -925,7 +925,8 @@ defmodule Phoenix.LiveViewTest do
   Awaits all current `assign_async` and `start_async` for a given LiveView or element.
 
   It renders the LiveView or Element once complete and returns the result.
-  By default, the timeout is 100ms, but a custom time may be passed to override.
+  The default `timeout` is [ExUnit](https://hexdocs.pm/ex_unit/ExUnit.html#configure/1)'s
+  `assert_receive_timeout` (100 ms).
 
   ## Examples
 
@@ -1284,7 +1285,9 @@ defmodule Phoenix.LiveViewTest do
 
   @doc """
   Asserts a live patch will happen to a given path within `timeout`
-  milliseconds. The default `timeout` is 100.
+  milliseconds. 
+  The default `timeout` is [ExUnit](https://hexdocs.pm/ex_unit/ExUnit.html#configure/1)'s
+  `assert_receive_timeout` (100 ms).
 
   It always returns `:ok`.
 
@@ -1351,7 +1354,8 @@ defmodule Phoenix.LiveViewTest do
 
   @doc """
   Asserts a redirect will happen to a given path within `timeout` milliseconds.
-  The default `timeout` is 100.
+  The default `timeout` is [ExUnit](https://hexdocs.pm/ex_unit/ExUnit.html#configure/1)'s
+  `assert_receive_timeout` (100 ms).
 
   It returns the flash messages from said redirect, if any.
   Note the flash will contain string keys.


### PR DESCRIPTION
In #2655 there was one `assert_patch` that was missed, which is still using a default timeout of 100ms.
This PR fixes this inconsistency, and also updates the other functions documentation to mention that `assert_receive_timeout` is the default value.