### PR TITLE
Reduce JS.commands payload by moving defaults to client

### DIFF
--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -2,6 +2,7 @@ import DOM from "./dom"
 import ARIA from "./aria"
 
 let focusStack = null
+let default_transition_time = 200
 
 let JS = {
   exec(eventType, phxEvent, view, sourceEl, defaults){
@@ -170,6 +171,7 @@ let JS = {
   },
 
   toggle(eventType, view, el, display, ins, outs, time){
+    time = time || default_transition_time
     let [inClasses, inStartClasses, inEndClasses] = ins || [[], [], []]
     let [outClasses, outStartClasses, outEndClasses] = outs || [[], [], []]
     if(inClasses.length > 0 || outClasses.length > 0){
@@ -232,6 +234,7 @@ let JS = {
   },
 
   addOrRemoveClasses(el, adds, removes, transition, time, view){
+    time = time || default_transition_time
     let [transitionRun, transitionStart, transitionEnd] = transition || [[], [], []]
     if(transitionRun.length > 0){
       let onStart = () => {

--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -39,7 +39,7 @@ let JS = {
 
   // commands
 
-  exec_exec(eventType, phxEvent, view, sourceEl, el, [attr, to]){
+  exec_exec(eventType, phxEvent, view, sourceEl, el, {attr, to}){
     let nodes = to ? DOM.all(document, to) : [sourceEl]
     nodes.forEach(node => {
       let encodedJS = node.getAttribute(attr)

--- a/assets/test/js_test.js
+++ b/assets/test/js_test.js
@@ -13,6 +13,11 @@ let setupView = (content) => {
 describe("JS", () => {
   beforeEach(() => {
     global.document.body.innerHTML = ""
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
   })
 
   describe("exec_toggle", () => {
@@ -34,19 +39,20 @@ describe("JS", () => {
 
       expect(modal.style.display).toEqual("")
       JS.exec("click", click.getAttribute("phx-click"), view, click)
-      window.requestAnimationFrame(() => {
-        expect(modal.style.display).toEqual("none")
+      jest.runAllTimers()
 
-        JS.exec("click", click.getAttribute("phx-click"), view, click)
-        window.requestAnimationFrame(() => {
-          expect(modal.style.display).toEqual("block")
-          expect(showEndCalled).toBe(true)
-          expect(hideEndCalled).toBe(true)
-          expect(showStartCalled).toBe(true)
-          expect(hideStartCalled).toBe(true)
-          done()
-        })
-      })
+      expect(modal.style.display).toEqual("none")
+
+      JS.exec("click", click.getAttribute("phx-click"), view, click)
+      jest.runAllTimers()
+
+      expect(modal.style.display).toEqual("block")
+      expect(showEndCalled).toBe(true)
+      expect(hideEndCalled).toBe(true)
+      expect(showStartCalled).toBe(true)
+      expect(hideStartCalled).toBe(true)
+
+      done()
     })
 
     test("with display", done => {
@@ -67,22 +73,23 @@ describe("JS", () => {
 
       expect(modal.style.display).toEqual("")
       JS.exec("click", click.getAttribute("phx-click"), view, click)
-      window.requestAnimationFrame(() => {
-        expect(modal.style.display).toEqual("none")
+      jest.runAllTimers()
 
-        JS.exec("click", click.getAttribute("phx-click"), view, click)
-        window.requestAnimationFrame(() => {
-          expect(modal.style.display).toEqual("inline-block")
-          expect(showEndCalled).toBe(true)
-          expect(hideEndCalled).toBe(true)
-          expect(showStartCalled).toBe(true)
-          expect(hideStartCalled).toBe(true)
-          done()
-        })
-      })
+      expect(modal.style.display).toEqual("none")
+
+      JS.exec("click", click.getAttribute("phx-click"), view, click)
+      jest.runAllTimers()
+
+      expect(modal.style.display).toEqual("inline-block")
+      expect(showEndCalled).toBe(true)
+      expect(hideEndCalled).toBe(true)
+      expect(showStartCalled).toBe(true)
+      expect(hideStartCalled).toBe(true)
+      done()
     })
 
-    test("with in and out classes", done => {
+    test("with in and out classes", (done) => {
+      jest.useFakeTimers()
       let view = setupView(`
       <div id="modal">modal</div>
       <div id="click" phx-click='[["toggle", {"to": "#modal", "ins": [["fade-in"],[],[]], "outs": [["fade-out"],[],[]]}]]'></div>
@@ -101,30 +108,27 @@ describe("JS", () => {
       expect(modal.style.display).toEqual("")
       expect(modal.classList.contains("fade-out")).toBe(false)
       expect(modal.classList.contains("fade-in")).toBe(false)
-      JS.exec("click", click.getAttribute("phx-click"), view, click)
-      window.requestAnimationFrame(() => {
-        window.requestAnimationFrame(() => {
-          window.requestAnimationFrame(() => {
-            expect(modal.classList.contains("fade-out")).toBe(true)
-            expect(modal.classList.contains("fade-in")).toBe(false)
 
-            JS.exec("click", click.getAttribute("phx-click"), view, click)
-            window.requestAnimationFrame(() => {
-              window.requestAnimationFrame(() => {
-                window.requestAnimationFrame(() => {
-                  expect(modal.classList.contains("fade-out")).toBe(false)
-                  expect(modal.classList.contains("fade-in")).toBe(true)
-                  expect(showEndCalled).toBe(true)
-                  expect(hideEndCalled).toBe(true)
-                  expect(showStartCalled).toBe(true)
-                  expect(hideStartCalled).toBe(true)
-                  done()
-                })
-              })
-            })
-          })
-        })
-      })
+      // toggle in
+      JS.exec("click", click.getAttribute("phx-click"), view, click)
+      jest.advanceTimersByTime(100)
+      expect(modal.classList.contains("fade-out")).toBe(true)
+      expect(modal.classList.contains("fade-in")).toBe(false)
+      jest.runAllTimers()
+
+      // toggle out
+      JS.exec("click", click.getAttribute("phx-click"), view, click)
+      jest.advanceTimersByTime(100)
+      expect(modal.classList.contains("fade-out")).toBe(false)
+      expect(modal.classList.contains("fade-in")).toBe(true)
+      jest.runAllTimers()
+
+      expect(showEndCalled).toBe(true)
+      expect(hideEndCalled).toBe(true)
+      expect(showStartCalled).toBe(true)
+      expect(hideStartCalled).toBe(true)
+
+      done()
     })
   })
 
@@ -138,11 +142,15 @@ describe("JS", () => {
       let click = document.querySelector("#click")
 
       expect(Array.from(modal.classList)).toEqual(["modal"])
+
       JS.exec("click", click.getAttribute("phx-click"), view, click)
-      setTimeout(() => {
-        expect(Array.from(modal.classList)).toEqual(["modal", "fade-out"])
-        done()
-      }, 200)
+      jest.advanceTimersByTime(100)
+
+      expect(Array.from(modal.classList)).toEqual(["modal", "fade-out"])
+      jest.runAllTimers()
+
+      expect(Array.from(modal.classList)).toEqual(["modal"])
+      done()
     })
 
     test("with multiple selector", done => {
@@ -157,12 +165,19 @@ describe("JS", () => {
 
       expect(Array.from(modal1.classList)).toEqual(["modal"])
       expect(Array.from(modal2.classList)).toEqual(["modal"])
+
       JS.exec("click", click.getAttribute("phx-click"), view, click)
-      setTimeout(() => {
-        expect(Array.from(modal1.classList)).toEqual(["modal", "fade-out"])
-        expect(Array.from(modal2.classList)).toEqual(["modal", "fade-out"])
-        done()
-      }, 200)
+      jest.advanceTimersByTime(100)
+
+      expect(Array.from(modal1.classList)).toEqual(["modal", "fade-out"])
+      expect(Array.from(modal2.classList)).toEqual(["modal", "fade-out"])
+
+      jest.runAllTimers()
+
+      expect(Array.from(modal1.classList)).toEqual(["modal"])
+      expect(Array.from(modal2.classList)).toEqual(["modal"])
+
+      done()
     })
   })
 
@@ -242,15 +257,15 @@ describe("JS", () => {
       JS.exec("click", add.getAttribute("phx-click"), view, add)
       JS.exec("click", add.getAttribute("phx-click"), view, add)
       JS.exec("click", add.getAttribute("phx-click"), view, add)
-      window.requestAnimationFrame(() => {
-        expect(Array.from(modal.classList)).toEqual(["modal", "class1"])
+      jest.runAllTimers()
 
-        JS.exec("click", remove.getAttribute("phx-click"), view, remove)
-        window.requestAnimationFrame(() => {
-          expect(Array.from(modal.classList)).toEqual(["modal"])
-          done()
-        })
-      })
+      expect(Array.from(modal.classList)).toEqual(["modal", "class1"])
+
+      JS.exec("click", remove.getAttribute("phx-click"), view, remove)
+      jest.runAllTimers()
+
+      expect(Array.from(modal.classList)).toEqual(["modal"])
+      done()
     })
 
     test("with multiple selector", done => {
@@ -266,17 +281,17 @@ describe("JS", () => {
       let remove = document.querySelector("#remove")
 
       JS.exec("click", add.getAttribute("phx-click"), view, add)
-      window.requestAnimationFrame(() => {
-        expect(Array.from(modal1.classList)).toEqual(["modal", "class1"])
-        expect(Array.from(modal2.classList)).toEqual(["modal", "class1"])
+      jest.runAllTimers()
 
-        JS.exec("click", remove.getAttribute("phx-click"), view, remove)
-        window.requestAnimationFrame(() => {
-          expect(Array.from(modal1.classList)).toEqual(["modal"])
-          expect(Array.from(modal2.classList)).toEqual(["modal"])
-          done()
-        })
-      })
+      expect(Array.from(modal1.classList)).toEqual(["modal", "class1"])
+      expect(Array.from(modal2.classList)).toEqual(["modal", "class1"])
+
+      JS.exec("click", remove.getAttribute("phx-click"), view, remove)
+      jest.runAllTimers()
+
+      expect(Array.from(modal1.classList)).toEqual(["modal"])
+      expect(Array.from(modal2.classList)).toEqual(["modal"])
+      done()
     })
   })
 
@@ -290,19 +305,15 @@ describe("JS", () => {
       let toggle = document.querySelector("#toggle")
 
       JS.exec("click", toggle.getAttribute("phx-click"), view, toggle)
+      jest.runAllTimers()
 
-      window.requestAnimationFrame(() => {
-        window.requestAnimationFrame(() => {
-          expect(Array.from(modal.classList)).toEqual(["modal", "class1"])
-          JS.exec("click", toggle.getAttribute("phx-click"), view, toggle)
-          window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => {
-              expect(Array.from(modal.classList)).toEqual(["modal"])
-              done()
-            })
-          })
-        })
-      })
+      expect(Array.from(modal.classList)).toEqual(["modal", "class1"])
+
+      JS.exec("click", toggle.getAttribute("phx-click"), view, toggle)
+      jest.runAllTimers()
+
+      expect(Array.from(modal.classList)).toEqual(["modal"])
+      done()
     })
     test("with multiple selector", done => {
       let view = setupView(`
@@ -315,21 +326,16 @@ describe("JS", () => {
       let toggle = document.querySelector("#toggle")
 
       JS.exec("click", toggle.getAttribute("phx-click"), view, toggle)
+      jest.runAllTimers()
 
-      window.requestAnimationFrame(() => {
-        window.requestAnimationFrame(() => {
-          expect(Array.from(modal1.classList)).toEqual(["modal", "class1"])
-          expect(Array.from(modal2.classList)).toEqual(["modal", "class1"])
-          JS.exec("click", toggle.getAttribute("phx-click"), view, toggle)
-          window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => {
-              expect(Array.from(modal1.classList)).toEqual(["modal"])
-              expect(Array.from(modal2.classList)).toEqual(["modal"])
-              done()
-            })
-          })
-        })
-      })
+      expect(Array.from(modal1.classList)).toEqual(["modal", "class1"])
+      expect(Array.from(modal2.classList)).toEqual(["modal", "class1"])
+      JS.exec("click", toggle.getAttribute("phx-click"), view, toggle)
+      jest.runAllTimers()
+      
+      expect(Array.from(modal1.classList)).toEqual(["modal"])
+      expect(Array.from(modal2.classList)).toEqual(["modal"])
+      done()
     })
   })
 
@@ -535,9 +541,9 @@ describe("JS", () => {
 
       expect(modal.style.display).toEqual("")
       JS.exec("click", click.getAttribute("phx-click"), view, click)
-      window.requestAnimationFrame(() => {
-        expect(modal.style.display).toEqual("none")
-      })
+      jest.runAllTimers()
+
+      expect(modal.style.display).toEqual("none")
     })
   })
 

--- a/assets/test/js_test.js
+++ b/assets/test/js_test.js
@@ -618,7 +618,7 @@ describe("JS", () => {
     test("executes command", done => {
       let view = setupView(`
       <div id="modal" phx-remove='[["push", {"event": "clicked"}]]'>modal</div>
-      <div id="click" phx-click='[["exec",["phx-remove","#modal"]]]'></div>
+      <div id="click" phx-click='[["exec",{"attr": "phx-remove", "to": "#modal"}]]'></div>
       `)
       let click = document.querySelector("#click")
       view.pushEvent = (eventType, sourceEl, targetCtx, event, meta) => {

--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -307,7 +307,7 @@ defmodule Phoenix.LiveView.JS do
     opts = validate_keys(opts, :toggle, [:to, :in, :out, :display, :time])
     in_classes = transition_class_names(opts[:in])
     out_classes = transition_class_names(opts[:out])
-    time = opts[:time] || @default_transition_time
+    time = opts[:time]
 
     put_op(js, "toggle", %{
       to: opts[:to],
@@ -358,7 +358,7 @@ defmodule Phoenix.LiveView.JS do
   def show(js, opts) when is_list(opts) do
     opts = validate_keys(opts, :show, [:to, :transition, :display, :time])
     transition = transition_class_names(opts[:transition])
-    time = opts[:time] || @default_transition_time
+    time = opts[:time]
 
     put_op(js, "show", %{
       to: opts[:to],
@@ -407,7 +407,7 @@ defmodule Phoenix.LiveView.JS do
   def hide(js, opts) when is_list(opts) do
     opts = validate_keys(opts, :hide, [:to, :transition, :time])
     transition = transition_class_names(opts[:transition])
-    time = opts[:time] || @default_transition_time
+    time = opts[:time]
 
     put_op(js, "hide", %{
       to: opts[:to],
@@ -453,7 +453,7 @@ defmodule Phoenix.LiveView.JS do
   @doc "See `add_class/1`."
   def add_class(%JS{} = js, names, opts) when is_binary(names) and is_list(opts) do
     opts = validate_keys(opts, :add_class, [:to, :transition, :time])
-    time = opts[:time] || @default_transition_time
+    time = opts[:time]
 
     put_op(js, "add_class", %{
       to: opts[:to],
@@ -498,7 +498,7 @@ defmodule Phoenix.LiveView.JS do
 
   def toggle_class(%JS{} = js, names, opts) when is_binary(names) and is_list(opts) do
     opts = validate_keys(opts, :toggle_class, [:to, :transition, :time])
-    time = opts[:time] || @default_transition_time
+    time = opts[:time]
 
     put_op(js, "toggle_class", %{
       to: opts[:to],
@@ -545,7 +545,7 @@ defmodule Phoenix.LiveView.JS do
   @doc "See `remove_class/1`."
   def remove_class(%JS{} = js, names, opts) when is_binary(names) and is_list(opts) do
     opts = validate_keys(opts, :remove_class, [:to, :transition, :time])
-    time = opts[:time] || @default_transition_time
+    time = opts[:time]
 
     put_op(js, "remove_class", %{
       to: opts[:to],
@@ -596,7 +596,7 @@ defmodule Phoenix.LiveView.JS do
   def transition(%JS{} = js, transition, opts)
       when (is_binary(transition) or is_tuple(transition)) and is_list(opts) do
     opts = validate_keys(opts, :transition, [:to, :time])
-    time = opts[:time] || @default_transition_time
+    time = opts[:time]
 
     put_op(js, "transition", %{
       time: time,
@@ -889,8 +889,16 @@ defmodule Phoenix.LiveView.JS do
   end
 
   defp put_op(%JS{ops: ops} = js, kind, args) do
+    args = drop_nil_values(args)
     %JS{js | ops: ops ++ [[kind, args]]}
   end
+
+  defp drop_nil_values(args) when is_map(args) do
+    Enum.reject(args, fn {_k, v} -> is_nil(v) end)
+    |> Map.new()
+  end
+
+  defp drop_nil_values(args), do: args
 
   defp class_names(nil), do: []
 
@@ -898,7 +906,7 @@ defmodule Phoenix.LiveView.JS do
     String.split(names, " ")
   end
 
-  defp transition_class_names(nil), do: [[], [], []]
+  defp transition_class_names(nil), do: nil
 
   defp transition_class_names(transition) when is_binary(transition),
     do: [class_names(transition), [], []]

--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -183,7 +183,7 @@ defmodule Phoenix.LiveView.JS do
       |> put_target()
       |> put_value()
 
-    put_op(js, "push", Enum.into(opts, %{event: event}))
+    put_op(js, "push", Keyword.put(opts, :event, event))
   end
 
   @doc """
@@ -223,12 +223,12 @@ defmodule Phoenix.LiveView.JS do
   @doc "See `dispatch/2`."
   def dispatch(%JS{} = js, event, opts) do
     opts = validate_keys(opts, :dispatch, [:to, :detail, :bubbles])
-    args = %{event: event, to: opts[:to]}
+    args = [event: event, to: opts[:to]]
 
     args =
       case Keyword.fetch(opts, :bubbles) do
         {:ok, val} when is_boolean(val) ->
-          Map.put(args, :bubbles, val)
+          Keyword.put(args, :bubbles, val)
 
         {:ok, other} ->
           raise ArgumentError, "expected :bubbles to be a boolean, got: #{inspect(other)}"
@@ -255,7 +255,7 @@ defmodule Phoenix.LiveView.JS do
           """
 
         {_, {:ok, detail}} ->
-          Map.put(args, :detail, detail)
+          Keyword.put(args, :detail, detail)
 
         {_, :error} ->
           args
@@ -309,13 +309,13 @@ defmodule Phoenix.LiveView.JS do
     out_classes = transition_class_names(opts[:out])
     time = opts[:time]
 
-    put_op(js, "toggle", %{
+    put_op(js, "toggle",
       to: opts[:to],
       display: opts[:display],
       ins: in_classes,
       outs: out_classes,
       time: time
-    })
+    )
   end
 
   @doc """
@@ -360,12 +360,12 @@ defmodule Phoenix.LiveView.JS do
     transition = transition_class_names(opts[:transition])
     time = opts[:time]
 
-    put_op(js, "show", %{
+    put_op(js, "show",
       to: opts[:to],
       display: opts[:display],
       transition: transition,
       time: time
-    })
+    )
   end
 
   @doc """
@@ -409,11 +409,11 @@ defmodule Phoenix.LiveView.JS do
     transition = transition_class_names(opts[:transition])
     time = opts[:time]
 
-    put_op(js, "hide", %{
+    put_op(js, "hide",
       to: opts[:to],
       transition: transition,
       time: time
-    })
+    )
   end
 
   @doc """
@@ -455,12 +455,12 @@ defmodule Phoenix.LiveView.JS do
     opts = validate_keys(opts, :add_class, [:to, :transition, :time])
     time = opts[:time]
 
-    put_op(js, "add_class", %{
+    put_op(js, "add_class",
       to: opts[:to],
       names: class_names(names),
       transition: transition_class_names(opts[:transition]),
       time: time
-    })
+    )
   end
 
   @doc """
@@ -500,12 +500,12 @@ defmodule Phoenix.LiveView.JS do
     opts = validate_keys(opts, :toggle_class, [:to, :transition, :time])
     time = opts[:time]
 
-    put_op(js, "toggle_class", %{
+    put_op(js, "toggle_class",
       to: opts[:to],
       names: class_names(names),
       transition: transition_class_names(opts[:transition]),
       time: time
-    })
+    )
   end
 
   @doc """
@@ -547,12 +547,12 @@ defmodule Phoenix.LiveView.JS do
     opts = validate_keys(opts, :remove_class, [:to, :transition, :time])
     time = opts[:time]
 
-    put_op(js, "remove_class", %{
+    put_op(js, "remove_class",
       to: opts[:to],
       names: class_names(names),
       transition: transition_class_names(opts[:transition]),
       time: time
-    })
+    )
   end
 
   @doc """
@@ -598,11 +598,11 @@ defmodule Phoenix.LiveView.JS do
     opts = validate_keys(opts, :transition, [:to, :time])
     time = opts[:time]
 
-    put_op(js, "transition", %{
+    put_op(js, "transition",
       time: time,
       to: opts[:to],
       transition: transition_class_names(transition)
-    })
+    )
   end
 
   @doc """
@@ -632,7 +632,7 @@ defmodule Phoenix.LiveView.JS do
   @doc "See `set_attribute/1`."
   def set_attribute(%JS{} = js, {attr, val}, opts) when is_list(opts) do
     opts = validate_keys(opts, :set_attribute, [:to])
-    put_op(js, "set_attr", %{to: opts[:to], attr: [attr, val]})
+    put_op(js, "set_attr", to: opts[:to], attr: [attr, val])
   end
 
   @doc """
@@ -662,7 +662,7 @@ defmodule Phoenix.LiveView.JS do
   @doc "See `remove_attribute/1`."
   def remove_attribute(%JS{} = js, attr, opts) when is_list(opts) do
     opts = validate_keys(opts, :remove_attribute, [:to])
-    put_op(js, "remove_attr", %{to: opts[:to], attr: attr})
+    put_op(js, "remove_attr", to: opts[:to], attr: attr)
   end
 
   @doc """
@@ -707,12 +707,12 @@ defmodule Phoenix.LiveView.JS do
   @doc "See `toggle_attribute/1`."
   def toggle_attribute(%JS{} = js, {attr, val}, opts) when is_list(opts) do
     opts = validate_keys(opts, :toggle_attribute, [:to])
-    put_op(js, "toggle_attr", %{to: opts[:to], attr: [attr, val]})
+    put_op(js, "toggle_attr", to: opts[:to], attr: [attr, val])
   end
 
   def toggle_attribute(%JS{} = js, {attr, val1, val2}, opts) when is_list(opts) do
     opts = validate_keys(opts, :toggle_attribute, [:to])
-    put_op(js, "toggle_attr", %{to: opts[:to], attr: [attr, val1, val2]})
+    put_op(js, "toggle_attr", to: opts[:to], attr: [attr, val1, val2])
   end
 
   @doc """
@@ -734,7 +734,7 @@ defmodule Phoenix.LiveView.JS do
   @doc "See `focus/1`."
   def focus(%JS{} = js, opts) when is_list(opts) do
     opts = validate_keys(opts, :focus, [:to])
-    put_op(js, "focus", %{to: opts[:to]})
+    put_op(js, "focus", to: opts[:to])
   end
 
   @doc """
@@ -756,7 +756,7 @@ defmodule Phoenix.LiveView.JS do
   @doc "See `focus_first/1`."
   def focus_first(%JS{} = js, opts) when is_list(opts) do
     opts = validate_keys(opts, :focus_first, [:to])
-    put_op(js, "focus_first", %{to: opts[:to]})
+    put_op(js, "focus_first", to: opts[:to])
   end
 
   @doc """
@@ -779,7 +779,7 @@ defmodule Phoenix.LiveView.JS do
   @doc "See `push_focus/1`."
   def push_focus(%JS{} = js, opts) when is_list(opts) do
     opts = validate_keys(opts, :push_focus, [:to])
-    put_op(js, "push_focus", %{to: opts[:to]})
+    put_op(js, "push_focus", to: opts[:to])
   end
 
   @doc """
@@ -790,7 +790,7 @@ defmodule Phoenix.LiveView.JS do
       JS.pop_focus()
   """
   def pop_focus(%JS{} = js \\ %JS{}) do
-    put_op(js, "pop_focus", %{})
+    put_op(js, "pop_focus", [])
   end
 
   @doc """
@@ -820,7 +820,7 @@ defmodule Phoenix.LiveView.JS do
   @doc "See `navigate/1`."
   def navigate(%JS{} = js, href, opts) when is_binary(href) and is_list(opts) do
     opts = validate_keys(opts, :navigate, [:replace])
-    put_op(js, "navigate", %{href: href, replace: !!opts[:replace]})
+    put_op(js, "navigate", href: href, replace: !!opts[:replace])
   end
 
   @doc """
@@ -850,7 +850,7 @@ defmodule Phoenix.LiveView.JS do
   @doc "See `patch/1`."
   def patch(%JS{} = js, href, opts) when is_binary(href) and is_list(opts) do
     opts = validate_keys(opts, :patch, [:replace])
-    put_op(js, "patch", %{href: href, replace: !!opts[:replace]})
+    put_op(js, "patch", href: href, replace: !!opts[:replace])
   end
 
   @doc """
@@ -884,8 +884,7 @@ defmodule Phoenix.LiveView.JS do
   @doc "See `exec/1`."
   def exec(%JS{} = js, attr, opts) when is_binary(attr) and is_list(opts) do
     opts = validate_keys(opts, :exec, [:to])
-    ops = if to = opts[:to], do: [attr, to], else: [attr]
-    put_op(js, "exec", ops)
+    put_op(js, "exec", attr: attr, to: opts[:to])
   end
 
   defp put_op(%JS{ops: ops} = js, kind, args) do
@@ -893,12 +892,10 @@ defmodule Phoenix.LiveView.JS do
     %JS{js | ops: ops ++ [[kind, args]]}
   end
 
-  defp drop_nil_values(args) when is_map(args) do
+  defp drop_nil_values(args) when is_list(args) do
     Enum.reject(args, fn {_k, v} -> is_nil(v) end)
     |> Map.new()
   end
-
-  defp drop_nil_values(args), do: args
 
   defp class_names(nil), do: []
 

--- a/test/phoenix_live_view/js_test.exs
+++ b/test/phoenix_live_view/js_test.exs
@@ -5,8 +5,11 @@ defmodule Phoenix.LiveView.JSTest do
 
   describe "exec" do
     test "with defaults" do
-      assert JS.exec("phx-remove") == %JS{ops: [["exec", ["phx-remove"]]]}
-      assert JS.exec("phx-remove", to: "#modal") == %JS{ops: [["exec", ["phx-remove", "#modal"]]]}
+      assert JS.exec("phx-remove") == %JS{ops: [["exec", %{attr: "phx-remove"}]]}
+
+      assert JS.exec("phx-remove", to: "#modal") == %JS{
+               ops: [["exec", %{attr: "phx-remove", to: "#modal"}]]
+             }
     end
   end
 

--- a/test/phoenix_live_view/js_test.exs
+++ b/test/phoenix_live_view/js_test.exs
@@ -71,7 +71,7 @@ defmodule Phoenix.LiveView.JSTest do
     test "with defaults" do
       assert JS.add_class("show") == %JS{
                ops: [
-                 ["add_class", %{names: ["show"], time: 200, to: nil, transition: [[], [], []]}]
+                 ["add_class", %{names: ["show"]}]
                ]
              }
 
@@ -79,7 +79,7 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "add_class",
-                   %{names: ["show"], time: 200, to: "#modal", transition: [[], [], []]}
+                   %{names: ["show"], to: "#modal"}
                  ]
                ]
              }
@@ -90,7 +90,7 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "add_class",
-                   %{names: ["show", "hl"], time: 200, to: nil, transition: [[], [], []]}
+                   %{names: ["show", "hl"]}
                  ]
                ]
              }
@@ -99,7 +99,7 @@ defmodule Phoenix.LiveView.JSTest do
     test "custom time" do
       assert JS.add_class("show", time: 543) == %JS{
                ops: [
-                 ["add_class", %{names: ["show"], time: 543, to: nil, transition: [[], [], []]}]
+                 ["add_class", %{names: ["show"], time: 543}]
                ]
              }
     end
@@ -109,7 +109,7 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "add_class",
-                   %{names: ["show"], time: 200, to: nil, transition: [["fade"], [], []]}
+                   %{names: ["show"], transition: [["fade"], [], []]}
                  ]
                ]
              }
@@ -118,7 +118,7 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "add_class",
-                   %{names: ["c"], time: 200, to: nil, transition: [["a", "b"], [], []]}
+                   %{names: ["c"], transition: [["a", "b"], [], []]}
                  ]
                ]
              }
@@ -129,8 +129,6 @@ defmodule Phoenix.LiveView.JSTest do
                    "add_class",
                    %{
                      names: ["show"],
-                     time: 200,
-                     to: nil,
                      transition: [["fade"], ["opacity-0"], ["opacity-100"]]
                    }
                  ]
@@ -145,9 +143,9 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "add_class",
-                   %{names: ["show"], time: 100, to: "#modal", transition: [[], [], []]}
+                   %{names: ["show"], time: 100, to: "#modal"}
                  ],
-                 ["add_class", %{names: ["hl"], time: 200, to: nil, transition: [[], [], []]}]
+                 ["add_class", %{names: ["hl"]}]
                ]
              }
     end
@@ -160,7 +158,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.add_class("show")) ==
-               "[[&quot;add_class&quot;,{&quot;names&quot;:[&quot;show&quot;],&quot;time&quot;:200,&quot;to&quot;:null,&quot;transition&quot;:[[],[],[]]}]]"
+               "[[&quot;add_class&quot;,{&quot;names&quot;:[&quot;show&quot;]}]]"
     end
   end
 
@@ -170,7 +168,7 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "remove_class",
-                   %{names: ["show"], time: 200, to: nil, transition: [[], [], []]}
+                   %{names: ["show"]}
                  ]
                ]
              }
@@ -179,7 +177,7 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "remove_class",
-                   %{names: ["show"], time: 200, to: "#modal", transition: [[], [], []]}
+                   %{names: ["show"], to: "#modal"}
                  ]
                ]
              }
@@ -190,7 +188,7 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "remove_class",
-                   %{names: ["show", "hl"], time: 200, to: nil, transition: [[], [], []]}
+                   %{names: ["show", "hl"]}
                  ]
                ]
              }
@@ -201,7 +199,7 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "remove_class",
-                   %{names: ["show"], time: 543, to: nil, transition: [[], [], []]}
+                   %{names: ["show"], time: 543}
                  ]
                ]
              }
@@ -212,7 +210,7 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "remove_class",
-                   %{names: ["show"], time: 200, to: nil, transition: [["fade"], [], []]}
+                   %{names: ["show"], transition: [["fade"], [], []]}
                  ]
                ]
              }
@@ -221,7 +219,7 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "remove_class",
-                   %{names: ["c"], time: 200, to: nil, transition: [["a", "b"], [], []]}
+                   %{names: ["c"], transition: [["a", "b"], [], []]}
                  ]
                ]
              }
@@ -232,8 +230,6 @@ defmodule Phoenix.LiveView.JSTest do
                    "remove_class",
                    %{
                      names: ["show"],
-                     time: 200,
-                     to: nil,
                      transition: [["fade"], ["opacity-0"], ["opacity-100"]]
                    }
                  ]
@@ -248,9 +244,9 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "remove_class",
-                   %{names: ["show"], time: 100, to: "#modal", transition: [[], [], []]}
+                   %{names: ["show"], time: 100, to: "#modal"}
                  ],
-                 ["remove_class", %{names: ["hl"], time: 200, to: nil, transition: [[], [], []]}]
+                 ["remove_class", %{names: ["hl"]}]
                ]
              }
     end
@@ -263,7 +259,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.remove_class("show")) ==
-               "[[&quot;remove_class&quot;,{&quot;names&quot;:[&quot;show&quot;],&quot;time&quot;:200,&quot;to&quot;:null,&quot;transition&quot;:[[],[],[]]}]]"
+               "[[&quot;remove_class&quot;,{&quot;names&quot;:[&quot;show&quot;]}]]"
     end
   end
 
@@ -273,7 +269,7 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "toggle_class",
-                   %{names: ["show"], time: 200, to: nil, transition: [[], [], []]}
+                   %{names: ["show"]}
                  ]
                ]
              }
@@ -282,7 +278,7 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "toggle_class",
-                   %{names: ["show"], time: 200, to: "#modal", transition: [[], [], []]}
+                   %{names: ["show"], to: "#modal"}
                  ]
                ]
              }
@@ -293,7 +289,7 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "toggle_class",
-                   %{names: ["show", "hl"], time: 200, to: nil, transition: [[], [], []]}
+                   %{names: ["show", "hl"]}
                  ]
                ]
              }
@@ -304,7 +300,7 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "toggle_class",
-                   %{names: ["show"], time: 543, to: nil, transition: [[], [], []]}
+                   %{names: ["show"], time: 543}
                  ]
                ]
              }
@@ -315,7 +311,7 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "toggle_class",
-                   %{names: ["show"], time: 200, to: nil, transition: [["fade"], [], []]}
+                   %{names: ["show"], transition: [["fade"], [], []]}
                  ]
                ]
              }
@@ -324,7 +320,7 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "toggle_class",
-                   %{names: ["c"], time: 200, to: nil, transition: [["a", "b"], [], []]}
+                   %{names: ["c"], transition: [["a", "b"], [], []]}
                  ]
                ]
              }
@@ -335,8 +331,6 @@ defmodule Phoenix.LiveView.JSTest do
                    "toggle_class",
                    %{
                      names: ["show"],
-                     time: 200,
-                     to: nil,
                      transition: [["fade"], ["opacity-0"], ["opacity-100"]]
                    }
                  ]
@@ -351,9 +345,9 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "toggle_class",
-                   %{names: ["show"], time: 100, to: "#modal", transition: [[], [], []]}
+                   %{names: ["show"], time: 100, to: "#modal"}
                  ],
-                 ["toggle_class", %{names: ["hl"], time: 200, to: nil, transition: [[], [], []]}]
+                 ["toggle_class", %{names: ["hl"]}]
                ]
              }
     end
@@ -366,7 +360,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.toggle_class("show")) ==
-               "[[&quot;toggle_class&quot;,{&quot;names&quot;:[&quot;show&quot;],&quot;time&quot;:200,&quot;to&quot;:null,&quot;transition&quot;:[[],[],[]]}]]"
+               "[[&quot;toggle_class&quot;,{&quot;names&quot;:[&quot;show&quot;]}]]"
     end
   end
 
@@ -377,13 +371,13 @@ defmodule Phoenix.LiveView.JSTest do
              }
 
       assert JS.dispatch("click") == %JS{
-               ops: [["dispatch", %{to: nil, event: "click"}]]
+               ops: [["dispatch", %{event: "click"}]]
              }
     end
 
     test "with optional flags" do
       assert JS.dispatch("click", bubbles: false) == %JS{
-               ops: [["dispatch", %{to: nil, event: "click", bubbles: false}]]
+               ops: [["dispatch", %{event: "click", bubbles: false}]]
              }
     end
 
@@ -409,7 +403,7 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  ["dispatch", %{to: "#modal", event: "click"}],
                  ["dispatch", %{to: "#keyboard", event: "keydown"}],
-                 ["dispatch", %{to: nil, event: "keyup"}]
+                 ["dispatch", %{event: "keyup"}]
                ]
              }
     end
@@ -426,7 +420,7 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "toggle",
-                   %{display: nil, ins: [[], [], []], outs: [[], [], []], time: 200, to: "#modal"}
+                   %{to: "#modal"}
                  ]
                ]
              }
@@ -439,10 +433,8 @@ defmodule Phoenix.LiveView.JSTest do
                    [
                      "toggle",
                      %{
-                       display: nil,
                        ins: [["fade-in", "d-block"], [], []],
                        outs: [["fade-out", "d-block"], [], []],
-                       time: 200,
                        to: "#modal"
                      }
                    ]
@@ -459,10 +451,8 @@ defmodule Phoenix.LiveView.JSTest do
                    [
                      "toggle",
                      %{
-                       display: nil,
                        ins: [["fade-in"], ["opacity-0"], ["opacity-100"]],
                        outs: [["fade-out"], ["opacity-100"], ["opacity-0"]],
-                       time: 200,
                        to: "#modal"
                      }
                    ]
@@ -475,7 +465,7 @@ defmodule Phoenix.LiveView.JSTest do
                ops: [
                  [
                    "toggle",
-                   %{display: nil, ins: [[], [], []], outs: [[], [], []], time: 123, to: "#modal"}
+                   %{time: 123, to: "#modal"}
                  ]
                ]
              }
@@ -488,9 +478,6 @@ defmodule Phoenix.LiveView.JSTest do
                    "toggle",
                    %{
                      display: "block",
-                     ins: [[], [], []],
-                     outs: [[], [], []],
-                     time: 200,
                      to: "#modal"
                    }
                  ]
@@ -509,34 +496,22 @@ defmodule Phoenix.LiveView.JSTest do
 
       assert js == %JS{
                ops: [
-                 [
-                   "toggle",
-                   %{to: "#modal", display: nil, ins: [[], [], []], outs: [[], [], []], time: 200}
-                 ],
-                 [
-                   "toggle",
-                   %{
-                     to: "#keyboard",
-                     display: nil,
-                     ins: [[], [], []],
-                     outs: [[], [], []],
-                     time: 123
-                   }
-                 ]
+                 ["toggle", %{to: "#modal"}],
+                 ["toggle", %{to: "#keyboard", time: 123}]
                ]
              }
     end
 
     test "encoding" do
       assert js_to_string(JS.toggle(to: "#modal")) ==
-               "[[&quot;toggle&quot;,{&quot;display&quot;:null,&quot;ins&quot;:[[],[],[]],&quot;outs&quot;:[[],[],[]],&quot;time&quot;:200,&quot;to&quot;:&quot;#modal&quot;}]]"
+               "[[&quot;toggle&quot;,{&quot;to&quot;:&quot;#modal&quot;}]]"
     end
   end
 
   describe "show" do
     test "with defaults" do
       assert JS.show(to: "#modal") == %JS{
-               ops: [["show", %{display: nil, transition: [[], [], []], time: 200, to: "#modal"}]]
+               ops: [["show", %{to: "#modal"}]]
              }
     end
 
@@ -547,9 +522,7 @@ defmodule Phoenix.LiveView.JSTest do
                    [
                      "show",
                      %{
-                       display: nil,
                        transition: [["fade-in", "d-block"], [], []],
-                       time: 200,
                        to: "#modal"
                      }
                    ]
@@ -566,13 +539,11 @@ defmodule Phoenix.LiveView.JSTest do
                    [
                      "show",
                      %{
-                       display: nil,
                        transition: [
                          ["fade-in", "d-block"],
                          ["opacity-0", "-translate-x-full"],
                          ["opacity-100", "translate-x-0"]
                        ],
-                       time: 200,
                        to: "#modal"
                      }
                    ]
@@ -582,14 +553,14 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "custom time" do
       assert JS.show(to: "#modal", time: 123) == %JS{
-               ops: [["show", %{display: nil, transition: [[], [], []], time: 123, to: "#modal"}]]
+               ops: [["show", %{time: 123, to: "#modal"}]]
              }
     end
 
     test "custom display" do
       assert JS.show(to: "#modal", display: "block") == %JS{
                ops: [
-                 ["show", %{display: "block", transition: [[], [], []], time: 200, to: "#modal"}]
+                 ["show", %{display: "block", to: "#modal"}]
                ]
              }
     end
@@ -605,22 +576,22 @@ defmodule Phoenix.LiveView.JSTest do
 
       assert js == %JS{
                ops: [
-                 ["show", %{to: "#modal", display: nil, transition: [[], [], []], time: 200}],
-                 ["show", %{to: "#keyboard", display: nil, transition: [[], [], []], time: 123}]
+                 ["show", %{to: "#modal"}],
+                 ["show", %{to: "#keyboard", time: 123}]
                ]
              }
     end
 
     test "encoding" do
       assert js_to_string(JS.show(to: "#modal")) ==
-               "[[&quot;show&quot;,{&quot;display&quot;:null,&quot;time&quot;:200,&quot;to&quot;:&quot;#modal&quot;,&quot;transition&quot;:[[],[],[]]}]]"
+               "[[&quot;show&quot;,{&quot;to&quot;:&quot;#modal&quot;}]]"
     end
   end
 
   describe "hide" do
     test "with defaults" do
       assert JS.hide(to: "#modal") == %JS{
-               ops: [["hide", %{transition: [[], [], []], time: 200, to: "#modal"}]]
+               ops: [["hide", %{to: "#modal"}]]
              }
     end
 
@@ -632,7 +603,6 @@ defmodule Phoenix.LiveView.JSTest do
                      "hide",
                      %{
                        transition: [["fade-out", "d-block"], [], []],
-                       time: 200,
                        to: "#modal"
                      }
                    ]
@@ -654,7 +624,6 @@ defmodule Phoenix.LiveView.JSTest do
                          ["opacity-0", "-translate-x-full"],
                          ["opacity-100", "translate-x-0"]
                        ],
-                       time: 200,
                        to: "#modal"
                      }
                    ]
@@ -664,7 +633,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "custom time" do
       assert JS.hide(to: "#modal", time: 123) == %JS{
-               ops: [["hide", %{transition: [[], [], []], time: 123, to: "#modal"}]]
+               ops: [["hide", %{time: 123, to: "#modal"}]]
              }
     end
 
@@ -679,33 +648,33 @@ defmodule Phoenix.LiveView.JSTest do
 
       assert js == %JS{
                ops: [
-                 ["hide", %{to: "#modal", transition: [[], [], []], time: 200}],
-                 ["hide", %{to: "#keyboard", transition: [[], [], []], time: 123}]
+                 ["hide", %{to: "#modal"}],
+                 ["hide", %{to: "#keyboard", time: 123}]
                ]
              }
     end
 
     test "encoding" do
       assert js_to_string(JS.hide(to: "#modal")) ==
-               "[[&quot;hide&quot;,{&quot;time&quot;:200,&quot;to&quot;:&quot;#modal&quot;,&quot;transition&quot;:[[],[],[]]}]]"
+               "[[&quot;hide&quot;,{&quot;to&quot;:&quot;#modal&quot;}]]"
     end
   end
 
   describe "transition" do
     test "with defaults" do
       assert JS.transition("shake") == %JS{
-               ops: [["transition", %{transition: [["shake"], [], []], time: 200, to: nil}]]
+               ops: [["transition", %{transition: [["shake"], [], []]}]]
              }
 
       assert JS.transition("shake", to: "#modal") == %JS{
-               ops: [["transition", %{transition: [["shake"], [], []], time: 200, to: "#modal"}]]
+               ops: [["transition", %{transition: [["shake"], [], []], to: "#modal"}]]
              }
 
       assert JS.transition("shake swirl", to: "#modal") == %JS{
                ops: [
                  [
                    "transition",
-                   %{transition: [["shake", "swirl"], [], []], time: 200, to: "#modal"}
+                   %{transition: [["shake", "swirl"], [], []], to: "#modal"}
                  ]
                ]
              }
@@ -716,7 +685,6 @@ defmodule Phoenix.LiveView.JSTest do
                    "transition",
                    %{
                      transition: [["shake", "swirl"], ["opacity-0", "a"], ["opacity-100", "b"]],
-                     time: 200,
                      to: "#modal"
                    }
                  ]
@@ -741,7 +709,7 @@ defmodule Phoenix.LiveView.JSTest do
 
       assert js == %JS{
                ops: [
-                 ["transition", %{to: "#modal", transition: [["shake"], [], []], time: 200}],
+                 ["transition", %{to: "#modal", transition: [["shake"], [], []]}],
                  ["transition", %{to: "#keyboard", transition: [["hl"], [], []], time: 123}]
                ]
              }
@@ -749,7 +717,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.transition("shake", to: "#modal")) ==
-               "[[&quot;transition&quot;,{&quot;time&quot;:200,&quot;to&quot;:&quot;#modal&quot;,&quot;transition&quot;:[[&quot;shake&quot;],[],[]]}]]"
+               "[[&quot;transition&quot;,{&quot;to&quot;:&quot;#modal&quot;,&quot;transition&quot;:[[&quot;shake&quot;],[],[]]}]]"
     end
   end
 
@@ -757,7 +725,7 @@ defmodule Phoenix.LiveView.JSTest do
     test "with defaults" do
       assert JS.set_attribute({"aria-expanded", "true"}) == %JS{
                ops: [
-                 ["set_attr", %{attr: ["aria-expanded", "true"], to: nil}]
+                 ["set_attr", %{attr: ["aria-expanded", "true"]}]
                ]
              }
 
@@ -776,8 +744,8 @@ defmodule Phoenix.LiveView.JSTest do
 
       assert js == %JS{
                ops: [
-                 ["set_attr", %{to: nil, attr: ["expanded", "true"]}],
-                 ["set_attr", %{to: nil, attr: ["has-popup", "true"]}],
+                 ["set_attr", %{attr: ["expanded", "true"]}],
+                 ["set_attr", %{attr: ["has-popup", "true"]}],
                  ["set_attr", %{to: "#dropdown", attr: ["has-popup", "true"]}]
                ]
              }
@@ -791,7 +759,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.set_attribute({"disabled", "true"})) ==
-               "[[&quot;set_attr&quot;,{&quot;attr&quot;:[&quot;disabled&quot;,&quot;true&quot;],&quot;to&quot;:null}]]"
+               "[[&quot;set_attr&quot;,{&quot;attr&quot;:[&quot;disabled&quot;,&quot;true&quot;]}]]"
     end
   end
 
@@ -799,7 +767,7 @@ defmodule Phoenix.LiveView.JSTest do
     test "with defaults" do
       assert JS.remove_attribute("aria-expanded") == %JS{
                ops: [
-                 ["remove_attr", %{attr: "aria-expanded", to: nil}]
+                 ["remove_attr", %{attr: "aria-expanded"}]
                ]
              }
 
@@ -818,8 +786,8 @@ defmodule Phoenix.LiveView.JSTest do
 
       assert js == %JS{
                ops: [
-                 ["remove_attr", %{to: nil, attr: "expanded"}],
-                 ["remove_attr", %{to: nil, attr: "has-popup"}],
+                 ["remove_attr", %{attr: "expanded"}],
+                 ["remove_attr", %{attr: "has-popup"}],
                  ["remove_attr", %{to: "#dropdown", attr: "has-popup"}]
                ]
              }
@@ -833,7 +801,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.remove_attribute("disabled")) ==
-               "[[&quot;remove_attr&quot;,{&quot;attr&quot;:&quot;disabled&quot;,&quot;to&quot;:null}]]"
+               "[[&quot;remove_attr&quot;,{&quot;attr&quot;:&quot;disabled&quot;}]]"
     end
   end
 
@@ -841,7 +809,7 @@ defmodule Phoenix.LiveView.JSTest do
     test "with defaults" do
       assert JS.toggle_attribute({"open", "true"}) == %JS{
                ops: [
-                 ["toggle_attr", %{attr: ["open", "true"], to: nil}]
+                 ["toggle_attr", %{attr: ["open", "true"]}]
                ]
              }
 
@@ -867,8 +835,8 @@ defmodule Phoenix.LiveView.JSTest do
 
       assert js == %JS{
                ops: [
-                 ["toggle_attr", %{to: nil, attr: ["aria-expanded", "true", "false"]}],
-                 ["toggle_attr", %{to: nil, attr: ["open", "true"]}],
+                 ["toggle_attr", %{attr: ["aria-expanded", "true", "false"]}],
+                 ["toggle_attr", %{attr: ["open", "true"]}],
                  ["toggle_attr", %{to: "#dropdown", attr: ["disabled", "true"]}]
                ]
              }
@@ -882,16 +850,16 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.toggle_attribute({"disabled", "true"})) ==
-               "[[&quot;toggle_attr&quot;,{&quot;attr&quot;:[&quot;disabled&quot;,&quot;true&quot;],&quot;to&quot;:null}]]"
+               "[[&quot;toggle_attr&quot;,{&quot;attr&quot;:[&quot;disabled&quot;,&quot;true&quot;]}]]"
 
       assert js_to_string(JS.toggle_attribute({"aria-expanded", "true", "false"})) ==
-               "[[&quot;toggle_attr&quot;,{&quot;attr&quot;:[&quot;aria-expanded&quot;,&quot;true&quot;,&quot;false&quot;],&quot;to&quot;:null}]]"
+               "[[&quot;toggle_attr&quot;,{&quot;attr&quot;:[&quot;aria-expanded&quot;,&quot;true&quot;,&quot;false&quot;]}]]"
     end
   end
 
   describe "focus" do
     test "with defaults" do
-      assert JS.focus() == %JS{ops: [["focus", %{to: nil}]]}
+      assert JS.focus() == %JS{ops: [["focus", %{}]]}
       assert JS.focus(to: "input") == %JS{ops: [["focus", %{to: "input"}]]}
     end
 
@@ -901,7 +869,7 @@ defmodule Phoenix.LiveView.JSTest do
         |> JS.focus()
 
       assert js == %JS{
-               ops: [["set_attr", %{attr: ["expanded", "true"], to: nil}], ["focus", %{to: nil}]]
+               ops: [["set_attr", %{attr: ["expanded", "true"]}], ["focus", %{}]]
              }
     end
 
@@ -912,13 +880,13 @@ defmodule Phoenix.LiveView.JSTest do
     end
 
     test "encoding" do
-      assert js_to_string(JS.focus()) == "[[&quot;focus&quot;,{&quot;to&quot;:null}]]"
+      assert js_to_string(JS.focus()) == "[[&quot;focus&quot;,{}]]"
     end
   end
 
   describe "focus_first" do
     test "with defaults" do
-      assert JS.focus_first() == %JS{ops: [["focus_first", %{to: nil}]]}
+      assert JS.focus_first() == %JS{ops: [["focus_first", %{}]]}
       assert JS.focus_first(to: "input") == %JS{ops: [["focus_first", %{to: "input"}]]}
     end
 
@@ -929,8 +897,8 @@ defmodule Phoenix.LiveView.JSTest do
 
       assert js == %JS{
                ops: [
-                 ["set_attr", %{attr: ["expanded", "true"], to: nil}],
-                 ["focus_first", %{to: nil}]
+                 ["set_attr", %{attr: ["expanded", "true"]}],
+                 ["focus_first", %{}]
                ]
              }
     end
@@ -942,13 +910,13 @@ defmodule Phoenix.LiveView.JSTest do
     end
 
     test "encoding" do
-      assert js_to_string(JS.focus_first()) == "[[&quot;focus_first&quot;,{&quot;to&quot;:null}]]"
+      assert js_to_string(JS.focus_first()) == "[[&quot;focus_first&quot;,{}]]"
     end
   end
 
   describe "push_focus" do
     test "with defaults" do
-      assert JS.push_focus() == %JS{ops: [["push_focus", %{to: nil}]]}
+      assert JS.push_focus() == %JS{ops: [["push_focus", %{}]]}
       assert JS.push_focus(to: "input") == %JS{ops: [["push_focus", %{to: "input"}]]}
     end
 
@@ -959,8 +927,8 @@ defmodule Phoenix.LiveView.JSTest do
 
       assert js == %JS{
                ops: [
-                 ["set_attr", %{attr: ["expanded", "true"], to: nil}],
-                 ["push_focus", %{to: nil}]
+                 ["set_attr", %{attr: ["expanded", "true"]}],
+                 ["push_focus", %{}]
                ]
              }
     end
@@ -972,7 +940,7 @@ defmodule Phoenix.LiveView.JSTest do
     end
 
     test "encoding" do
-      assert js_to_string(JS.push_focus()) == "[[&quot;push_focus&quot;,{&quot;to&quot;:null}]]"
+      assert js_to_string(JS.push_focus()) == "[[&quot;push_focus&quot;,{}]]"
     end
   end
 
@@ -987,7 +955,7 @@ defmodule Phoenix.LiveView.JSTest do
         |> JS.pop_focus()
 
       assert js == %JS{
-               ops: [["set_attr", %{attr: ["expanded", "true"], to: nil}], ["pop_focus", %{}]]
+               ops: [["set_attr", %{attr: ["expanded", "true"]}], ["pop_focus", %{}]]
              }
     end
 


### PR DESCRIPTION
Closes #2600.

Removing all nil values should work fine as the values on the client are just going to be undefined instead of null then.

Maybe I should add some e2e tests as well? Wdyt?