### PR TITLE
Fix scroll hook when the root element has overflow Y as "scroll" or "auto"

### DIFF
--- a/assets/js/phoenix_live_view/hooks.js
+++ b/assets/js/phoenix_live_view/hooks.js
@@ -58,8 +58,10 @@ let Hooks = {
 }
 
 let findScrollContainer = (el) => {
+  // the scroll event won't be fired on the html/body element even if overflow is set
+  // therefore we return null to instead listen for scroll events on document
+  if (["HTML", "BODY"].indexOf(el.nodeName.toUpperCase()) >= 0) return null
   if(["scroll", "auto"].indexOf(getComputedStyle(el).overflowY) >= 0) return el
-  if(document.documentElement === el) return null
   return findScrollContainer(el.parentElement)
 }
 


### PR DESCRIPTION
When the root element has the overflowY as "auto" or "auto", this element will be returned.
As it never scroll, the event will never be launched. 
We want to always return null if the scrollContainer is the root (HTML) element.