### PR TITLE
Allow foreign items in stream containers

### DIFF
--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -29,7 +29,8 @@ defmodule Phoenix.LiveViewTest.E2E.Layout do
   def render("live.html", assigns) do
     ~H"""
     <meta name="csrf-token" content={Plug.CSRFProtection.get_csrf_token()} />
-    <script src="/assets/phoenix/phoenix.min.js"></script>
+    <script src="/assets/phoenix/phoenix.min.js">
+    </script>
     <script type="module">
       import {LiveSocket} from "/assets/phoenix_live_view/phoenix_live_view.esm.js"
 
@@ -46,6 +47,34 @@ defmodule Phoenix.LiveViewTest.E2E.Layout do
   end
 end
 
+defmodule Phoenix.LiveViewTest.E2E.Hooks do
+  import Phoenix.LiveView
+
+  require Logger
+
+  def on_mount(:default, _params, _session, socket) do
+    socket
+    |> attach_hook(:eval_handler, :handle_event, &handle_eval_event/3)
+    |> then(&{:cont, &1})
+  end
+
+  # evaluates the given code in the process of the LiveView
+  # see playwright evalLV() function
+  defp handle_eval_event("sandbox:eval", %{"value" => code}, socket) do
+    {result, _} = Code.eval_string(code, [socket: socket], __ENV__)
+
+    Logger.debug("lv:#{inspect(self())} eval result: #{inspect(result)}")
+
+    case result do
+      {:noreply, %Phoenix.LiveView.Socket{} = socket} -> {:halt, socket}
+      %Phoenix.LiveView.Socket{} = socket -> {:halt, socket}
+      _ -> {:halt, socket}
+    end
+  end
+
+  defp handle_eval_event(_, _, socket), do: {:cont, socket}
+end
+
 defmodule Phoenix.LiveViewTest.E2E.Router do
   use Phoenix.Router
   import Phoenix.LiveView.Router
@@ -56,7 +85,9 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
     plug :protect_from_forgery
   end
 
-  live_session :default, layout: {Phoenix.LiveViewTest.E2E.Layout, :live} do
+  live_session :default,
+    layout: {Phoenix.LiveViewTest.E2E.Layout, :live},
+    on_mount: {Phoenix.LiveViewTest.E2E.Hooks, :default} do
     scope "/", Phoenix.LiveViewTest do
       pipe_through(:browser)
 
@@ -159,7 +190,7 @@ end
     strategy: :one_for_one
   )
 
-IO.puts "Starting e2e server on port #{Phoenix.LiveViewTest.E2E.Endpoint.config(:http)[:port]}"
+IO.puts("Starting e2e server on port #{Phoenix.LiveViewTest.E2E.Endpoint.config(:http)[:port]}")
 
 unless IEx.started?() do
   # when running the test server manually, we halt after

--- a/test/e2e/utils.js
+++ b/test/e2e/utils.js
@@ -14,6 +14,16 @@ const syncLV = async (page) => {
   return Promise.all(promises);
 };
 
+// this function executes the given code inside the liveview that is responsible
+// for the given selector; it uses private phoenix live view js functions, so it could
+// break in the future
+// we handle the evaluation in a LV hook
+const evalLV = async (page, code, selector="[data-phx-main]") => await page.evaluate(([code, selector]) => {
+  window.liveSocket.main.withinTargets(selector, (targetView, targetCtx) => {
+    targetView.pushEvent("event", document.body, targetCtx, "sandbox:eval", { value: code })
+  });
+}, [code, selector]);
+
 const attributeMutations = (page, selector) => {
   // this is a bit of a hack, basically we create a MutationObserver on the page
   // that will record any changes to a selector until the promise is awaited
@@ -53,4 +63,4 @@ const attributeMutations = (page, selector) => {
   };
 }
 
-module.exports = { randomString, syncLV, attributeMutations };
+module.exports = { randomString, syncLV, evalLV, attributeMutations };

--- a/test/phoenix_live_view/integrations/stream_test.exs
+++ b/test/phoenix_live_view/integrations/stream_test.exs
@@ -531,22 +531,33 @@ defmodule Phoenix.LiveView.StreamTest do
            end) =~ ~r/streams can only be consumed directly by a for comprehension/
   end
 
-  test "stream raises when there are items with invalid IDs", %{conn: conn} do
+  test "stream raises when nodes without id are in container", %{conn: conn} do
     {:ok, lv, _html} = live(conn, "/stream")
 
     assert Phoenix.LiveViewTest.HooksLive.exits_with(lv, ArgumentError, fn ->
-             render_click(lv, "stream-invalid-ids", %{})
+             render_click(lv, "stream-no-id", %{})
            end) =~
-             ~r/a container with phx-update=\"stream\" must only contain stream children with the id set to the `dom_id` of the stream item/
+             ~r/setting phx-update to "stream" requires setting an ID on each child/
   end
 
-  test "stream raises when non stream items are in container", %{conn: conn} do
+  test "issue #3260 - supports non-stream items with id in stream container", %{conn: conn} do
     {:ok, lv, _html} = live(conn, "/stream")
 
-    assert Phoenix.LiveViewTest.HooksLive.exits_with(lv, ArgumentError, fn ->
-             render_click(lv, "stream-invalid-item", %{})
-           end) =~
-             ~r/a container with phx-update=\"stream\" must only contain stream children with the id set to the `dom_id` of the stream item/
+    render_click(lv, "stream-extra-with-id", %{})
+    html = render(lv)
+
+    assert [{"users-1", "chris"}, {"users-2", "callan"}, {"users-empty", "Empty!"}] =
+             users_in_dom(html, "users")
+
+    assert render_click(lv, "reset-users", %{}) |> users_in_dom("users") == [
+             {"users-empty", "Empty!"}
+           ]
+
+    assert render_click(lv, "append-users", %{}) |> users_in_dom("users") == [
+             {"users-empty", "Empty!"},
+             {"users-4", "foo"},
+             {"users-3", "last_user"}
+           ]
   end
 
   test "handles high frequency updates properly", %{conn: conn} do

--- a/test/support/live_views/streams.ex
+++ b/test/support/live_views/streams.ex
@@ -11,20 +11,39 @@ defmodule Phoenix.LiveViewTest.StreamLive do
     """
   end
 
