### PR TITLE
reject empty string in class_names

### DIFF
--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -901,7 +901,7 @@ defmodule Phoenix.LiveView.JS do
   defp class_names(nil), do: []
 
   defp class_names(names) do
-    String.split(names, " ")
+    String.split(names, " ") |> Enum.reject(&(&1 == ""))
   end
 
   defp transition_class_names(nil), do: nil

--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -901,7 +901,7 @@ defmodule Phoenix.LiveView.JS do
   defp class_names(nil), do: []
 
   defp class_names(names) do
-    String.split(names, " ") |> Enum.reject(&(&1 == ""))
+    String.split(names, " ", trim: true)
   end
 
   defp transition_class_names(nil), do: nil


### PR DESCRIPTION
Class name passed to `element.classList.add(name)` must not be empty in JavaScript.

This change will handle cases like this correctly:
```elixir
JS.show(transition: {"transition", "opacity-0", ""})
```