### PR TITLE
remove attrs even if they don't start with data-

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -406,7 +406,7 @@ let DOM = {
     for(let i = targetAttrs.length - 1; i >= 0; i--){
       let name = targetAttrs[i].name
       if(isIgnored){
-        if(name.startsWith("data-") && !source.hasAttribute(name) && ![PHX_REF, PHX_REF_SRC].includes(name)){ target.removeAttribute(name) }
+        if(!source.hasAttribute(name) && ![PHX_REF, PHX_REF_SRC].includes(name)){ target.removeAttribute(name) }
       } else {
         if(!source.hasAttribute(name)){ target.removeAttribute(name) }
       }

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -66,6 +66,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
 
       live "/3026", Phoenix.LiveViewTest.E2E.Issue3026Live
       live "/3040", Phoenix.LiveViewTest.E2E.Issue3040Live
+      live "/3044", Phoenix.LiveViewTest.E2E.Issue3044Live
     end
   end
 end

--- a/test/e2e/tests/issues/3044.spec.js
+++ b/test/e2e/tests/issues/3044.spec.js
@@ -1,0 +1,17 @@
+const { test, expect } = require("@playwright/test");
+const { syncLV } = require("../../utils");
+
+test("attributes on phx-update='ignore' can be toggled", async ({ page }) => {
+  await page.goto("/issues/3044");
+  await syncLV(page);
+
+  await expect(page.locator("input")).not.toHaveAttribute("disabled");
+  await page.locator("button").click();
+  await syncLV(page);
+  
+  await expect(page.locator("input")).toHaveAttribute("disabled");
+  await page.locator("button").click();
+  await syncLV(page);
+
+  await expect(page.locator("input")).not.toHaveAttribute("disabled");
+});

--- a/test/support/e2e/issues/issue_3044.ex
+++ b/test/support/e2e/issues/issue_3044.ex
@@ -1,0 +1,26 @@
+defmodule Phoenix.LiveViewTest.E2E.Issue3044Live do
+  use Phoenix.LiveView
+
+  @impl Phoenix.LiveView
+  def mount(_, _, socket) do
+    {:ok, assign(socket, :disabled, false)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("toggle", _, socket) do
+    {:noreply, update(socket, :disabled, &(not &1))}
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <input
+      value={if @disabled, do: "disabled", else: "not disabled"}
+      disabled={@disabled}
+      phx-update="ignore"
+      id="test-input"
+    />
+    <button phx-click="toggle">Toggle</button>
+    """
+  end
+end


### PR DESCRIPTION
Fixes #3044

Previously, we only remove attributes starting with `data-` when phx-update is set to "ignore". I'm not quite sure why, so please verify if we can indeed proceed with this.