### PR TITLE
Fix assert_patch/3 doc to return path instead of :ok

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1308,7 +1308,7 @@ defmodule Phoenix.LiveViewTest do
   The default `timeout` is [ExUnit](https://hexdocs.pm/ex_unit/ExUnit.html#configure/1)'s
   `assert_receive_timeout` (100 ms).
 
-  It always returns `:ok`.
+  It returns the new path.
 
   To assert on the flash message, you can assert on the result of the
   rendered LiveView.


### PR DESCRIPTION
- 78c24a5a4, changed the return from :ok to path but it wasn't changed in the doc.