### PR TITLE
Fix open_browser not working on WSL for project under unix FS

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1573,7 +1573,17 @@ defmodule Phoenix.LiveViewTest do
           {"open", [path]}
 
         {:unix, _} ->
-          {"xdg-open", [path]}
+          if System.find_executable("cmd.exe") do
+            win_path_regex = ~r{^\\(?:\\[^\\]+\\)*([^<>:]*)$}x
+            if Regex.match?(win_path_regex, path) do
+              # Use cmd.exe for WSL with project dir under windows path
+              {"cmd.exe", ["/c", "start", path]}
+            else
+              {"xdg-open", [path]}
+            end
+          else
+            {"xdg-open", [path]}
+          end
       end
 
     System.cmd(cmd, args)

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1574,8 +1574,7 @@ defmodule Phoenix.LiveViewTest do
 
         {:unix, _} ->
           if System.find_executable("cmd.exe") do
-            win_path_regex = ~r/\\/
-            if Regex.match?(win_path_regex, path) do
+            if path =~ "\\" do
               # Use cmd.exe for WSL with project dir under windows path
               {"cmd.exe", ["/c", "start", path]}
             else

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1573,13 +1573,9 @@ defmodule Phoenix.LiveViewTest do
           {"open", [path]}
 
         {:unix, _} ->
-          if System.find_executable("cmd.exe") do
-            if path =~ "\\" do
-              # Use cmd.exe for WSL with project dir under windows path
-              {"cmd.exe", ["/c", "start", path]}
-            else
-              {"xdg-open", [path]}
-            end
+          if path =~ "\\" and System.find_executable("cmd.exe") != nil do
+            # Use cmd.exe for WSL with project dir under Windows path
+            {"cmd.exe", ["/c", "start", path]}
           else
             {"xdg-open", [path]}
           end

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1573,11 +1573,7 @@ defmodule Phoenix.LiveViewTest do
           {"open", [path]}
 
         {:unix, _} ->
-          if System.find_executable("cmd.exe") do
-            {"cmd.exe", ["/c", "start", path]}
-          else
-            {"xdg-open", [path]}
-          end
+          {"xdg-open", [path]}
       end
 
     System.cmd(cmd, args)

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1574,7 +1574,7 @@ defmodule Phoenix.LiveViewTest do
 
         {:unix, _} ->
           if System.find_executable("cmd.exe") do
-            win_path_regex = ~r{^\\(?:\\[^\\]+\\)*([^<>:]*)$}x
+            win_path_regex = ~r/^([^\\]+\\)*?$/
             if Regex.match?(win_path_regex, path) do
               # Use cmd.exe for WSL with project dir under windows path
               {"cmd.exe", ["/c", "start", path]}

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1574,7 +1574,7 @@ defmodule Phoenix.LiveViewTest do
 
         {:unix, _} ->
           if System.find_executable("cmd.exe") do
-            win_path_regex = ~r/^([^\\]+\\)*?$/
+            win_path_regex = ~r/\\/
             if Regex.match?(win_path_regex, path) do
               # Use cmd.exe for WSL with project dir under windows path
               {"cmd.exe", ["/c", "start", path]}


### PR DESCRIPTION
- Fixes #3063
- I am not sure why `cmd.exe` check was done for `unix` condition (could find it was added here https://github.com/phoenixframework/phoenix_live_view/commit/a6494c579d4750da9b437f35907d7e87aa5cf579 by @josevalim). But even if it is for the WSL case, it is not working. I think the better way is to treat WSL as another variant of Linux and use the same flow.