### PR TITLE
Don't create new uploaders for inputs with no new entries

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -1044,8 +1044,12 @@ export default class View {
         if(numFileInputsInProgress === 0){ onComplete() }
       });
 
-      this.uploaders[inputEl] = uploader
       let entries = uploader.entries().map(entry => entry.toPreflightPayload())
+
+      if (entries.length === 0) {
+        numFileInputsInProgress--
+        return
+      }
 
       let payload = {
         ref: inputEl.getAttribute(PHX_UPLOAD_REF),


### PR DESCRIPTION
Fixes https://github.com/phoenixframework/phoenix_live_view/issues/3052

The existing code will create new `LiveUploader`s for input elements that have no entries to be uploaded. As currently written, the `LiveUploader` never calls the provided callback when there are no entries to process and thus never decrements `numFileInputsInProgress`.

This change does not create new `LiveUploader`s for inputs with no new entries and updates the closed over counter to reflect that fact. I don't love this solution but there are a lot of moving parts in here and I wasn't confident about making a bigger change.

Additionally, I deleted line 1047 because it doesn't appear to do anything useful. It is using an object as a key which doesn't seem right to me. It sets `this.uploaders` to `{[object HTMLInputElement]: LiveUploader}` with the last write winning.