### PR TITLE
Support handle_event hooks on LiveComponents

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1429,7 +1429,8 @@ defmodule Phoenix.LiveView do
   lifecycle stages: `:handle_params`, `:handle_event`, `:handle_info`, `:handle_async`, and
   `:after_render`. To attach a hook to the `:mount` stage, use `on_mount/1`.
 
-  > Note: only `:after_render` hooks are currently supported in LiveComponents.
+  > Note: only `:after_render` and `:handle_event` hooks are currently supported in
+  > LiveComponents.
 
   ## Return Values
 

--- a/lib/phoenix_live_view/lifecycle.ex
+++ b/lib/phoenix_live_view/lifecycle.ex
@@ -95,7 +95,7 @@ defmodule Phoenix.LiveView.Lifecycle do
   end
 
   defp lifecycle(socket, stage) do
-    if Utils.cid(socket) && stage not in [:after_render] do
+    if Utils.cid(socket) && stage not in [:after_render, :handle_event] do
       raise ArgumentError, "lifecycle hooks are not supported on stateful components."
     end
 

--- a/test/phoenix_live_view/integrations/hooks_test.exs
+++ b/test/phoenix_live_view/integrations/hooks_test.exs
@@ -295,8 +295,30 @@ defmodule Phoenix.LiveView.HooksTest do
     assert render_async(lv) =~ "task:o.\n"
   end
 
+  test "attach/detach_hook with a handle_event live component socket", %{conn: conn} do
+    {:ok, lv, _html} = live(conn, "/lifecycle/components/handle_event")
+    lv |> element("#attach") |> render_click()
+    lv |> element("#hook") |> render_click()
+    assert render_async(lv) =~ "counter: 1"
+
+    lv |> element("#hook") |> render_click()
+    assert render_async(lv) =~ "counter: 2"
+
+    lv |> element("#detach-component-hook") |> render_click()
+    Process.flag(:trap_exit, true)
+
+    assert ExUnit.CaptureLog.capture_log(fn ->
+             try do
+               lv |> element("#hook") |> render_click()
+             catch
+               :exit, _ -> :ok
+             end
+           end) =~
+             "** (UndefinedFunctionError) function Phoenix.LiveViewTest.HooksEventComponent.handle_event/3 is undefined"
+  end
+
   test "attach_hook raises when given a live component socket", %{conn: conn} do
-    {:ok, lv, _html} = live(conn, "/lifecycle/components")
+    {:ok, lv, _html} = live(conn, "/lifecycle/components/handle_info")
 
     assert HooksLive.exits_with(lv, ArgumentError, fn ->
              lv |> element("#attach") |> render_click()
@@ -304,7 +326,7 @@ defmodule Phoenix.LiveView.HooksTest do
   end
 
   test "detach_hook raises when given a live component socket", %{conn: conn} do
-    {:ok, lv, _html} = live(conn, "/lifecycle/components")
+    {:ok, lv, _html} = live(conn, "/lifecycle/components/handle_info")
 
     assert HooksLive.exits_with(lv, ArgumentError, fn ->
              lv |> element("#detach") |> render_click()

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -117,7 +117,7 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/lifecycle/halt-mount", HooksLive.HaltMount
     live "/lifecycle/redirect-cont-mount", HooksLive.RedirectMount, :cont
     live "/lifecycle/redirect-halt-mount", HooksLive.RedirectMount, :halt
-    live "/lifecycle/components", HooksLive.WithComponent
+    live "/lifecycle/components/:type", HooksLive.WithComponent
     live "/lifecycle/handle-params-not-defined", HooksLive.HandleParamsNotDefined
     live "/lifecycle/handle-info-not-defined", HooksLive.HandleInfoNotDefined
     live "/lifecycle/on-mount-options", HooksLive.OnMountOptions


### PR DESCRIPTION
LiveComponents can now attach `:handle_event` hooks. The previous tests have been updated to use `handle_info` which will likely not be supported by LiveComponents as they don't have a `:handle_info`.