### PR TITLE
prevent reducing structs in extract_streams

### DIFF
--- a/lib/phoenix_live_view/test/dom.ex
+++ b/lib/phoenix_live_view/test/dom.ex
@@ -260,7 +260,7 @@ defmodule Phoenix.LiveViewTest.DOM do
   defp deep_merge_diff(_target, source),
     do: source
 
-  def extract_streams(%{} = source, streams) do
+  def extract_streams(%{} = source, streams) when not is_struct(source) do
     Enum.reduce(source, streams, fn
       {@stream_id, stream}, acc -> [stream | acc]
       {_key, value}, acc -> extract_streams(value, acc)


### PR DESCRIPTION
Should fix #3141

I didn't expect structs in the rendered tree? If someone has an idea how to force this I could add a test as well...