### PR TITLE
Fix links to phx-hook docs

### DIFF
--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -22,7 +22,7 @@ callback, for example:
 | [Key Events](#key-events) | `phx-keydown`, `phx-keyup`, `phx-window-keydown`, `phx-window-keyup`, `phx-key` |
 | [Scroll Events](#scroll-events-and-infinite-stream-pagination) | `phx-viewport-top`, `phx-viewport-bottom` |
 | [DOM Patching](dom-patching.md) | `phx-mounted`, `phx-update`, `phx-remove` |
-| [JS Interop](js-interop.md#client-hooks) | `phx-hook` |
+| [JS Interop](js-interop.md#client-hooks-via-phx-hook) | `phx-hook` |
 | [Lifecycle Events](#lifecycle-events) | `phx-mounted`, `phx-disconnected`, `phx-connected` |
 | [Rate Limiting](#rate-limiting-events-with-debounce-and-throttle) | `phx-debounce`, `phx-throttle` |
 | [Static tracking](`Phoenix.LiveView.static_changed?/1`) | `phx-track-static` |

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1398,7 +1398,7 @@ defmodule Phoenix.LiveView do
 
   > Note: This function is for server-side lifecycle callbacks.
   > For client-side hooks, see the
-  > [JS Interop guide](js-interop.html#client-hooks).
+  > [JS Interop guide](js-interop.html#client-hooks-via-phx-hook).
 
   Hooks provide a mechanism to tap into key stages of the LiveView
   lifecycle in order to bind/update assigns, intercept events,
@@ -1504,7 +1504,7 @@ defmodule Phoenix.LiveView do
 
   > Note: This function is for server-side lifecycle callbacks.
   > For client-side hooks, see the
-  > [JS Interop guide](js-interop.html#client-hooks).
+  > [JS Interop guide](js-interop.html#client-hooks-via-phx-hook).
 
   If no hook is found, this function is a no-op.
 


### PR DESCRIPTION
Some links were correctly pointing to `#client-hooks-via-phx-hook`, some
not.
