### PR TITLE
do not use childrenOnly when patching stream items

### DIFF
--- a/test/e2e/tests/streams.spec.js
+++ b/test/e2e/tests/streams.spec.js
@@ -160,6 +160,32 @@ test("stream reset properly reorders items", async ({ page }) => {
   ]);
 });
 
+test("stream reset updates attributes", async ({ page }) => {
+  await page.goto("/stream");
+  await syncLV(page);
+
+  await expect(await usersInDom(page, "users")).toEqual([
+    { id: "users-1", text: "chris" },
+    { id: "users-2", text: "callan" }
+  ]);
+
+  await expect(await page.locator("#users-1").getAttribute("data-count")).toEqual("0");
+  await expect(await page.locator("#users-2").getAttribute("data-count")).toEqual("0");
+
+  await page.getByRole("button", { name: "Reorder" }).click();
+  await syncLV(page);
+
+  await expect(await usersInDom(page, "users")).toEqual([
+    { id: "users-3", text: "peter" },
+    { id: "users-1", text: "chris" },
+    { id: "users-4", text: "mona" }
+  ]);
+
+  await expect(await page.locator("#users-1").getAttribute("data-count")).toEqual("1");
+  await expect(await page.locator("#users-3").getAttribute("data-count")).toEqual("1");
+  await expect(await page.locator("#users-4").getAttribute("data-count")).toEqual("1");
+});
+
 test.describe("Issue #2656", () => {
   test("stream reset works when patching", async ({ page }) => {
     await page.goto("/healthy/fruits");

--- a/test/phoenix_live_view/integrations/stream_test.exs
+++ b/test/phoenix_live_view/integrations/stream_test.exs
@@ -143,6 +143,32 @@ defmodule Phoenix.LiveView.StreamTest do
            ]
   end
 
+  test "updates attributes on reset", %{conn: conn} do
+    {:ok, lv, _} = live(conn, "/stream")
+
+    assert lv |> render() |> users_in_dom("users") == [
+             {"users-1", "chris"},
+             {"users-2", "callan"}
+           ]
+
+    html = render(lv)
+    assert Floki.find(html, "#users-1") |> Floki.attribute("data-count") == ["0"]
+    assert Floki.find(html, "#users-2") |> Floki.attribute("data-count") == ["0"]
+
+    lv |> render_hook("reset-users-reorder", %{})
+
+    assert lv |> render() |> users_in_dom("users") == [
+             {"users-3", "peter"},
+             {"users-1", "chris"},
+             {"users-4", "mona"}
+           ]
+
+    html = render(lv)
+    assert Floki.find(html, "#users-1") |> Floki.attribute("data-count") == ["1"]
+    assert Floki.find(html, "#users-3") |> Floki.attribute("data-count") == ["1"]
+    assert Floki.find(html, "#users-4") |> Floki.attribute("data-count") == ["1"]
+  end
+
   test "stream reset on patch", %{conn: conn} do
     {:ok, lv, _html} = live(conn, "/healthy/fruits")
 
@@ -802,17 +828,19 @@ defmodule Phoenix.LiveView.StreamTest do
            ]
   end
 
-  test "issue #3129 - streams asynchronously assigned and rendered inside a comprehension", %{conn: conn} do
+  test "issue #3129 - streams asynchronously assigned and rendered inside a comprehension", %{
+    conn: conn
+  } do
     {:ok, lv, _html} = live(conn, "/stream/inside-for")
 
     html = render_async(lv)
 
     assert ul_list_children(html) == [
-              {"items-a", "A"},
-              {"items-b", "B"},
-              {"items-c", "C"},
-              {"items-d", "D"}
-            ]
+             {"items-a", "A"},
+             {"items-b", "B"},
+             {"items-c", "C"},
+             {"items-d", "D"}
+           ]
   end
 
   defp assert_pruned_stream(lv) do

--- a/test/support/live_views/streams.ex
+++ b/test/support/live_views/streams.ex
@@ -31,7 +31,7 @@ defmodule Phoenix.LiveViewTest.StreamLive do
   def render(assigns) do
     ~H"""
     <div id="users" phx-update="stream">
-      <div :for={{id, user} <- @streams.users} id={id}>
+      <div :for={{id, user} <- @streams.users} id={id} data-count={@count}>
         <%= user.name %>
         <button phx-click="delete" phx-value-id={id}>delete</button>
         <button phx-click="update" phx-value-id={id}>update</button>
@@ -43,7 +43,7 @@ defmodule Phoenix.LiveViewTest.StreamLive do
       </div>
     </div>
     <div id="admins" phx-update="stream">
-      <div :for={{id, user} <- @streams.admins} id={id}>
+      <div :for={{id, user} <- @streams.admins} id={id} data-count={@count}>
         <%= user.name %>
         <button phx-click="admin-delete" phx-value-id={id}>delete</button>
         <button phx-click="admin-update" phx-value-id={id}>update</button>
@@ -74,6 +74,7 @@ defmodule Phoenix.LiveViewTest.StreamLive do
      |> assign(:invalid_consume, false)
      |> assign(:invalid_ids, false)
      |> assign(:invalid_item, false)
+     |> assign(:count, 0)
      |> stream(:users, @users)
      |> stream(:admins, [user(1, "chris-admin"), user(2, "callan-admin")])}
   end
@@ -113,12 +114,14 @@ defmodule Phoenix.LiveViewTest.StreamLive do
   end
 
   def handle_event("reset-users", _, socket) do
-    {:noreply, stream(socket, :users, [], reset: true)}
+    {:noreply, socket |> update(:count, &(&1 + 1)) |> stream(:users, [], reset: true)}
   end
 
   def handle_event("reset-users-reorder", %{}, socket) do
     {:noreply,
-     stream(socket, :users, [user(3, "peter"), user(1, "chris"), user(4, "mona")], reset: true)}
+     socket
+     |> update(:count, &(&1 + 1))
+     |> stream(:users, [user(3, "peter"), user(1, "chris"), user(4, "mona")], reset: true)}
   end
 
   def handle_event("stream-users", _, socket) do


### PR DESCRIPTION
Fixes #3216.

Initially reported here: https://elixirforum.com/t/updating-a-stream-with-reset-true-does-not-update-element-attributes/63011

Also fixes #3223.