### PR TITLE
fix singular throttle event dispatched two times

### DIFF
--- a/assets/test/debounce_test.js
+++ b/assets/test/debounce_test.js
@@ -240,6 +240,25 @@ describe("throttle", function (){
       done()
     })
   })
+
+  test("triggers only once when there is only one event", done => {
+    let calls = 0
+    let el = container().querySelector("#throttle-200")
+
+    el.addEventListener("click", e => {
+      DOM.debounce(el, e, "phx-debounce", 100, "phx-throttle", 200, () => true, () => {
+        calls++
+        el.innerText = `now:${calls}`
+      })
+    })
+    DOM.dispatchEvent(el, "click")
+    expect(calls).toBe(1)
+    expect(el.innerText).toBe("now:1")
+    after(250, () => {
+      expect(calls).toBe(1)
+      done()
+    })
+  })
 })
 
 


### PR DESCRIPTION
Relates to: #3097

So, in #3097 I changed the throttle behavior to also dispatch an event after the throttle time has passed to make sure that the last event is dispatched. However, this caused the event to be dispatched twice in the case that there was only one event in the first place.

This fixes that, although the throttle code is still a bit of a mess and should probably be refactored completely at some point.