### PR TITLE
Add reset option to assign_async/4 to clear previous results

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1877,6 +1877,7 @@ defmodule Phoenix.LiveView do
   ## Options
 
     * `:supervisor` - allows you to specify a `Task.Supervisor` to supervise the task.
+    * `:reset` - remove previous results during async operation when true. Defaults to false
 
 
   ## Examples

--- a/lib/phoenix_live_view/async.ex
+++ b/lib/phoenix_live_view/async.ex
@@ -36,13 +36,15 @@ defmodule Phoenix.LiveView.Async do
       end
     end
 
+    reset = Keyword.get(opts, :reset, false)
+
     new_assigns =
       Enum.map(keys, fn key ->
-        case socket.assigns do
-          %{^key => %AsyncResult{ok?: true} = existing} ->
+        case {reset, socket.assigns} do
+          {false, %{^key => %AsyncResult{ok?: true} = existing}} ->
             {key, AsyncResult.loading(existing, keys)}
 
-          %{} ->
+          _ ->
             {key, AsyncResult.loading(keys)}
         end
       end)

--- a/test/phoenix_live_view/integrations/assign_async_test.exs
+++ b/test/phoenix_live_view/integrations/assign_async_test.exs
@@ -110,6 +110,35 @@ defmodule Phoenix.LiveView.AssignAsyncTest do
       assert render_async(lv) =~ "lc_data: 123"
     end
 
+    test "keeps previous values when updating async assign", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, "/assign_async?test=lc_ok")
+      assert render_async(lv) =~ "lc_data: 123"
+
+      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.AssignAsyncLive.LC,
+        id: "lc",
+        action: :assign_async_reset,
+        reset: false
+      )
+
+      assert render(lv) =~ "lc_data: 123"
+      assert render_async(lv) =~ "lc_data: 456"
+    end
+
+    test "when using the reset flag", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, "/assign_async?test=lc_ok")
+      assert render_async(lv) =~ "lc_data: 123"
+
+      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.AssignAsyncLive.LC,
+        id: "lc",
+        action: :assign_async_reset,
+        reset: true
+      )
+
+      assert render(lv) =~ "loading"
+      refute render(lv) =~ "lc_data: 123"
+      assert render_async(lv) =~ "lc_data: 456"
+    end
+
     test "raise during execution", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/assign_async?test=lc_raise")
 

--- a/test/support/live_views/general.ex
+++ b/test/support/live_views/general.ex
@@ -502,6 +502,11 @@ defmodule Phoenix.LiveViewTest.AssignAsyncLive.LC do
     {:ok, cancel_async(socket, socket.assigns.lc_data)}
   end
 
+  def update(%{action: :assign_async_reset, reset: reset}, socket) do
+    fun = fn -> Process.sleep(50); {:ok, %{lc_data: 456}} end
+    {:ok, assign_async(socket, :lc_data, fun, reset: reset)}
+  end
+
   def update(%{action: :renew_canceled}, socket) do
     {:ok,
      assign_async(socket, :lc_data, fn ->


### PR DESCRIPTION
Sometimes it is desirable to clear the results during an assign_async
- for example when performing an async search, if the term has changed but the results are still loading, it doesn't make contextual sense when the term doesn't match the results. In these cases it's better to clear out the old results during loading.

This commit adds a `reset` flag to assign_async that will ignore previous results if set to true resulting in the liveview rendering with a default %AsyncResult{} struct.