### PR TITLE
don't add _unused fields for hidden inputs

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -104,7 +104,8 @@ let serializeForm = (form, metadata, onlyNames = []) => {
     if(onlyNames.length === 0 || onlyNames.indexOf(key) >= 0){
       let inputs = elements.filter(input => input.name === key)
       let isUnused = !inputs.some(input => (DOM.private(input, PHX_HAS_FOCUSED) || DOM.private(input, PHX_HAS_SUBMITTED)))
-      if(isUnused && !(submitter && submitter.name == key)){
+      let hidden = inputs.every(input => input.type === "hidden")
+      if(isUnused && !(submitter && submitter.name == key) && !hidden){
         params.append(prependFormDataKey(key, "_unused_"), "")
       }
       params.append(key, val)


### PR DESCRIPTION
Based on a message in the Elixir Slack. With large forms that contains multiple hidden inputs, the payload size increases unnecessarily because of the `_unused` parameters. I currently don't see a reason to send thoses for fields that are only based on hidden inputs. If there are any, please correct me :)