### PR TITLE
Fix typo in 'Arbitrary async operations' section

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -167,7 +167,7 @@ defmodule Phoenix.LiveView do
   `start_async/3` is used to fetch the organization asynchronously. The
   `c:handle_async/3` callback is called when the task completes or exits,
   with the results wrapped in either `{:ok, result}` or `{:exit, reason}`.
-  The `AsyncResult` module is used to directly to update the state of the
+  The `AsyncResult` module provides functions to update the state of the
   async operation, but you can also assign any value directly to the socket
   if you want to handle the state yourself.
 


### PR DESCRIPTION
There's an extra "to" in "used to directly to update", but instead of simply removing it I thought a small rewording would make the sentence clearer.

Note that in the paragraph preceeding the code example we already said "For this, you can use ... and the AsyncResult module directly:"