### PR TITLE
Feature: Allow error reason to get to the server

### DIFF
--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -133,7 +133,7 @@ defmodule Phoenix.LiveView.Upload do
     conf = get_upload_by_ref!(socket, config_ref)
 
     if conf.external do
-      put_upload_error(socket, conf.name, entry_ref, :external_client_failure)
+      put_upload_error(socket, conf.name, entry_ref, external_client_failure: reason)
     else
       socket
     end


### PR DESCRIPTION
This PR aims to allow external upload error reason to get to the server. This will enable the server to render error messages in a live view, providing a more seamless and informative user experience.

See [this post](https://elixirforum.com/t/how-can-i-get-external-upload-error-reason/62083) for more details.

Please be aware that this PR introduces a breaking change. However, I think it is necessary to ensure that the argument passed to the [UploadEntity error](https://github.com/phoenixframework/phoenix_live_view/blob/main/assets/js/phoenix_live_view/upload_entry.js#L83) function remains useful in the context of external uploads. 
