### PR TITLE
Revert #2097

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -406,7 +406,7 @@ export default class LiveSocket {
           DOM.findPhxSticky(document).forEach(el => newMainEl.appendChild(el))
           this.outgoingMainEl.replaceWith(newMainEl)
           this.outgoingMainEl = null
-          callback && requestAnimationFrame(() => callback(linkRef))
+          callback && callback(linkRef)
           onDone()
         })
       }


### PR DESCRIPTION
Fixes #2293.

https://github.com/phoenixframework/phoenix_live_view/pull/2097 wrapped the join callback in an animation frame, therefore delaying the history push until the DOM is already patched. This causes relative file paths to be incorrectly resolved. Because #2173 adds the animation frame to the scroll function, this should still work as expected and at least in my manual tests it does.

Adding some E2E tests for the scroll restoration is on my todo list for https://github.com/phoenixframework/phoenix_live_view/issues/3034.