### PR TITLE
consider any touched input as not _unused_

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -102,8 +102,8 @@ let serializeForm = (form, metadata, onlyNames = []) => {
   let elements = Array.from(form.elements)
   for(let [key, val] of formData.entries()){
     if(onlyNames.length === 0 || onlyNames.indexOf(key) >= 0){
-      let input = elements.find(input => input.name === key)
-      let isUnused = !(DOM.private(input, PHX_HAS_FOCUSED) || DOM.private(input, PHX_HAS_SUBMITTED))
+      let inputs = elements.filter(input => input.name === key)
+      let isUnused = !inputs.some(input => (DOM.private(input, PHX_HAS_FOCUSED) || DOM.private(input, PHX_HAS_SUBMITTED)))
       if(isUnused && !(submitter && submitter.name == key)){
         params.append(prependFormDataKey(key, "_unused_"), "")
       }

--- a/test/phoenix_live_view/integrations/event_test.exs
+++ b/test/phoenix_live_view/integrations/event_test.exs
@@ -128,7 +128,7 @@ defmodule Phoenix.LiveView.EventTest do
                   end}
                )
 
-               assert_receive {:DOWN, _ref, :process, ^pid, _reason}
+               assert_receive {:DOWN, _ref, :process, ^pid, _reason}, 500
              end) =~ "Got: {:reply, :boom"
     end
 


### PR DESCRIPTION
This fixes an issue where a hidden input with the same name as another input element leads to fields always being sent as `_unused_field`. Now, every input element with the given name must be unused.