### PR TITLE
Fix expandURL to allow JS.patch/2 with query params

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -775,17 +775,13 @@ export default class LiveSocket {
   historyRedirect(href, linkState, flash){
     if(!this.isConnected() || !this.main.isMain()){ return Browser.redirect(href, flash) }
 
-    // convert to full href if only path prefix
-    if(/^\/$|^\/[^\/]+.*$/.test(href)){
-      let {protocol, host} = window.location
-      href = `${protocol}//${host}${href}`
-    }
+    let url = View.expandURL(href)
     let scroll = window.scrollY
-    this.withPageLoading({to: href, kind: "redirect"}, done => {
-      this.replaceMain(href, flash, (linkRef) => {
+    this.withPageLoading({to: url, kind: "redirect"}, done => {
+      this.replaceMain(url, flash, (linkRef) => {
         if(linkRef === this.linkRef){
-          Browser.pushState(linkState, {type: "redirect", id: this.main.id, scroll: scroll}, href)
-          DOM.dispatchEvent(window, "phx:navigate", {detail: {href, patch: false, pop: false}})
+          Browser.pushState(linkState, {type: "redirect", id: this.main.id, scroll: scroll}, url)
+          DOM.dispatchEvent(window, "phx:navigate", {detail: {href: url, patch: false, pop: false}})
           this.registerNewLocation(window.location)
         }
         done()

--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -629,7 +629,7 @@ export default class View {
   }
 
   expandURL(to){
-    return to.startsWith("/") ? `${window.location.protocol}//${window.location.host}${to}` : to
+    return to.startsWith("/") || to.startsWith("?") ? `${window.location.protocol}//${window.location.host}${to}` : to
   }
 
   onRedirect({to, flash}){ this.liveSocket.redirect(to, flash) }


### PR DESCRIPTION
I have an app where I modify query params with JS commands, like: `Phoenix.LiveView.JS.patch("?one=two")`.

The URL sent to the channel becomes: `%{"url" => "?one=two"}`, which results in `CaseClauseError` in `Phoenix.LiveView.Channel.verified_mount/8`

SEE:  #2518 and #2334