### PR TITLE
Don't assert HTML in LiveViewTest

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -334,7 +334,7 @@ defmodule Phoenix.LiveViewTest do
       end
 
     start_proxy(path, %{
-      html: Phoenix.ConnTest.html_response(conn, 200),
+      html: format_response(conn, 200),
       connect_params: conn.private[:live_view_connect_params] || %{},
       connect_info: conn.private[:live_view_connect_info] || prune_conn(conn) || %{},
       live_module: live_module,
@@ -356,6 +356,18 @@ defmodule Phoenix.LiveViewTest do
 
   defp prune_conn(conn) do
     %{conn | resp_body: nil, resp_headers: []}
+  end
+
+  defp format_response(conn, status) do
+    body = Phoenix.ConnTest.response(conn, status)
+    format =
+      conn
+      |> Phoenix.Controller.get_format()
+      |> String.to_atom()
+
+    _ = Phoenix.ConnTest.response_content_type(conn, format)
+
+    body
   end
 
   defp error_redirect_conn(conn) do

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -334,7 +334,7 @@ defmodule Phoenix.LiveViewTest do
       end
 
     start_proxy(path, %{
-      html: format_response(conn, 200),
+      response: Phoenix.ConnTest.response(conn, 200),
       connect_params: conn.private[:live_view_connect_params] || %{},
       connect_info: conn.private[:live_view_connect_info] || prune_conn(conn) || %{},
       live_module: live_module,
@@ -356,18 +356,6 @@ defmodule Phoenix.LiveViewTest do
 
   defp prune_conn(conn) do
     %{conn | resp_body: nil, resp_headers: []}
-  end
-
-  defp format_response(conn, status) do
-    body = Phoenix.ConnTest.response(conn, status)
-    format =
-      conn
-      |> Phoenix.Controller.get_format()
-      |> String.to_atom()
-
-    _ = Phoenix.ConnTest.response_content_type(conn, format)
-
-    body
   end
 
   defp error_redirect_conn(conn) do
@@ -392,7 +380,7 @@ defmodule Phoenix.LiveViewTest do
     opts =
       Map.merge(opts, %{
         caller: {self(), ref},
-        html: opts.html,
+        html: opts.response,
         connect_params: opts.connect_params,
         connect_info: opts.connect_info,
         live_module: opts.live_module,
@@ -1750,7 +1738,7 @@ defmodule Phoenix.LiveViewTest do
     static_token = token_func.(root.static_token)
 
     start_proxy(url, %{
-      html: html,
+      response: html,
       live_redirect: {root.id, root_token, static_token},
       connect_params: root.connect_params,
       connect_info: root.connect_info,


### PR DESCRIPTION
This is the first piece that needs to change to allow LiveView Native to utilize the LiveView test harness.

The format, after the LV render is complete, is being asserted as `html`. This PR changes that presumed format and will assert the content type based upon the format that the `conn` is set to.

However, there is a larger issue: `Phoenix.LiveViewTest.DOM` is forcing a downcase of all tag names. Whereas LiveView Native templates adhere to a type sensitive casing that matches the upstream UI framework it is targeting. For example, in SwiftUI:

```swift
ZStack {
  Text("Hello, world!")
}
```

in LVN ends up being:

```html
<ZStack>
  <Text>Hello, world!</Text>
</ZStack>
```

But when testing using `Phoenix.LiveViewTest` if we do:

```elixir
{:ok, lv, _markup} =
  conn
  |> Plug.Conn.put_req_header("accept", "text/gameboy")
  |> live("/home")

assert lv |> element("Text") |> render() =~ "Hello, world!"
```

this will fail because `Text` won't be found as a tag name, instead Floki (via Mochi) is downcasing all tag names with a resulting document of:

```html
<zstack><text>Hello, world!</text><zstack>
```

This appears to be happening here in Mochi: https://github.com/philss/floki/blob/v0.35.2/src/floki_mochi_html.erl#L271

I've looked at `fast_html` and it also is forcing tag names to be downcased. Reading through the HTML spec and there is no opinion on if tag names *must* be downcased: https://html.spec.whatwg.org/multipage/syntax.html#syntax-tag-name

> Tags contain a tag name, giving the element's name. HTML elements all have names that only use ASCII alphanumerics. In the HTML syntax, tag names, even those for foreign elements, may be written with any mix of lower- and uppercase letters that, when converted to all-lowercase, matches the element's tag name; tag names are case-insensitive.

So I am looking for some direction here. There are a few options that I see:

1. LVN writes its own `ClientProxy` that can be registered at compile-time for each given format with `Phoenix.LiveViewTest.ClientProxy` being the fallback for `html`.
2. LVN writes its own parser module to conditionally swap out `Phoenix.LiveViewTest.DOM`
3. I can PR Floki to add a parser argument to Floki's Mochi impementation to preserve the tag name casing

I'm less excited for #1 and #2 as they're a huge lift, but I welcome feedback or thoughts on this.