### PR TITLE
warn on expensive assigns

### DIFF
--- a/test/phoenix_live_view/integrations/expensive_assigns_test.exs
+++ b/test/phoenix_live_view/integrations/expensive_assigns_test.exs
@@ -1,0 +1,57 @@
+defmodule Phoenix.LiveViewTest.ExpensiveAssignsTest do
+  # this is intentionally async: false as we change the application
+  # environment and recompile files!
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  import Phoenix.ConnTest
+
+  import Phoenix.LiveViewTest
+  alias Phoenix.LiveViewTest.Endpoint
+
+  @endpoint Endpoint
+
+  setup_all do
+    Application.put_env(:phoenix_live_view, :warn_on_expensive_assigns, true)
+    # TODO: can we make this better?
+    Code.compile_file(__DIR__ <> "/../../../lib/phoenix_live_view/async.ex")
+    Code.compile_file(__DIR__ <> "/../../../lib/phoenix_live_view/utils.ex")
+
+    on_exit(fn ->
+      Application.put_env(:phoenix_live_view, :warn_on_expensive_assigns, false)
+      Code.compile_file(__DIR__ <> "/../../../lib/phoenix_live_view/async.ex")
+      Code.compile_file(__DIR__ <> "/../../../lib/phoenix_live_view/utils.ex")
+    end)
+  end
+
+  setup do
+    {:ok, conn: Plug.Test.init_test_session(Phoenix.ConnTest.build_conn(), %{})}
+  end
+
+  test "warns when storing socket in assigns", %{conn: conn} do
+    _ =
+      capture_io(:stderr, fn ->
+        {:ok, lv, _html} = live(conn, "/warn-on-expensive-assigns")
+        render_async(lv)
+
+        send(self(), {:lv, lv})
+      end)
+
+    lv =
+      receive do
+        {:lv, lv} -> lv
+      end
+
+    warnings =
+      capture_io(:stderr, fn ->
+        render_hook(lv, "expensive_assigns")
+      end)
+
+    assert warnings =~ "you are accessing the LiveView socket in the assigned function my_fun"
+    assert warnings =~ "you are accessing the LiveView socket in the assigned function fun"
+
+    assert warnings =~
+             "you are assigning the LiveView socket itself into the assign nested_socket"
+  end
+end

--- a/test/support/live_views/warn_on_expensive_assigns.ex
+++ b/test/support/live_views/warn_on_expensive_assigns.ex
@@ -1,0 +1,31 @@
+defmodule Phoenix.LiveViewTest.WarnOnExpensiveAssignsLive do
+  use Phoenix.LiveView
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :bar, "bar")}
+  end
+
+  defp do_something_with(x), do: x
+
+  @impl Phoenix.LiveView
+  def handle_event("expensive_assigns", _params, socket) do
+    socket
+    |> assign(:my_fun, fn -> do_something_with(socket.assigns.bar) end)
+    |> assign(:nested, %{
+      fun: fn x ->
+        do_something_with(x)
+        do_something_with(socket.assigns.bar)
+      end
+    })
+    |> assign(:nested_socket, socket)
+    |> then(&{:noreply, &1})
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <h1>Hello!</h1>
+    """
+  end
+end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -47,6 +47,7 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/live-reload", ReloadLive
     live "/assign_async", AssignAsyncLive
     live "/start_async", StartAsyncLive
+    live "/warn-on-expensive-assigns", WarnOnExpensiveAssignsLive
 
     # controller test
     get "/controller/:type", Controller, :incoming


### PR DESCRIPTION
Work in progress. It would be nice if we could have compile time warnings. Without too big changes this only seems reasonable for the async functions. Wdyt?
