### PR TITLE
Doc update for `Phoenix.LiveView.stream_insert/4`

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1734,8 +1734,7 @@ defmodule Phoenix.LiveView do
   By default, the item is appended to the parent DOM container.
   The `:at` option may be provided to insert an item at a particular index in
   the collection on the client. If the item already exists in the parent DOM
-  container then it will be updated. In this case the `:at` option will have no
-  effect.
+  container then it will be updated.
 
   See `stream/4` for inserting multiple items at once.
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1734,7 +1734,7 @@ defmodule Phoenix.LiveView do
   By default, the item is appended to the parent DOM container.
   The `:at` option may be provided to insert an item at a particular index in
   the collection on the client. If the item already exists in the parent DOM
-  container then it will be updated.
+  container then it will be updated in place.
 
   See `stream/4` for inserting multiple items at once.
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1732,8 +1732,10 @@ defmodule Phoenix.LiveView do
   Returns an updated `socket`.
 
   By default, the item is appended to the parent DOM container.
-  The `:at` option may be provided to insert or update an item
-  to a particular index in the collection on the client.
+  The `:at` option may be provided to insert an item at a particular index in
+  the collection on the client. If the item already exists in the parent DOM
+  container then it will be updated. In this case the `:at` option will have no
+  effect.
 
   See `stream/4` for inserting multiple items at once.
 
@@ -1752,7 +1754,7 @@ defmodule Phoenix.LiveView do
 
       stream_insert(socket, :songs, %Song{id: 2, title: "Song 2"}, at: 0)
 
-  Or updating an existing song, while also moving it to the top of the collection:
+  Or updating an existing song (in this case the `:at` option has no effect):
 
       stream_insert(socket, :songs, %Song{id: 1, title: "Song 1 updated"}, at: 0)
 


### PR DESCRIPTION
Update the docs to make it clear that in the case where the item already exists in the parent DOM container, it's position will not be changed regardless of the value of the `:at` option. In particular, I removed the phrase, "while also moving it to the top of the collection", which was inaccurate.