### PR TITLE
Ensure streams are always present in LiveViewTest

### DIFF
--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -721,10 +721,11 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
         {:ok, view} ->
           rendered = DOM.merge_diff(view.rendered, diff)
           new_view = %ClientProxy{view | rendered: rendered}
+          streams = DOM.extract_streams(rendered, rendered.streams)
 
           %{state | views: Map.update!(state.views, topic, fn _ -> new_view end)}
-          |> patch_view(new_view, DOM.render_diff(rendered), rendered.streams)
-          |> detect_added_or_removed_children(new_view, html_before, rendered.streams)
+          |> patch_view(new_view, DOM.render_diff(rendered), streams)
+          |> detect_added_or_removed_children(new_view, html_before, streams)
 
         :error ->
           state
@@ -758,6 +759,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
     |> Enum.reduce(state, fn {id, session, static}, acc ->
       case fetch_view_by_id(acc, id) do
         {:ok, view} ->
+          streams = DOM.extract_streams(view.rendered, streams)
           patch_view(acc, view, DOM.inner_html!(html_before, view.id), streams)
 
         :error ->
@@ -765,6 +767,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
           child_view = build_child(view, id: id, session_token: session, static_token: static)
 
           {child_view, rendered, _resp} = mount_view(acc, child_view, nil, nil)
+          streams = DOM.extract_streams(rendered, streams)
 
           acc
           |> put_view(child_view, rendered)

--- a/lib/phoenix_live_view/test/dom.ex
+++ b/lib/phoenix_live_view/test/dom.ex
@@ -260,14 +260,14 @@ defmodule Phoenix.LiveViewTest.DOM do
   defp deep_merge_diff(_target, source),
     do: source
 
-  defp extract_streams(%{} = source, streams) do
+  def extract_streams(%{} = source, streams) do
     Enum.reduce(source, streams, fn
       {@stream_id, stream}, acc -> [stream | acc]
       {_key, value}, acc -> extract_streams(value, acc)
     end)
   end
 
-  defp extract_streams(_value, acc), do: acc
+  def extract_streams(_value, acc), do: acc
 
   # Diff rendering
 
@@ -408,12 +408,6 @@ defmodule Phoenix.LiveViewTest.DOM do
       !content_changed? ->
         {tag, attrs, updated_appended}
     end
-  end
-
-  # return the children as is if there are no entries in the list of streams;
-  # this could be caused by an update in a parent live view
-  defp apply_phx_update("stream", _html_tree, {tag, attrs, appended_children} = _node, []) do
-    {tag, attrs, appended_children}
   end
 
   defp apply_phx_update("stream", html_tree, {tag, attrs, appended_children} = node, streams) do

--- a/test/phoenix_live_view/integrations/stream_test.exs
+++ b/test/phoenix_live_view/integrations/stream_test.exs
@@ -407,6 +407,25 @@ defmodule Phoenix.LiveView.StreamTest do
              ~r/a container with phx-update=\"stream\" must only contain stream children with the id set to the `dom_id` of the stream item/
   end
 
+  test "handles high frequency updates properly", %{conn: conn} do
+    {:ok, lv, _html} = live(conn, "/stream/high-frequency-stream-and-non-stream-updates")
+
+    for _i <- 1..50 do
+      assert lv |> render_hook("insert_item")
+      Process.sleep(10)
+    end
+
+    [{_tag, _attributes, children}] = render(lv) |> Floki.find("#mystream")
+    assert length(children) == 50
+
+    # wait for more updates
+    Process.sleep(100)
+
+    # we should still have 50 items
+    [{_tag, _attributes, children}] = render(lv) |> Floki.find("#mystream")
+    assert length(children) == 50
+  end
+
   describe "limit" do
     test "limit is enforced on mount, but not dead render", %{conn: conn} do
       conn = get(conn, "/stream/limit")

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -128,6 +128,7 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/stream/reset-lc", StreamResetLCLive
     live "/stream/limit", StreamLimitLive
     live "/stream/nested", StreamNestedLive
+    live "/stream/high-frequency-stream-and-non-stream-updates", HighFrequencyStreamAndNoStreamUpdatesLive
 
     # healthy
     live "/healthy/:category", HealthyLive


### PR DESCRIPTION
So apparently there were situations where updates to other parts of the DOM would lead to apply_phx_update being called with an empty streams list, despite changes in the children. As far as I understand this is caused by merge_diff only extracting streams from the new diff, but there could still be stream changes in the existing rendered state that would lead to DOM updates. Extracting the streams from the rendered again in merge_rendered fixes this.

Fixes #3100.
Relates to #3078.

I did not find any situation where apply_phx_update is called with empty streams after this change, so it **could** be fixed now. Someone with more insights into the inner workings of LiveViewTest should check if this makes any sense. I added a test case that fails with the old code.