### PR TITLE
Update Uploads guide code example for consistency

### DIFF
--- a/guides/server/uploads.md
+++ b/guides/server/uploads.md
@@ -140,8 +140,8 @@ spec will contain errors. Use
 helper function to render a friendly error message:
 
 ```elixir
-def error_to_string(:too_large), do: "Too large"
-def error_to_string(:not_accepted), do: "You have selected an unacceptable file type"
+defp error_to_string(:too_large), do: "Too large"
+defp error_to_string(:not_accepted), do: "You have selected an unacceptable file type"
 ```
 
 For error messages that affect all entries, use
@@ -149,7 +149,7 @@ For error messages that affect all entries, use
 helper function to render a friendly error message:
 
 ```elixir
-def error_to_string(:too_many_files), do: "You have selected too many files"
+defp error_to_string(:too_many_files), do: "You have selected too many files"
 ```
 
 ### Cancel an entry


### PR DESCRIPTION
The appendix defines `error_to_string/1` as a private function, so this does the same for the earlier appearance of that function.