### PR TITLE
Clarify failed handling for async_result

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2976,7 +2976,7 @@ defmodule Phoenix.Component do
   ```heex
   <.async_result :let={org} assign={@org}>
     <:loading>Loading organization...</:loading>
-    <:failed :let={reason}>there was an error loading the organization</:failed>
+    <:failed :let={{:error, reason}}>there was an error loading the organization: <%= reason %></:failed>
     <%= if org do %>
       <%= org.name %>
     <% else %>


### PR DESCRIPTION
I was [tripping up](https://elixirforum.com/t/not-understanding-how-to-handle-failures-from-assign-async/60845) that `{:error, reason}` pattern is needed due to expecting the failed slot to pass just the reason, not the error tuple.

[LiveView's docs](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#module-async-assigns) say to return `{:error, reason}`, and to use `<:failed :let={_reason}>there was an error loading the organization</:failed>`. That suggests that `reason` is the same thing that you returned, but it in fact is the full `{:error, reason}`.