### PR TITLE
Refactor stream handling in LiveViewTest

### DIFF
--- a/lib/phoenix_live_view/test/dom.ex
+++ b/lib/phoenix_live_view/test/dom.ex
@@ -427,7 +427,7 @@ defmodule Phoenix.LiveViewTest.DOM do
 
     cond do
       # reorder and/or remove stream children
-      content_changed? && type == "stream" ->
+      content_changed? && type == "stream" && !Enum.empty?(streams) ->
         children = updated_existing_children ++ updated_appended
 
         # we always reduce over all streams, even if only one of them is actually relevant
@@ -499,6 +499,10 @@ defmodule Phoenix.LiveViewTest.DOM do
           end)
 
         {tag, attrs, new_children}
+
+      content_changed? && type == "stream" ->
+        # return the current children, they are probably from a nested LV
+        {tag, attrs, updated_existing_children ++ updated_appended}
 
       content_changed? && type == "append" ->
         {tag, attrs, updated_existing_children ++ updated_appended}

--- a/test/phoenix_live_view/integrations/stream_test.exs
+++ b/test/phoenix_live_view/integrations/stream_test.exs
@@ -180,6 +180,24 @@ defmodule Phoenix.LiveView.StreamTest do
     assert has_element?(lv, "li", "Oranges")
   end
 
+  describe "within nested lv" do
+    test "does not clear stream when parent updates", %{conn: conn} do
+      {:ok, lv, html} = live(conn, "/stream/nested")
+      lv = find_live_child(lv, "nested")
+
+      # let the parent update
+      Process.sleep(100)
+
+      assert ids_in_ul_list(render(lv)) == ["items-a", "items-b", "items-c", "items-d"]
+
+      html = assert lv |> element("button", "Filter") |> render_click()
+      assert ids_in_ul_list(html) == ["items-b", "items-c", "items-d"]
+
+      html = assert lv |> element("button", "Reset") |> render_click()
+      assert ids_in_ul_list(html) == ["items-a", "items-b", "items-c", "items-d"]
+    end
+  end
+
   describe "issue #2994" do
     test "can filter and reset a stream", %{conn: conn} do
       {:ok, lv, html} = live(conn, "/stream/reset")

--- a/test/phoenix_live_view/integrations/stream_test.exs
+++ b/test/phoenix_live_view/integrations/stream_test.exs
@@ -182,7 +182,7 @@ defmodule Phoenix.LiveView.StreamTest do
 
   describe "within nested lv" do
     test "does not clear stream when parent updates", %{conn: conn} do
-      {:ok, lv, html} = live(conn, "/stream/nested")
+      {:ok, lv, _html} = live(conn, "/stream/nested")
       lv = find_live_child(lv, "nested")
 
       # let the parent update

--- a/test/phoenix_live_view/integrations/stream_test.exs
+++ b/test/phoenix_live_view/integrations/stream_test.exs
@@ -327,7 +327,9 @@ defmodule Phoenix.LiveView.StreamTest do
       assert_pruned_stream(lv)
     end
 
-    test "issue #2982 - can reorder a stream with LiveComponents as direct stream children", %{conn: conn} do
+    test "issue #2982 - can reorder a stream with LiveComponents as direct stream children", %{
+      conn: conn
+    } do
       {:ok, lv, html} = live(conn, "/stream/reset-lc")
 
       assert ids_in_ul_list(html) == ["items-a", "items-b", "items-c", "items-d"]
@@ -343,7 +345,16 @@ defmodule Phoenix.LiveView.StreamTest do
     assert ids_in_ul_list(html) == ["items-a", "items-b", "items-c", "items-d"]
 
     html = assert lv |> element("button", "Bulk insert") |> render_click()
-    assert ids_in_ul_list(html) == ["items-a", "items-e", "items-f", "items-g", "items-b", "items-c", "items-d"]
+
+    assert ids_in_ul_list(html) == [
+             "items-a",
+             "items-e",
+             "items-f",
+             "items-g",
+             "items-b",
+             "items-c",
+             "items-d"
+           ]
   end
 
   test "any stream insert for elements already in the DOM does not reorder", %{conn: conn} do
@@ -378,9 +389,28 @@ defmodule Phoenix.LiveView.StreamTest do
            end) =~ ~r/streams can only be consumed directly by a for comprehension/
   end
 
