### PR TITLE
Add phx-feedback-group

### DIFF
--- a/assets/js/phoenix_live_view/constants.js
+++ b/assets/js/phoenix_live_view/constants.js
@@ -38,6 +38,7 @@ export const PHX_VIEWPORT_TOP = "viewport-top"
 export const PHX_VIEWPORT_BOTTOM = "viewport-bottom"
 export const PHX_TRIGGER_ACTION = "trigger-action"
 export const PHX_FEEDBACK_FOR = "feedback-for"
+export const PHX_FEEDBACK_GROUP = "feedback-group"
 export const PHX_HAS_FOCUSED = "phx-has-focused"
 export const FOCUSABLE_INPUTS = ["text", "textarea", "number", "email", "password", "search", "tel", "url", "date", "time", "datetime-local", "color", "range"]
 export const CHECKABLE_INPUTS = ["checkbox", "radio"]

--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -289,17 +289,25 @@ let DOM = {
     }
   },
 
-  maybeHideFeedback(container, inputs, phxFeedbackFor){
+  maybeHideFeedback(container, inputs, phxFeedbackFor, phxFeedbackGroup){
     let feedbacks = []
     // if there are multiple inputs with the same name
     // (for example the default checkbox renders a hidden input as well)
     // we must only add the no feedback class if none of them have been focused yet
     let inputNamesFocused = {}
+    // an entry in this object will be true if NO input in the group has been focused yet
+    let feedbackGroups = {}
 
     inputs.forEach(input => {
+      const group = input.getAttribute(phxFeedbackGroup)
+      // initialize the group to true if it doesn't exist
+      if(group && !(group in feedbackGroups)) feedbackGroups[group] = true
+      // initialize the focused state to false if it doesn't exist
       if(!(input.name in inputNamesFocused)) inputNamesFocused[input.name] = false
       if(this.private(input, PHX_HAS_FOCUSED) || this.private(input, PHX_HAS_SUBMITTED)){
         inputNamesFocused[input.name] = true
+        // the input was focused, therefore the group will NOT get phx-no-feedback
+        if(group) feedbackGroups[group] = false
       }
     })
 
@@ -308,6 +316,10 @@ let DOM = {
         feedbacks.push(name)
         if(name.endsWith("[]")){ feedbacks.push(name.slice(0, -2)) }
       }
+    }
+
+    for(const [group, noFeedback] of Object.entries(feedbackGroups)){
+      if(noFeedback) feedbacks.push(group)
     }
 
     if(feedbacks.length > 0){

--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -2,6 +2,7 @@ import {
   PHX_COMPONENT,
   PHX_DISABLE_WITH,
   PHX_FEEDBACK_FOR,
+  PHX_FEEDBACK_GROUP,
   PHX_PRUNE,
   PHX_ROOT_ID,
   PHX_SESSION,
@@ -86,6 +87,7 @@ export default class DOMPatch {
     let {selectionStart, selectionEnd} = focused && DOM.hasSelectionRange(focused) ? focused : {}
     let phxUpdate = liveSocket.binding(PHX_UPDATE)
     let phxFeedbackFor = liveSocket.binding(PHX_FEEDBACK_FOR)
+    let phxFeedbackGroup = liveSocket.binding(PHX_FEEDBACK_GROUP)
     let disableWith = liveSocket.binding(PHX_DISABLE_WITH)
     let phxViewportTop = liveSocket.binding(PHX_VIEWPORT_TOP)
     let phxViewportBottom = liveSocket.binding(PHX_VIEWPORT_BOTTOM)
@@ -132,7 +134,7 @@ export default class DOMPatch {
         // tell morphdom how to add a child
         addChild: (parent, child) => {
           let {ref, streamAt, limit} = this.getStreamInsert(child)
-          if(ref === undefined) { return parent.appendChild(child) }
+          if(ref === undefined){ return parent.appendChild(child) }
 
           DOM.putSticky(child, PHX_STREAM_REF, el => el.setAttribute(PHX_STREAM_REF, ref))
 
@@ -294,7 +296,7 @@ export default class DOMPatch {
       })
     }
 
-    DOM.maybeHideFeedback(targetContainer, trackedInputs, phxFeedbackFor)
+    DOM.maybeHideFeedback(targetContainer, trackedInputs, phxFeedbackFor, phxFeedbackGroup)
 
     liveSocket.silenceEvents(() => DOM.restoreFocus(focused, selectionStart, selectionEnd))
     DOM.dispatchEvent(document, "phx:update")

--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -106,7 +106,6 @@ import {
   closestPhxBinding,
   closure,
   debug,
-  isObject,
   maybe
 } from "./utils"
 
@@ -732,7 +731,7 @@ export default class LiveSocket {
     }, false)
   }
 
-  maybeScroll(scroll) {
+  maybeScroll(scroll){
     if(typeof(scroll) === "number"){
       requestAnimationFrame(() => {
         window.scrollTo(0, scroll)


### PR DESCRIPTION
This PR introduces `phx-feedback-group`. Setting this attribute on an input will set the `phx-no-feedback` class to elements with the corresponding `phx-feedback-for` attribute only if all inputs in the same `phx-feedback-group` did not receive any inputs yet.

References #2968.

Code adapted from #2968:

```elixir
Application.put_env(:composite_input, CompositeInput.Endpoint,
  http: [ip: {127, 0, 0, 1}, port: 4001],
  server: true,
  render_errors: [
    formats: [html: CompositeInput.ErrorHTML],
    layout: false
  ],
  live_view: [signing_salt: "aaaaaaaa"],
  secret_key_base: String.duplicate("a", 64)
)

Application.put_env(:ex_money, :default_cldr_backend, CompositeInput.Cldr)

Mix.install([
  {:plug_cowboy, "~> 2.6"},
  {:jason, "~> 1.0"},
  {:phoenix, "~> 1.7.10"},
  {:phoenix_live_view, "~> 0.20.2"},
  {:phoenix_html, "~> 3.0"},
  {:phoenix_ecto, "~> 4.4"},
  {:ecto, "~> 3.11"},
  {:ex_cldr, "~> 2.37"},
  {:ex_cldr_numbers, "~> 2.32"},
  {:ex_cldr_currencies, "~> 2.15"},
  {:ex_money, "~> 5.15", runtime: false},
  {:ex_money_sql, "~> 1.10"}
])

defmodule CompositeInput.ErrorHTML do
  def render(template, _assigns) do
    Phoenix.Controller.status_message_from_template(template)
  end
end

defmodule CompositeInput.Layouts do
  use Phoenix.Component

  def render("root.html", assigns) do
    ~H"""
    <!DOCTYPE html>
    <html lang="en">
      <head>
        <meta charset="utf-8" />
        <meta name="viewport" content="width=device-width, initial-scale=1" />
        <meta name="csrf-token" content={Phoenix.Controller.get_csrf_token()} />
        <.live_title>CompositeInput</.live_title>
        <script
          src={"https://unpkg.com/phoenix@#{Application.spec(:phoenix, :vsn)}/priv/static/phoenix.min.js"}
        >
        </script>
        <%!-- <script
          src={"https://unpkg.com/phoenix_live_view@#{Application.spec(:phoenix_live_view, :vsn)}/priv/static/phoenix_live_view.min.js"}
        >
        </script> --%>
        <script src="https://cdn.jsdelivr.net/gh/SteffenDE/phoenix_live_view@feedback_groups_assets/priv/static/phoenix_live_view.js"></script>
        <script src="https://cdn.tailwindcss.com?plugins=forms">
        </script>
        <script type="module">
          const liveSocket = new LiveView.LiveSocket("/live", Phoenix.Socket);
          liveSocket.connect();

          tailwind.config = {
            plugins: [
              tailwind.plugin(({ addVariant }) => addVariant("phx-no-feedback", [".phx-no-feedback&", ".phx-no-feedback &"])),
              tailwind.plugin(({ addVariant }) => addVariant("phx-click-loading", [".phx-click-loading&", ".phx-click-loading &"])),
              tailwind.plugin(({ addVariant }) => addVariant("phx-submit-loading", [".phx-submit-loading&", ".phx-submit-loading &"])),
              tailwind.plugin(({ addVariant }) => addVariant("phx-change-loading", [".phx-change-loading&", ".phx-change-loading &"])),
            ]
          };
        </script>
      </head>
      <body>
        <%= @inner_content %>
      </body>
    </html>
    """
  end

  def render("app.html", assigns) do
    ~H"""
    <main class="px-4 py-20 sm:px-6 lg:px-8">
      <div class="mx-auto max-w-2xl">
        <%= @inner_content %>
      </div>
    </main>
    """
  end
end

defmodule CompositeInput.Cldr do
  use Cldr,
    locales: ["en", "pt"],
    default_locale: "pt",
    providers: [Cldr.Number, Money]
end

defmodule CompositeInput.CoreComponents do
  use Phoenix.Component

  def button(assigns) do
    ~H"""
    <button
      type={@type}
      class={[
        "phx-submit-loading:opacity-75 rounded-lg bg-zinc-900 hover:bg-zinc-700 py-2 px-3",
        "text-sm font-semibold leading-6 text-white active:text-white/80"
      ]}
    >
      <%= render_slot(@inner_block) %>
    </button>
    """
  end

  def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
    assigns
    |> assign(:field, nil)
    |> assign(:errors, Enum.map(field.errors, &translate_error/1))
    |> assign_new(:id, fn -> field.id end)
    |> assign_new(:name, fn -> field.name end)
    |> assign_new(:value, fn -> field.value end)
    |> input()
  end

  def input(%{type: "money"} = assigns) do
    assigns =
      assigns
      |> update(:value, fn
        %{"amount" => amount, "currency" => currency} -> %{amount: amount, currency: currency}
        %{amount: amount, currency: currency} -> %{amount: amount, currency: currency}
        nil -> nil
      end)
      |> assign_new(:default_currency, fn ->
        backend = Money.default_backend()
        Cldr.Currency.current_currency_from_locale(backend.get_locale())
      end)

    ~H"""
    <div phx-feedback-for={@name}>
      <.label for={@id}><%= @label %></.label>
      <div class="relative mt-2 rounded-lg">
        <input
          type="text"
          inputmode="numeric"
          id={"#{@id}_amount"}
          name={"#{@name}[amount]"}
          value={@value[:amount]}
          placeholder="0.00"
          class={[
            "block w-full rounded-lg border-0 pr-20 text-zinc-900 ring-1 ring-inset ring-zinc-300 placeholder:text-zinc-400 focus:ring-1 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6",
            "phx-no-feedback:ring-zinc-300 phx-no-feedback:focus:ring-zinc-400",
            @errors == [] && "ring-zinc-300 focus:ring-zinc-400",
            @errors != [] && "ring-rose-400 focus:ring-rose-400"
          ]}
          phx-feedback-group={@name}
        />
        <div class="absolute inset-y-0 right-0 flex items-center">
          <label for={"#{@id}_currency"} class="sr-only">Currency</label>
          <select
            id={"#{@id}_currency"}
            name={"#{@name}[currency]"}
            class="h-full rounded-lg border-0 bg-transparent py-0 pl-2 pr-7 text-zinc-500 focus:ring-1 focus:ring-inset focus:ring-zinc-600 sm:text-sm"
            phx-feedback-group={@name}
          >
            <%= Phoenix.HTML.Form.options_for_select(
              Money.known_currencies(),
              @value[:currency] || @default_currency
            ) %>
          </select>
        </div>
      </div>
      <.error :for={msg <- @errors}><%= msg %></.error>
    </div>
    """
  end

  def label(assigns) do
    ~H"""
    <label for={@for} class="block text-sm font-semibold leading-6 text-zinc-800">
      <%= render_slot(@inner_block) %>
    </label>
    """
  end

  def error(assigns) do
    ~H"""
    <p class="mt-3 flex gap-3 text-sm leading-6 text-rose-600 phx-no-feedback:hidden">
      <%= render_slot(@inner_block) %>
    </p>
    """
  end

  def translate_error({msg, opts}) do
    Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
      opts
      |> Keyword.get(String.to_existing_atom(key), key)
      |> to_string()
    end)
  end
end

defmodule CompositeInput.HomeLive do
  use Phoenix.LiveView, layout: {CompositeInput.Layouts, :app}

  import CompositeInput.CoreComponents

  defmodule Data do
    use Ecto.Schema
    import Ecto.Changeset

    @primary_key false

    embedded_schema do
      field :datetime, :naive_datetime
      field :price, Money.Ecto.Map.Type
    end

    def changeset(data, attrs) do
      data
      |> cast(attrs, [:datetime, :price])
      |> validate_required([:datetime, :price])
      |> validate_change(:datetime, fn field, value ->
        if NaiveDateTime.compare(value, NaiveDateTime.local_now()) == :gt do
          [{field, "can't be in the future"}]
        else
          []
        end
      end)
    end
  end

  def render(assigns) do
    ~H"""
    <.form for={@form} phx-change="validate" phx-submit="save" class="mt-10 space-y-8 bg-white">
      <.input type="money" field={@form[:price]} label="Price" />

      <div phx-feedback-for={@form[:datetime].name}>
        <.label for={@form[:datetime].id}>Datetime</.label>
        <div class="mt-2">
          <%= Phoenix.HTML.Form.datetime_select(
            @form,
            :datetime,
            Enum.map(~w[year month day hour minute]a, fn select ->
              {select,
               class:
                 "rounded-md border border-gray-300 bg-white shadow-sm focus:border-zinc-400 focus:ring-0 sm:text-sm", "phx-feedback-group": @form[:datetime].name}
            end)
          ) %>
        </div>
        <.error :for={error <- @form[:datetime].errors}><%= translate_error(error) %></.error>
      </div>

      <div class="mt-2 flex items-center justify-between gap-6">
        <.button type="submit">
          Submit
        </.button>
      </div>
    </.form>
    """
  end

  def mount(_params, _session, socket) do
    data = %Data{}

    changeset =
      Data.changeset(data, %{datetime: NaiveDateTime.add(NaiveDateTime.local_now(), 1, :day)})

    {:ok,
     socket
     |> assign(:data, data)
     |> assign(:form, to_form(changeset))}
  end

  def handle_event("validate", %{"data" => data_params}, socket) do
    changeset = Data.changeset(socket.assigns.data, data_params)
    {:noreply, assign(socket, :form, to_form(%{changeset | action: :validate}))}
  end

  def handle_event("save", %{"data" => data_params}, socket) do
    changeset = Data.changeset(socket.assigns.data, data_params)

    case Ecto.Changeset.apply_action(changeset, :insert) do
      {:ok, data} -> {:noreply, assign(socket, :data, data)}
      {:error, changeset} -> {:noreply, assign(socket, :form, to_form(changeset))}
    end
  end
end

defmodule CompositeInput.Router do
  use Phoenix.Router
  import Phoenix.LiveView.Router

  pipeline :browser do
    plug :accepts, ["html"]
    plug :put_root_layout, {CompositeInput.Layouts, :root}
  end

  scope "/", CompositeInput do
    pipe_through :browser

    live "/", HomeLive, :index
  end
end

defmodule CompositeInput.Endpoint do
  use Phoenix.Endpoint, otp_app: :composite_input

  socket "/live", Phoenix.LiveView.Socket

  plug CompositeInput.Router
end

{:ok, _} = Supervisor.start_link([CompositeInput.Endpoint], strategy: :one_for_one)
Process.sleep(:infinity)
```