### PR TITLE
Support multiple formats in LiveView

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -530,13 +530,14 @@ defmodule Phoenix.LiveComponent do
     quote do
       import Phoenix.LiveView
       @behaviour Phoenix.LiveComponent
+      @phoenix_live_opts unquote(opts)
       @before_compile Phoenix.LiveView.Renderer
 
       # Phoenix.Component must come last so its @before_compile runs last
       use Phoenix.Component, Keyword.take(unquote(opts), [:global_prefixes])
 
       @doc false
-      def __live__, do: %{kind: :component, module: __MODULE__, layout: false}
+      def __live__, do: %{kind: :component, module: __MODULE__, layouts: false, formats: [:html]}
     end
   end
 

--- a/lib/phoenix_live_view/controller.ex
+++ b/lib/phoenix_live_view/controller.ex
@@ -6,6 +6,8 @@ defmodule Phoenix.LiveView.Controller do
   alias Phoenix.LiveView
   alias Phoenix.LiveView.Socket
 
+  import Phoenix.LiveView.Utils, only: [get_format: 1]
+
   @doc """
   Renders a live view from a Plug request and sends an HTML response
   from within a controller.
@@ -41,7 +43,7 @@ defmodule Phoenix.LiveView.Controller do
         conn
         |> Phoenix.Controller.put_view(LiveView.Static)
         |> Phoenix.Controller.render(
-          "template.html",
+          "template." <> get_format(conn),
           Map.merge(socket_assigns, %{content: content, live_module: view})
         )
 

--- a/lib/phoenix_live_view/html_engine.ex
+++ b/lib/phoenix_live_view/html_engine.ex
@@ -30,9 +30,25 @@ defmodule Phoenix.LiveView.HTMLEngine do
       trim: trim,
       caller: __CALLER__,
       source: source,
-      tag_handler: __MODULE__,
+      tag_handler: get_tag_handler(path),
       annotate_tagged_content: debug_annotations? && (&annotate_tagged_content/1)
     )
+  end
+
+  defp get_tag_handler(path) do
+    tag_type =
+      path
+      |> Path.basename()
+      |> String.split(".")
+      |> Enum.slice(1..-2)
+      |> Enum.join(".")
+      |> String.to_atom()
+
+    case Application.fetch_env(:phoenix_live_view, :tag_handlers) do
+      {:ok, tag_handlers} -> tag_handlers
+      _ -> []
+    end
+    |> Keyword.get(tag_type, __MODULE__)
   end
 
   @behaviour Phoenix.LiveView.TagEngine

--- a/lib/phoenix_live_view/renderer.ex
+++ b/lib/phoenix_live_view/renderer.ex
@@ -3,61 +3,126 @@ defmodule Phoenix.LiveView.Renderer do
 
   alias Phoenix.LiveView.{Rendered, Socket}
 
+  import Phoenix.LiveView.Utils, only: [get_format: 1]
+
   defmacro __before_compile__(%{module: module, file: file} = env) do
     render? = Module.defines?(module, {:render, 1})
     root = Path.dirname(file)
-    filename = template_filename(module)
-    templates = Phoenix.Template.find_all(root, filename)
+    formats = Module.get_attribute(module, :phoenix_live_opts)[:formats] || [:html]
+
+    templates = Enum.reduce(formats, [], fn(format, templates_acc) ->
+      filename = template_filename(module, format)
+
+      case Phoenix.Template.find_all(root, filename) do
+        [] -> templates_acc
+        templates when is_list(templates) ->
+          List.insert_at(templates_acc, -1, {format, templates})
+      end
+    end)
 
     case {render?, templates} do
-      {true, [template | _]} ->
-        IO.warn(
-          "ignoring template #{inspect(template)} because the LiveView " <>
-            "#{inspect(env.module)} defines a render/1 function",
-          Macro.Env.stacktrace(env)
-        )
-
+      {true, []}->
         :ok
 
-      {true, []} ->
-        :ok
+      {true, templates} ->
+        templates_list = 
+          templates
+          |> Keyword.values()
+          |> Enum.map(fn([template | _]) -> "\n* #{template}" end)
 
-      {false, [template]} ->
-        ext = template |> Path.extname() |> String.trim_leading(".") |> String.to_atom()
-        engine = Map.fetch!(Phoenix.Template.engines(), ext)
-        ast = engine.compile(template, filename)
+        message = "ignoring these templates:\n" <>
+          templates_list <>
+          "\nbecause the LiveView #{inspect(env.module)} defines a render/1 function"
 
-        quote do
-          @file unquote(template)
-          @external_resource unquote(template)
-          def render(var!(assigns)) when is_map(var!(assigns)) do
-            unquote(ast)
-          end
-        end
-
-      {false, [_ | _]} ->
-        IO.warn(
-          "multiple templates were found for #{inspect(env.module)}: #{inspect(templates)}",
-          Macro.Env.stacktrace(env)
-        )
+        IO.warn(message, Macro.Env.stacktrace(env))
 
         :ok
 
       {false, []} ->
-        template = Path.join(root, filename <> ".heex")
+        templates = Enum.map(formats, fn(format) ->
+          filename = template_filename(module, format)
+          template = Path.join(root, filename <> ".heex")
+          {format, template}
+        end)
 
         quote do
-          @external_resource unquote(template)
+          for format <- unquote(formats) do
+            @external_resource unquote(templates)[format]
+          end
+        end
+
+      {false, templates} ->
+        case verify_no_multiple_templates(templates) do
+          {:warn, message} ->
+            IO.warn(
+              "multiple templates were found for #{inspect(env.module)}:\n#{message}",
+              Macro.Env.stacktrace(env)
+            )
+
+            :ok
+          :ok ->
+            templates = Enum.into(templates, [], fn({key, [template]}) ->
+              ext = template |> Path.extname() |> String.trim_leading(".") |> String.to_atom()
+              engine = Map.fetch!(Phoenix.Template.engines(), ext)
+              filename = Path.basename(template)
+              ast = engine.compile(template, filename)
+              {key, %{path: template, ast: ast}}
+            end)
+
+            render_ast = 
+              quote do
+                def render(var!(assigns)) when is_map(var!(assigns)) do
+                  format = Phoenix.LiveView.Utils.get_format(var!(assigns).socket)
+                  apply(__MODULE__, :"render_#{format}", [var!(assigns)])
+                end
+              end
+
+            render_format_asts = 
+              for format <- formats do
+                quote do
+                  @file unquote(templates[format][:path])
+                  @external_resource unquote(templates[format][:path])
+                  def unquote(:"render_#{format}")(var!(assigns)) do
+                    unquote(templates[format][:ast])
+                  end
+                end
+              end
+
+            [render_ast | render_format_asts]
         end
     end
   end
 
-  defp template_filename(module) do
+  defp verify_no_multiple_templates(templates) do
+    templates
+    |> Keyword.values()
+    |> Enum.reduce([], fn 
+      [_template], acc -> acc
+      [], acc -> acc
+      [_ | _] = templates, acc -> 
+        [templates | acc]
+    end)
+    |> case do
+      [] -> :ok
+      templates ->
+        template_list = 
+          templates
+          |> List.flatten()
+          |> Enum.map(fn(template) ->
+            "\n* #{template}"
+          end)
+          |> Enum.join()
+
+        {:warn, template_list}
+    end
+  end
+
+  defp template_filename(module, format) do
     module
     |> Module.split()
     |> List.last()
     |> Macro.underscore()
-    |> Kernel.<>(".html")
+    |> Kernel.<>(".#{format}")
   end
 
   @doc """
