### PR TITLE
Update to_form action in 'Form bindings' guide

### DIFF
--- a/guides/client/form-bindings.md
+++ b/guides/client/form-bindings.md
@@ -53,8 +53,7 @@ callbacks, to validate and attempt to save the parameter accordingly:
       form =
         %User{}
         |> Accounts.change_user(params)
-        |> Map.put(:action, :insert)
-        |> to_form()
+        |> to_form(action: :validate)
 
       {:noreply, assign(socket, form: form)}
     end


### PR DESCRIPTION
Update the code example (4+ years old) to set the form/changeset action to a conventional name unrelated to database operations, as suggested elsewhere in the docs [1].

Also use the new `:action` option added to `to_form` in v1.0 [2].

[1]: https://github.com/phoenixframework/phoenix_live_view/blame/6648f774354e308efc26d7e44e6e68d5a1b12fe1/lib/phoenix_component.ex#L2188-L2193
[2]: https://github.com/phoenixframework/phoenix_live_view/commit/d9124684fbc41f39abf9b5e37014f53b03e7ef46#diff-8a399cc9a3e142ef2ff2b7437ba397cb3affa4ed0346b53eb087d4d303b0f781

---

Notes:

1. I've also reviewed other places where `to_form` is used, this was the only occurrence that seemed to deserve an update.
2. I'm not strong about using the new option `to_form(..., action: :validate)`; if we want to keep the example backwards-compatible we shall keep using a `Map.put(:action, :validate)`.