### PR TITLE
Avoid parsing components on test render_diff

### DIFF
--- a/lib/phoenix_live_view/test/dom.ex
+++ b/lib/phoenix_live_view/test/dom.ex
@@ -273,21 +273,21 @@ defmodule Phoenix.LiveViewTest.DOM do
 
   def render_diff(rendered) do
     rendered
-    |> Phoenix.LiveView.Diff.to_iodata(fn cid, contents ->
-      contents
-      |> IO.iodata_to_binary()
-      |> parse()
-      |> List.wrap()
-      |> Enum.map(walk_fun(&inject_cid_attr(&1, cid)))
-      |> to_html()
-    end)
+    |> Phoenix.LiveView.Diff.to_iodata(&add_cid_attr/2)
     |> IO.iodata_to_binary()
     |> parse()
     |> List.wrap()
   end
 
-  defp inject_cid_attr({tag, attrs, children}, cid) do
-    {tag, [{@phx_component, to_string(cid)}] ++ attrs, children}
+  defp add_cid_attr(cid, [head | tail]) do
+    head_with_cid = Regex.replace(
+      ~r/^((?:<!--.*-->)?<[^\s>]+)/,
+      IO.iodata_to_binary(head),
+      "\\1 #{@phx_component}=\"#{to_string(cid)}\"",
+      global: false
+    )
+
+    [head_with_cid | tail]
   end
 
   # Patching


### PR DESCRIPTION
Today when running tests, render_diff parses each live component with Floki to add the data-phx-component attribute. This parse has a significant cost on tests with a lot of live components. 

The project I'm working on has some pages with a large number of nested live components used to dynamically create a form, and all of this components get rerendered on every form change (someday we'll fix this 🤞). 

This PR modifies this diff rendering to use Regex.replace instead of Floki to add the data-phx-component attribute.

With this change the time to run the test for the page mentioned above went from 12.3 seconds to 5.2 seconds, and the full test suite with `--max-cases 1` went from 192 seconds to 170 seconds.