### PR TITLE
Rename async_result failure slot let binding in docs

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2976,7 +2976,7 @@ defmodule Phoenix.Component do
   ```heex
   <.async_result :let={org} assign={@org}>
     <:loading>Loading organization...</:loading>
-    <:failed :let={reason}>there was an error loading the organization</:failed>
+    <:failed :let={_failure}>there was an error loading the organization</:failed>
     <%= if org do %>
       <%= org.name %>
     <% else %>

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -116,7 +116,7 @@ defmodule Phoenix.LiveView do
   ```heex
   <.async_result :let={org} assign={@org}>
     <:loading>Loading organization...</:loading>
-    <:failed :let={_reason}>there was an error loading the organization</:failed>
+    <:failed :let={_failure}>there was an error loading the organization</:failed>
     <%= org.name %>
   </.async_result>
   ```


### PR DESCRIPTION
Just a small change to avoid confusion with the `async_result` `:failed` slot let binding.

[The docs](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#module-async-assigns) suggest returning `{:error, reason}` for failures, which implies that the `reason` in the binding is the same thing you returned. In fact it's the entire failure- one of `{:error, reason} | {:exit, reason} | reason`.


Follow up to #2991