### PR TITLE
Show field errors on submit when field hasn't been "used"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ This shows one example for the textarea input, but there are more cases that nee
 
 ```diff
    def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
-+    errors = if Phoenix.Component.used_input?(field), do: field.errors, else: []
++    errors = if Phoenix.Component.used_input?(field) || field.form.action == :submit, do: field.errors, else: []
 
      assigns
      |> assign(field: nil, id: assigns.id || field.id)


### PR DESCRIPTION
re: LiveView 1.0.0-rc0

If a user submits the form without changing the input, no errors are shown. 

This change will show field errors if the input is used **or** the form action is `:submit`.

Something to think about, developers could be using different words to represent the submit action. eg. `:save`