### PR TITLE
bulk insert stream items at index != -1 (fixes #3023)

### DIFF
--- a/test/e2e/tests/streams.spec.js
+++ b/test/e2e/tests/streams.spec.js
@@ -277,3 +277,19 @@ test.describe("Issue #2982", () => {
     await expect(await listItems(page)).toEqual(["items-e", "items-a", "items-f", "items-g"]);
   });
 });
+
+test.describe("Issue #3023", () => {
+  const listItems = async (page) => page.locator("ul > li").evaluateAll(list => list.map(el => el.id));
+
+  test("can bulk insert items at a specific index", async ({ page }) => {
+    await page.goto("/stream/reset");
+    await syncLV(page);
+
+    await expect(await listItems(page)).toEqual(["items-a", "items-b", "items-c", "items-d"]);
+
+    await page.getByRole("button", { name: "Bulk insert" }).click();
+    await syncLV(page);
+
+    await expect(await listItems(page)).toEqual(["items-a", "items-e", "items-f", "items-g", "items-b", "items-c", "items-d"]);
+  });
+});

--- a/test/phoenix_live_view/integrations/stream_test.exs
+++ b/test/phoenix_live_view/integrations/stream_test.exs
@@ -319,6 +319,15 @@ defmodule Phoenix.LiveView.StreamTest do
     end
   end
 
+  test "issue #3023 - can bulk insert at index != -1", %{conn: conn} do
+    {:ok, lv, html} = live(conn, "/stream/reset")
+
+    assert ids_in_ul_list(html) == ["items-a", "items-b", "items-c", "items-d"]
+
+    html = assert lv |> element("button", "Bulk insert") |> render_click()
+    assert ids_in_ul_list(html) == ["items-a", "items-e", "items-f", "items-g", "items-b", "items-c", "items-d"]
+  end
+
   test "stream raises when attempting to consume ahead of for", %{conn: conn} do
     {:ok, lv, _html} = live(conn, "/stream")
 

--- a/test/support/live_views/streams.ex
+++ b/test/support/live_views/streams.ex
@@ -293,6 +293,7 @@ defmodule Phoenix.LiveViewTest.StreamResetLive do
     <button phx-click="reset">Reset</button>
     <button phx-click="prepend">Prepend</button>
     <button phx-click="append">Append</button>
+    <button phx-click="bulk-insert">Bulk insert</button>
     """
   end
 
@@ -357,6 +358,20 @@ defmodule Phoenix.LiveViewTest.StreamResetLive do
        :items,
        %{id: "a" <> "#{System.unique_integer()}", name: "#{System.unique_integer()}"},
        at: -1
+     )}
+  end
+
+  def handle_event("bulk-insert", _, socket) do
+    {:noreply,
+     stream(
+       socket,
+       :items,
+       [
+        %{id: "e", name: "E"},
+        %{id: "f", name: "F"},
+        %{id: "g", name: "G"},
+       ],
+       at: 1
      )}
   end
 end


### PR DESCRIPTION
Fixes #3023.

Let's discuss if we want #3024 or this.

Issue: The LiveViewTest client seems to not handle this properly. Does not matter if I reverse the items or not, the order is always reversed.