### PR TITLE
skip reordering elements with no parent, fix phx-remove on re-added stream items

### DIFF
--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -331,14 +331,15 @@ export default class DOMPatch {
   }
 
   removeStreamChildElement(child){
-    if(!this.maybePendingRemove(child)){
-      if(this.streamInserts[child.id]){
-        // we need to store children so we can morph them later
-        this.streamComponentRestore[child.id] = child
+    // we need to store the node if it is actually re-added in the same patch
+    // we do NOT want to execute phx-remove, we do NOT want to call onNodeDiscarded
+    if(this.streamInserts[child.id]){
+      this.streamComponentRestore[child.id] = child
+      child.remove()
+    } else {
+      // only remove the element now if it has no phx-remove binding
+      if(!this.maybePendingRemove(child)){
         child.remove()
-      } else {
-        child.remove()
-        // TODO: check if we really don't want to call discarded for re-added stream items
         this.onNodeDiscarded(child)
       }
     }

--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -365,6 +365,12 @@ export default class DOMPatch {
       return
     }
 
+    // check if the element has a parent element;
+    // it doesn't if we are currently recursively morphing (restoring a saved stream child)
+    // because the element is not yet added to the real dom;
+    // reordering does not make sense in that case anyway
+    if(!el.parentElement) return
+
     if(streamAt === 0){
       el.parentElement.insertBefore(el, el.parentElement.firstElementChild)
     } else if(streamAt > 0){

--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -370,7 +370,7 @@ export default class DOMPatch {
     // it doesn't if we are currently recursively morphing (restoring a saved stream child)
     // because the element is not yet added to the real dom;
     // reordering does not make sense in that case anyway
-    if(!el.parentElement) return
+    if(!el.parentElement){ return }
 
     if(streamAt === 0){
       el.parentElement.insertBefore(el, el.parentElement.firstElementChild)

--- a/test/e2e/tests/streams.spec.js
+++ b/test/e2e/tests/streams.spec.js
@@ -726,3 +726,34 @@ test("stream nested in a LiveComponent is properly restored on reset", async ({ 
     { id: "nested-items-a-g", text: "N-G" },
   ]);
 });
+
+test("phx-remove is handled correctly when restoring nodes", async ({ page }) => {
+  await page.goto("/stream/reset?phx-remove");
+  await syncLV(page);
+
+  await expect(await listItems(page)).toEqual([
+    { id: "items-a", text: "A" },
+    { id: "items-b", text: "B" },
+    { id: "items-c", text: "C" },
+    { id: "items-d", text: "D" }
+  ]);
+
+  await page.getByRole("button", { name: "Filter" }).click();
+  await syncLV(page);
+
+  await expect(await listItems(page)).toEqual([
+    { id: "items-b", text: "B" },
+    { id: "items-c", text: "C" },
+    { id: "items-d", text: "D" }
+  ]);
+
+  await page.getByRole("button", { name: "Reset" }).click();
+  await syncLV(page);
+
+  await expect(await listItems(page)).toEqual([
+    { id: "items-a", text: "A" },
+    { id: "items-b", text: "B" },
+    { id: "items-c", text: "C" },
+    { id: "items-d", text: "D" }
+  ]);
+});

--- a/test/support/live_views/streams.ex
+++ b/test/support/live_views/streams.ex
@@ -301,7 +301,7 @@ defmodule Phoenix.LiveViewTest.StreamResetLive do
 
   # see https://github.com/phoenixframework/phoenix_live_view/issues/2994
 
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
     socket
     |> stream(:items, [
       %{id: "a", name: "A"},
@@ -309,13 +309,18 @@ defmodule Phoenix.LiveViewTest.StreamResetLive do
       %{id: "c", name: "C"},
       %{id: "d", name: "D"}
     ])
+    |> assign(:use_phx_remove, is_map(params) && params["phx-remove"])
     |> then(&{:ok, &1})
   end
 
   def render(assigns) do
     ~H"""
     <ul phx-update="stream" id="thelist">
-      <li :for={{id, item} <- @streams.items} id={id}>
+      <li
+        :for={{id, item} <- @streams.items}
+        id={id}
+        phx-remove={if @use_phx_remove, do: Phoenix.LiveView.JS.hide()}
+      >
         <%= item.name %>
       </li>
     </ul>


### PR DESCRIPTION
This would throw otherwise while trying to reorder an element that is not in the DOM.

We also had a bug where stream items with phx-remove were removed, despite re-adding them in a stream reset.