### PR TITLE
[Doc improvement] Fix dead links, adjust link names

### DIFF
--- a/guides/cheatsheets/html-attrs.cheatmd
+++ b/guides/cheatsheets/html-attrs.cheatmd
@@ -100,11 +100,11 @@ Attribute values can be:
 
 ## DOM Element Lifecycle
 
-| Attribute                                  | Value                                                                                  |
-|--------------------------------------------|----------------------------------------------------------------------------------------|
-| [`phx-mounted`](../client/dom-patching.md) | [JS commands](../client/bindings.md#js-commands) executed after the element is mounted |
-| [`phx-remove`](../client/dom-patching.md)  | [JS commands](../client/bindings.md#js-commands) executed during the element removal   |
-| [`phx-update`](../client/dom-patching.md)  | `"replace"` (default), `"stream"` or `"ignore"`, configures DOM patching behavior      |
+| Attribute                                           | Value                                                                                  |
+|-----------------------------------------------------|----------------------------------------------------------------------------------------|
+| [`phx-mounted`](../client/bindings.md#dom-patching) | [JS commands](../client/bindings.md#js-commands) executed after the element is mounted |
+| [`phx-remove`](../client/bindings.md#dom-patching)  | [JS commands](../client/bindings.md#js-commands) executed during the element removal   |
+| [`phx-update`](../client/bindings.md#dom-patching)  | `"replace"` (default), `"stream"` or `"ignore"`, configures DOM patching behavior      |
 
 #### lib/hello_web/live/hello_live.html.heex
 

--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -23,7 +23,7 @@ except for the following LiveView specific options:
     section below for details.
   * `uploaders` – a reference to a user-defined uploaders namespace, containing
     client callbacks for client-side direct-to-cloud uploads. See the
-    [External Uploads guide](uploads-external.md) for details.
+    [External uploads guide](uploads-external.md) for details.
 
 ## Debugging Client Events
 

--- a/guides/client/uploads-external.md
+++ b/guides/client/uploads-external.md
@@ -1,4 +1,4 @@
-# External Uploads
+# Uploads (External)
 
 > This guide continues from the configuration started in the
 > server [Uploads guide](uploads.html).

--- a/guides/client/uploads-external.md
+++ b/guides/client/uploads-external.md
@@ -1,4 +1,4 @@
-# Uploads (External)
+# External uploads
 
 > This guide continues from the configuration started in the
 > server [Uploads guide](uploads.html).

--- a/guides/introduction/welcome.md
+++ b/guides/introduction/welcome.md
@@ -300,6 +300,5 @@ These guides focus on LiveView bindings and client-side integration:
 
 * [Bindings](bindings.md)
 * [Form bindings](form-bindings.md)
-* [DOM patching and temporary assigns](dom-patching.md)
 * [JavaScript interoperability](js-interop.md)
 * [Uploads (External)](uploads-external.md)

--- a/guides/introduction/welcome.md
+++ b/guides/introduction/welcome.md
@@ -302,4 +302,4 @@ These guides focus on LiveView bindings and client-side integration:
 * [Bindings](bindings.md)
 * [Form bindings](form-bindings.md)
 * [JavaScript interoperability](js-interop.md)
-* [Uploads (External)](uploads-external.md)
+* [External uploads](uploads-external.md)

--- a/guides/introduction/welcome.md
+++ b/guides/introduction/welcome.md
@@ -286,13 +286,14 @@ split on server-side and client-side:
 These guides focus on server-side functionality:
 
 * [Assigns and HEEx templates](assigns-eex.md)
+* [Deployments](deployments.md)
 * [Error and exception handling](error-handling.md)
-* [Live Layouts](live-layouts.md)
-* [Live Navigation](live-navigation.md)
-* [Security considerations of the LiveView model](security-model.md)
+* [Live layouts](live-layouts.md)
+* [Live navigation](live-navigation.md)
+* [Security considerations](security-model.md)
 * [Telemetry](telemetry.md)
 * [Uploads](uploads.md)
-* [Using Gettext for internationalization](using-gettext.md)
+* [Gettext for internationalization](using-gettext.md)
 
 ### Client-side
 

--- a/guides/server/uploads.md
+++ b/guides/server/uploads.md
@@ -212,7 +212,7 @@ ultimately fail.
 For these reasons, it is best if uploads are stored elsewhere, such as the
 database (depending on the size and contents) or a separate storage service.
 For more information on implementing client-side, direct-to-cloud uploads,
-see the [External Uploads guide](uploads-external.md).
+see the [External uploads guide](uploads-external.md) for details.
 
 ## Appendix A: UploadLive
 

--- a/mix.exs
+++ b/mix.exs
@@ -68,7 +68,7 @@ defmodule Phoenix.LiveView.MixProject do
       extras: extras(),
       groups_for_extras: groups_for_extras(),
       groups_for_modules: groups_for_modules(),
-      groups_for_functions: [
+      groups_for_docs: [
         Components: &(&1[:type] == :component),
         Macros: &(&1[:type] == :macro)
       ],


### PR DESCRIPTION
This PR:
* fix dead links of dom patching related docs
* adjust link names in `Welcome.md` to match the ones in sidebar
* fix ex_doc warnings - `warning: :groups_for_functions is deprecated, please use :groups_for_docs instead`
* sync link name of uploads-external.md