### PR TITLE
Fix `Phoenix.LiveViewTest.file_input/4` ignoring `last_modified` option

### DIFF
--- a/lib/phoenix_live_view/test/structs.ex
+++ b/lib/phoenix_live_view/test/structs.ex
@@ -91,10 +91,12 @@ defmodule Phoenix.LiveViewTest.Upload do
         raise ArgumentError, "the :content of the binary entry file data is required."
 
     relative_path = Map.get(entry, :relative_path)
+    last_modified = Map.get(entry, :last_modified)
 
     %{
       "name" => name,
       "content" => content,
+      "last_modified" => last_modified,
       "relative_path" => relative_path,
       "ref" => to_string(System.unique_integer([:positive])),
       "size" => entry[:size] || byte_size(content),

--- a/test/phoenix_live_view/upload/external_test.exs
+++ b/test/phoenix_live_view/upload/external_test.exs
@@ -224,19 +224,25 @@ defmodule Phoenix.LiveView.UploadExternalTest do
     parent = self()
 
     avatar =
-      file_input(lv, "form", :avatar, [%{name: "foo.jpeg", content: String.duplicate("ok", 100)}])
+      file_input(lv, "form", :avatar, [
+        %{
+          name: "foo.jpeg",
+          content: String.duplicate("ok", 100),
+          last_modified: 1_594_171_879_000
+        }
+      ])
 
     assert render_upload(avatar, "foo.jpeg", 100) =~ upload_complete
 
     run(lv, fn socket ->
       Phoenix.LiveView.consume_uploaded_entries(socket, :avatar, fn meta, entry ->
-        {:ok, send(parent, {:consume, meta, entry.client_name})}
+        {:ok, send(parent, {:consume, meta, entry.client_name, entry.client_last_modified})}
       end)
 
       {:reply, :ok, socket}
     end)
 
-    assert_receive {:consume, %{uploader: "S3"}, "foo.jpeg"}
+    assert_receive {:consume, %{uploader: "S3"}, "foo.jpeg", 1_594_171_879_000}
     refute render(lv) =~ upload_complete
   end
 


### PR DESCRIPTION
`Phoenix.LiveViewTest.file_input/4` is ignoring the option `last_modified`, so it's impossible to populate `entry.client_last_modified` with this test function as the documentation says.

### Before

```elixir
[test/phoenix_live_view/upload/external_test.exs:233: Phoenix.LiveView.UploadExternalTest."test consume_uploaded_entries"/1]
file_input(lv, "form", :avatar, [
  %{name: "foo.jpeg", content: String.duplicate("ok", 100), last_modified: 1_594_171_879_000}
]) #=> #Phoenix.LiveViewTest.Upload<
  selector: nil,
  entries: [
    %{
      "content" => "okokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokok",
      "name" => "foo.jpeg",
      "ref" => "9417",
      "relative_path" => nil,
      "size" => 200,
      "type" => "image/jpeg"
    }
  ],
  ...
>

[test/phoenix_live_view/upload/external_test.exs:239: Phoenix.LiveView.UploadExternalTest."test consume_uploaded_entries"/1]
entry #=> %Phoenix.LiveView.UploadEntry{
  progress: 100,
  preflighted?: true,
  upload_config: :avatar,
  upload_ref: "phx-F9CfhwGDfrW4fgdD",
  ref: "1924",
  uuid: "d3bd3c54-cb47-4e41-a40a-6b4ecbf9e294",
  valid?: true,
  done?: true,
  cancelled?: false,
  client_name: "foo.jpeg",
  client_relative_path: nil,
  client_size: 200,
  client_type: "image/jpeg",
  client_last_modified: nil,
  client_meta: nil
}
```

### After

```elixir
[test/phoenix_live_view/upload/external_test.exs:233: Phoenix.LiveView.UploadExternalTest."test consume_uploaded_entries"/1]
file_input(lv, "form", :avatar, [
  %{name: "foo.jpeg", content: String.duplicate("ok", 100), last_modified: 1_594_171_879_000}
]) #=> #Phoenix.LiveViewTest.Upload<
  selector: nil,
  entries: [
    %{
      "content" => "okokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokokok",
      "last_modified" => 1594171879000,
      "name" => "foo.jpeg",
      "ref" => "4354",
      "relative_path" => nil,
      "size" => 200,
      "type" => "image/jpeg"
    }
  ],
  ...
>

[test/phoenix_live_view/upload/external_test.exs:239: Phoenix.LiveView.UploadExternalTest."test consume_uploaded_entries"/1]
entry #=> %Phoenix.LiveView.UploadEntry{
  progress: 100,
  preflighted?: true,
  upload_config: :avatar,
  upload_ref: "phx-F9CffrMSpNMdjAdC",
  ref: "1923",
  uuid: "61511cac-9568-4e5d-8bed-ede46331ce4c",
  valid?: true,
  done?: true,
  cancelled?: false,
  client_name: "foo.jpeg",
  client_relative_path: nil,
  client_size: 200,
  client_type: "image/jpeg",
  client_last_modified: 1594171879000,
  client_meta: nil
}
```