### PR TITLE
fix isInViewport

### DIFF
--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -25,13 +25,17 @@ let JS = {
     return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length > 0)
   },
 
+  // returns true if any part of the element is inside the viewport
   isInViewport(el){
     const rect = el.getBoundingClientRect()
+    const windowHeight = window.innerHeight || document.documentElement.clientHeight
+    const windowWidth = window.innerWidth || document.documentElement.clientWidth
+
     return (
-      rect.top >= 0 &&
-        rect.left >= 0 &&
-        rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-        rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+      rect.right > 0 &&
+      rect.bottom > 0 &&
+      rect.left < windowWidth &&
+      rect.top < windowHeight
     )
   },
 


### PR DESCRIPTION
This adjusts isInViewport to only return false when the whole element is outside the viewport.

Fixes #3091.
Relates to #2928.
Relates to #2929.