### PR TITLE
Implement toggle_attribute (refs #2004)

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 [
   import_deps: [:phoenix],
+  plugins: [Phoenix.LiveView.HTMLFormatter],
   inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Enhancements
   * Add `JS.toggle_class`
+  * Add `JS.toggle_attribute`
   * Force update select options when the options changed from the server while a select has focus
   * Introduce `phx-feedback-group` for handling feedback for composite input groups
   * Add `validate_attrs` to slots

--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -113,6 +113,24 @@ let JS = {
     this.toggleClasses(el, names, transition, view)
   },
 
+  exec_toggle_attr(eventType, phxEvent, view, sourceEl, el, {attr: [attr, val1, val2]}){
+    if(el.hasAttribute(attr)){
+      if(val2 !== undefined){
+        // toggle between val1 and val2
+        if(el.getAttribute(attr) === val1){
+          this.setOrRemoveAttrs(el, [[attr, val2]], [])
+        } else {
+          this.setOrRemoveAttrs(el, [[attr, val1]], [])
+        }
+      } else {
+        // remove attr
+        this.setOrRemoveAttrs(el, [], [attr])
+      }
+    } else {
+      this.setOrRemoveAttrs(el, [[attr, val1]], [])
+    }
+  },
+
   exec_transition(eventType, phxEvent, view, sourceEl, el, {time, transition}){
     this.addOrRemoveClasses(el, [], [], transition, time, view)
   },
@@ -245,9 +263,9 @@ let JS = {
   setOrRemoveAttrs(el, sets, removes){
     let [prevSets, prevRemoves] = DOM.getSticky(el, "attrs", [[], []])
 
-    let alteredAttrs = sets.map(([attr, _val]) => attr).concat(removes);
-    let newSets = prevSets.filter(([attr, _val]) => !alteredAttrs.includes(attr)).concat(sets);
-    let newRemoves = prevRemoves.filter((attr) => !alteredAttrs.includes(attr)).concat(removes);
+    let alteredAttrs = sets.map(([attr, _val]) => attr).concat(removes)
+    let newSets = prevSets.filter(([attr, _val]) => !alteredAttrs.includes(attr)).concat(sets)
+    let newRemoves = prevRemoves.filter((attr) => !alteredAttrs.includes(attr)).concat(removes)
 
     DOM.putSticky(el, "attrs", currentEl => {
       newRemoves.forEach(attr => currentEl.removeAttribute(attr))

--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -21,6 +21,7 @@ defmodule Phoenix.LiveView.JS do
     * `remove_class` - Remove classes from elements, with optional transitions
     * `set_attribute` - Set an attribute on elements
     * `remove_attribute` - Remove an attribute from elements
+    * `toggle_attribute` - Sets or removes element attribute based on attribute presence.
     * `show` - Show elements, with optional transitions
     * `hide` - Hide elements, with optional transitions
     * `toggle` - Shows or hides elements based on visibility, with optional transitions
@@ -662,6 +663,56 @@ defmodule Phoenix.LiveView.JS do
   def remove_attribute(%JS{} = js, attr, opts) when is_list(opts) do
     opts = validate_keys(opts, :remove_attribute, [:to])
     put_op(js, "remove_attr", %{to: opts[:to], attr: attr})
+  end
+
+  @doc """
+  Sets or removes element attribute based on attribute presence.
+
+  Accepts a two or three-element tuple:
+
+  * `{attr, val}` - Sets the attribute to the given value or removes it
+  * `{attr, val1, val2}` - Toggles the attribute between `val1` and `val2`
+
+  ## Options
+
+    * `:to` - The optional DOM selector to set or remove attributes from.
+      Defaults to the interacted element.
+
+  ## Examples
+
+      <button phx-click={JS.toggle_attribute({"aria-expanded", "true", "false"}, to: "#dropdown")}>
+        toggle
+      </button>
+
+      <button phx-click={JS.toggle_attribute({"open", "true"}, to: "#dialog")}>
+        toggle
+      </button>
+
+  """
+  def toggle_attribute({attr, val}), do: toggle_attribute(%JS{}, {attr, val}, [])
+  def toggle_attribute({attr, val1, val2}), do: toggle_attribute(%JS{}, {attr, val1, val2}, [])
+
+  @doc "See `toggle_attribute/1`."
+  def toggle_attribute({attr, val}, opts) when is_list(opts),
+    do: toggle_attribute(%JS{}, {attr, val}, opts)
+
+  def toggle_attribute({attr, val1, val2}, opts) when is_list(opts),
+    do: toggle_attribute(%JS{}, {attr, val1, val2}, opts)
+
+  def toggle_attribute(%JS{} = js, {attr, val}), do: toggle_attribute(js, {attr, val}, [])
+
+  def toggle_attribute(%JS{} = js, {attr, val1, val2}),
+    do: toggle_attribute(js, {attr, val1, val2}, [])
+
+  @doc "See `toggle_attribute/1`."
+  def toggle_attribute(%JS{} = js, {attr, val}, opts) when is_list(opts) do
+    opts = validate_keys(opts, :toggle_attribute, [:to])
+    put_op(js, "toggle_attr", %{to: opts[:to], attr: [attr, val]})
+  end
+
+  def toggle_attribute(%JS{} = js, {attr, val1, val2}, opts) when is_list(opts) do
+    opts = validate_keys(opts, :toggle_attribute, [:to])
+    put_op(js, "toggle_attr", %{to: opts[:to], attr: [attr, val1, val2]})
   end
 
   @doc """

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -59,6 +59,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
 
       live "/upload", Phoenix.LiveViewTest.E2E.UploadLive
       live "/form", Phoenix.LiveViewTest.E2E.FormLive
+      live "/js", Phoenix.LiveViewTest.E2E.JsLive
     end
 
     scope "/issues" do

--- a/test/e2e/tests/js.spec.js
+++ b/test/e2e/tests/js.spec.js
@@ -1,0 +1,82 @@
+const { test, expect } = require("@playwright/test");
+const { syncLV, attributeMutations } = require("../utils");
+
+test("toggle_attribute", async ({ page }) => {
+  await page.goto("/js");
+  await syncLV(page);
+
+  await expect(page.locator("#my-modal")).not.toBeVisible();
+
+  let changes = attributeMutations(page, "#my-modal");
+  await page.getByRole("button", { name: "toggle modal" }).click();
+  // wait for the transition time (set to 50)
+  await page.waitForTimeout(100);
+  await expect(await changes()).toEqual(expect.arrayContaining([
+    { attr: "style", oldValue: "display: none;", newValue: "display: block;" },
+    { attr: "aria-expanded", oldValue: "false", newValue: "true" },
+    { attr: "open", oldValue: null, newValue: "true" },
+    // chrome and firefox first transition from null to "" and then to "fade-in";
+    // safari goes straight from null to "fade-in", therefore we do not perform an exact match
+    expect.objectContaining({ attr: "class", newValue: "fade-in" }),
+    expect.objectContaining({ attr: "class", oldValue: "fade-in" }),
+  ]));
+  await expect(page.locator("#my-modal")).not.toHaveClass("fade-in");
+  await expect(page.locator("#my-modal")).toHaveAttribute("aria-expanded", "true");
+  await expect(page.locator("#my-modal")).toHaveAttribute("open", "true");
+  await expect(page.locator("#my-modal")).toBeVisible();
+
+  changes = attributeMutations(page, "#my-modal");
+  await page.getByRole("button", { name: "toggle modal" }).click();
+  // wait for the transition time (set to 50)
+  await page.waitForTimeout(100);
+  await expect(await changes()).toEqual(expect.arrayContaining([
+    { attr: "style", oldValue: "display: block;", newValue: "display: none;" },
+    { attr: "aria-expanded", oldValue: "true", newValue: "false" },
+    { attr: "open", oldValue: "true", newValue: null },
+    expect.objectContaining({ attr: "class", newValue: "fade-out" }),
+    expect.objectContaining({ attr: "class", oldValue: "fade-out" }),
+  ]));
+  await expect(page.locator("#my-modal")).not.toHaveClass("fade-out");
+  await expect(page.locator("#my-modal")).toHaveAttribute("aria-expanded", "false");
+  await expect(page.locator("#my-modal")).not.toHaveAttribute("open");
+  await expect(page.locator("#my-modal")).not.toBeVisible();
+});
+
+test("set and remove_attribute", async ({ page }) => {
+  await page.goto("/js");
+  await syncLV(page);
+
+  await expect(page.locator("#my-modal")).not.toBeVisible();
+
+  let changes = attributeMutations(page, "#my-modal");
+  await page.getByRole("button", { name: "show modal" }).click();
+  // wait for the transition time (set to 50)
+  await page.waitForTimeout(100);
+  await expect(await changes()).toEqual(expect.arrayContaining([
+    { attr: "style", oldValue: "display: none;", newValue: "display: block;" },
+    { attr: "aria-expanded", oldValue: "false", newValue: "true" },
+    { attr: "open", oldValue: null, newValue: "true" },
+    expect.objectContaining({ attr: "class", newValue: "fade-in" }),
+    expect.objectContaining({ attr: "class", oldValue: "fade-in" }),
+  ]));
+  await expect(page.locator("#my-modal")).not.toHaveClass("fade-in");
+  await expect(page.locator("#my-modal")).toHaveAttribute("aria-expanded", "true");
+  await expect(page.locator("#my-modal")).toHaveAttribute("open", "true");
+  await expect(page.locator("#my-modal")).toBeVisible();
+
+  changes = attributeMutations(page, "#my-modal");
+  await page.getByRole("button", { name: "hide modal" }).click();
+  // wait for the transition time (set to 50)
+  await page.waitForTimeout(100);
+  await expect(await changes()).toEqual(expect.arrayContaining([
+    { attr: "style", oldValue: "display: block;", newValue: "display: none;" },
+    { attr: "aria-expanded", oldValue: "true", newValue: "false" },
+    { attr: "open", oldValue: "true", newValue: null },
+    expect.objectContaining({ attr: "class", newValue: "fade-out" }),
+    expect.objectContaining({ attr: "class", oldValue: "fade-out" }),
+  ]));
+  await expect(page.locator("#my-modal")).not.toHaveClass("fade-out");
+  await expect(page.locator("#my-modal")).toHaveAttribute("aria-expanded", "false");
+  await expect(page.locator("#my-modal")).not.toHaveAttribute("open");
+  await expect(page.locator("#my-modal")).not.toBeVisible();
+});

--- a/test/phoenix_live_view/js_test.exs
+++ b/test/phoenix_live_view/js_test.exs
@@ -837,6 +837,58 @@ defmodule Phoenix.LiveView.JSTest do
     end
   end
 
+  describe "toggle_attribute" do
+    test "with defaults" do
+      assert JS.toggle_attribute({"open", "true"}) == %JS{
+               ops: [
+                 ["toggle_attr", %{attr: ["open", "true"], to: nil}]
+               ]
+             }
+
+      assert JS.toggle_attribute({"open", "true"}, to: "#dropdown") == %JS{
+               ops: [
+                 ["toggle_attr", %{attr: ["open", "true"], to: "#dropdown"}]
+               ]
+             }
+
+      assert JS.toggle_attribute({"aria-expanded", "true", "false"}, to: "#dropdown") == %JS{
+               ops: [
+                 ["toggle_attr", %{attr: ["aria-expanded", "true", "false"], to: "#dropdown"}]
+               ]
+             }
+    end
+
+    test "composability" do
+      js =
+        {"aria-expanded", "true", "false"}
+        |> JS.toggle_attribute()
+        |> JS.toggle_attribute({"open", "true"})
+        |> JS.toggle_attribute({"disabled", "true"}, to: "#dropdown")
+
+      assert js == %JS{
+               ops: [
+                 ["toggle_attr", %{to: nil, attr: ["aria-expanded", "true", "false"]}],
+                 ["toggle_attr", %{to: nil, attr: ["open", "true"]}],
+                 ["toggle_attr", %{to: "#dropdown", attr: ["disabled", "true"]}]
+               ]
+             }
+    end
+
+    test "raises with unknown options" do
+      assert_raise ArgumentError, ~r/invalid option for toggle_attribute/, fn ->
+        JS.toggle_attribute({"disabled", "true"}, bad: :opt)
+      end
+    end
+
+    test "encoding" do
+      assert js_to_string(JS.toggle_attribute({"disabled", "true"})) ==
+               "[[&quot;toggle_attr&quot;,{&quot;attr&quot;:[&quot;disabled&quot;,&quot;true&quot;],&quot;to&quot;:null}]]"
+
+      assert js_to_string(JS.toggle_attribute({"aria-expanded", "true", "false"})) ==
+               "[[&quot;toggle_attr&quot;,{&quot;attr&quot;:[&quot;aria-expanded&quot;,&quot;true&quot;,&quot;false&quot;],&quot;to&quot;:null}]]"
+    end
+  end
+
   describe "focus" do
     test "with defaults" do
       assert JS.focus() == %JS{ops: [["focus", %{to: nil}]]}

--- a/test/support/e2e/js_live.ex
+++ b/test/support/e2e/js_live.ex
@@ -1,0 +1,41 @@
+defmodule Phoenix.LiveViewTest.E2E.JsLive do
+  use Phoenix.LiveView
+
+  alias Phoenix.LiveView.JS
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <div id="my-modal" aria-expanded="false" style="display: none;">Test</div>
+
+    <button phx-click={
+      JS.show(to: "#my-modal", transition: "fade-in", time: 50)
+      |> JS.set_attribute({"aria-expanded", "true"}, to: "#my-modal")
+      |> JS.set_attribute({"open", "true"}, to: "#my-modal")
+    }>
+      show modal
+    </button>
+
+    <button phx-click={
+      JS.hide(to: "#my-modal", transition: "fade-out", time: 50)
+      |> JS.set_attribute({"aria-expanded", "false"}, to: "#my-modal")
+      |> JS.remove_attribute("open", to: "#my-modal")
+    }>
+      hide modal
+    </button>
+
+    <button phx-click={
+      JS.toggle(to: "#my-modal", in: "fade-in", out: "fade-out", time: 50)
+      |> JS.toggle_attribute({"aria-expanded", "true", "false"}, to: "#my-modal")
+      |> JS.toggle_attribute({"open", "true"}, to: "#my-modal")
+    }>
+      toggle modal
+    </button>
+    """
+  end
+end


### PR DESCRIPTION
This builds upon #2004 and expands toggle_attribute to also support toggling between two values. It also adds an end to end test.

Closes #2004.