### PR TITLE
Expand aliases in live_session arguments

### DIFF
--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -287,9 +287,11 @@ defmodule Phoenix.LiveView.Router do
 
       {:root_layout, {mod, template}}, acc when is_atom(mod) and is_binary(template) ->
         template = Phoenix.LiveView.Utils.normalize_layout(template, "live_session :root_layout")
+        mod = Phoenix.Router.scoped_alias(module, mod)
         Map.put(acc, :root_layout, {mod, String.to_atom(template)})
 
       {:root_layout, {mod, template}}, acc when is_atom(mod) and is_atom(template) ->
+        mod = Phoenix.Router.scoped_alias(module, mod)
         Map.put(acc, :root_layout, {mod, template})
 
       {:root_layout, false}, acc ->
@@ -304,9 +306,11 @@ defmodule Phoenix.LiveView.Router do
 
       {:layout, {mod, template}}, acc when is_atom(mod) and is_binary(template) ->
         template = Phoenix.LiveView.Utils.normalize_layout(template, "live_session :layout")
+        mod = Phoenix.Router.scoped_alias(module, mod)
         Map.put(acc, :layout, {mod, template})
 
       {:layout, {mod, template}}, acc when is_atom(mod) and is_atom(template) ->
+        mod = Phoenix.Router.scoped_alias(module, mod)
         Map.put(acc, :layout, {mod, template})
 
       {:layout, false}, acc ->
@@ -324,6 +328,9 @@ defmodule Phoenix.LiveView.Router do
           on_mount
           |> List.wrap()
           |> Enum.map(&Phoenix.LiveView.Lifecycle.validate_on_mount!(module, &1))
+          |> Enum.map(fn {hook_module, arg} ->
+            {Phoenix.Router.scoped_alias(module, hook_module), arg}
+          end)
           |> Phoenix.LiveView.Lifecycle.prepare_on_mount!()
 
         Map.put(acc, :on_mount, hooks)

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -65,15 +65,15 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/router/foobarbaz/nested/index", FooBarLive.Nested.Index, :index
     live "/router/foobarbaz/nested/show", FooBarLive.Nested.Index, :show
     live "/router/foobarbaz/custom", FooBarLive, :index, as: :custom_foo_bar
-    live "/router/foobarbaz/with_live", Phoenix.LiveViewTest.Live.Nested.Module, :action
+    live "/router/foobarbaz/with_live", Live.Nested.Module, :action
     live "/router/foobarbaz/nosuffix", NoSuffix, :index, as: :custom_route
 
     # integration layout
-    live_session :styled_layout, root_layout: {Phoenix.LiveViewTest.LayoutView, :styled} do
+    live_session :styled_layout, root_layout: {LayoutView, :styled} do
       live "/styled-elements", ElementsLive
     end
 
-    live_session :app_layout, root_layout: {Phoenix.LiveViewTest.LayoutView, :app} do
+    live_session :app_layout, root_layout: {LayoutView, :app} do
       live "/layout", LayoutLive
     end
 
@@ -161,28 +161,23 @@ defmodule Phoenix.LiveViewTest.Router do
       live "/thermo-live-session-merged", ThermostatLive
     end
 
-    live_session :lifecycle, on_mount: Phoenix.LiveViewTest.HaltConnectedMount do
+    live_session :lifecycle, on_mount: HaltConnectedMount do
       live "/lifecycle/halt-connected-mount", HooksLive.Noop
     end
 
-    live_session :mount_mod_arg, on_mount: {Phoenix.LiveViewTest.MountArgs, :inlined} do
+    live_session :mount_mod_arg, on_mount: {MountArgs, :inlined} do
       live "/lifecycle/mount-mod-arg", HooksLive.Noop
     end
 
-    live_session :mount_mods,
-      on_mount: [Phoenix.LiveViewTest.OnMount, Phoenix.LiveViewTest.OtherOnMount] do
+    live_session :mount_mods, on_mount: [OnMount, OtherOnMount] do
       live "/lifecycle/mount-mods", HooksLive.Noop
     end
 
-    live_session :mount_mod_args,
-      on_mount: [
-        {Phoenix.LiveViewTest.OnMount, :other},
-        {Phoenix.LiveViewTest.OtherOnMount, :other}
-      ] do
+    live_session :mount_mod_args, on_mount: [{OnMount, :other}, {OtherOnMount, :other}] do
       live "/lifecycle/mount-mods-args", HooksLive.Noop
     end
 
-    live_session :layout, layout: {Phoenix.LiveViewTest.LayoutView, :live_override} do
+    live_session :layout, layout: {LayoutView, :live_override} do
       live "/dashboard-live-session-layout", LayoutLive
     end
   end


### PR DESCRIPTION
Closes #1636.

This is a breaking change for anyone currently using `live_session` in a scope where aliases are not expanded.