### PR TITLE
Support {:halt, render_with/2} in mount hook

### DIFF
--- a/test/phoenix_live_view/integrations/hooks_test.exs
+++ b/test/phoenix_live_view/integrations/hooks_test.exs
@@ -47,6 +47,19 @@ defmodule Phoenix.LiveView.HooksTest do
                  end
   end
 
+  test "on_mount hook halts with {:halt, render_with} socket", %{conn: conn} do
+    {:ok, _, html} = live(conn, "/lifecycle/render-with-mount")
+    assert html =~ "RENDER_WITH"
+  end
+
+  test "on_mount hook raises with both render_with and redirect", %{conn: conn} do
+    assert_raise Plug.Conn.WrapperError,
+                 ~r(the hook {Phoenix.LiveViewTest.HooksLive.HaltRenderWithRedirectMount, :default} for lifecycle event :mount attempted to halt using both redirect and render_with),
+                 fn ->
+                   live(conn, "/lifecycle/halt-render-with-redirect-mount")
+                 end
+  end
+
   test "on_mount hook halts with redirected socket", %{conn: conn} do
     assert {:error, {:live_redirect, %{to: "/lifecycle"}}} =
              live(conn, "/lifecycle/redirect-halt-mount")

--- a/test/support/live_views/lifecycle.ex
+++ b/test/support/live_views/lifecycle.ex
@@ -166,6 +166,34 @@ defmodule Phoenix.LiveViewTest.HooksLive.HaltMount do
   def render(assigns), do: ~H"<div></div>"
 end
 
+defmodule Phoenix.LiveViewTest.HooksLive.RenderWithMount do
+  use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
+
+  on_mount __MODULE__
+
+  def on_mount(:default, _, _, socket),
+    do: {:halt, render_with(socket, fn assigns -> ~H(RENDER_WITH) end)}
+
+  def render(assigns), do: ~H"<div></div>"
+end
+
+defmodule Phoenix.LiveViewTest.HooksLive.HaltRenderWithRedirectMount do
+  use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
+
+  on_mount __MODULE__
+
+  def on_mount(:default, _, _, socket) do
+    socket =
+      socket
+      |> push_navigate(to: "/lifecycle")
+      |> render_with(fn assigns -> ~H(RENDER_WITH) end)
+
+    {:halt, socket}
+  end
+
+  def render(assigns), do: ~H"<div></div>"
+end
+
 defmodule Phoenix.LiveViewTest.HooksLive.RedirectMount do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
 

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -115,6 +115,8 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/lifecycle/bad-mount", HooksLive.BadMount
     live "/lifecycle/own-mount", HooksLive.OwnMount
     live "/lifecycle/halt-mount", HooksLive.HaltMount
+    live "/lifecycle/render-with-mount", HooksLive.RenderWithMount
+    live "/lifecycle/halt-render-with-redirect-mount", HooksLive.HaltRenderWithRedirectMount
     live "/lifecycle/redirect-cont-mount", HooksLive.RedirectMount, :cont
     live "/lifecycle/redirect-halt-mount", HooksLive.RedirectMount, :halt
     live "/lifecycle/components", HooksLive.WithComponent


### PR DESCRIPTION
Previously, it was only possible to `{:halt, redirect}` or `{:cont, socket}` in a mount hook. This commit adds the ability to use halt if render_with has been specified.

When both render_with and redirect are specified, an ArgumentError is raised, as it is ambigious which should be used.