### PR TITLE
update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@
   * Fix phx-disabled-with not restoring button disabled state on empty diff acknowledgement
   * Fix stream reset not ordering items correctly
   * Send `{:shutdown, :cancel}` to `handle_async/3` on `cancel_async`
+  * Prevent events from child LiveViews from bubbling up to root LiveView when child is not mounted yet
+  * Fix `phx-mounted` being called twice for stream items
+  * Do not move existing stream items when prepending
 
 ### Enhancements
   * Add `JS.toggle_class`
   * Force update select options when the options changed from the server while a select has focus
   * Introduce `phx-feedback-group` for handling feedback for composite input groups
+  * Add `validate_attrs` to slots
+  * Support `phx-viewport` bindings in scrollable containers
 
 ## 0.20.3 (2024-01-02)
 


### PR DESCRIPTION
concerning

> Do not move existing stream items when prepending

I'm not sure if this is actually a bugfix, as the documentation currently mentions appends explicitly:

> When the client updates an existing item with an "append" operation (passing the at: -1 option), the item will remain in the same location as it was previously, and will not be moved to the end of the parent children. To both update an existing item and move it to the end of a collection, issue a stream_delete, followed by a stream_insert.

We currently don't mention prepends there, so actually one could call this a breaking change. We should probably at least update the documentation. wdyt?