### PR TITLE
clarify that assigns can only be shared across parent-child LiveViews

### DIFF
--- a/guides/server/security-model.md
+++ b/guides/server/security-model.md
@@ -88,7 +88,7 @@ as you would with plug:
 
 We use [`assign_new/3`](`Phoenix.Component.assign_new/3`). This is a
 convenience to avoid fetching the `current_user` multiple times across
-LiveViews.
+parent-child LiveViews.
 
 Now we can use the hook whenever relevant. One option is to specify
 the hook in your router under `live_session`:

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1149,7 +1149,7 @@ defmodule Phoenix.Component do
   ## Sharing assigns
 
   It is possible to share assigns between the Plug pipeline and LiveView on disconnected render
-  and between LiveViews when connected.
+  and between parent-child LiveViews when connected.
 
   ### When disconnected
 


### PR DESCRIPTION
Fixes https://github.com/phoenixframework/phoenix_live_view/issues/3205

Hopefully, this is enough of a hint to avoid the confusion that assigns could be shared across root LiveViews.

I also considered mentioning that assigns can be shared between `conn` and LiveViews in `security-model.md`, but opted for the minimal change instead.