### PR TITLE
Add JSDoc for hook examples

### DIFF
--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -223,6 +223,9 @@ like this:
 Then a hook callback object could be defined and passed to the socket:
 
 ```javascript
+/**
+ * @type {Object.<string, import("phoenix_live_view").ViewHook>}
+ */
 let Hooks = {}
 Hooks.PhoneNumber = {
   mounted() {
@@ -281,6 +284,9 @@ For example, to implement infinite scrolling, one can pass the current page usin
 And then in the client:
 
 ```javascript
+/**
+ * @type {import("phoenix_live_view").ViewHook}
+ */
 Hooks.InfiniteScroll = {
   page() { return this.el.dataset.page },
   mounted(){
@@ -304,6 +310,9 @@ However, the data attribute approach is not a good approach if you need to frequ
 And then on the client:
 
 ```javascript
+/**
+ * @type {import("phoenix_live_view").ViewHook}
+ */
 Hooks.Chart = {
   mounted(){
     this.handleEvent("points", ({points}) => MyChartLib.addPoints(points))

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1667,6 +1667,9 @@ defmodule Phoenix.LiveView do
   Replying to a client event:
 
       # JavaScript:
+      # /**
+      #  * @type {Object.<string, import("phoenix_live_view").ViewHook>}
+      #  */
       # let Hooks = {}
       # Hooks.ClientHook = {
       #   mounted() {


### PR DESCRIPTION
@chrismccord, reopened this which was previously incorporated into #2892 PR

--- 

I've added JSDoc annotations to the Hook usage examples in order to enhance IDE autocomplete functionality. Often, developers find themselves referring back to the documentation to recall a Hook's structure and its associated functions. Embedding type documentation directly within the code streamlines this process, offering a more efficient development experience.