### PR TITLE
Fix handle_async callback typing

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -557,7 +557,7 @@ defmodule Phoenix.LiveComponent do
               {:noreply, Socket.t()} | {:reply, map, Socket.t()}
 
   @callback handle_async(
-              name :: atom,
+              name :: term,
               async_fun_result :: {:ok, term} | {:exit, term},
               socket :: Socket.t()
             ) ::

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -296,7 +296,7 @@ defmodule Phoenix.LiveView do
   refer to the ["Arbitrary async operations"](#module-arbitrary-async-operations) section.
   """
   @callback handle_async(
-              name :: atom,
+              name :: term,
               async_fun_result :: {:ok, term} | {:exit, term},
               socket :: Socket.t()
             ) ::


### PR DESCRIPTION
Actualy, the `name` argument in `Phoenix.LiveView.start_async/3` and `cancel_async/3` can use values other than atoms. However, in the `handle_async` callback for `Phoenix.LiveView` and `Phoenix.LiveComponent`, the `name` argument is typed as `atom`. Therefore, I propose modifying the callback to assign the `term` type to `name`.

```ex
  @callback handle_async(
              name :: atom,  # <<<<<<<<<<<<<<<<< This type should be term
              async_fun_result :: {:ok, term} | {:exit, term},
              socket :: Socket.t()
            ) ::
              {:noreply, Socket.t()}
```

I think #2935 overlooked this.
