### PR TITLE
Clarify options to LiveViewTest.element

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1136,8 +1136,16 @@ defmodule Phoenix.LiveViewTest do
              |> element(~s{[href="/foo"][id="foo.bar.baz"]})
              |> render() =~ "Increment</a>"
   """
-  def element(%View{proxy: proxy}, selector, text_filter \\ nil) when is_binary(selector) do
+  def element(%View{proxy: proxy}, selector, text_filter) when is_binary(selector) and is_binary(text_filter) do
     %Element{proxy: proxy, selector: selector, text_filter: text_filter}
+  end
+
+  def element(%View{proxy: proxy}, selector, %Regex{} = text_filter) when is_binary(selector) do
+    %Element{proxy: proxy, selector: selector, text_filter: text_filter}
+  end
+
+  def element(%View{proxy: proxy}, selector, _text_filter) when is_binary(selector) do
+    %Element{proxy: proxy, selector: selector}
   end
 
   @doc """


### PR DESCRIPTION
I think it might be nice to pattern match that the text_filter option to `element` is either a string or a regex. I recently accidentally typed this:

```
      view
      |> element("button", title: "Info Toast")
```

and the error did not immediately jump out at me, because instead of some kind of error about my call site I got this:

```
07:23:06.272 [error] GenServer #PID<0.337.0> terminating
** (FunctionClauseError) no function clause matching in Regex.match?/2
    (elixir 1.16.2) lib/regex.ex:328: Regex.match?([title: "Info Toast"], "")
    (elixir 1.16.2) lib/enum.ex:4274: Enum.filter_list/2
    (phoenix_live_view 0.20.14) lib/phoenix_live_view/test/client_proxy.ex:900: Phoenix.LiveViewTest.ClientProxy.select_node/2
    (phoenix_live_view 0.20.14) lib/phoenix_live_view/test/client_proxy.ex:317: Phoenix.LiveViewTest.ClientProxy.handle_info/2
    (stdlib 5.2.2) gen_server.erl:1095: :gen_server.try_handle_info/3
    (stdlib 5.2.2) gen_server.erl:1183: :gen_server.handle_msg/6
    (stdlib 5.2.2) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
Last message: {:EXIT, #PID<0.336.0>, {:function_clause, [{Regex, :match?, [[title: "Info Toast"], ""], [file: ~c"lib/regex.ex", line: 328]}, {Enum, :filter_list, 2, [file: ~c"lib/e
num.ex", line: 4274]}, {Phoenix.LiveViewTest.ClientProxy, :select_node, 2, [file: ~c"lib/phoenix_live_view/test/client_proxy.ex", line: 900]}, {Phoenix.LiveViewTest.ClientProxy, :h
andle_info, 2, [file: ~c"lib/phoenix_live_view/test/client_proxy.ex", line: 317]}, {:gen_server, :try_handle_info, 3, [file: ~c"gen_server.erl", line: 1095]}, {:gen_server, :handle
_msg, 6, [file: ~c"gen_server.erl", line: 1183]}, {:proc_lib, :init_p_do_apply, 3, [file: ~c"proc_lib.erl", line: 241]}]}}


  1) test LiveToast.send_toast/7 renders correctly (DemoWeb.HomeLiveTest)
     test/demo_web/live/home_live_test.exs:18
     ** (EXIT from #PID<0.336.0>) an exception was raised:
     
          ** (FunctionClauseError) no function clause matching in Regex.match?/2

          The following arguments were given to Regex.match?/2:

              # 1
              [title: "Info Toast"]

              # 2
              ""

          Attempted function clauses (showing 1 out of 1):

              def match?(%Regex{} = regex, string) when is_binary(string)

          stacktrace:
            (elixir 1.16.2) lib/regex.ex:328: Regex.match?/2
            (elixir 1.16.2) lib/enum.ex:4274: Enum.filter_list/2
            (phoenix_live_view 0.20.14) lib/phoenix_live_view/test/client_proxy.ex:900: Phoenix.LiveViewTest.ClientProxy.select_node/2
            (phoenix_live_view 0.20.14) lib/phoenix_live_view/test/client_proxy.ex:317: Phoenix.LiveViewTest.ClientProxy.handle_info/2
            (stdlib 5.2.2) gen_server.erl:1095: :gen_server.try_handle_info/3
            (stdlib 5.2.2) gen_server.erl:1183: :gen_server.handle_msg/6
            (stdlib 5.2.2) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
```

So I proposed a potential refactoring in this PR but feel free to suggest something different.