+  test "stream raises when there are items with invalid IDs", %{conn: conn} do
+    {:ok, lv, _html} = live(conn, "/stream")
+
+    assert Phoenix.LiveViewTest.HooksLive.exits_with(lv, ArgumentError, fn ->
+             render_click(lv, "stream-invalid-ids", %{}) |> IO.inspect()
+           end) =~
+             ~r/a container with phx-update=\"stream\" must only contain stream children with the id set to the `dom_id` of the stream item/
+  end
+
+  test "stream raises when non stream items are in container", %{conn: conn} do
+    {:ok, lv, _html} = live(conn, "/stream")
+
+    assert Phoenix.LiveViewTest.HooksLive.exits_with(lv, ArgumentError, fn ->
+             render_click(lv, "stream-invalid-item", %{}) |> IO.inspect()
+           end) =~
+             ~r/a container with phx-update=\"stream\" must only contain stream children with the id set to the `dom_id` of the stream item/
+  end
+
   describe "limit" do
     test "limit is enforced on mount, but not dead render", %{conn: conn} do
       conn = get(conn, "/stream/limit")
+
       assert html_response(conn, 200) |> ids_in_ul_list() == [
                "items-1",
                "items-2",
@@ -392,167 +422,173 @@ defmodule Phoenix.LiveView.StreamTest do
                "items-8",
                "items-9",
                "items-10"
-            ]
+             ]
 
       {:ok, _lv, html} = live(conn)
 
       assert ids_in_ul_list(html) == [
-        "items-6",
-        "items-7",
-        "items-8",
-        "items-9",
-        "items-10"
-      ]
+               "items-6",
+               "items-7",
+               "items-8",
+               "items-9",
+               "items-10"
+             ]
     end
 
     test "removes item at front when appending and limit is negative", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/stream/limit")
 
-      assert lv |> render_hook("configure", %{"at" => "-1", "limit" => "-5"}) |> ids_in_ul_list()== [
-        "items-6",
-        "items-7",
-        "items-8",
-        "items-9",
-        "items-10"
-      ]
+      assert lv |> render_hook("configure", %{"at" => "-1", "limit" => "-5"}) |> ids_in_ul_list() ==
+               [
+                 "items-6",
+                 "items-7",
+                 "items-8",
+                 "items-9",
+                 "items-10"
+               ]
 
-      assert lv |> render_hook("insert_1") |> ids_in_ul_list()== [
-        "items-7",
-        "items-8",
-        "items-9",
-        "items-10",
-        "items-11"
-      ]
+      assert lv |> render_hook("insert_1") |> ids_in_ul_list() == [
+               "items-7",
+               "items-8",
+               "items-9",
+               "items-10",
+               "items-11"
+             ]
 
-      assert lv |> render_hook("insert_10") |> ids_in_ul_list()== [
-        "items-17",
-        "items-18",
-        "items-19",
-        "items-20",
-        "items-21"
-      ]
+      assert lv |> render_hook("insert_10") |> ids_in_ul_list() == [
+               "items-17",
+               "items-18",
+               "items-19",
+               "items-20",
+               "items-21"
+             ]
     end
 
     test "removes item at back when prepending and limit is positive", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/stream/limit")
 
-      assert lv |> render_hook("configure", %{"at" => "0", "limit" => "5"}) |> ids_in_ul_list() == [
-        "items-10",
-        "items-9",
-        "items-8",
-        "items-7",
-        "items-6"
-      ]
+      assert lv |> render_hook("configure", %{"at" => "0", "limit" => "5"}) |> ids_in_ul_list() ==
+               [
+                 "items-10",
+                 "items-9",
+                 "items-8",
+                 "items-7",
+                 "items-6"
+               ]
 
-      assert lv |> render_hook("insert_1") |> ids_in_ul_list()== [
-        "items-11",
-        "items-10",
-        "items-9",
-        "items-8",
-        "items-7"
-      ]
+      assert lv |> render_hook("insert_1") |> ids_in_ul_list() == [
+               "items-11",
+               "items-10",
+               "items-9",
+               "items-8",
+               "items-7"
+             ]
 
-      assert lv |> render_hook("insert_10") |> ids_in_ul_list()== [
-        "items-21",
-        "items-20",
-        "items-19",
-        "items-18",
-        "items-17"
-      ]
+      assert lv |> render_hook("insert_10") |> ids_in_ul_list() == [
+               "items-21",
+               "items-20",
+               "items-19",
+               "items-18",
+               "items-17"
+             ]
     end
 
     test "does nothing if appending and positive limit is reached", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/stream/limit")
 
-      assert lv |> render_hook("configure", %{"at" => "-1", "limit" => "5"}) |> ids_in_ul_list() == [
-        "items-1",
-        "items-2",
-        "items-3",
-        "items-4",
-        "items-5"
-      ]
+      assert lv |> render_hook("configure", %{"at" => "-1", "limit" => "5"}) |> ids_in_ul_list() ==
+               [
+                 "items-1",
+                 "items-2",
+                 "items-3",
+                 "items-4",
+                 "items-5"
+               ]
 
       # adding new items should do nothing, as the limit is reached