-  def render(%{invalid_ids: true} = assigns) do
+  def render(%{no_id: true} = assigns) do
     ~H"""
     <div id="users" phx-update="stream">
-      <div :for={{id, _user} <- @streams.users} id={"prefixed-#{id}"} />
+      <div only-child>Empty!</div>
+      <div :for={{id, _user} <- @streams.users} id={id} />
     </div>
+
+    <style>
+      [only-child] {
+        display: none;
+      }
+      [only-child]:only-child {
+        display: block;
+      }
+    </style>
     """
   end
 
-  def render(%{invalid_item: true} = assigns) do
+  def render(%{extra_item_with_id: true} = assigns) do
     ~H"""
     <div id="users" phx-update="stream">
-      <div :for={{id, _user} <- @streams.users} id={id} />
-      <div id="another-item"></div>
+      <div :for={{id, user} <- @streams.users} id={id}><%= user.name %></div>
+      <div id="users-empty" only-child>Empty!</div>
     </div>
+
+    <style>
+      [only-child] {
+        display: none;
+      }
+      [only-child]:only-child {
+        display: block;
+      }
+    </style>
     """
   end
 
@@ -68,12 +87,12 @@ defmodule Phoenix.LiveViewTest.StreamLive do
     %{id: 3, name: "last_user"}
   ]
 
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
     {:ok,
      socket
      |> assign(:invalid_consume, false)
-     |> assign(:invalid_ids, false)
-     |> assign(:invalid_item, false)
+     |> assign(:no_id, false)
+     |> assign(:extra_item_with_id, Map.has_key?(params, "empty_item"))
      |> assign(:count, 0)
      |> stream(:users, @users)
      |> stream(:admins, [user(1, "chris-admin"), user(2, "callan-admin")])}
@@ -160,12 +179,12 @@ defmodule Phoenix.LiveViewTest.StreamLive do
     {:noreply, assign(socket, :invalid_consume, true)}
   end
 
-  def handle_event("stream-invalid-ids", _, socket) do
-    {:noreply, assign(socket, :invalid_ids, true) |> stream(:users, @users)}
+  def handle_event("stream-no-id", _, socket) do
+    {:noreply, assign(socket, :no_id, true) |> stream(:users, @users)}
   end
 
-  def handle_event("stream-invalid-item", _, socket) do
-    {:noreply, assign(socket, :invalid_item, true) |> stream(:users, @users)}
+  def handle_event("stream-extra-with-id", _, socket) do
+    {:noreply, assign(socket, :extra_item_with_id, true) |> stream(:users, @users)}
   end
 
   def handle_call({:run, func}, _, socket), do: func.(socket)


### PR DESCRIPTION
This change allows for foreign items to be rendered in a stream container. It is mainly useful for having a simple way to show an empty state, by doing something like

```html
<div id="users" phx-update="stream">
  <div id="users-empty" class="only:block hidden">Empty!</div>
  <div :for={{id, user} <- @streams.users} id={id}><%= user.name %></div>
</div>
```

Closes #3260.

Non-stream items **must still have a unique id**.