### PR TITLE
Allow partially resetting an async result when using multiple assign

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1915,8 +1915,8 @@ defmodule Phoenix.LiveView do
   ## Options
 
     * `:supervisor` - allows you to specify a `Task.Supervisor` to supervise the task.
-    * `:reset` - remove previous results during async operation when true. Defaults to false
-
+    * `:reset` - remove previous results during async operation when true. Possible values are
+      `true`, `false`, or a list of keys to reset. Defaults to `false`.
 
   ## Examples
 

--- a/lib/phoenix_live_view/async.ex
+++ b/lib/phoenix_live_view/async.ex
@@ -171,6 +171,8 @@ defmodule Phoenix.LiveView.Async do
 
     new_assigns =
       Enum.map(keys, fn key ->
+        reset = if is_list(reset), do: key in reset, else: reset
+
         case {reset, socket.assigns} do
           {false, %{^key => %AsyncResult{ok?: true} = existing}} ->
             {key, AsyncResult.loading(existing, keys)}


### PR DESCRIPTION
In circumstances where `assign_async/4` is being used to async assign multiple results, it is possible that some of the results should persist during loading, and others should not.

In this case, a list of keys can be passed to the `reset` option, and only those keys will be reset during the async operation.