### PR TITLE
Properly order elements when resetting stream (LiveViewTest)

### DIFF
--- a/test/phoenix_live_view/integrations/stream_test.exs
+++ b/test/phoenix_live_view/integrations/stream_test.exs
@@ -108,14 +108,45 @@ defmodule Phoenix.LiveView.StreamTest do
     {:ok, lv, _} = live(conn, "/stream")
     assert lv |> element("#users div") |> has_element?()
 
+    assert lv |> render() |> users_in_dom("users") == [
+      {"users-1", "chris"},
+      {"users-2", "callan"}
+    ]
+
     lv |> render_hook("reset-users", %{})
     refute lv |> element("#users div") |> has_element?()
+
+    assert lv |> render() |> users_in_dom("users") == []
 
     lv |> render_hook("stream-users", %{})
     assert lv |> element("#users div") |> has_element?()
 
+    assert lv |> render() |> users_in_dom("users") == [
+      {"users-1", "chris"},
+      {"users-2", "callan"}
+    ]
+
     lv |> render_hook("reset-users", %{})
     refute lv |> element("#users div") |> has_element?()
+
+    assert lv |> render() |> users_in_dom("users") == []
+  end
+
+  test "properly orders elements on reset", %{conn: conn} do
+    {:ok, lv, _} = live(conn, "/stream")
+
+    assert lv |> render() |> users_in_dom("users") == [
+      {"users-1", "chris"},
+      {"users-2", "callan"}
+    ]
+
+    lv |> render_hook("reset-users-reorder", %{})
+
+    assert lv |> render() |> users_in_dom("users") == [
+      {"users-3", "peter"},
+      {"users-1", "chris"},
+      {"users-4", "mona"}
+    ]
   end
 
   test "stream reset on patch", %{conn: conn} do

--- a/test/support/live_views/streams.ex
+++ b/test/support/live_views/streams.ex
@@ -49,6 +49,10 @@ defmodule Phoenix.LiveViewTest.StreamLive do
      |> stream(:admins, [user(1, "chris-admin"), user(2, "callan-admin")])}
   end
 
+  def handle_event("reset-users-reorder", %{}, socket) do
+    {:noreply, stream(socket, :users, [user(3, "peter"), user(1, "chris"), user(4, "mona")], reset: true)}
+  end
+
   def handle_event("delete", %{"id" => dom_id}, socket) do
     {:noreply, stream_delete_by_dom_id(socket, :users, dom_id)}
   end


### PR DESCRIPTION
Fixes #2970

The recent changes in the LiveViewTest module concerning stream resets introduced an issue where elements were not properly ordered. This should fix this issue by basically reverting to the old code while enforcing that the `data-phx-stream` attribute is always properly set.

Relates to #2906
Relates to #2677

I do not fully grasp the stream reset code yet, so please evaluate if this is really the correct solution. I added a test case for the ordering.