### PR TITLE
fix live components being destroyed in some circumstances

### DIFF
--- a/assets/js/phoenix_live_view/rendered.js
+++ b/assets/js/phoenix_live_view/rendered.js
@@ -65,7 +65,6 @@ export let modifyRoot = (html, attrs, clearInnerHTML) => {
       }
       tagNameEndsAt = i
       tag = html.slice(iAtOpen + 1, tagNameEndsAt)
-      i++
       // Scan the opening tag for id, if there is any
       for(i; i < html.length; i++){
         if(html.charAt(i) === ">" ){ break }

--- a/assets/test/modify_root_test.js
+++ b/assets/test/modify_root_test.js
@@ -105,4 +105,17 @@ ${"\t"}class="px-5"><div id="menu">MENU</div></div>`)
     expect(result[1]).toEqual(`<!-- <before> -->`)
     expect(result[2]).toEqual(`<!-- <after> --><!-- <after2> -->`)
   })
+
+  test("does not extract id from inner element", () => {
+    const html = "<div>\n  <div id=\"verify-payment-data-component\" data-phx-id=\"phx-F6AZf4FwSR4R50pB-39\" data-phx-skip></div>\n</div>"
+    const attrs = {
+      "data-phx-id": "phx-F6AZf4FwSR4R50pB-c-3",
+      "data-phx-component": 3,
+      "data-phx-skip": true
+    }
+
+    let [strippedHTML, _commentBefore, _commentAfter] = modifyRoot(html, attrs, true);
+
+    expect(strippedHTML).toEqual("<div data-phx-id=\"phx-F6AZf4FwSR4R50pB-c-3\" data-phx-component=\"3\" data-phx-skip></div>");
+  })
 })


### PR DESCRIPTION
So, I had a very weird bug with a live component that got destroyed on updates in some cirumstances (lv latest main). After morphdom applied the patches, the wrapping div of the live component that contains the `data-phx-component` attribute was replaced with the inner element. Consequently, any events targeting the live component failed client side with the error `no component found matching phx-target of 3`.

I dug very deep to find out that it relates to https://github.com/phoenixframework/phoenix_live_view/pull/2891. It would not happen when the PHX_MAGIC_ID is checked first.
But this was not to root cause. Actually, `modifyRoot` would move the inner elements id to the parent element when phx-skip is true. This PR tries to fix this by first checking if the HTML tag is already closed before searching for an ID.

Disclaimer: I am not sure if this is actually the correct solution.

Edit: I force pushed another change. Seems to have been a simple off by one...