### PR TITLE
Lazily initialize page_title on test client

### DIFF
--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -143,7 +143,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
       session: session,
       test_supervisor: test_supervisor,
       url: url,
-      page_title: root_page_title(root_html)
+      page_title: :unset
     }
 
     try do
@@ -481,6 +481,11 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
     :ok = Phoenix.LiveView.Channel.ping(pid)
     send(self(), {:sync_render_event, el, :upload_progress, payload, from})
     {:reply, :ok, state}
+  end
+
+  def handle_call(:page_title, _from, %{page_title: :unset} = state) do
+    state = %{state | page_title: root_page_title(state.html)}
+    {:reply, {:ok, state.page_title}, state}
   end
 
   def handle_call(:page_title, _from, state) do

--- a/test/phoenix_live_view/integrations/layout_test.exs
+++ b/test/phoenix_live_view/integrations/layout_test.exs
@@ -76,6 +76,10 @@ defmodule Phoenix.LiveView.LayoutTest do
     {:ok, view, _html} = live(conn, "/styled-elements")
     assert page_title(view) == "Styled"
 
+    {:ok, view, _html} = live(conn, "/styled-elements")
+    render_click(view, "#live-push-patch-button")
+    assert page_title(view) == "Styled"
+
     {:ok, no_title_tag_view, _html} = live(conn, "/parent_layout")
     assert page_title(no_title_tag_view) == nil
   end


### PR DESCRIPTION
Today on each test client startup, Phoenix does a search to get the page title. To avoid this cost when the test doesn't need the title, this PR moves the page title search to be done only when the this value gets requested, and if the value hasn't been set by the LiveView.