### PR TITLE
Assign index when nesting inside a list occurs.

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -90,9 +90,11 @@ let serializeForm = (form, metadata, onlyNames = []) => {
 
   const params = new URLSearchParams()
 
+  let index = 0;
   for(let [key, val] of formData.entries()){
     if(onlyNames.length === 0 || onlyNames.indexOf(key) >= 0){
-      params.append(key, val)
+      // replace foo[][bar] with foo[0][bar] so we can support nesting from a select multiple
+      params.append(key.replace('[][',`[${index++}][`), val)
     }
   }
 


### PR DESCRIPTION
This allows the use of nesting inside a list on a select multiple field by inserting the index.

# Why

Plug does not support nesting without index. See the red warning here: https://hexdocs.pm/plug/Plug.Conn.Query.html
It expects either foo[] or foo[0][bar]

This is fine if you have multiple input fields, you can assign a name with an index. However, on a select multiple, you are not able to insert a different name for each option.

For example the following select:

```
<select name="foo[][bar]" multiple>
<option value=1 selected>Value 1</option>
<option value=2 selected>Value 2</option>
</select>
```
Will result in the browser sending: `foo[][bar]=1&foo[][bar]=2`, but the decode will throw all but one value away.

By automatically adding the index when nesting is detected it will turn this into something that IS allowed by Plug, namely: `foo[0][bar]=1&foo[1][bar]=2`


# How?

By looking for the string `[][` in the `name` we can detect nesting and change it to `[index][`. The replace won't do anything on other lists or standard field names.

Note: this MR was proposed after Jose pointed out the limitation here https://github.com/elixir-plug/plug/issues/1210 