### PR TITLE
Align LiveViewTest with JS DOM patching for phx-update="ignore"

### DIFF
--- a/lib/phoenix_live_view/test/dom.ex
+++ b/lib/phoenix_live_view/test/dom.ex
@@ -432,9 +432,18 @@ defmodule Phoenix.LiveViewTest.DOM do
     {tag, attrs, new_children}
   end
 
-  defp apply_phx_update("ignore", _state, node, _streams) do
-    verify_phx_update_id!("ignore", attribute(node, "id"), node)
-    node
+  defp apply_phx_update("ignore", html_tree, node, _streams) do
+    container_id = attribute(node, "id")
+    verify_phx_update_id!("ignore", container_id, node)
+
+    {tag, attrs_before, children_before} = by_id(html_tree, container_id)
+    {_tag, attrs, _children} = node
+
+    attrs =
+      Enum.reject(attrs_before, fn {name, _} -> String.starts_with?(name, "data-") end) ++
+        Enum.filter(attrs, fn {name, _} -> String.starts_with?(name, "data-") end)
+
+    {tag, attrs, children_before}
   end
 
   defp apply_phx_update(type, _state, node, _streams) when type in [nil, "replace"] do

--- a/test/phoenix_live_view/test/dom_test.exs
+++ b/test/phoenix_live_view/test/dom_test.exs
@@ -224,6 +224,34 @@ defmodule Phoenix.LiveViewTest.DOMTest do
       assert new_html =~ ~S(<div id="2">b</div>)
       assert new_html =~ ~S(<div id="3">a</div>)
     end
+
+    test "patches only container data attributes when phx-update=ignore" do
+      html = """
+      <div data-phx-session="SESSIONMAIN" data-phx-main="true" id="phx-458">
+      <div id="div" remove data-remove update="a" data-update="a" phx-update="ignore">
+        <div id="1">a</div>
+      </div>
+      </div>
+      """
+
+      inner_html = """
+      <div id="div" update="b" data-update="b" add data-add phx-update="ignore">
+        <div id="1" class="foo">b</div>
+      </div>
+      """
+
+      {new_html, _removed_cids} = DOM.patch_id("phx-458", DOM.parse(html), DOM.parse(inner_html), [])
+
+      new_html = DOM.to_html(new_html)
+
+      assert new_html =~ ~S( remove)
+      refute new_html =~ ~S( data-remove)
+      assert new_html =~ ~S( update="a")
+      assert new_html =~ ~S( data-update="b")
+      refute new_html =~ ~S( add)
+      assert new_html =~ ~S( data-add)
+      assert new_html =~ ~S(<div id="1">a</div>)
+    end
   end
 
   describe "merge_diff" do


### PR DESCRIPTION
Fixes #3119 

Patch data attributes consistently, but not others.

a774138
> The "ignore" behaviour is frequently used when you need to integrate with another JS library. Updates from the server to the element's content and attributes are ignored, *except for data attributes*. Changes, additions, and removals from the server to data attributes are merged with the ignored element which can be used to pass data to the JS handler.