### PR TITLE
Remove unecessary `` around LiveView and LiveComponent from docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -407,7 +407,7 @@ generated user module:
 ### Enhancements
   * Support [`submitter`](https://developer.mozilla.org/en-US/docs/Web/API/SubmitEvent/submitter) on form submit events.
   * Avoid compile-time dependency for `attr` when referencing structs
-  * Validate reserved assigns. Attempting to assign `:uploads`, `:streams`, `:live_action`, `:socket`, `:myself` will now raise in `LiveView` and `LiveComponent`
+  * Validate reserved assigns. Attempting to assign `:uploads`, `:streams`, `:live_action`, `:socket`, `:myself` will now raise in LiveView and LiveComponent
 
 ## 0.18.16 (2023-02-23)
 
@@ -1668,7 +1668,7 @@ let liveSocket = new LiveSocket("/live", Socket, {...})
 
 ### Backwards incompatible changes
   - `phx-value` has no effect, use `phx-value-*` instead
-  - The `:path_params` key in session has no effect (use `handle_params` in `LiveView` instead)
+  - The `:path_params` key in session has no effect (use `handle_params` in LiveView instead)
 
 ## 0.1.1 (2019-08-27)
 

--- a/guides/introduction/welcome.md
+++ b/guides/introduction/welcome.md
@@ -246,7 +246,7 @@ LiveView to a separate module. For these cases, LiveView provides
 
 Components have their own `mount/3` and `handle_event/3` callbacks, as
 well as their own state with change tracking support. Components are also
-lightweight as they "run" in the same process as the parent `LiveView`.
+lightweight as they "run" in the same process as the parent LiveView.
 However, this means an error in a component would cause the whole view to
 fail to render. See `Phoenix.LiveComponent` for a complete rundown on components.
 

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -908,8 +908,8 @@ defmodule Phoenix.Component do
 
   ## Containers
 
-  When a `LiveView` is rendered, its contents are wrapped in a container. By default,
-  the container is a `div` tag with a handful of `LiveView` specific attributes.
+  When a LiveView is rendered, its contents are wrapped in a container. By default,
+  the container is a `div` tag with a handful of LiveView-specific attributes.
 
   The container can be customized in different ways:
 
@@ -1998,8 +1998,8 @@ defmodule Phoenix.Component do
   @doc """
   A function component for rendering `Phoenix.LiveComponent` within a parent LiveView.
 
-  While `LiveView`s can be nested, each LiveView starts its own process. A `LiveComponent` provides
-  similar functionality to `LiveView`, except they run in the same process as the `LiveView`,
+  While LiveViews can be nested, each LiveView starts its own process. A LiveComponent provides
+  similar functionality to LiveView, except they run in the same process as the LiveView,
   with its own encapsulated state. That's why they are called stateful components.
 
   ## Attributes

--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -423,7 +423,7 @@ defmodule Phoenix.LiveComponent do
   ## Live patches and live redirects
 
   A template rendered inside a component can use `<.link patch={...}>` and
-  `<.link navigate={...}>`. Patches are always handled by the parent `LiveView`,
+  `<.link navigate={...}>`. Patches are always handled by the parent LiveView,
   as components do not provide `handle_params`.
 
   ## Cost of live components

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -349,12 +349,12 @@ defmodule Phoenix.LiveView do
     * `:global_prefixes` - the global prefixes to use for components. See
       `Global Attributes` in `Phoenix.Component` for more information.
 
-    * `:layout` - configures the layout the `LiveView` will be rendered in.
+    * `:layout` - configures the layout the LiveView will be rendered in.
       This layout can be overridden by on `c:mount/3` or via the `:layout`
       option in `Phoenix.LiveView.Router.live_session/2`
 
-    * `:log` - configures the log level for the `LiveView`, either false
-      or a Log level
+    * `:log` - configures the log level for the LiveView, either `false`
+      or a log level
 
   """
 
@@ -411,11 +411,11 @@ defmodule Phoenix.LiveView do
     * `:container` - an optional tuple for the HTML tag and DOM attributes to
       be used for the LiveView container. For example: `{:li, style: "color: blue;"}`.
 
-    * `:layout` - configures the layout the `LiveView` will be rendered in.
+    * `:layout` - configures the layout the LiveView will be rendered in.
       This layout can be overridden by on `c:mount/3` or via the `:layout`
       option in `Phoenix.LiveView.Router.live_session/2`
 
-    * `:log` - configures the log level for the `LiveView`, either false
+    * `:log` - configures the log level for the LiveView, either `false`
       or a log level
 
     * `:on_mount` - a list of tuples with module names and argument to be invoked

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -203,10 +203,10 @@ defmodule Phoenix.LiveViewTest do
   Spawns a connected LiveView process.
 
   If a `path` is given, then a regular `get(conn, path)`
-  is done and the page is upgraded to a `LiveView`. If
+  is done and the page is upgraded to a LiveView. If
   no path is given, it assumes a previously rendered
   `%Plug.Conn{}` is given, which will be converted to
-  a `LiveView` immediately.
+  a LiveView immediately.
 
   ## Examples
 


### PR DESCRIPTION
I found most of "LiveView" and "LiveComponent" in the doc is not wrapped by ``. 

This PR:
+ remove the `` around LiveView and LiveComponent, to keep their format consistent.
+ fix small typos, such as:
  - `Log` -> `log`