### PR TITLE
Fix order of stream elements when using stream reset (fixes #2895)

### DIFF
--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -196,17 +196,9 @@ export default class DOMPatch {
             Array.from(fromEl.children).filter(child => {
               let {resetKept} = this.getStreamInsert(child)
               return resetKept
-            }).sort((a, b) => {
-              let aIdx = toIds.indexOf(a.id)
-              let bIdx = toIds.indexOf(b.id)
-              if(aIdx === bIdx){
-                return 0
-              } else if(aIdx < bIdx){
-                return -1
-              } else {
-                return 1
-              }
-            }).forEach(child => fromEl.appendChild(child))
+            }).forEach((child) => {
+              this.streamInserts[child.id].streamAt = toIds.indexOf(child.id)
+            })
           }
         },
         onNodeDiscarded: (el) => this.onNodeDiscarded(el),


### PR DESCRIPTION
Hi there, this PR should address #2895.

I added a single file script to reproduce:

```elixir
Application.put_env(:sample, Example.Endpoint,
  http: [ip: {127, 0, 0, 1}, port: 5001],
  server: true,
  live_view: [signing_salt: "aaaaaaaa"],
  secret_key_base: String.duplicate("a", 64)
)

Mix.install([
  {:plug_cowboy, "~> 2.5"},
  {:jason, "~> 1.0"},
  {:phoenix, "~> 1.7.10", override: true},
  {:phoenix_live_view, github: "phoenixframework/phoenix_live_view", branch: "main"}
])

defmodule Example.ErrorView do
  def render(template, _), do: Phoenix.Controller.status_message_from_template(template)
end

defmodule Example.HomeLive do
  use Phoenix.LiveView, layout: {__MODULE__, :live}

 def mount(_params, _session, socket) do
    socket
    |> stream(:items, [%{id: "a", name: "A"}, %{id: "b", name: "B"}, %{id: "c", name: "C"}, %{id: "d", name: "D"}])
    |> then(&{:ok, &1})
  end

  def handle_event("reorder", _, socket) do
    {:noreply, stream(socket, :items, [%{id: "e", name: "E"}, %{id: "a", name: "A"}, %{id: "f", name: "F"}, %{id: "g", name: "G"}], reset: true)}
  end

  def render("live.html", assigns) do
    ~H"""
    <script src="https://cdn.jsdelivr.net/npm/phoenix@1.7.10/priv/static/phoenix.min.js"></script>
    <script src="https://cdn.jsdelivr.net/gh/phoenixframework/phoenix_live_view@main/priv/static/phoenix_live_view.js"></script>
    <%!-- uncomment to use the fix --%>
    <%!-- <script src="https://cdn.jsdelivr.net/gh/SteffenDE/phoenix_live_view@fix_reset_order_assets/priv/static/phoenix_live_view.js"></script> --%>
    <script>
      let liveSocket = new window.LiveView.LiveSocket("/live", window.Phoenix.Socket, {
        hooks: {
          FakeHook: {
            mounted() {}
          }
        }
      })
      liveSocket.connect()
    </script>
    <style>
      * { font-size: 1.1em; }
    </style>
    <%= @inner_content %>
    """
  end

  def render(assigns) do
    ~H"""
    <ul phx-update="stream" id="thelist">
      <li id={id} :for={{id, item} <- @streams.items}>
        <%= item.name %>
      </li>
    </ul>

    <button phx-click="reorder">Reorder</button>
    """
  end
end


defmodule Example.Router do
  use Phoenix.Router
  import Phoenix.LiveView.Router

  pipeline :browser do
    plug(:accepts, ["html"])
  end

  scope "/", Example do
    pipe_through(:browser)

    live("/", HomeLive, :index)
  end
end

defmodule Example.Endpoint do
  use Phoenix.Endpoint, otp_app: :sample
  socket("/live", Phoenix.LiveView.Socket)
  plug(Example.Router)
end

{:ok, _} = Supervisor.start_link([Example.Endpoint], strategy: :one_for_one)
Process.sleep(:infinity)
```

Note that we initialize a stream of items as `[a, b, c, d]` and later reset the stream to `[e, a, f, g]`. With LV main the stream is reset as `[a, e, f, g]` instead. I'm not that into the LV javascript code, so I'd appreciate if someone with more insights could assess if there are any unexpected consequences.

To use the branch with the fix, change the source of the LV javascript as noted in the script:

```elixir
    <script src="https://cdn.jsdelivr.net/gh/phoenixframework/phoenix_live_view@main/priv/static/phoenix_live_view.js"></script>
    <%!-- uncomment to use the fix --%>
    <%!-- <script src="https://cdn.jsdelivr.net/gh/SteffenDE/phoenix_live_view@fix_reset_order_assets/priv/static/phoenix_live_view.js"></script> --%>
```

Fixes #2895.