### PR TITLE
[docs] Use ~p instead of Routes in the example.

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2206,7 +2206,7 @@ defmodule Phoenix.Component do
   Without said attribute, the `form` method and csrf token are discarded.
 
   ```heex
-  <.form :let={f} for={@changeset} action={Routes.comment_path(:create, @comment)}>
+  <.form :let={f} for={@changeset} action={~p"/comments/#{@comment}"}>
     <.input field={f[:body]} />
   </.form>
   ```


### PR DESCRIPTION
Minor docs update.

I was reading the docs and I noticed `Routes.comment_path(:create, @comment)`. Since this isn't really the current way, I thought it might be potentially confusing to a new user.