### PR TITLE
Ignore HTML comments

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -519,7 +519,7 @@ let DOM = {
         if(!childNode.id){
           // Skip warning if it's an empty text node (e.g. a new-line)
           let isEmptyTextNode = childNode.nodeType === Node.TEXT_NODE && childNode.nodeValue.trim() === ""
-          if(!isEmptyTextNode){
+          if(!isEmptyTextNode && && childNode.nodeType !== childNode.COMMENT_NODE){
             logError("only HTML element tags with an id are allowed inside containers with phx-update.\n\n" +
               `removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"\n\n`)
           }

--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -519,7 +519,7 @@ let DOM = {
         if(!childNode.id){
           // Skip warning if it's an empty text node (e.g. a new-line)
           let isEmptyTextNode = childNode.nodeType === Node.TEXT_NODE && childNode.nodeValue.trim() === ""
-          if(!isEmptyTextNode && && childNode.nodeType !== childNode.COMMENT_NODE){
+          if(!isEmptyTextNode && childNode.nodeType !== Node.COMMENT_NODE){
             logError("only HTML element tags with an id are allowed inside containers with phx-update.\n\n" +
               `removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"\n\n`)
           }


### PR DESCRIPTION
Hello, I found that when I try to render nested components I got this kind of errors in my browser console.

![Screenshot_20240307_174120](https://github.com/phoenixframework/phoenix_live_view/assets/445264/1321ef40-d0ea-4eac-81db-a433bc084ff3)


This happens because each component is surrounded by an HTML comment. In this PR I just skip the comment nodes I found.

The error disappears in my project and everything is working properly but let me know if I have to take into account anything else.