### PR TITLE
Do not blur readOnly elements when restoring focus

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -479,7 +479,6 @@ let DOM = {
     if(!DOM.isTextualInput(focused)){ return }
 
     let wasFocused = focused.matches(":focus")
-    if(focused.readOnly){ focused.blur() }
     if(!wasFocused){ focused.focus() }
     if(this.hasSelectionRange(focused)){
       focused.setSelectionRange(selectionStart, selectionEnd)


### PR DESCRIPTION
Fixes https://github.com/phoenixframework/phoenix_live_view/issues/3164.

As mentioned in the issue, I'm not sure what the original intention is behind blurring readonly elements when restoring focus. Since the original logic is explicitly checking for readonly elements to be blurred, it's possible this breaks some expected behaviour that I am unaware of.