### PR TITLE
Dont insert newlines around script/style tag content if phx-no-format

### DIFF
--- a/lib/phoenix_live_view/html_algebra.ex
+++ b/lib/phoenix_live_view/html_algebra.ex
@@ -170,7 +170,7 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
     {:block, group(nest(children, :reset))}
   end
 
-  defp to_algebra({:tag_block, name, attrs, block, _meta}, context) when name in @languages do
+  defp to_algebra({:tag_block, name, attrs, block, meta}, context) when name in @languages do
     children = block_to_algebra(block, %{context | mode: :preserve})
 
     # Convert the whole block to text as there are no
@@ -194,7 +194,7 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
     doc =
       case lines do
         [] ->
-          empty()
+          line()
 
         _ ->
           text =
@@ -202,7 +202,10 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
             |> Enum.map(&remove_indentation(&1, indentation))
             |> text_to_algebra(0, [])
 
-          nest(concat(line(), text), 2)
+          case meta do
+            %{mode: :preserve} -> text
+            _ -> concat(nest(concat(line(), text), 2), line())
+          end
       end
 
     group =
@@ -211,7 +214,6 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
         build_attrs(attrs, "", context.opts),
         ">",
         doc,
-        line(),
         "</#{name}>"
       ])
       |> group()

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -1715,6 +1715,18 @@ if Version.match?(System.version(), ">= 1.13.0") do
 
       assert_formatter_output(
         """
+        <script phx-no-format><%= raw(js_code()) %></script>
+        """,
+        """
+        <script
+          phx-no-format
+        ><%= raw(js_code()) %></script>
+        """,
+        line_length: 5
+      )
+
+      assert_formatter_output(
+        """
         <span phx-no-format class="underline">Check</span> Messages
         """,
         """


### PR DESCRIPTION
A tag containing no lines is now converted to a single `line()` instead of `empty()` to preserve compatibility with existing tests and formatted code.

Fixes #3134