### PR TITLE
Update Telemetry guide. Closes #3036

### DIFF
--- a/guides/server/telemetry.md
+++ b/guides/server/telemetry.md
@@ -146,7 +146,7 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
 
   * `[:phoenix, :live_view, :render, :start]` - Dispatched by a `Phoenix.LiveView`
     immediately before [`render/1`](`c:Phoenix.LiveComponent.render/1`) is invoked.
-    
+
     * Measurement:
 
           %{system_time: System.monotonic_time}
@@ -207,7 +207,7 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
           %{
             socket: Phoenix.LiveView.Socket.t,
             component: atom,
-            assigns_sockets: {map(), Phoenix.LiveView.Socket.t}
+            assigns_sockets: [{map(), Phoenix.LiveView.Socket.t}]
           }
 
   * `[:phoenix, :live_component, :update, :stop]` - Dispatched by a `Phoenix.LiveComponent`
@@ -226,8 +226,8 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
           %{
             socket: Phoenix.LiveView.Socket.t,
             component: atom,
-            assigns_sockets: {map(), Phoenix.LiveView.Socket.t},
-            sockets: Phoenix.LiveView.Socket.t
+            assigns_sockets: [{map(), Phoenix.LiveView.Socket.t}],
+            sockets: [Phoenix.LiveView.Socket.t]
           }
 
   * `[:phoenix, :live_component, :update, :exception]` - Dispatched by a `Phoenix.LiveComponent`
@@ -248,7 +248,7 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
             kind: atom,
             reason: term,
             component: atom,
-            assigns_sockets: {map(), Phoenix.LiveView.Socket.t}
+            assigns_sockets: [{map(), Phoenix.LiveView.Socket.t}]
           }
 
   * `[:phoenix, :live_component, :handle_event, :start]` - Dispatched by a `Phoenix.LiveComponent`


### PR DESCRIPTION
Corrects `assigns_sockets` and `sockets` structure based on input from @rhcarvalho in #3036.

For reference metadata sample inspected from: https://github.com/phoenixframework/phoenix_live_view/blob/2d573f7e2fc02f04869568b00b05fd869e51abfd/test/phoenix_live_view/integrations/telemetry_test.exs#L298-L299

        %{
          socket: #Phoenix.LiveView.Socket<
            id: "phx-F6x_rk-dj4e2Pi2E",
            endpoint: Phoenix.LiveViewTest.Endpoint,
            view: Phoenix.LiveViewTest.WithMultipleTargets,
            parent_pid: nil,
            root_pid: nil,
            router: Phoenix.LiveViewTest.Router,
            assigns: %{
              disabled: [],
              message: nil,
              names: ["chris", "jose"],
              from: nil,
              live_action: nil,
              __changed__: %{
                disabled: true,
                message: true,
                names: true,
                from: true,
                parent_selector: true
              },
              flash: %{},
              parent_selector: "#parent_id"
            },
            transport_pid: nil,
            ...
          >,
          sockets: [
            #Phoenix.LiveView.Socket<
              id: "phx-F6x_rk-dj4e2Pi2E",
              endpoint: Phoenix.LiveViewTest.Endpoint,
              view: Phoenix.LiveViewTest.WithMultipleTargets,
              parent_pid: nil,
              root_pid: nil,
              router: Phoenix.LiveViewTest.Router,
              assigns: %{
                disabled: false,
                id: "chris",
                name: "chris",
                from: nil,
                __changed__: %{
                  disabled: true,
                  id: true,
                  name: true,
                  from: true,
                  flash: true,
                  parent_id: true,
                  dup_name: true
                },
                flash: %{},
                myself: %Phoenix.LiveComponent.CID{cid: 1},
                parent_id: "#parent_id",
                dup_name: nil
              },
              transport_pid: nil,
              ...
            >,
            #Phoenix.LiveView.Socket<
              id: "phx-F6x_rk-dj4e2Pi2E",
              endpoint: Phoenix.LiveViewTest.Endpoint,
              view: Phoenix.LiveViewTest.WithMultipleTargets,
              parent_pid: nil,
              root_pid: nil,
              router: Phoenix.LiveViewTest.Router,
              assigns: %{
                disabled: false,
                id: "jose",
                name: "jose",
                from: nil,
                __changed__: %{
                  disabled: true,
                  id: true,
                  name: true,
                  from: true,
                  flash: true,
                  parent_id: true,
                  dup_name: true
                },
                flash: %{},
                myself: %Phoenix.LiveComponent.CID{cid: 2},
                parent_id: "#parent_id",
                dup_name: nil
              },
              transport_pid: nil,
              ...
            >
          ],
          component: Phoenix.LiveViewTest.StatefulComponent,
          telemetry_span_context: #Reference<0.2913059682.722468868.193295>,
          assigns_sockets: [
            {%{
               disabled: false,
               id: "chris",
               name: "chris",
               from: nil,
               parent_id: "#parent_id"
             },
             #Phoenix.LiveView.Socket<
               id: "phx-F6x_rk-dj4e2Pi2E",
               endpoint: Phoenix.LiveViewTest.Endpoint,
               view: Phoenix.LiveViewTest.WithMultipleTargets,
               parent_pid: nil,
               root_pid: nil,
               router: Phoenix.LiveViewTest.Router,
               assigns: %{
                 name: "unknown",
                 __changed__: %{
                   name: true,
                   flash: true,
                   parent_id: true,
                   dup_name: true
                 },
                 flash: %{},
                 myself: %Phoenix.LiveComponent.CID{cid: 1},
                 parent_id: nil,
                 dup_name: nil
               },
               transport_pid: nil,
               ...
             >},
            {%{
               disabled: false,
               id: "jose",
               name: "jose",
               from: nil,
               parent_id: "#parent_id"
             },
             #Phoenix.LiveView.Socket<
               id: "phx-F6x_rk-dj4e2Pi2E",
               endpoint: Phoenix.LiveViewTest.Endpoint,
               view: Phoenix.LiveViewTest.WithMultipleTargets,
               parent_pid: nil,
               root_pid: nil,
               router: Phoenix.LiveViewTest.Router,
               assigns: %{
                 name: "unknown",
                 __changed__: %{
                   name: true,
                   flash: true,
                   parent_id: true,
                   dup_name: true
                 },
                 flash: %{},
                 myself: %Phoenix.LiveComponent.CID{cid: 2},
                 parent_id: nil,
                 dup_name: nil
               },
               transport_pid: nil,
               ...
             >}
          ]
        }