### PR TITLE
Morph DOM nodes when restoring stream items

### DIFF
--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -57,6 +57,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/stream/reset", StreamResetLive
       live "/stream/reset-lc", StreamResetLCLive
       live "/stream/limit", StreamLimitLive
+      live "/stream/nested-component-reset", StreamNestedComponentResetLive
       live "/healthy/:category", HealthyLive
 
       live "/upload", E2E.UploadLive

--- a/test/e2e/tests/streams.spec.js
+++ b/test/e2e/tests/streams.spec.js
@@ -192,73 +192,111 @@ test.describe("Issue #2656", () => {
 });
 
 // helper function used below
-const listItems = async (page) => page.locator("ul > li").evaluateAll(list => list.map(el => el.id));
+const listItems = async (page) => page.locator("ul > li").evaluateAll(list => list.map(el => ({ id: el.id, text: el.innerText })));
 
 test.describe("Issue #2994", () => {
   test("can filter and reset a stream", async ({ page }) => {
     await page.goto("/stream/reset");
     await syncLV(page);
 
-    await expect(await listItems(page)).toEqual(["items-a", "items-b", "items-c", "items-d"]);
+    await expect(await listItems(page)).toEqual([
+      { id: "items-a", text: "A" },
+      { id: "items-b", text: "B" },
+      { id: "items-c", text: "C" },
+      { id: "items-d", text: "D" }
+    ]);
 
     await page.getByRole("button", { name: "Filter" }).click();
     await syncLV(page);
 
-    await expect(await listItems(page)).toEqual(["items-b", "items-c", "items-d"]);
+    await expect(await listItems(page)).toEqual([
+      { id: "items-b", text: "B" },
+      { id: "items-c", text: "C" },
+      { id: "items-d", text: "D" }
+    ]);
 
     await page.getByRole("button", { name: "Reset" }).click();
     await syncLV(page);
 
-    await expect(await listItems(page)).toEqual(["items-a", "items-b", "items-c", "items-d"]);
+    await expect(await listItems(page)).toEqual([
+      { id: "items-a", text: "A" },
+      { id: "items-b", text: "B" },
+      { id: "items-c", text: "C" },
+      { id: "items-d", text: "D" }
+    ]);
   });
 
   test("can reorder stream", async ({ page }) => {
     await page.goto("/stream/reset");
     await syncLV(page);
 
-    await expect(await listItems(page)).toEqual(["items-a", "items-b", "items-c", "items-d"]);
+    await expect(await listItems(page)).toEqual([
+      { id: "items-a", text: "A" },
+      { id: "items-b", text: "B" },
+      { id: "items-c", text: "C" },
+      { id: "items-d", text: "D" }
+    ]);
 
     await page.getByRole("button", { name: "Reorder" }).click();
     await syncLV(page);
 
-    await expect(await listItems(page)).toEqual(["items-b", "items-a", "items-c", "items-d"]);
+    await expect(await listItems(page)).toEqual([
+      { id: "items-b", text: "B" },
+      { id: "items-a", text: "A" },
+      { id: "items-c", text: "C" },
+      { id: "items-d", text: "D" }
+    ]);
   });
 
   test("can filter and then prepend / append stream", async ({ page }) => {
     await page.goto("/stream/reset");
     await syncLV(page);
 
-    await expect(await listItems(page)).toEqual(["items-a", "items-b", "items-c", "items-d"]);
+    await expect(await listItems(page)).toEqual([
+      { id: "items-a", text: "A" },
+      { id: "items-b", text: "B" },
+      { id: "items-c", text: "C" },
+      { id: "items-d", text: "D" }
+    ]);
 
     await page.getByRole("button", { name: "Filter" }).click();
     await syncLV(page);
 
-    await expect(await listItems(page)).toEqual(["items-b", "items-c", "items-d"]);
+    await expect(await listItems(page)).toEqual([
+      { id: "items-b", text: "B" },
+      { id: "items-c", text: "C" },
+      { id: "items-d", text: "D" }
+    ]);
 
     await page.getByRole("button", { name: "Prepend", exact: true }).click();
     await syncLV(page);
 
     await expect(await listItems(page)).toEqual([
-      expect.stringMatching(/items-a-.*/),
-      "items-b",
-      "items-c",
-      "items-d"
+      { id: expect.stringMatching(/items-a-.*/), text: expect.any(String) },
+      { id: "items-b", text: "B" },
+      { id: "items-c", text: "C" },
+      { id: "items-d", text: "D" }
     ]);
 
     await page.getByRole("button", { name: "Reset" }).click();
     await syncLV(page);
 
-    await expect(await listItems(page)).toEqual(["items-a", "items-b", "items-c", "items-d"]);
+    await expect(await listItems(page)).toEqual([
+      { id: "items-a", text: "A" },
+      { id: "items-b", text: "B" },
+      { id: "items-c", text: "C" },
+      { id: "items-d", text: "D" }
+    ]);
 
     await page.getByRole("button", { name: "Append", exact: true }).click();
     await syncLV(page);
 
     await expect(await listItems(page)).toEqual([
-      "items-a",
-      "items-b",
-      "items-c",
-      "items-d",
-      expect.stringMatching(/items-a-.*/),
+      { id: "items-a", text: "A" },
+      { id: "items-b", text: "B" },
+      { id: "items-c", text: "C" },
+      { id: "items-d", text: "D" },
+      { id: expect.stringMatching(/items-a-.*/), text: expect.any(String) }
     ]);
   });
 });
@@ -268,12 +306,22 @@ test.describe("Issue #2982", () => {
     await page.goto("/stream/reset-lc");
     await syncLV(page);
 
-    await expect(await listItems(page)).toEqual(["items-a", "items-b", "items-c", "items-d"]);
+    await expect(await listItems(page)).toEqual([
+      { id: "items-a", text: "A" },
+      { id: "items-b", text: "B" },
+      { id: "items-c", text: "C" },
+      { id: "items-d", text: "D" }
+    ]);
 
     await page.getByRole("button", { name: "Reorder" }).click();
     await syncLV(page);
 
-    await expect(await listItems(page)).toEqual(["items-e", "items-a", "items-f", "items-g"]);
+    await expect(await listItems(page)).toEqual([
+      { id: "items-e", text: "E" },
+      { id: "items-a", text: "A" },
+      { id: "items-f", text: "F" },
+      { id: "items-g", text: "G" },
+    ]);
   });
 });
 
