### PR TITLE
add validate_attrs: false to slots

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1630,6 +1630,9 @@ defmodule Phoenix.Component do
   * `:required` - marks a slot as required. If a caller does not pass a value for a required slot,
   a compilation warning is emitted. Otherwise, an omitted slot will default to `[]`.
 
+  * `:validate_attrs` - when set to `false`, no warning is emitted when a caller passes attributes
+  to a slot defined without a do block. If not set, defaults to `true`.
+
   * `:doc` - documentation for the slot. Any slot attributes declared
   will have their documentation listed alongside the slot.
 

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -164,7 +164,8 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                    line: func1_line + 3,
                    name: :inner_block,
                    opts: [],
-                   required: false
+                   required: false,
+                   validate_attrs: true
                  }
                ],
                line: func1_line + 4
@@ -416,7 +417,8 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                    name: :inner_block,
                    opts: [],
                    attrs: [],
-                   required: false
+                   required: false,
+                   validate_attrs: true
                  }
                ],
                line: FunctionComponentWithSlots.fun_with_slot_line()
@@ -431,7 +433,8 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                    name: :footer,
                    opts: [],
                    attrs: [],
-                   required: false
+                   required: false,
+                   validate_attrs: true
                  },
                  %{
                    doc: nil,
@@ -439,7 +442,8 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                    name: :header,
                    opts: [],
                    attrs: [],
-                   required: false
+                   required: false,
+                   validate_attrs: true
                  }
                ],
                line: FunctionComponentWithSlots.fun_with_named_slots_line()
@@ -464,7 +468,8 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                        type: :any
                      }
                    ],
-                   required: true
+                   required: true,
+                   validate_attrs: true
                  }
                ],
                line: FunctionComponentWithSlots.fun_with_slot_attrs_line()
@@ -499,7 +504,8 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                        type: :string
                      }
                    ],
-                   required: false
+                   required: false,
+                   validate_attrs: true
                  }
                ],
                line: FunctionComponentWithSlots.table_line()
@@ -557,7 +563,8 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                    name: :slot,
                    opts: [],
                    attrs: [],
-                   required: false
+                   required: false,
+                   validate_attrs: true
                  }
                ],
                line: Bodyless.example2_line() + 1
@@ -813,7 +820,8 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
                      }
                    ],
                    opts: [],
-                   required: false
+                   required: false,
+                   validate_attrs: true
                  }
                ],
                line: line + 29


### PR DESCRIPTION
Based on the discussion in #2331, this PR introduces a new slot attribute `validate_attrs` that can be set to false to prevent slots without any attrs defined from emitting a warning when attributes are passed.

Relates to #2331.
Relates to #2811.