### PR TITLE
DOM.wantsNewTab(e) returns true for target="namedTab"

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -70,7 +70,8 @@ let DOM = {
     let wantsNewTab = e.ctrlKey || e.shiftKey || e.metaKey || (e.button && e.button === 1)
     let isDownload = (e.target instanceof HTMLAnchorElement && e.target.hasAttribute("download"))
     let isTargetBlank = e.target.hasAttribute("target") && e.target.getAttribute("target").toLowerCase() === "_blank"
-    return wantsNewTab || isTargetBlank || isDownload
+    let isTargetNamedTab = e.target.hasAttribute("target") && !e.target.getAttribute("target").startsWith("_")
+    return wantsNewTab || isTargetBlank || isDownload || isTargetNamedTab
   },
 
   isUnloadableFormSubmit(e){


### PR DESCRIPTION
Currently opening a link with `target="name"` unloads live_socket because phoenix thinks it opens in the current tab, when in reality it doesn't. 

This change fixes it by checking if target is a named tab. These are valid values:


Value | Description
-- | --
_blank | Opens the linked document in a new window or tab
_self | Opens the linked document in the same frame as it was clicked (this is default)
_parent | Opens the linked document in the parent frame
_top | Opens the linked document in the full body of the window
framename | Opens the linked document in the named iframe

Check is a bit naive, I'm simply comparing if "target" doesn't start with underscore and adding it to previous checks. Should be enough?

Closes #3184