### PR TITLE
fix typo

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1767,7 +1767,7 @@ defmodule Phoenix.LiveView do
       end
 
   See `stream_delete_by_dom_id/3` to remove an item without requiring the
-  original datastructure.
+  original data structure.
   """
   def stream_delete(%Socket{} = socket, name, item) do
     update_stream(socket, name, &LiveStream.delete_item(&1, item))
@@ -1778,7 +1778,7 @@ defmodule Phoenix.LiveView do
 
   Behaves just like `stream_delete/3`, but accept the precomputed DOM id,
   which allows deleting from a stream without fetching or building the original
-  stream datastructure.
+  stream datas tructure.
 
   ## Examples
 

--- a/lib/phoenix_live_view/async_result.ex
+++ b/lib/phoenix_live_view/async_result.ex
@@ -1,6 +1,6 @@
 defmodule Phoenix.LiveView.AsyncResult do
   @moduledoc ~S'''
-  Provides a datastructure for tracking the state of an async assign.
+  Provides a data structure for tracking the state of an async assign.
 
   See the `Async Operations` section of the `Phoenix.LiveView` docs for more information.
 


### PR DESCRIPTION
In the documentation, `data structure` is written as `datastructure`.