### PR TITLE
Overriding the default confirm behaviour - Make the example work

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2570,21 +2570,24 @@ defmodule Phoenix.Component do
   a custom javascript implementation:
 
   ```javascript
+  // Compared to a javascript window.confirm, the custom dialog does not block
+  // javascript execution. Therefore to make this work as expected we store
+  // the successful confirmation as an attribute and re-trigger the click event.
+  // On the second click, the `data-confirm-resolved` attribute is set and we proceed.
+  const RESOLVED_ATTRIBUTE = "data-confirm-resolved";
   // listen on document.body, so it's executed before the default of
   // phoenix_html, which is listening on the window object
-  const RESOLVED_ATTRIBUTE = "data-confirm-resolved";
-
   document.body.addEventListener('phoenix.link.click', function (e) {
     // Prevent default implementation
     e.stopPropagation();
     // Introduce alternative implementation
     var message = e.target.getAttribute("data-confirm");
-    if(!message){ return true; }
+    if(!message){ return; }
 
     // Confirm is resolved execute the click event
     if (e.target?.hasAttribute(RESOLVED_ATTRIBUTE)) {
-        e.target.removeAttribute(RESOLVED_ATTRIBUTE);
-        return true;
+      e.target.removeAttribute(RESOLVED_ATTRIBUTE);
+      return;
     }
 
     // Confirm is needed, preventDefault and show your modal
@@ -2595,11 +2598,11 @@ defmodule Phoenix.Component do
       message: message,
       callback: function (value) {
         if (value == true) {
-            // Customer confirmed, re-trigger the click event.
-            e.target?.click();
+          // Customer confirmed, re-trigger the click event.
+          e.target?.click();
         } else {
-            // Customer canceled
-            e.target?.removeAttribute(RESOLVED_ATTRIBUTE);
+          // Customer canceled
+          e.target?.removeAttribute(RESOLVED_ATTRIBUTE);
         }
       }
     })

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2887,7 +2887,7 @@ defmodule Phoenix.Component do
       "the optional override for the accept attribute. Defaults to :accept specified by allow_upload"
   )
 
-  attr.(:rest, :global, include: ~w(webkitdirectory required disabled))
+  attr.(:rest, :global, include: ~w(webkitdirectory required disabled capture form))
 
   def live_file_input(%{upload: upload} = assigns) do
     assigns = assign_new(assigns, :accept, fn -> upload.accept != :any && upload.accept end)

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2342,6 +2342,7 @@ defmodule Phoenix.Component do
     <.input type="text" field={ef[:email]} placeholder="email" />
     <.input type="text" field={ef[:name]} placeholder="name" />
     <button
+      type="button"
       name="mailing_list[emails_drop][]"
       value={ef.index}
       phx-click={JS.dispatch("change")}


### PR DESCRIPTION
Add a working example of overriding the `data-confirm` behaviour