### PR TITLE
warn if socket is used in start_async / assign_async

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -167,6 +167,8 @@ defmodule Phoenix.LiveView do
 
   alias Phoenix.LiveView.{Socket, LiveStream, Async}
 
+  require Phoenix.LiveView.Async
+
   @type unsigned_params :: map
 
   @doc """
@@ -1908,10 +1910,8 @@ defmodule Phoenix.LiveView do
         send_update(parent, Component, data)
       end)
   """
-  def assign_async(%Socket{} = socket, key_or_keys, func, opts \\ [])
-      when (is_atom(key_or_keys) or is_list(key_or_keys)) and
-             is_function(func, 0) do
-    Async.assign_async(socket, key_or_keys, func, opts)
+  defmacro assign_async(socket, key_or_keys, func, opts \\ []) do
+    Async.assign_async(socket, key_or_keys, func, opts, __CALLER__)
   end
 
   @doc """
@@ -1923,6 +1923,10 @@ defmodule Phoenix.LiveView do
   of the caller LiveView or LiveComponent.
 
   The task is only started when the socket is connected.
+
+  ## Options
+
+    * `:supervisor` - allows you to specify a `Task.Supervisor` to supervise the task.
 
   ## Examples
 
@@ -1945,8 +1949,8 @@ defmodule Phoenix.LiveView do
 
   See the moduledoc for more information.
   """
-  def start_async(%Socket{} = socket, name, func) when is_function(func, 0) do
-    Async.start_async(socket, name, func)
+  defmacro start_async(socket, name, func, opts \\ []) do
+    Async.start_async(socket, name, func, opts, __CALLER__)
   end
 
   @doc """

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -167,8 +167,6 @@ defmodule Phoenix.LiveView do
 
   alias Phoenix.LiveView.{Socket, LiveStream, Async}
 
-  require Phoenix.LiveView.Async
-
   @type unsigned_params :: map
 
   @doc """

--- a/lib/phoenix_live_view/async.ex
+++ b/lib/phoenix_live_view/async.ex
@@ -14,7 +14,7 @@ defmodule Phoenix.LiveView.Async do
     # prevent false positives, for example
     # start_async(socket, :foo, function_that_returns_the_anonymous_function(socket))
     if match?({:&, _, _}, func) or match?({:fn, _, _}, func) do
-      Macro.prewalk(Macro.expand(func, env), fn
+      Macro.prewalk(func, fn
         {:socket, meta, nil} ->
           warn.(
             """

--- a/lib/phoenix_live_view/async.ex
+++ b/lib/phoenix_live_view/async.ex
@@ -5,6 +5,7 @@ defmodule Phoenix.LiveView.Async do
 
   defp validate_function_env(func, op, env) do
     warn =
+      # TODO: Remove conditional once we require Elixir v1.14+
       if Version.match?(System.version(), ">= 1.14.0") do
         fn msg, env -> IO.warn(msg, env) end
       else

--- a/test/phoenix_component/verify_test.exs
+++ b/test/phoenix_component/verify_test.exs
@@ -544,7 +544,7 @@ defmodule Phoenix.ComponentVerifyTest do
         end
       end)
 
-    assert warnings == ""
+    refute warnings =~ "undefined attribute"
   end
 
   test "does warn for unknown attribute in slot without do-block when validate_attrs is true" do

--- a/test/phoenix_live_view_test.exs
+++ b/test/phoenix_live_view_test.exs
@@ -301,4 +301,87 @@ defmodule Phoenix.LiveViewUnitTest do
       end
     end
   end
+
+  describe "async operations" do
+    import ExUnit.CaptureIO
+
+    for fun <- [:assign_async, :start_async] do
+      test "warns when passing socket to #{fun} function" do
+        warnings =
+          capture_io(:stderr, fn ->
+            Code.eval_string("""
+            defmodule AssignAsyncSocket do
+              use Phoenix.LiveView
+
+              def mount(_params, _session, socket) do
+                {:ok, #{unquote(fun)}(socket, :foo, fn ->
+                  do_something(socket.assigns)
+                end)}
+              end
+
+              defp do_something(_socket), do: :ok
+            end
+            """)
+          end)
+
+        assert warnings =~
+                 "you are accessing the LiveView Socket inside a function given to #{unquote(fun)}"
+      end
+
+      test "does not warn when accessing socket outside of function passed to #{fun}" do
+        warnings =
+          capture_io(:stderr, fn ->
+            Code.eval_string("""
+            defmodule AssignAsyncSocket do
+              use Phoenix.LiveView
+
+              def mount(_params, _session, socket) do
+                socket = assign(socket, :foo, :bar)
+                foo = socket.assigns.foo
+
+                {:ok, #{unquote(fun)}(socket, :foo, fn ->
+                  do_something(foo)
+                end)}
+              end
+
+              defp do_something(assigns), do: :ok
+            end
+            """)
+          end)
+
+        refute warnings =~
+                 "you are accessing the LiveView Socket inside a function given to #{unquote(fun)}"
+      end
+
+      test "does not warn when argument is not a function (#{fun})" do
+        warnings =
+          capture_io(:stderr, fn ->
+            Code.eval_string("""
+            defmodule AssignAsyncSocket do
+              use Phoenix.LiveView
+
+              def mount(_params, _session, socket) do
+                socket = assign(socket, :foo, :bar)
+
+                {:ok, #{unquote(fun)}(socket, :foo, function_that_returns_the_func(socket))}
+              end
+
+              defp function_that_returns_the_func(socket) do
+                foo = socket.assigns.foo
+
+                fn ->
+                  do_something(foo)
+                end
+              end
+
+              defp do_something(assigns), do: :ok
+            end
+            """)
+          end)
+
+        refute warnings =~
+                 "you are accessing the LiveView Socket inside a function given to #{unquote(fun)}"
+      end
+    end
+  end
 end

--- a/test/phoenix_live_view_test.exs
+++ b/test/phoenix_live_view_test.exs
@@ -344,7 +344,7 @@ defmodule Phoenix.LiveViewUnitTest do
                 end)}
               end
 
-              defp do_something(assigns), do: :ok
+              defp do_something(_assigns), do: :ok
             end
             """)
           end)
@@ -374,7 +374,7 @@ defmodule Phoenix.LiveViewUnitTest do
                 end
               end
 
-              defp do_something(assigns), do: :ok
+              defp do_something(_assigns), do: :ok
             end
             """)
           end)


### PR DESCRIPTION
This PR only focuses on the async ops part of #3157. I'm not that knowledgeable when it comes to macros, but this seems to work fine and does not rely on runtime checks.