### PR TITLE
fix various issues with limiting streams

### DIFF
--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -126,9 +126,7 @@ export default class DOMPatch {
           this.liveSocket.owner(el, (view) => {
             if(view === this.view){
               Array.from(el.children).forEach(child => {
-                if(!this.streamInserts[child.id]){
-                  this.removeStreamChildElement(child)
-                }
+                this.removeStreamChildElement(child)
               })
             }
           })

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1746,6 +1746,7 @@ defmodule Phoenix.LiveView do
   def stream_insert(%Socket{} = socket, name, item, opts \\ []) do
     at = Keyword.get(opts, :at, -1)
     limit = Keyword.get(opts, :limit)
+
     update_stream(socket, name, &LiveStream.insert_item(&1, item, at, limit))
   end
 
@@ -1819,7 +1820,7 @@ defmodule Phoenix.LiveView do
         Enum.reduce(items, new_socket, fn item, acc -> stream_insert(acc, name, item, opts) end)
 
       %{} ->
-        config = get_in(streams, [:__configured__, name]) || []
+        config = get_in(streams, [:__configured__, name]) || opts
 
         ref =
           if cid = socket.assigns[:myself] do

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1820,7 +1820,8 @@ defmodule Phoenix.LiveView do
         Enum.reduce(items, new_socket, fn item, acc -> stream_insert(acc, name, item, opts) end)
 
       %{} ->
-        config = get_in(streams, [:__configured__, name]) || opts
+        config = get_in(streams, [:__configured__, name]) || []
+        opts = Keyword.merge(opts, config)
 
         ref =
           if cid = socket.assigns[:myself] do
@@ -1829,7 +1830,7 @@ defmodule Phoenix.LiveView do
             to_string(streams.__ref__)
           end
 
-        stream = LiveStream.new(name, ref, items, config)
+        stream = LiveStream.new(name, ref, items, opts)
 
         socket
         |> Phoenix.Component.update(:streams, fn streams ->

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -55,6 +55,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/stream", Phoenix.LiveViewTest.StreamLive
       live "/stream/reset", Phoenix.LiveViewTest.StreamResetLive
       live "/stream/reset-lc", Phoenix.LiveViewTest.StreamResetLCLive
+      live "/stream/limit", Phoenix.LiveViewTest.StreamLimitLive
       live "/healthy/:category", Phoenix.LiveViewTest.HealthyLive
 
       live "/upload", Phoenix.LiveViewTest.E2E.UploadLive

--- a/test/support/live_views/streams.ex
+++ b/test/support/live_views/streams.ex
@@ -438,6 +438,8 @@ defmodule Phoenix.LiveViewTest.StreamLimitLive do
   # see https://github.com/phoenixframework/phoenix_live_view/issues/2686
 
   def mount(_params, _session, socket) do
+    socket = stream_configure(socket, :items, [])
+
     {:noreply, socket} = handle_event("configure", %{"at" => "-1", "limit" => "-5"}, socket)
     {:ok, socket}
   end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -126,6 +126,7 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/stream", StreamLive
     live "/stream/reset", StreamResetLive
     live "/stream/reset-lc", StreamResetLCLive
+    live "/stream/limit", StreamLimitLive
 
     # healthy
     live "/healthy/:category", HealthyLive


### PR DESCRIPTION
https://github.com/phoenixframework/phoenix_live_view/commit/997f15cadc86703134b1755f1fa2a3808ff91b2a introduces an issue where limits were not correctly enforced when adding items in bulk, this PR addresses this.

It also fixes an issue with limits being applied differently on resets, because we previously did not remove stream elements when they were being re-added later. I think this was initially introduced to avoid issues with live components not being correctly rendered because of the PHX_SKIP optimization. To counteract this, we now remove all elements on reset to force them being added in the correct order, but also store the live component DOM nodes to correctly restore them.

References #2686.