### PR TITLE
add options attribute to inputs_for/1

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2404,6 +2404,14 @@ defmodule Phoenix.Component do
     """
   )
 
+  attr.(:options, :list,
+    default: [],
+    doc: """
+    Any additional options for the `Phoenix.HTML.FormData` protocol
+    implementation.
+    """
+  )
+
   slot.(:inner_block, required: true, doc: "The content rendered for each nested form.")
 
   @persistent_id "_persistent_id"
@@ -2415,6 +2423,7 @@ defmodule Phoenix.Component do
       parent_form.options
       |> Keyword.take([:multipart])
       |> Keyword.merge(options)
+      |> Keyword.merge(assigns.options)
 
     forms = parent_form.impl.to_form(parent_form.source, parent_form, field_name, options)
     seen_ids = for f <- forms, vid = f.params[@persistent_id], into: %{}, do: {vid, true}

--- a/test/phoenix_component/components_test.exs
+++ b/test/phoenix_component/components_test.exs
@@ -521,6 +521,26 @@ defmodule Phoenix.LiveView.ComponentsTest do
                </form>
                """
     end
+
+    test "with FormData implementation options" do
+      assigns = %{}
+
+      template = ~H"""
+        <.form :let={f} as={:myform}>
+          <.inputs_for
+            :let={finner}
+            field={f[:inner]}}
+            options={[foo: "bar"]}
+          >
+            <p><%= finner.options[:foo] %></p>
+          </.inputs_for>
+        </.form>
+      """
+
+      html = t2h(template)
+      assert [p] = Floki.find(html, "p")
+      assert Floki.text(p) =~ "bar"
+    end
   end
 
   describe "live_file_input/1" do


### PR DESCRIPTION
`Phoenix.HTML.FormData.to_form/4` allows for arbitrary protocol-specific options to be passed in the fourth argument. `Phoenix.Component.inputs_for/1` currently only supports options specific to the protocol implementation for `Ecto.Changeset`. This PR adds a new `options` attribute that can be used to pass any additional options for other implementations.

Context: `Flop.Phoenix` implements the `FormData` protocol for the `Flop.Meta` struct and relies on a `fields` option to be passed. This is currently only possible with the `inputs_for/4` function that was moved to `PhoenixHTMLHelpers`, but not with the `inputs_for` component.

Relates to https://github.com/woylie/flop_phoenix/issues/299.