@@ -79,10 +144,11 @@ defmodule Phoenix.LiveView.Renderer do
             |> view.render()
             |> check_rendered!(view)
           else
+            format = get_format(socket)
             template =
               view.__info__(:compile)[:source]
               |> Path.dirname()
-              |> Path.join(template_filename(view) <> ".heex")
+              |> Path.join(template_filename(view, format) <> ".heex")
 
             raise ~s'''
             render/1 was not implemented for #{inspect(view)}.
@@ -108,9 +174,10 @@ defmodule Phoenix.LiveView.Renderer do
       {layout_mod, layout_template} ->
         assigns = put_in(assigns[:inner_content], inner_content)
         assigns = put_in(assigns.__changed__[:inner_content], true)
+        format = get_format(socket)
 
         layout_mod
-        |> Phoenix.Template.render(to_string(layout_template), "html", assigns)
+        |> Phoenix.Template.render(to_string(layout_template), format, assigns)
         |> check_rendered!(layout_mod)
 
       false ->
@@ -141,7 +208,16 @@ defmodule Phoenix.LiveView.Renderer do
   defp layout(socket, view) do
     case socket.private do
       %{live_layout: layout} -> layout
-      %{} -> view.__live__()[:layout]
+      %{} ->
+        format =
+          socket
+          |> get_format()
+          |> String.to_atom()
+
+        case view.__live__()[:layouts] do
+         layouts when is_list(layouts) -> layouts[format] 
+         _ -> false
+        end
     end
   end
 end

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -16,7 +16,7 @@ defmodule Phoenix.LiveView.Static do
   Acts as a view via put_view to maintain the
   controller render + instrumentation stack.
   """
-  def render("template.html", %{content: content}) do
+  def render("template." <> _format, %{content: content}) do
     content
   end
 


### PR DESCRIPTION
This PR introduces formats to LiveView. Now LV can render multiple content type formats not just HTML. This is to allow LiveView Native to treat the platforms (i.e. `swiftui`, `jetpack`, `winui3`) as formats instead of just using query params.

This PR will also allow for format specific layouts to be rendered in LiveView instead of always `html`. In LiveView Native we had to introduce a bunch of macro work-arounds to get layout rendering to work. This will do away with at least half of our code to leverage the internal format rendering this PR allows for.

There are some breaking changes and I will highlight each of those below. But in most cases this should be a backwards compatible change. For example, now for `use Phoenix.LiveView` it should get `format`, and `layouts` just like `Phoenix.Controller` does:

```elixir
# both of these configurations are necessary

# this first will allow the `HTML.Engine` to be configured to allow for a format-specific tag_handler
config :phoenix_live_view, :tag_handlers, [
  gameboy: LiveViewNative.TagEngine,
]

# this will allow the new formats to declare their engine. Because we can override the tag_handler
# I expect this to almost always be `Phoenix.HTML.Engine` and we could make it a default if no overriding engine is provided
config :phoenix_template, :format_encoders, [
  gameboy: Phoenix.HTML.Engine
]

def MyAppWeb.Layout do
  use MyAppWeb, :html

  embed_templates "layouts/*html"
  embed_templates "layouts/*gameboy", suffix: "_gameboy"
end

def MyAppWeb.HomeLive do
  use Phoenix.LiveView,
    formats: [:html, :gameboy],
    layouts: [
      html: {MyAppWeb.Layout, :app},
      gameboy: {MyAppWeb.Layout, :app_gameboy}
    ]
end
```

However the prior form still works:

```elixir
def MyAppWeb.HomeLive do
  use Phoenix.LiveView, layout: {MyAppWeb.Layout, :app}
end
```

In this case `:formats` defaults to `[:html]` and the `:layout` key will be dropped and replaced with `layouts: [html: {MyAppWeb.Layout, :app}]`

I did not introduce multiple formats to function component or LiveView components yet as I want to first get feedback on this implementation as the PR is growing large.

When providing the `live_layout` in your `mount` function I did not implement any format specificity here. Because we have `render_with` I believe that branching on formats should delegate to `render_with` and within those render functions should then return the desired layout if it is to be overridden:

```elixir
def MyAppWeb.HomeLive do
  def mount(params, session, socket) do
    case get_format(session) do
      :html -> {:ok, socket, layout: {MyAppWeb.Layouts, :custom_layout}}
      :gameboy -> render_with(socket, &MyAppWeb.GameboyLive.render/1, layout: MyAppWeb.Layouts, :custom_gameboy)
    end
  end
end
```

Because root layouts are only rendered for DeadViews there really wasn't anything to change in LV itself as long as the formats are set up properly for DeadView rendering in the Router

TODO:

- [ ] update documentation
- [ ] write tests for non-html formats