@@ -282,18 +330,29 @@ test.describe("Issue #3023", () => {
     await page.goto("/stream/reset");
     await syncLV(page);
 
-    await expect(await listItems(page)).toEqual(["items-a", "items-b", "items-c", "items-d"]);
+    await expect(await listItems(page)).toEqual([
+      { id: "items-a", text: "A" },
+      { id: "items-b", text: "B" },
+      { id: "items-c", text: "C" },
+      { id: "items-d", text: "D" }
+    ]);
 
     await page.getByRole("button", { name: "Bulk insert" }).click();
     await syncLV(page);
 
-    await expect(await listItems(page)).toEqual(["items-a", "items-e", "items-f", "items-g", "items-b", "items-c", "items-d"]);
+    await expect(await listItems(page)).toEqual([
+      { id: "items-a", text: "A" },
+      { id: "items-e", text: "E" },
+      { id: "items-f", text: "F" },
+      { id: "items-g", text: "G" },
+      { id: "items-b", text: "B" },
+      { id: "items-c", text: "C" },
+      { id: "items-d", text: "D" }
+    ]);
   });
 });
 
 test.describe("stream limit - issue #2686", () => {
-  const listItems = async (page) => page.locator("ul > li").evaluateAll(list => list.map(el => el.id));
-
   test("limit is enforced on mount, but not dead render", async ({ page, request }) => {
     const html = await (request.get("/stream/limit").then(r => r.text()));
     for (let i = 1; i <= 10; i++) {
@@ -304,11 +363,11 @@ test.describe("stream limit - issue #2686", () => {
     await syncLV(page);
 
     await expect(await listItems(page)).toEqual([
-      "items-6",
-      "items-7",
-      "items-8",
-      "items-9",
-      "items-10"
+      { id: "items-6", text: "6" },
+      { id: "items-7", text: "7" },
+      { id: "items-8", text: "8" },
+      { id: "items-9", text: "9" },
+      { id: "items-10", text: "10" }
     ]);
   });
 
@@ -324,22 +383,21 @@ test.describe("stream limit - issue #2686", () => {
     await syncLV(page);
 
     await expect(await listItems(page)).toEqual([
-      "items-7",
-      "items-8",
-      "items-9",
-      "items-10",
-      "items-11"
+      { id: "items-7", text: "7" },
+      { id: "items-8", text: "8" },
+      { id: "items-9", text: "9" },
+      { id: "items-10", text: "10" },
+      { id: "items-11", text: "11" }
     ]);
-
     await page.getByRole("button", { name: "add 10", exact: true }).click();
     await syncLV(page);
 
     await expect(await listItems(page)).toEqual([
-      "items-17",
-      "items-18",
-      "items-19",
-      "items-20",
-      "items-21"
+      { id: "items-17", text: "17" },
+      { id: "items-18", text: "18" },
+      { id: "items-19", text: "19" },
+      { id: "items-20", text: "20" },
+      { id: "items-21", text: "21" }
     ]);
   });
 
@@ -353,33 +411,33 @@ test.describe("stream limit - issue #2686", () => {
     await syncLV(page);
 
     await expect(await listItems(page)).toEqual([
-      "items-10",
-      "items-9",
-      "items-8",
-      "items-7",
-      "items-6"
+      { id: "items-10", text: "10" },
+      { id: "items-9", text: "9" },
+      { id: "items-8", text: "8" },
+      { id: "items-7", text: "7" },
+      { id: "items-6", text: "6" }
     ]);
 
     await page.getByRole("button", { name: "add 1", exact: true }).click();
     await syncLV(page);
 
     await expect(await listItems(page)).toEqual([
-      "items-11",
-      "items-10",
-      "items-9",
-      "items-8",
-      "items-7"
+      { id: "items-11", text: "11" },
+      { id: "items-10", text: "10" },
+      { id: "items-9", text: "9" },
+      { id: "items-8", text: "8" },
+      { id: "items-7", text: "7" }
     ]);
 
     await page.getByRole("button", { name: "add 10", exact: true }).click();
     await syncLV(page);
 
     await expect(await listItems(page)).toEqual([
-      "items-21",
-      "items-20",
-      "items-19",
-      "items-18",
-      "items-17"
+      { id: "items-21", text: "21" },
+      { id: "items-20", text: "20" },
+      { id: "items-19", text: "19" },
+      { id: "items-18", text: "18" },
+      { id: "items-17", text: "17" }
     ]);
   });
 
@@ -401,7 +459,7 @@ test.describe("stream limit - issue #2686", () => {
     for (let i = 1; i <= 5; i++) {
       await page.getByRole("button", { name: "add 1", exact: true }).click();
       await syncLV(page);
-      items.push(`items-${i}`);
+      items.push({ id: `items-${i}`, text: i.toString() });
       await expect(await listItems(page)).toEqual(items);
     }
 
@@ -410,11 +468,11 @@ test.describe("stream limit - issue #2686", () => {
     await syncLV(page);
 
     await expect(await listItems(page)).toEqual([
-      "items-1",
-      "items-2",
-      "items-3",
-      "items-4",
-      "items-5"
+      { id: "items-1", text: "1" },
+      { id: "items-2", text: "2" },
+      { id: "items-3", text: "3" },
+      { id: "items-4", text: "4" },
+      { id: "items-5", text: "5" }
     ]);
 
     // same when bulk inserting
@@ -422,11 +480,11 @@ test.describe("stream limit - issue #2686", () => {
     await syncLV(page);
 
     await expect(await listItems(page)).toEqual([
-      "items-1",
-      "items-2",
-      "items-3",
-      "items-4",
-      "items-5"
+      { id: "items-1", text: "1" },
+      { id: "items-2", text: "2" },
+      { id: "items-3", text: "3" },
+      { id: "items-4", text: "4" },
+      { id: "items-5", text: "5" }
     ]);
   });
 
@@ -448,7 +506,7 @@ test.describe("stream limit - issue #2686", () => {
     for (let i = 1; i <= 5; i++) {
       await page.getByRole("button", { name: "add 1", exact: true }).click();
       await syncLV(page);
-      items.unshift(`items-${i}`);
+      items.unshift({ id: `items-${i}`, text: i.toString() });
       await expect(await listItems(page)).toEqual(items);
     }
 
@@ -457,11 +515,11 @@ test.describe("stream limit - issue #2686", () => {
     await syncLV(page);
 
     await expect(await listItems(page)).toEqual([
-      "items-5",
-      "items-4",
-      "items-3",
-      "items-2",
-      "items-1"
+      { id: "items-5", text: "5" },
+      { id: "items-4", text: "4" },
+      { id: "items-3", text: "3" },
+      { id: "items-2", text: "2" },
+      { id: "items-1", text: "1" }
     ]);
 
     // same when bulk inserting
@@ -469,11 +527,11 @@ test.describe("stream limit - issue #2686", () => {
     await syncLV(page);
 
     await expect(await listItems(page)).toEqual([
-      "items-5",
-      "items-4",
-      "items-3",
-      "items-2",
-      "items-1"
+      { id: "items-5", text: "5" },
+      { id: "items-4", text: "4" },
+      { id: "items-3", text: "3" },
+      { id: "items-2", text: "2" },
+      { id: "items-1", text: "1" }
     ]);
   });
 
@@ -488,21 +546,21 @@ test.describe("stream limit - issue #2686", () => {
 
     // we tried to insert 10 items
     await expect(await listItems(page)).toEqual([
-      "items-1",
-      "items-10",
-      "items-9",
-      "items-8",
-      "items-7"
+      { id: "items-1", text: "1" },
+      { id: "items-10", text: "10" },
+      { id: "items-9", text: "9" },
+      { id: "items-8", text: "8" },
+      { id: "items-7", text: "7" }
     ]);
 
     await page.getByRole("button", { name: "add 10", exact: true }).click();
     await syncLV(page);
     await expect(await listItems(page)).toEqual([
-      "items-1",
-      "items-20",
-      "items-19",
-      "items-18",
-      "items-17"
+      { id: "items-1", text: "1" },
+      { id: "items-20", text: "20" },
+      { id: "items-19", text: "19" },
+      { id: "items-18", text: "18" },
+      { id: "items-17", text: "17" }
     ]);
 
     await page.locator("input[name='at']").fill("1");
@@ -512,21 +570,21 @@ test.describe("stream limit - issue #2686", () => {
 
     // we tried to insert 10 items
     await expect(await listItems(page)).toEqual([
-      "items-10",
-      "items-5",
-      "items-4",
-      "items-3",
-      "items-2"
+      { id: "items-10", text: "10" },
+      { id: "items-5", text: "5" },
+      { id: "items-4", text: "4" },
+      { id: "items-3", text: "3" },
+      { id: "items-2", text: "2" }
     ]);
 
     await page.getByRole("button", { name: "add 10", exact: true }).click();
     await syncLV(page);
     await expect(await listItems(page)).toEqual([
-      "items-20",
-      "items-5",
-      "items-4",
-      "items-3",
-      "items-2"
+      { id: "items-20", text: "20" },
+      { id: "items-5", text: "5" },
+      { id: "items-4", text: "4" },
+      { id: "items-3", text: "3" },
+      { id: "items-2", text: "2" }
     ]);
   });
 });
@@ -535,35 +593,136 @@ test("any stream insert for elements already in the DOM does not reorder", async
   await page.goto("/stream/reset");
   await syncLV(page);
 
-  await expect(await listItems(page)).toEqual(["items-a", "items-b", "items-c", "items-d"]);
+  await expect(await listItems(page)).toEqual([
+    { id: "items-a", text: "A" },
+    { id: "items-b", text: "B" },
+    { id: "items-c", text: "C" },
+    { id: "items-d", text: "D" }
+  ]);
 
   await page.getByRole("button", { name: "Prepend C" }).click();
   await syncLV(page);
-  await expect(await listItems(page)).toEqual(["items-a", "items-b", "items-c", "items-d"]);
+  await expect(await listItems(page)).toEqual([
+    { id: "items-a", text: "A" },
+    { id: "items-b", text: "B" },
+    { id: "items-c", text: "C" },
+    { id: "items-d", text: "D" }
+  ]);
 
   await page.getByRole("button", { name: "Append C" }).click();
   await syncLV(page);
-  await expect(await listItems(page)).toEqual(["items-a", "items-b", "items-c", "items-d"]);
+  await expect(await listItems(page)).toEqual([
+    { id: "items-a", text: "A" },
+    { id: "items-b", text: "B" },
+    { id: "items-c", text: "C" },
+    { id: "items-d", text: "D" }
+  ]);
 
   await page.getByRole("button", { name: "Insert C at 1" }).click();
   await syncLV(page);
-  await expect(await listItems(page)).toEqual(["items-a", "items-b", "items-c", "items-d"]);
+  await expect(await listItems(page)).toEqual([
+    { id: "items-a", text: "A" },
+    { id: "items-b", text: "B" },
+    { id: "items-c", text: "C" },
+    { id: "items-d", text: "D" }
+  ]);
 
   await page.getByRole("button", { name: "Insert at 1", exact: true }).click();
   await syncLV(page);
   await expect(await listItems(page)).toEqual([
-    "items-a",
-    expect.stringMatching(/items-a-.*/),
-    "items-b",
-    "items-c",
-    "items-d"
+    { id: "items-a", text: "A" },
+    { id: expect.stringMatching(/items-a-.*/), text: expect.any(String) },
+    { id: "items-b", text: "B" },
+    { id: "items-c", text: "C" },
+    { id: "items-d", text: "D" }
   ]);
 
   await page.getByRole("button", { name: "Reset" }).click();
   await syncLV(page);
-  await expect(await listItems(page)).toEqual(["items-a", "items-b", "items-c", "items-d"]);
+  await expect(await listItems(page)).toEqual([
+    { id: "items-a", text: "A" },
+    { id: "items-b", text: "B" },
+    { id: "items-c", text: "C" },
+    { id: "items-d", text: "D" }
+  ]);
 
   await page.getByRole("button", { name: "Delete C and insert at 1" }).click();
   await syncLV(page);
-  await expect(await listItems(page)).toEqual(["items-a", "items-c", "items-b", "items-d"]);
+  await expect(await listItems(page)).toEqual([
+    { id: "items-a", text: "A" },
+    { id: "items-c", text: "C" },
+    { id: "items-b", text: "B" },
+    { id: "items-d", text: "D" }
+  ]);
+});
+
+test("stream nested in a LiveComponent is properly restored on reset", async ({ page }) => {
+  await page.goto("/stream/nested-component-reset");
+  await syncLV(page);
+
+  const childItems = async (page, id) => page.locator(`#${id} div[phx-update=stream] > *`).evaluateAll(div => div.map(el => ({ id: el.id, text: el.innerText })));
+
+  await expect(await listItems(page)).toEqual([
+    { id: "items-a", text: expect.stringMatching(/A/) },
+    { id: "items-b", text: expect.stringMatching(/B/) },
+    { id: "items-c", text: expect.stringMatching(/C/) },
+    { id: "items-d", text: expect.stringMatching(/D/) }
+  ]);
+
+  for (let id of ["a", "b", "c", "d"]) {
+    await expect(await childItems(page, `items-${id}`)).toEqual([
+      { id: `nested-items-${id}-a`, text: "N-A" },
+      { id: `nested-items-${id}-b`, text: "N-B" },
+      { id: `nested-items-${id}-c`, text: "N-C" },
+      { id: `nested-items-${id}-d`, text: "N-D" },
+    ])
+  }
+
+  // now reorder the nested stream of items-a
+  await page.locator("#items-a button").click();
+  await syncLV(page);
+
+  await expect(await childItems(page, "items-a")).toEqual([
+    { id: "nested-items-a-e", text: "N-E" },
+    { id: "nested-items-a-a", text: "N-A" },
+    { id: "nested-items-a-f", text: "N-F" },
+    { id: "nested-items-a-g", text: "N-G" },
+  ]);
+  // unchanged
+  for (let id of ["b", "c", "d"]) {
+    await expect(await childItems(page, `items-${id}`)).toEqual([
+      { id: `nested-items-${id}-a`, text: "N-A" },
+      { id: `nested-items-${id}-b`, text: "N-B" },
+      { id: `nested-items-${id}-c`, text: "N-C" },
+      { id: `nested-items-${id}-d`, text: "N-D" },
+    ])
+  }
+
+  // now reorder the parent stream
+  await page.locator("#parent-reorder").click();
+  await syncLV(page);
+  await expect(await listItems(page)).toEqual([
+    { id: "items-e", text: expect.stringMatching(/E/) },
+    { id: "items-a", text: expect.stringMatching(/A/) },
+    { id: "items-f", text: expect.stringMatching(/F/) },
+    { id: "items-g", text: expect.stringMatching(/G/) },
+  ]);
+
+  // the new children's stream items have the correct order
+  for (let id of ["e", "f", "g"]) {
+    await expect(await childItems(page, `items-${id}`)).toEqual([
+      { id: `nested-items-${id}-a`, text: "N-A" },
+      { id: `nested-items-${id}-b`, text: "N-B" },
+      { id: `nested-items-${id}-c`, text: "N-C" },
+      { id: `nested-items-${id}-d`, text: "N-D" },
+    ])
+  }
+
+  // Item A has the same children as before, still reordered
+  await expect(await childItems(page, "items-a")).toEqual([
+    { id: "nested-items-a-e", text: "N-E" },
+    { id: "nested-items-a-a", text: "N-A" },
+    { id: "nested-items-a-f", text: "N-F" },
+    { id: "nested-items-a-g", text: "N-G" },
+  ]);
 });

--- a/test/phoenix_live_view/integrations/stream_test.exs
+++ b/test/phoenix_live_view/integrations/stream_test.exs
@@ -188,13 +188,29 @@ defmodule Phoenix.LiveView.StreamTest do
       # let the parent update
       Process.sleep(100)
 
-      assert ids_in_ul_list(render(lv)) == ["items-a", "items-b", "items-c", "items-d"]
+      assert ul_list_children(render(lv)) == [
+               {"items-a", "A"},
+               {"items-b", "B"},
+               {"items-c", "C"},
+               {"items-d", "D"}
+             ]
 
       html = assert lv |> element("button", "Filter") |> render_click()
-      assert ids_in_ul_list(html) == ["items-b", "items-c", "items-d"]
+
+      assert ul_list_children(html) == [
+               {"items-b", "B"},
+               {"items-c", "C"},
+               {"items-d", "D"}
+             ]
 
       html = assert lv |> element("button", "Reset") |> render_click()
-      assert ids_in_ul_list(html) == ["items-a", "items-b", "items-c", "items-d"]
+
+      assert ul_list_children(html) == [
+               {"items-a", "A"},
+               {"items-b", "B"},
+               {"items-c", "C"},
+               {"items-d", "D"}
+             ]
     end
   end
 
@@ -202,42 +218,97 @@ defmodule Phoenix.LiveView.StreamTest do
     test "can filter and reset a stream", %{conn: conn} do
       {:ok, lv, html} = live(conn, "/stream/reset")
 
-      assert ids_in_ul_list(html) == ["items-a", "items-b", "items-c", "items-d"]
+      assert ul_list_children(html) == [
+               {"items-a", "A"},
+               {"items-b", "B"},
+               {"items-c", "C"},
+               {"items-d", "D"}
+             ]
 
       html = assert lv |> element("button", "Filter") |> render_click()
-      assert ids_in_ul_list(html) == ["items-b", "items-c", "items-d"]
+
+      assert ul_list_children(html) == [
+               {"items-b", "B"},
+               {"items-c", "C"},
+               {"items-d", "D"}
+             ]
 
       html = assert lv |> element("button", "Reset") |> render_click()
-      assert ids_in_ul_list(html) == ["items-a", "items-b", "items-c", "items-d"]
+
+      assert ul_list_children(html) == [
+               {"items-a", "A"},
+               {"items-b", "B"},
+               {"items-c", "C"},
+               {"items-d", "D"}
+             ]
     end
 
     test "can reorder stream", %{conn: conn} do
       {:ok, lv, html} = live(conn, "/stream/reset")
 
-      assert ids_in_ul_list(html) == ["items-a", "items-b", "items-c", "items-d"]
+      assert ul_list_children(html) == [
+               {"items-a", "A"},
+               {"items-b", "B"},
+               {"items-c", "C"},
+               {"items-d", "D"}
+             ]
 
       html = assert lv |> element("button", "Reorder") |> render_click()
-      assert ids_in_ul_list(html) == ["items-b", "items-a", "items-c", "items-d"]
+
+      assert ul_list_children(html) == [
+               {"items-b", "B"},
+               {"items-a", "A"},
+               {"items-c", "C"},
+               {"items-d", "D"}
+             ]
     end
 
     test "can filter and then prepend / append stream", %{conn: conn} do
       {:ok, lv, html} = live(conn, "/stream/reset")
 
-      assert ids_in_ul_list(html) == ["items-a", "items-b", "items-c", "items-d"]
+      assert ul_list_children(html) == [
+               {"items-a", "A"},
+               {"items-b", "B"},
+               {"items-c", "C"},
+               {"items-d", "D"}
+             ]
 
       html = assert lv |> element("button", "Filter") |> render_click()
-      assert ids_in_ul_list(html) == ["items-b", "items-c", "items-d"]
+
+      assert ul_list_children(html) == [
+               {"items-b", "B"},
+               {"items-c", "C"},
+               {"items-d", "D"}
+             ]
 
       html = assert lv |> element(~s(button[phx-click="prepend"]), "Prepend") |> render_click()
-      assert [<<"items-a-", _::binary>>, "items-b", "items-c", "items-d"] = ids_in_ul_list(html)
+
+      assert [
+               {<<"items-a-", _::binary>>, _},
+               {"items-b", "B"},
+               {"items-c", "C"},
+               {"items-d", "D"}
+             ] = ul_list_children(html)
 
       html = assert lv |> element("button", "Reset") |> render_click()
-      assert ids_in_ul_list(html) == ["items-a", "items-b", "items-c", "items-d"]
+
+      assert ul_list_children(html) == [
+               {"items-a", "A"},
+               {"items-b", "B"},
+               {"items-c", "C"},
+               {"items-d", "D"}
+             ]
 
       html = assert lv |> element(~s(button[phx-click="append"]), "Append") |> render_click()
 
-      assert ["items-a", "items-b", "items-c", "items-d", <<"items-a-", _::binary>>] =
-               ids_in_ul_list(html)
+      assert [
+               {"items-a", "A"},
+               {"items-b", "B"},
+               {"items-c", "C"},
+               {"items-d", "D"},
+               {<<"items-a-", _::binary>>, _}
+             ] =
+               ul_list_children(html)
     end
   end
 
@@ -332,53 +403,98 @@ defmodule Phoenix.LiveView.StreamTest do
     } do
       {:ok, lv, html} = live(conn, "/stream/reset-lc")
 
-      assert ids_in_ul_list(html) == ["items-a", "items-b", "items-c", "items-d"]
+      assert ul_list_children(html) == [
+               {"items-a", "A"},
+               {"items-b", "B"},
+               {"items-c", "C"},
+               {"items-d", "D"}
+             ]
 
       html = assert lv |> element("button", "Reorder") |> render_click()
-      assert ids_in_ul_list(html) == ["items-e", "items-a", "items-f", "items-g"]
+
+      assert ul_list_children(html) == [
+               {"items-e", "E"},
+               {"items-a", "A"},
+               {"items-f", "F"},
+               {"items-g", "G"}
+             ]
     end
   end
 
   test "issue #3023 - can bulk insert at index != -1", %{conn: conn} do
     {:ok, lv, html} = live(conn, "/stream/reset")
 
-    assert ids_in_ul_list(html) == ["items-a", "items-b", "items-c", "items-d"]
+    assert ul_list_children(html) == [
+             {"items-a", "A"},
+             {"items-b", "B"},
+             {"items-c", "C"},
+             {"items-d", "D"}
+           ]
 
     html = assert lv |> element("button", "Bulk insert") |> render_click()
 
-    assert ids_in_ul_list(html) == [
-             "items-a",
-             "items-e",
-             "items-f",
-             "items-g",
-             "items-b",
-             "items-c",
-             "items-d"
+    assert ul_list_children(html) == [
+             {"items-a", "A"},
+             {"items-e", "E"},
+             {"items-f", "F"},
+             {"items-g", "G"},
+             {"items-b", "B"},
+             {"items-c", "C"},
+             {"items-d", "D"}
            ]
   end
 
   test "any stream insert for elements already in the DOM does not reorder", %{conn: conn} do
     {:ok, lv, html} = live(conn, "/stream/reset")
 
-    assert ids_in_ul_list(html) == ["items-a", "items-b", "items-c", "items-d"]
+    assert ul_list_children(html) == [
+             {"items-a", "A"},
+             {"items-b", "B"},
+             {"items-c", "C"},
+             {"items-d", "D"}
+           ]
 
     html = assert lv |> element("button", "Prepend C") |> render_click()
-    assert ids_in_ul_list(html) == ["items-a", "items-b", "items-c", "items-d"]
+
+    assert ul_list_children(html) == [
+             {"items-a", "A"},
+             {"items-b", "B"},
+             {"items-c", "C"},
+             {"items-d", "D"}
+           ]
 
     html = assert lv |> element("button", "Append C") |> render_click()
-    assert ids_in_ul_list(html) == ["items-a", "items-b", "items-c", "items-d"]
+
+    assert ul_list_children(html) == [
+             {"items-a", "A"},
+             {"items-b", "B"},
+             {"items-c", "C"},
+             {"items-d", "D"}
+           ]
 
     html = assert lv |> element("button", "Insert C at 1") |> render_click()
-    assert ids_in_ul_list(html) == ["items-a", "items-b", "items-c", "items-d"]
+
+    assert ul_list_children(html) == [
+             {"items-a", "A"},
+             {"items-b", "B"},
+             {"items-c", "C"},
+             {"items-d", "D"}
+           ]
 
     html = assert lv |> element("button", "Insert at 1") |> render_click()
-    assert ["items-a", _, "items-b", "items-c", "items-d"] = ids_in_ul_list(html)
+
+    assert [{"items-a", "A"}, _, {"items-b", "B"}, {"items-c", "C"}, {"items-d", "D"}] =
+             ul_list_children(html)
 
     html = assert lv |> element("button", "Reset") |> render_click()
-    assert ["items-a", "items-b", "items-c", "items-d"] = ids_in_ul_list(html)
+
+    assert [{"items-a", "A"}, {"items-b", "B"}, {"items-c", "C"}, {"items-d", "D"}] =
+             ul_list_children(html)
 
     html = assert lv |> element("button", "Delete C and insert at 1") |> render_click()
-    assert ["items-a", "items-c", "items-b", "items-d"] = ids_in_ul_list(html)
+
+    assert [{"items-a", "A"}, {"items-c", "C"}, {"items-b", "B"}, {"items-d", "D"}] =
+             ul_list_children(html)
   end
 
   test "stream raises when attempting to consume ahead of for", %{conn: conn} do
@@ -411,185 +527,261 @@ defmodule Phoenix.LiveView.StreamTest do
     test "limit is enforced on mount, but not dead render", %{conn: conn} do
       conn = get(conn, "/stream/limit")
 
-      assert html_response(conn, 200) |> ids_in_ul_list() == [
-               "items-1",
-               "items-2",
-               "items-3",
-               "items-4",
-               "items-5",
-               "items-6",
-               "items-7",
-               "items-8",
-               "items-9",
-               "items-10"
+      assert html_response(conn, 200) |> ul_list_children() == [
+               {"items-1", "1"},
+               {"items-2", "2"},
+               {"items-3", "3"},
+               {"items-4", "4"},
+               {"items-5", "5"},
+               {"items-6", "6"},
+               {"items-7", "7"},
+               {"items-8", "8"},
+               {"items-9", "9"},
+               {"items-10", "10"}
              ]
 
       {:ok, _lv, html} = live(conn)
 
-      assert ids_in_ul_list(html) == [
-               "items-6",
-               "items-7",
-               "items-8",
-               "items-9",
-               "items-10"
+      assert ul_list_children(html) == [
+               {"items-6", "6"},
+               {"items-7", "7"},
+               {"items-8", "8"},
+               {"items-9", "9"},
+               {"items-10", "10"}
              ]
     end
 
     test "removes item at front when appending and limit is negative", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/stream/limit")
 
-      assert lv |> render_hook("configure", %{"at" => "-1", "limit" => "-5"}) |> ids_in_ul_list() ==
+      assert lv
+             |> render_hook("configure", %{"at" => "-1", "limit" => "-5"})
+             |> ul_list_children() ==
                [
-                 "items-6",
-                 "items-7",
-                 "items-8",
-                 "items-9",
-                 "items-10"
+                 {"items-6", "6"},
+                 {"items-7", "7"},
+                 {"items-8", "8"},
+                 {"items-9", "9"},
+                 {"items-10", "10"}
                ]
 
-      assert lv |> render_hook("insert_1") |> ids_in_ul_list() == [
-               "items-7",
-               "items-8",
-               "items-9",
-               "items-10",
-               "items-11"
+      assert lv |> render_hook("insert_1") |> ul_list_children() == [
+               {"items-7", "7"},
+               {"items-8", "8"},
+               {"items-9", "9"},
+               {"items-10", "10"},
+               {"items-11", "11"}
              ]
 
-      assert lv |> render_hook("insert_10") |> ids_in_ul_list() == [
-               "items-17",
-               "items-18",
-               "items-19",
-               "items-20",
-               "items-21"
+      assert lv |> render_hook("insert_10") |> ul_list_children() == [
+               {"items-17", "17"},
+               {"items-18", "18"},
+               {"items-19", "19"},
+               {"items-20", "20"},
+               {"items-21", "21"}
              ]
     end
 
     test "removes item at back when prepending and limit is positive", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/stream/limit")
 
-      assert lv |> render_hook("configure", %{"at" => "0", "limit" => "5"}) |> ids_in_ul_list() ==
+      assert lv |> render_hook("configure", %{"at" => "0", "limit" => "5"}) |> ul_list_children() ==
                [
-                 "items-10",
-                 "items-9",
-                 "items-8",
-                 "items-7",
-                 "items-6"
+                 {"items-10", "10"},
+                 {"items-9", "9"},
+                 {"items-8", "8"},
+                 {"items-7", "7"},
+                 {"items-6", "6"}
                ]
 
-      assert lv |> render_hook("insert_1") |> ids_in_ul_list() == [
-               "items-11",
-               "items-10",
-               "items-9",
-               "items-8",
-               "items-7"
+      assert lv |> render_hook("insert_1") |> ul_list_children() == [
+               {"items-11", "11"},
+               {"items-10", "10"},
+               {"items-9", "9"},
+               {"items-8", "8"},
+               {"items-7", "7"}
              ]
 
-      assert lv |> render_hook("insert_10") |> ids_in_ul_list() == [
-               "items-21",
-               "items-20",
-               "items-19",
-               "items-18",
-               "items-17"
+      assert lv |> render_hook("insert_10") |> ul_list_children() == [
+               {"items-21", "21"},
+               {"items-20", "20"},
+               {"items-19", "19"},
+               {"items-18", "18"},
+               {"items-17", "17"}
              ]
     end
 
     test "does nothing if appending and positive limit is reached", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/stream/limit")
 
-      assert lv |> render_hook("configure", %{"at" => "-1", "limit" => "5"}) |> ids_in_ul_list() ==
+      assert lv |> render_hook("configure", %{"at" => "-1", "limit" => "5"}) |> ul_list_children() ==
                [
-                 "items-1",
-                 "items-2",
-                 "items-3",
-                 "items-4",
-                 "items-5"
+                 {"items-1", "1"},
+                 {"items-2", "2"},
+                 {"items-3", "3"},
+                 {"items-4", "4"},
+                 {"items-5", "5"}
                ]
 
       # adding new items should do nothing, as the limit is reached
-      assert lv |> render_hook("insert_1") |> ids_in_ul_list() == [
-               "items-1",
-               "items-2",
-               "items-3",
-               "items-4",
-               "items-5"
+      assert lv |> render_hook("insert_1") |> ul_list_children() == [
+               {"items-1", "1"},
+               {"items-2", "2"},
+               {"items-3", "3"},
+               {"items-4", "4"},
+               {"items-5", "5"}
              ]
 
-      assert lv |> render_hook("insert_10") |> ids_in_ul_list() == [
-               "items-1",
-               "items-2",
-               "items-3",
-               "items-4",
-               "items-5"
+      assert lv |> render_hook("insert_10") |> ul_list_children() == [
+               {"items-1", "1"},
+               {"items-2", "2"},
+               {"items-3", "3"},
+               {"items-4", "4"},
+               {"items-5", "5"}
              ]
     end
 
     test "does nothing if prepending and negative limit is reached", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/stream/limit")
 
-      assert lv |> render_hook("configure", %{"at" => "0", "limit" => "-5"}) |> ids_in_ul_list() ==
+      assert lv |> render_hook("configure", %{"at" => "0", "limit" => "-5"}) |> ul_list_children() ==
                [
-                 "items-5",
-                 "items-4",
-                 "items-3",
-                 "items-2",
-                 "items-1"
+                 {"items-5", "5"},
+                 {"items-4", "4"},
+                 {"items-3", "3"},
+                 {"items-2", "2"},
+                 {"items-1", "1"}
                ]
 
       # adding new items should do nothing, as the limit is reached
-      assert lv |> render_hook("insert_1") |> ids_in_ul_list() == [
-               "items-5",
-               "items-4",
-               "items-3",
-               "items-2",
-               "items-1"
+      assert lv |> render_hook("insert_1") |> ul_list_children() == [
+               {"items-5", "5"},
+               {"items-4", "4"},
+               {"items-3", "3"},
+               {"items-2", "2"},
+               {"items-1", "1"}
              ]
 
-      assert lv |> render_hook("insert_10") |> ids_in_ul_list() == [
-               "items-5",
-               "items-4",
-               "items-3",
-               "items-2",
-               "items-1"
+      assert lv |> render_hook("insert_10") |> ul_list_children() == [
+               {"items-5", "5"},
+               {"items-4", "4"},
+               {"items-3", "3"},
+               {"items-2", "2"},
+               {"items-1", "1"}
              ]
     end
 
     test "arbitrary index", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/stream/limit")
 
-      assert lv |> render_hook("configure", %{"at" => "1", "limit" => "5"}) |> ids_in_ul_list() ==
+      assert lv |> render_hook("configure", %{"at" => "1", "limit" => "5"}) |> ul_list_children() ==
                [
-                 "items-1",
-                 "items-10",
-                 "items-9",
-                 "items-8",
-                 "items-7"
+                 {"items-1", "1"},
+                 {"items-10", "10"},
+                 {"items-9", "9"},
+                 {"items-8", "8"},
+                 {"items-7", "7"}
                ]
 
-      assert lv |> render_hook("insert_10") |> ids_in_ul_list() == [
-               "items-1",
-               "items-20",
-               "items-19",
-               "items-18",
-               "items-17"
+      assert lv |> render_hook("insert_10") |> ul_list_children() == [
+               {"items-1", "1"},
+               {"items-20", "20"},
+               {"items-19", "19"},
+               {"items-18", "18"},
+               {"items-17", "17"}
              ]
 
-      assert lv |> render_hook("configure", %{"at" => "1", "limit" => "-5"}) |> ids_in_ul_list() ==
+      assert lv |> render_hook("configure", %{"at" => "1", "limit" => "-5"}) |> ul_list_children() ==
                [
-                 "items-10",
-                 "items-5",
-                 "items-4",
-                 "items-3",
-                 "items-2"
+                 {"items-10", "10"},
+                 {"items-5", "5"},
+                 {"items-4", "4"},
+                 {"items-3", "3"},
+                 {"items-2", "2"}
                ]
 
-      assert lv |> render_hook("insert_10") |> ids_in_ul_list() == [
-               "items-20",
-               "items-5",
-               "items-4",
-               "items-3",
-               "items-2"
+      assert lv |> render_hook("insert_10") |> ul_list_children() == [
+               {"items-20", "20"},
+               {"items-5", "5"},
+               {"items-4", "4"},
+               {"items-3", "3"},
+               {"items-2", "2"}
              ]
     end
+  end
+
+  @tag skip: "waiting for #3104"
+  test "stream nested in a LiveComponent is properly restored on reset", %{conn: conn} do
+    {:ok, lv, _html} = live(conn, "/stream/nested-component-reset")
+
+    childItems = fn html, id ->
+      html
+      |> DOM.parse()
+      |> DOM.all("##{id} div[phx-update=stream] > *")
+      |> Enum.map(fn {_tag, _attrs, [text | _children]} = child ->
+        {DOM.attribute(child, "id"), String.trim(text)}
+      end)
+    end
+
+    assert render(lv) |> ul_list_children() == [
+             {"items-a", "A"},
+             {"items-b", "B"},
+             {"items-c", "C"},
+             {"items-d", "D"}
+           ]
+
+    for id <- ["a", "b", "c", "d"] do
+      assert render(lv) |> childItems.("items-#{id}") == [
+               {"nested-items-#{id}-a", "N-A"},
+               {"nested-items-#{id}-b", "N-B"},
+               {"nested-items-#{id}-c", "N-C"},
+               {"nested-items-#{id}-d", "N-D"}
+             ]
+    end
+
+    # now reorder the nested stream of items-a
+    assert lv |> element("#items-a button") |> render_click() |> childItems.("items-a") == [
+             {"nested-items-a-e", "N-E"},
+             {"nested-items-a-a", "N-A"},
+             {"nested-items-a-f", "N-F"},
+             {"nested-items-a-g", "N-G"}
+           ]
+
+    # unchanged
+    for id <- ["b", "c", "d"] do
+      assert render(lv) |> childItems.("items-#{id}") == [
+               {"nested-items-#{id}-a", "N-A"},
+               {"nested-items-#{id}-b", "N-B"},
+               {"nested-items-#{id}-c", "N-C"},
+               {"nested-items-#{id}-d", "N-D"}
+             ]
+    end
+
+    # now reorder the parent stream
+    assert lv |> element("#parent-reorder") |> render_click() |> ul_list_children() == [
+             {"items-e", "E"},
+             {"items-a", "A"},
+             {"items-f", "F"},
+             {"items-g", "G"}
+           ]
+
+    # the new children's stream items have the correct order
+    for id <- ["e", "f", "g"] do
+      assert render(lv) |> childItems.("items-#{id}") == [
+               {"nested-items-#{id}-a", "N-A"},
+               {"nested-items-#{id}-b", "N-B"},
+               {"nested-items-#{id}-c", "N-C"},
+               {"nested-items-#{id}-d", "N-D"}
+             ]
+    end
+
+    # Item A has the same children as before, still reordered
+    assert render(lv) |> childItems.("items-a") == [
+             {"nested-items-a-e", "N-E"},
+             {"nested-items-a-a", "N-A"},
+             {"nested-items-a-f", "N-F"},
+             {"nested-items-a-g", "N-G"}
+           ]
   end
 
   defp assert_pruned_stream(lv) do
@@ -607,10 +799,12 @@ defmodule Phoenix.LiveView.StreamTest do
     end)
   end
 
-  defp ids_in_ul_list(html) do
+  defp ul_list_children(html) do
     html
     |> DOM.parse()
     |> DOM.all("ul > li")
-    |> Enum.map(fn child -> DOM.attribute(child, "id") end)
+    |> Enum.map(fn {_tag, _attrs, [text | _children]} = child ->
+      {DOM.attribute(child, "id"), String.trim(text)}
+    end)
   end
 end

--- a/test/support/live_views/streams.ex
+++ b/test/support/live_views/streams.ex
@@ -634,3 +634,105 @@ defmodule Phoenix.LiveViewTest.StreamNestedLive do
     """
   end
 end
+
+defmodule Phoenix.LiveViewTest.StreamNestedComponentResetLive do
+  use Phoenix.LiveView
+
+  defmodule InnerComponent do
+    use Phoenix.LiveComponent
+
+    # we already initialized the stream
+    def update(assigns, %{assigns: %{id: _}} = socket) do
+      {:ok, assign(socket, assigns)}
+    end
+
+    # first mount
+    def update(assigns, socket) do
+      socket
+      |> assign(assigns)
+      |> stream(
+        :nested,
+        [
+          %{id: assigns.id <> "-a", name: "N-A"},
+          %{id: assigns.id <> "-b", name: "N-B"},
+          %{id: assigns.id <> "-c", name: "N-C"},
+          %{id: assigns.id <> "-d", name: "N-D"}
+        ],
+        reset: true
+      )
+      |> then(&{:ok, &1})
+    end
+
+    def handle_event("reorder", _, socket) do
+      socket =
+        stream(
+          socket,
+          :nested,
+          [
+            %{id: socket.assigns.id <> "-e", name: "N-E"},
+            %{id: socket.assigns.id <> "-a", name: "N-A"},
+            %{id: socket.assigns.id <> "-f", name: "N-F"},
+            %{id: socket.assigns.id <> "-g", name: "N-G"}
+          ],
+          reset: true
+        )
+
+      {:noreply, socket}
+    end
+
+    def render(assigns) do
+      ~H"""
+      <li id={@id}>
+        <%= @item.name %>
+        <div id={@id <> "-nested"} phx-update="stream" style="display: flex; gap: 4px;">
+          <span :for={{id, item} <- @streams.nested} id={id}><%= item.name %></span>
+        </div>
+        <button phx-click="reorder" phx-target={@myself}>Reorder</button>
+      </li>
+      """
+    end
+  end
+
+  def render(assigns) do
+    ~H"""
+    <ul phx-update="stream" id="thelist">
+      <.live_component
+        :for={{id, item} <- @streams.items}
+        module={InnerComponent}
+        id={id}
+        item={item}
+      />
+    </ul>
+
+    <button phx-click="reorder" id="parent-reorder">Reorder</button>
+    """
+  end
+
+  def mount(_params, _session, socket) do
+    socket
+    |> stream(:items, [
+      %{id: "a", name: "A"},
+      %{id: "b", name: "B"},
+      %{id: "c", name: "C"},
+      %{id: "d", name: "D"}
+    ])
+    |> then(&{:ok, &1})
+  end
+
+  def handle_event("reorder", _, socket) do
+    socket =
+      stream(
+        socket,
+        :items,
+        [
+          %{id: "e", name: "E"},
+          %{id: "a", name: "A"},
+          %{id: "f", name: "F"},
+          %{id: "g", name: "G"}
+        ],
+        reset: true
+      )
+
+    {:noreply, socket}
+  end
+end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -128,6 +128,7 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/stream/reset-lc", StreamResetLCLive
     live "/stream/limit", StreamLimitLive
     live "/stream/nested", StreamNestedLive
+    live "/stream/nested-component-reset", StreamNestedComponentResetLive
 
     # healthy
     live "/healthy/:category", HealthyLive


### PR DESCRIPTION
This is a followup to #3070 and #3035.

When adjusting the stream component restore functionality in #3070, I accidentally broke live components in streams, but the tests did not detect this because they only checked the id of the stream items and not their content. Therefore, this commit also adjusts the tests.

Another problem that was introduced in #3035 by not leaving re-inserted items in the DOM is that nested streams inside live components inside streams would not be restored properly. This commit addresses this by recursively running morphdom on the restored stream items.

The added LiveViewTest test relies on #3104, therefore it is currently skipped.