### PR TITLE
Do not format when empty

### DIFF
--- a/lib/phoenix_live_view/html_formatter.ex
+++ b/lib/phoenix_live_view/html_formatter.ex
@@ -245,9 +245,9 @@ defmodule Phoenix.LiveView.HTMLFormatter do
           raise ParseError, line: line, column: column, file: file, description: message
       end
 
-    # If the opening delimiter is a single character, such as ~H"...",
+    # If the opening delimiter is a single character, such as ~H"...", or the formatted code is empty,
     # do not add trailing newline.
-    newline = if match?(<<_>>, opts[:opening_delimiter]), do: [], else: ?\n
+    newline = if match?(<<_>>, opts[:opening_delimiter]) or formatted == [], do: [], else: ?\n
 
     # TODO: Remove IO.iodata_to_binary/1 call on Elixir v1.14+
     IO.iodata_to_binary([formatted, newline])

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -2063,6 +2063,14 @@ if Version.match?(System.version(), ">= 1.13.0") do
       )
     end
 
+    test "does not format when empty" do
+      assert_formatter_doesnt_change("")
+
+      assert_formatter_doesnt_change("", opening_delimiter: "\"")
+
+      assert_formatter_doesnt_change("", opening_delimiter: "\"\"\"")
+    end
+
     # TODO: Remove this `if` when we require Elixir 1.14+
     if function_exported?(EEx, :tokenize, 2) do
       test "handle EEx comments" do


### PR DESCRIPTION
I have discovered that `mix format` is adding a new line to empty `.heex` files. This PR ensures that the final new line is added only when the output is not empty. Otherwise, the file remains unchanged.