### PR TITLE
Update example to use types that ExAws expects

### DIFF
--- a/guides/client/uploads-external.md
+++ b/guides/client/uploads-external.md
@@ -268,7 +268,7 @@ def presign_upload(entry, socket) do
   {:ok, url} =
     ExAws.S3.presigned_url(config, :put, bucket, key,
       expires_in: 3600,
-      query_params: ["Content-Type": entry.client_type]
+      query_params: [{"Content-Type", entry.client_type}]
     )
    {:ok, %{uploader: "S3", key: key, url: url}, socket}
 end


### PR DESCRIPTION
Matches the type signature for what ExAws expects with presigning the upload URL.