### PR TITLE
Find element/3 by ID with special character via '#id\?' selector

### DIFF
--- a/lib/phoenix_live_view/test/dom.ex
+++ b/lib/phoenix_live_view/test/dom.ex
@@ -30,7 +30,23 @@ defmodule Phoenix.LiveViewTest.DOM do
 
   def all(html_tree, selector), do: Floki.find(html_tree, selector)
 
-  def maybe_one(html_tree, selector, type \\ :selector) do
+  def maybe_one(html_tree, selector, type \\ :selector)
+
+  def maybe_one(html_tree, "#" <> id_selector = selector, type) do
+    id = String.replace(id_selector, "\\", "")
+
+    case Floki.get_by_id(html_tree, id) do
+      nil ->
+        {:error, :none,
+         "expected #{type} #{inspect(selector)} to return a single element, but got none " <>
+           "within: \n\n" <> inspect_html(html_tree)}
+
+      node ->
+        {:ok, node}
+    end
+  end
+
+  def maybe_one(html_tree, selector, type) do
     case all(html_tree, selector) do
       [node] ->
         {:ok, node}

--- a/test/phoenix_live_view/integrations/elements_test.exs
+++ b/test/phoenix_live_view/integrations/elements_test.exs
@@ -27,6 +27,7 @@ defmodule Phoenix.LiveView.ElementsTest do
       assert view |> element("#scoped-render") |> has_element?()
       assert view |> element("div", "This is a div") |> has_element?()
       assert view |> element("#scoped-render", ~r/^This is a div$/) |> has_element?()
+      assert view |> element("#special-char\\?") |> has_element?()
 
       refute view |> element("#unknown") |> has_element?()
       refute view |> element("div", "no matching text") |> has_element?()

--- a/test/support/live_views/elements.ex
+++ b/test/support/live_views/elements.ex
@@ -10,6 +10,7 @@ defmodule Phoenix.LiveViewTest.ElementsLive do
     <div id="scoped-render"><span>This</span> is a div</div>
     <div>This</div>
     <div id="child-component"><.live_component module={Phoenix.LiveViewTest.ElementsComponent} id={1} /></div>
+    <span id="special-char?"></span>
 
     <%# basic render_* %>
     <span id="span-no-attr">This is a span</span>


### PR DESCRIPTION
Use `Floki.get_by_id/2` to support special chars in ID selectors.
As supported by JS `document.getElementById` in browsers.