### PR TITLE
Optimize maybeHideFeedback for initial page render

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -286,15 +286,16 @@ let DOM = {
   },
 
   maybeHideFeedback(container, inputs, phxFeedbackFor){
-    let selector;
+    let feedbacks = []
     inputs.forEach(input => {
       if(!(this.private(input, PHX_HAS_FOCUSED) || this.private(input, PHX_HAS_SUBMITTED))){
-        let feedbacks = [input.name]
-        if(input.name.endsWith("[]")){ feedbacks.push(input.name.slice(0, -2)) }
-        selector = feedbacks.map(f => `[${phxFeedbackFor}="${f}"]`).join(", ")
+        input.name.endsWith("[]") ? feedbacks.push(input.name.slice(0, -2)) : feedbacks.push(input.name)
       }
     })
-    DOM.all(container, selector, el => el.classList.add(PHX_NO_FEEDBACK_CLASS))
+    if (feedbacks.length > 0) {
+      let selector = feedbacks.map(f => `[${phxFeedbackFor}="${f}"]`).join(", ")
+      DOM.all(container, selector, el => el.classList.add(PHX_NO_FEEDBACK_CLASS))
+    }
   },
 
   resetForm(form, phxFeedbackFor){

--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -285,13 +285,16 @@ let DOM = {
     }
   },
 
-  maybeHideFeedback(container, input, phxFeedbackFor){
-    if(!(this.private(input, PHX_HAS_FOCUSED) || this.private(input, PHX_HAS_SUBMITTED))){
-      let feedbacks = [input.name]
-      if(input.name.endsWith("[]")){ feedbacks.push(input.name.slice(0, -2)) }
-      let selector = feedbacks.map(f => `[${phxFeedbackFor}="${f}"]`).join(", ")
-      DOM.all(container, selector, el => el.classList.add(PHX_NO_FEEDBACK_CLASS))
-    }
+  maybeHideFeedback(container, inputs, phxFeedbackFor){
+    let selector;
+    inputs.forEach(input => {
+      if(!(this.private(input, PHX_HAS_FOCUSED) || this.private(input, PHX_HAS_SUBMITTED))){
+        let feedbacks = [input.name]
+        if(input.name.endsWith("[]")){ feedbacks.push(input.name.slice(0, -2)) }
+        selector = feedbacks.map(f => `[${phxFeedbackFor}="${f}"]`).join(", ")
+      }
+    })
+    DOM.all(container, selector, el => el.classList.add(PHX_NO_FEEDBACK_CLASS))
   },
 
   resetForm(form, phxFeedbackFor){

--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -297,9 +297,7 @@ export default class DOMPatch {
       })
     }
 
-    trackedInputs.forEach(input => {
-      DOM.maybeHideFeedback(targetContainer, input, phxFeedbackFor)
-    })
+    DOM.maybeHideFeedback(targetContainer, trackedInputs, phxFeedbackFor)
 
     liveSocket.silenceEvents(() => DOM.restoreFocus(focused, selectionStart, selectionEnd))
     DOM.dispatchEvent(document, "phx:update")


### PR DESCRIPTION
This PR optimizes the initial page render for pages containing thousands of inputs; instead of calling `DOM.all` for each input, we build a selector to match all inputs and query the DOM.

From my testing, this has reduced the page rendering time from over 30 seconds to 4-5 seconds.