### PR TITLE
add tests for #3026, check if component exists

### DIFF
--- a/assets/js/phoenix_live_view/rendered.js
+++ b/assets/js/phoenix_live_view/rendered.js
@@ -155,7 +155,13 @@ export default class Rendered {
 
   getComponent(diff, cid){ return diff[COMPONENTS][cid] }
 
-  resetRender(cid){ this.rendered[COMPONENTS][cid].reset = true }
+  resetRender(cid){
+    // we are racing a component destroy, it could not exist, so
+    // make sure that we don't try to set reset on undefined
+    if(this.rendered[COMPONENTS][cid]){
+      this.rendered[COMPONENTS][cid].reset = true
+    }
+  }
 
   mergeDiff(diff){
     let newc = diff[COMPONENTS]

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -60,6 +60,12 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/upload", Phoenix.LiveViewTest.E2E.UploadLive
       live "/form", Phoenix.LiveViewTest.E2E.FormLive
     end
+
+    scope "/issues" do
+      pipe_through(:browser)
+
+      live "/3026", Phoenix.LiveViewTest.E2E.Issue3026Live
+    end
   end
 end
 

--- a/test/e2e/tests/issues/3026.spec.js
+++ b/test/e2e/tests/issues/3026.spec.js
@@ -1,0 +1,39 @@
+const { test, expect } = require("@playwright/test");
+const { syncLV } = require("../../utils");
+
+test("LiveComponent is re-rendered when racing destory", async ({ page }) => {
+  const errors = [];
+  page.on("pageerror", (err) => {
+    errors.push(err);
+  });
+
+  await page.goto("/issues/3026");
+  await syncLV(page);
+
+  await expect(page.locator("input[name='name']")).toHaveValue("John");
+
+  // submitting the form unloads the LiveComponent, but it is re-added shortly after
+  await page.locator("button").click();
+  await syncLV(page);
+
+  // the form elements inside the LC should still be visible
+  await expect(page.locator("input[name='name']")).toBeVisible();
+  await expect(page.locator("input[name='name']")).toHaveValue("John");
+
+  // quickly toggle status
+  for (let i = 0; i < 5; i++) {
+    await page.locator("select[name='status']").selectOption("connecting");
+    await syncLV(page);
+    // now the form is not rendered as status is connecting
+    await expect(page.locator("input[name='name']")).not.toBeVisible();
+
+    // set back to loading
+    await page.locator("select[name='status']").selectOption("loaded");
+    await syncLV(page);
+    // now the form is not rendered as status is connecting
+    await expect(page.locator("input[name='name']")).toBeVisible();
+  }
+
+  // no js errors should be thrown
+  await expect(errors).toEqual([]);
+});

--- a/test/support/e2e/issues/issue_3026.ex
+++ b/test/support/e2e/issues/issue_3026.ex
@@ -1,0 +1,90 @@
+defmodule Phoenix.LiveViewTest.E2E.Issue3026Live do
+  use Phoenix.LiveView
+
+  # https://github.com/phoenixframework/phoenix_live_view/issues/3026
+
+  defmodule Form do
+    use Phoenix.LiveComponent
+
+    def render(assigns) do
+      ~H"""
+      <div>
+        Example form
+
+        <.form for={to_form(%{})} phx-change="validate" phx-submit="submit">
+          <input label="Name" name="name" type="text" value={@name} />
+          <input label="Email" name="email" type="text" value={@email} />
+          <button type="submit">Submit</button>
+        </.form>
+      </div>
+      """
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    if connected?(socket) do
+      send(self(), :load)
+    end
+
+    status = if connected?(socket), do: :loading, else: :connecting
+
+    {:ok, assign(socket, :status, status)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_info(:load, socket) do
+    Process.sleep(200)
+
+    {:noreply, assign(socket, %{status: :loaded, name: "John", email: ""})}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("change_status", %{"status" => status}, socket) do
+    {:noreply, assign(socket, :status, String.to_existing_atom(status))}
+  end
+
+  def handle_event("validate", params, socket) do
+    {:noreply, assign(socket, %{name: params["name"], email: params["email"]})}
+  end
+
+  def handle_event("submit", _params, socket) do
+    send(self(), :load)
+    {:noreply, assign(socket, %{status: :loading})}
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <.form for={to_form(%{})} phx-change="change_status">
+      <select name="status" type="select">
+        <%= Phoenix.HTML.Form.options_for_select(options(), @status) %>
+      </select>
+    </.form>
+
+    <%= case @status do %>
+      <% :connecting -> %>
+        <.status status={@status} />
+      <% :loading -> %>
+        <.status status={@status} />
+      <% :connected -> %>
+        <.status status={@status} />
+      <% :loaded -> %>
+        <.live_component module={__MODULE__.Form} id="my-form" name={@name} email={@email} />
+    <% end %>
+    """
+  end
+
+  defp status(assigns) do
+    ~H"""
+    <div class="p-8 bg-gray-200 mb-4">
+      <%= @status %>
+    </div>
+    """
+  end
+
+  defp options do
+    ~w(connecting loading connected loaded)
+    |> Enum.map(fn status -> {String.capitalize(status), status} end)
+  end
+end


### PR DESCRIPTION
There was an issue with `resetRender` where we tried to set the `reset` property on undefined if the component was actually already destroyed. This fixes that by adding another check.

The PR also adds a specific e2e test for #3026.

Fixes #3026.