### PR TITLE
Fix readonly and disabled state not resetting properly

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -753,12 +753,13 @@ export default class View {
 
     DOM.all(document, `[${PHX_REF_SRC}="${this.id}"][${PHX_REF}="${ref}"]`, el => {
       let disabledVal = el.getAttribute(PHX_DISABLED)
+      let readOnlyVal = el.getAttribute(PHX_READONLY)
       // remove refs
       el.removeAttribute(PHX_REF)
       el.removeAttribute(PHX_REF_SRC)
       // restore inputs
-      if(el.getAttribute(PHX_READONLY) !== null){
-        el.readOnly = false
+      if(readOnlyVal !== null){
+        el.readOnly = readOnlyVal === "true" ? true : false
         el.removeAttribute(PHX_READONLY)
       }
       if(disabledVal !== null){
@@ -798,7 +799,8 @@ export default class View {
           el.setAttribute(PHX_DISABLE_WITH_RESTORE, el.innerText)
         }
         if(disableText !== ""){ el.innerText = disableText }
-        el.setAttribute(PHX_DISABLED, el.disabled)
+        // PHX_DISABLED could have already been set in disableForm
+        el.setAttribute(PHX_DISABLED, el.getAttribute(PHX_DISABLED) || el.disabled)
         el.setAttribute("disabled", "")
       }
     })


### PR DESCRIPTION
Fixes #2993
Fixes #1759

Hey there @chrismccord, while working on #1759 I noticed that your recent fix for #2993 actually breaks submit buttons in forms (as seen in the repro below) from restoring their disabled state. You can see this when changing the script src to LV main:

```elixir
Application.put_env(:sample, Example.Endpoint,
  http: [ip: {127, 0, 0, 1}, port: 5001],
  server: true,
  live_view: [signing_salt: "aaaaaaaa"],
  secret_key_base: String.duplicate("a", 64),
  pubsub_server: MyPubSub
)

Mix.install([
  {:plug_cowboy, "~> 2.5"},
  {:jason, "~> 1.0"},
  {:phoenix, "~> 1.7.10", override: true},
  {:phoenix_live_view, github: "phoenixframework/phoenix_live_view", branch: "main"}
])

defmodule Example.ErrorView do
  def render(template, _), do: Phoenix.Controller.status_message_from_template(template)
end

defmodule Example.HomeLive do
  use Phoenix.LiveView, layout: {__MODULE__, :live}

 def mount(_params, _session, socket) do
    socket
    |> then(&{:ok, &1})
  end

  def render("live.html", assigns) do
    ~H"""
    <script src="https://cdn.jsdelivr.net/npm/phoenix@1.7.10/priv/static/phoenix.min.js"></script>
    <%!-- <script src="https://cdn.jsdelivr.net/gh/phoenixframework/phoenix_live_view@main/priv/static/phoenix_live_view.js"></script> --%>
    <script src="https://cdn.jsdelivr.net/gh/SteffenDE/phoenix_live_view@disabled_readonly_fixes_assets/priv/static/phoenix_live_view.min.js"></script>
    <%!-- <script src="http://localhost:8000/priv/static/phoenix_live_view.js"></script> --%>
    <script>
      let liveSocket = new window.LiveView.LiveSocket("/live", window.Phoenix.Socket, {
        hooks: {
          FakeHook: {
            mounted() {}
          }
        }
      })
      liveSocket.connect()
    </script>
    <script src="https://cdn.tailwindcss.com"></script>
    <style>
      * { font-size: 1.1em; }
    </style>
    <%= @inner_content %>
    """
  end

  def handle_event("validate", _params, socket) do
    {:noreply, socket}
  end

  def handle_event("save", params, socket) do
    Process.sleep(1000)

    {:noreply, socket}
  end

  def handle_event("test-html", _params, socket) do
    Process.sleep(1000)

    {:noreply, socket}
  end

  def render(assigns) do
    ~H"""
    <form id="upload-form" phx-submit="save" phx-change="validate">
      <input type="text" name="a" readonly value="foo" class="read-only:bg-green-200" />
      <input type="text" name="b" value="bar" class="read-only:bg-green-200" />
      <button type="submit" phx-disable-with="Submitting" class="border border-black disabled:bg-gray-500">Submit</button>
    </form>

    <button phx-click="test-html" class="bg-gray-900 text-white rounded-lg p-4 disabled:bg-gray-300">HTML Button</button>
    <button phx-click="test-html" phx-disable-with="Loading..." class="bg-gray-900 text-white rounded-lg p-4 disabled:bg-gray-300">
      Broken HTML Button
    </button>
    """
  end
end

defmodule Example.Router do
  use Phoenix.Router
  import Phoenix.LiveView.Router

  pipeline :browser do
    plug(:accepts, ["html"])
  end

  scope "/", Example do
    pipe_through(:browser)

    live("/", HomeLive, :index)
  end
end

defmodule Example.Endpoint do
  use Phoenix.Endpoint, otp_app: :sample
  socket("/live", Phoenix.LiveView.Socket)
  plug(Example.Router)
end

{:ok, _} = Supervisor.start_link([Example.Endpoint, {Phoenix.PubSub, name: MyPubSub}], strategy: :one_for_one)
Process.sleep(:infinity)
```

This PR changes the way the readonly attribute is restored to be the same as the disabled value (the fix for #1759).