### PR TITLE
Add support for `form` attribute in `live_file_input/1`

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2868,7 +2868,7 @@ defmodule Phoenix.Component do
       "the optional override for the accept attribute. Defaults to :accept specified by allow_upload"
   )
 
-  attr.(:rest, :global, include: ~w(webkitdirectory required disabled))
+  attr.(:rest, :global, include: ~w(webkitdirectory required disabled form))
 
   def live_file_input(%{upload: upload} = assigns) do
     assigns = assign_new(assigns, :accept, fn -> upload.accept != :any && upload.accept end)


### PR DESCRIPTION
This allows to put this `<input>` outside of a particular `<form>`