-      assert lv |> render_hook("insert_1") |> ids_in_ul_list()== [
-        "items-1",
-        "items-2",
-        "items-3",
-        "items-4",
-        "items-5"
-      ]
+      assert lv |> render_hook("insert_1") |> ids_in_ul_list() == [
+               "items-1",
+               "items-2",
+               "items-3",
+               "items-4",
+               "items-5"
+             ]
 
       assert lv |> render_hook("insert_10") |> ids_in_ul_list() == [
-        "items-1",
-        "items-2",
-        "items-3",
-        "items-4",
-        "items-5"
-      ]
+               "items-1",
+               "items-2",
+               "items-3",
+               "items-4",
+               "items-5"
+             ]
     end
 
     test "does nothing if prepending and negative limit is reached", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/stream/limit")
 
-      assert lv |> render_hook("configure", %{"at" => "0", "limit" => "-5"}) |> ids_in_ul_list() == [
-        "items-5",
-        "items-4",
-        "items-3",
-        "items-2",
-        "items-1"
-      ]
+      assert lv |> render_hook("configure", %{"at" => "0", "limit" => "-5"}) |> ids_in_ul_list() ==
+               [
+                 "items-5",
+                 "items-4",
+                 "items-3",
+                 "items-2",
+                 "items-1"
+               ]
 
       # adding new items should do nothing, as the limit is reached
-      assert lv |> render_hook("insert_1") |> ids_in_ul_list()== [
-        "items-5",
-        "items-4",
-        "items-3",
-        "items-2",
-        "items-1"
-      ]
+      assert lv |> render_hook("insert_1") |> ids_in_ul_list() == [
+               "items-5",
+               "items-4",
+               "items-3",
+               "items-2",
+               "items-1"
+             ]
 
       assert lv |> render_hook("insert_10") |> ids_in_ul_list() == [
-        "items-5",
-        "items-4",
-        "items-3",
-        "items-2",
-        "items-1"
-      ]
+               "items-5",
+               "items-4",
+               "items-3",
+               "items-2",
+               "items-1"
+             ]
     end
 
     test "arbitrary index", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/stream/limit")
 
-      assert lv |> render_hook("configure", %{"at" => "1", "limit" => "5"}) |> ids_in_ul_list() == [
-        "items-1",
-        "items-10",
-        "items-9",
-        "items-8",
-        "items-7"
-      ]
-
-      assert lv |> render_hook("insert_10") |> ids_in_ul_list()== [
-        "items-1",
-        "items-20",
-        "items-19",
-        "items-18",
-        "items-17"
-      ]
-
-      assert lv |> render_hook("configure", %{"at" => "1", "limit" => "-5"}) |> ids_in_ul_list() == [
-        "items-10",
-        "items-5",
-        "items-4",
-        "items-3",
-        "items-2"
-      ]
+      assert lv |> render_hook("configure", %{"at" => "1", "limit" => "5"}) |> ids_in_ul_list() ==
+               [
+                 "items-1",
+                 "items-10",
+                 "items-9",
+                 "items-8",
+                 "items-7"
+               ]
 
       assert lv |> render_hook("insert_10") |> ids_in_ul_list() == [
-        "items-20",
-        "items-5",
-        "items-4",
-        "items-3",
-        "items-2"
-      ]
+               "items-1",
+               "items-20",
+               "items-19",
+               "items-18",
+               "items-17"
+             ]
+
+      assert lv |> render_hook("configure", %{"at" => "1", "limit" => "-5"}) |> ids_in_ul_list() ==
+               [
+                 "items-10",
+                 "items-5",
+                 "items-4",
+                 "items-3",
+                 "items-2"
+               ]
+
+      assert lv |> render_hook("insert_10") |> ids_in_ul_list() == [
+               "items-20",
+               "items-5",
+               "items-4",
+               "items-3",
+               "items-2"
+             ]
     end
   end
 

--- a/test/support/live_views/streams.ex
+++ b/test/support/live_views/streams.ex
@@ -7,7 +7,24 @@ defmodule Phoenix.LiveViewTest.StreamLive do
 
   def render(%{invalid_consume: true} = assigns) do
     ~H"""
-    <div :for={{id, _user} <- Enum.map(@streams.users, &(&1))} id={id} />
+    <div :for={{id, _user} <- Enum.map(@streams.users, & &1)} id={id} />
+    """
+  end
+
+  def render(%{invalid_ids: true} = assigns) do
+    ~H"""
+    <div id="users" phx-update="stream">
+      <div :for={{id, _user} <- @streams.users} id={"prefixed-#{id}"} />
+    </div>
+    """
+  end
+
+  def render(%{invalid_item: true} = assigns) do
+    ~H"""
+    <div id="users" phx-update="stream">
+      <div :for={{id, _user} <- @streams.users} id={id} />
+      <div id="another-item"></div>
+    </div>
     """
   end
 
