### PR TITLE
always emit event on blur, even if throttled (#2318)

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -256,7 +256,10 @@ let DOM = {
           })
         }
         if(this.once(el, "bind-debounce")){
-          el.addEventListener("blur", () => this.triggerCycle(el, DEBOUNCE_TRIGGER))
+          el.addEventListener("blur", () => {
+            // always trigger callback on blur
+            callback()
+          })
         }
     }
   },


### PR DESCRIPTION
I'm not sure about this. I didn't really look through all the `incCycle` / `triggerCycle` code to fully understand what it does. The tests still pass at least...

The change does not address mouseup events (see #2318), but I'm not sure if we should handle mouseup as that is probably only really relevant for range inputs and could have other consequences for other input types.