@@ -20,7 +37,9 @@ defmodule Phoenix.LiveViewTest.StreamLive do
         <button phx-click="update" phx-value-id={id}>update</button>
         <button phx-click="move-to-first" phx-value-id={id}>make first</button>
         <button phx-click="move-to-last" phx-value-id={id}>make last</button>
-        <button phx-click="move" phx-value-id={id} phx-value-name="moved" phx-value-at="1">move</button>
+        <button phx-click="move" phx-value-id={id} phx-value-name="moved" phx-value-at="1">
+          move
+        </button>
       </div>
     </div>
     <div id="admins" phx-update="stream">
@@ -53,6 +72,8 @@ defmodule Phoenix.LiveViewTest.StreamLive do
     {:ok,
      socket
      |> assign(:invalid_consume, false)
+     |> assign(:invalid_ids, false)
+     |> assign(:invalid_item, false)
      |> stream(:users, @users)
      |> stream(:admins, [user(1, "chris-admin"), user(2, "callan-admin")])}
   end
@@ -134,6 +155,14 @@ defmodule Phoenix.LiveViewTest.StreamLive do
 
   def handle_event("consume-stream-invalid", _, socket) do
     {:noreply, assign(socket, :invalid_consume, true)}
+  end
+
+  def handle_event("stream-invalid-ids", _, socket) do
+    {:noreply, assign(socket, :invalid_ids, true) |> stream(:users, @users)}
+  end
+
+  def handle_event("stream-invalid-item", _, socket) do
+    {:noreply, assign(socket, :invalid_item, true) |> stream(:users, @users)}
   end
 
   def handle_call({:run, func}, _, socket), do: func.(socket)
@@ -286,7 +315,7 @@ defmodule Phoenix.LiveViewTest.StreamResetLive do
   def render(assigns) do
     ~H"""
     <ul phx-update="stream" id="thelist">
-      <li id={id} :for={{id, item} <- @streams.items}>
+      <li :for={{id, item} <- @streams.items} id={id}>
         <%= item.name %>
       </li>
     </ul>
@@ -483,7 +512,12 @@ defmodule Phoenix.LiveViewTest.StreamResetLCLive do
   def render(assigns) do
     ~H"""
     <ul phx-update="stream" id="thelist">
-      <.live_component module={InnerComponent} id={id} item={item} :for={{id, item} <- @streams.items}/>
+      <.live_component
+        :for={{id, item} <- @streams.items}
+        module={InnerComponent}
+        id={id}
+        item={item}
+      />
     </ul>
 
     <button phx-click="reorder">Reorder</button>
@@ -506,8 +540,8 @@ defmodule Phoenix.LiveViewTest.StreamLimitLive do
   def render(assigns) do
     ~H"""
     <form phx-submit="configure">
-      at: <input type="text" name="at" value={@at}/>
-      limit: <input type="text" name="limit" value={@limit}/>
+      at: <input type="text" name="at" value={@at} /> limit:
+      <input type="text" name="limit" value={@limit} />
       <button type="submit">recreate stream</button>
     </form>
 
@@ -588,7 +622,7 @@ defmodule Phoenix.LiveViewTest.StreamNestedLive do
   end
 
   def handle_info(:tick, socket) do
-    {:noreply, update(socket, :foo, & &1 + 1)}
+    {:noreply, update(socket, :foo, &(&1 + 1))}
   end
 
   def render(assigns) do

--- a/test/support/live_views/streams.ex
+++ b/test/support/live_views/streams.ex
@@ -577,3 +577,26 @@ defmodule Phoenix.LiveViewTest.StreamLimitLive do
     |> stream(:items, items, opts)
   end
 end
+
+defmodule Phoenix.LiveViewTest.StreamNestedLive do
+  use Phoenix.LiveView
+
+  def mount(_params, _session, socket) do
+    :timer.send_interval(50, self(), :tick)
+
+    {:ok, assign(socket, :foo, 1)}
+  end
+
+  def handle_info(:tick, socket) do
+    {:noreply, update(socket, :foo, & &1 + 1)}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div id="nested-container">
+      <%= @foo %>
+      <%= live_render(@socket, Phoenix.LiveViewTest.StreamResetLive, id: "nested") %>
+    </div>
+    """
+  end
+end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -127,6 +127,7 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/stream/reset", StreamResetLive
     live "/stream/reset-lc", StreamResetLCLive
     live "/stream/limit", StreamLimitLive
+    live "/stream/nested", StreamNestedLive
 
     # healthy
     live "/healthy/:category", HealthyLive


### PR DESCRIPTION
This PR refactors the handling of streams in LiveViewTest to make it easier to understand. I mirrored the handling of streams in the JavaScript client, minus the morphdom related stuff.

It also adds a clause that *should*  handle the case of nested LiveViews where the LV parent updates. Currently, streams inside the child LV would be cleared. This *may* be a solution for that, although I'm not sure.