### PR TITLE
Refactor error handling

### DIFF
--- a/assets/js/phoenix_live_view/constants.js
+++ b/assets/js/phoenix_live_view/constants.js
@@ -1,8 +1,10 @@
 export const CONSECUTIVE_RELOADS = "consecutive-reloads"
+export const CONSECUTIVE_JOINS = "consecutive-joins"
 export const MAX_RELOADS = 10
 export const RELOAD_JITTER_MIN = 5000
 export const RELOAD_JITTER_MAX = 10000
 export const FAILSAFE_JITTER = 30000
+export const MAX_CHILD_JOIN_TRIES = 10
 export const PHX_EVENT_CLASSES = [
   "phx-click-loading", "phx-change-loading", "phx-submit-loading",
   "phx-keydown-loading", "phx-keyup-loading", "phx-blur-loading", "phx-focus-loading",

--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -2,6 +2,7 @@ import {
   BEFORE_UNLOAD_LOADER_TIMEOUT,
   CHECKABLE_INPUTS,
   CONSECUTIVE_RELOADS,
+  CONSECUTIVE_JOINS,
   PHX_AUTO_RECOVER,
   PHX_COMPONENT,
   PHX_CONNECTED_CLASS,
@@ -152,6 +153,7 @@ export default class View {
     this.children = this.parent ? null : {}
     this.root.children[this.id] = {}
     this.formsForRecovery = {}
+    this.maxChildJoinTries = this.liveSocket.maxChildJoinTries
     this.channel = this.liveSocket.channel(`lv:${this.id}`, () => {
       let url = this.href && this.expandURL(this.href)
       return {
@@ -316,7 +318,11 @@ export default class View {
       console.error(`LiveView asset version mismatch. JavaScript version ${this.liveSocket.version()} vs. server ${liveview_version}. To avoid issues, please ensure that your assets use the same version as the server.`)
     }
 
+    // reset the consecutive reloads counter (only relevant for the root view)
     Browser.dropLocal(this.liveSocket.localStorage, window.location.pathname, CONSECUTIVE_RELOADS)
+    // reset the consecutive joins and reloads counter for this view (only relevant for the child views)
+    Browser.dropLocal(this.liveSocket.localStorage, this.id, CONSECUTIVE_JOINS)
+    Browser.dropLocal(this.liveSocket.localStorage, this.id, CONSECUTIVE_RELOADS)
     this.applyDiff("mount", rendered, ({diff, events}) => {
       this.rendered = new Rendered(this.id, diff)
       let [html, streams] = this.renderContainer(null, "join")
@@ -805,12 +811,19 @@ export default class View {
     if(resp.live_redirect){ return this.onLiveRedirect(resp.live_redirect) }
     this.displayError([PHX_LOADING_CLASS, PHX_ERROR_CLASS, PHX_SERVER_ERROR_CLASS])
     this.log("error", () => ["unable to join", resp])
-    if(this.liveSocket.isConnected()){ this.liveSocket.reloadWithJitter(this) }
+    if(this.isMain()){
+      // only do a full page refresh if this is the main view,
+      // if it's a child view it will simply be rejoined (automatically by the Phoenix.Socket client)
+      return this.liveSocket.reloadWithJitter(this)
+    } else {
+      // handle the child view failing to join repeatedly
+      this.handleChildJoinError()
+    }
   }
 
   onClose(reason){
     if(this.isDestroyed()){ return }
-    if(this.liveSocket.hasPendingLink() && reason !== "leave"){
+    if(this.isMain() && this.liveSocket.hasPendingLink() && reason !== "leave"){
       return this.liveSocket.reloadWithJitter(this)
     }
     this.destroyAllChildren()
@@ -831,6 +844,31 @@ export default class View {
       } else {
         this.displayError([PHX_LOADING_CLASS, PHX_ERROR_CLASS, PHX_CLIENT_ERROR_CLASS])
       }
+    }
+  }
+
+  handleChildJoinError(){
+    let joinTries = Browser.updateLocal(this.liveSocket.localStorage, this.id, CONSECUTIVE_JOINS, 0, count => count + 1)
+    let childReloads = Browser.getLocal(this.liveSocket.localStorage, this.id, CONSECUTIVE_RELOADS) || 0
+    // the child join crashed consecutively for more than maxJoinTries, therefore we fallback
+    // to a full reload
+    if(joinTries >= this.maxChildJoinTries){
+      if(childReloads > 0){
+        this.log("error", () => ["child failed to join consecutively, even after reloading the page. We won't try again."])
+        this.destroy()
+        // TODO: check if this is correct
+        this.setContainerClasses(...[PHX_ERROR_CLASS, PHX_SERVER_ERROR_CLASS])
+        this.execAll(this.binding("disconnected"))
+        // TODO: really check if this is correct
+        //       I added this to prevent the parent from being stuck in the loading state, waiting
+        //       for the child view when we know it won't join because we've given up.
+        this.parent.ackJoin(this)
+        return
+      }
+      this.destroy()
+      Browser.updateLocal(this.liveSocket.localStorage, this.id, CONSECUTIVE_RELOADS, 1, count => count + 1)
+      // this will trigger a full page reload
+      this.liveSocket.reloadWithJitter(this.root)
     }
   }
 

--- a/assets/test/test_helpers.js
+++ b/assets/test/test_helpers.js
@@ -25,6 +25,7 @@ export let simulateJoinedView = (el, liveSocket) => {
   let view = new View(el, liveSocket)
   stubChannel(view)
   liveSocket.roots[view.id] = view
+  liveSocket.disconnected = false
   view.isConnected = () => true
   view.onJoin({rendered: {s: [el.innerHTML]}, liveview_version: require("../package.json").version})
   return view

--- a/test/e2e/support/error_live.ex
+++ b/test/e2e/support/error_live.ex
@@ -1,0 +1,200 @@
+defmodule Phoenix.LiveViewTest.E2E.ErrorLive do
+  use Phoenix.LiveView, layout: {__MODULE__, :live}
+
+  # TODO: find a way to silence the raise "boom" crashes
+
+  defmodule ChildLive do
+    use Phoenix.LiveView
+
+    @impl Phoenix.LiveView
+    def mount(_params, _session, socket) do
+      if connected?(socket) do
+        send(socket.parent_pid, {:child_mounted, self()})
+
+        receive do
+          :boom ->
+            raise "boom"
+
+          :boom_link ->
+            Process.link(socket.parent_pid)
+            raise "boom"
+
+          :ok_link ->
+            Process.link(socket.parent_pid)
+            :ok
+
+          _ ->
+            :ok
+        end
+      end
+
+      {:ok, socket}
+    end
+
+    @impl Phoenix.LiveView
+    def handle_event("boom", _params, _socket) do
+      raise "boom"
+    end
+
+    @impl Phoenix.LiveView
+    def render(assigns) do
+      ~H"""
+      <%= if connected?(@socket), do: "Child connected", else: "Child rendered (dead)" %>
+      <p id="child-render-time">child rendered at: <%= DateTime.utc_now() %></p>
+
+      <button phx-click="boom">Crash child</button>
+
+      <p class="if-phx-error">Error</p>
+      <p class="if-phx-client-error">Client Error</p>
+      <p class="if-phx-server-error">Server Error</p>
+      <p class="if-phx-disconnected">Disconnected</p>
+      <p class="if-phx-loading">Loading</p>
+      """
+    end
+  end
+
+  def render("live.html", assigns) do
+    ~H"""
+    <meta name="csrf-token" content={Plug.CSRFProtection.get_csrf_token()} />
+    <script src="/assets/phoenix/phoenix.min.js">
+    </script>
+    <script type="module">
+      import {LiveSocket} from "/assets/phoenix_live_view/phoenix_live_view.esm.js"
+      let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
+      let liveSocket = new LiveSocket("/live", window.Phoenix.Socket, {
+        params: {_csrf_token: csrfToken},
+        reloadJitterMax: 50,
+        reloadJitterMin: 50,
+        maxReloads: 5,
+        failsafeJitter: 30000,
+        maxChildJoinTries: 3,
+        // override Phoenix.Socket channel join backoff
+        rejoinAfterMs: (_tries) => 50
+      })
+      liveSocket.connect()
+      window.liveSocket = liveSocket
+    </script>
+
+    <%= @inner_content %>
+    """
+  end
+
+  @impl Phoenix.LiveView
+  def mount(%{"dead-mount" => "raise"}, _session, _socket), do: raise("boom")
+
+  def mount(%{"connected-mount" => "raise"}, _session, socket) do
+    if connected?(socket) do
+      raise "boom"
+    end
+
+    {:ok, socket}
+  end
+
+  def mount(%{"connected-child-mount-raise" => "link"}, _session, socket) do
+    # prevent infinite reconnect loop, as the parent always mounts successfully
+    # and therefore the clientside failsafe never triggers;
+    # therefore we only crash once
+    case get_connect_params(socket) do
+      %{"_mounts" => 0} ->
+        {:ok, assign(socket, child: true, want_fails: 1, have_fails: 0, link: true)}
+
+      _ ->
+        {:ok, assign(socket, child: true, want_fails: 1, have_fails: 1, link: true)}
+    end
+  end
+
+  def mount(%{"connected-child-mount-raise" => want_fails}, _session, socket) do
+    # we send the number of times the child mount should fail
+    # to test that the page is not reloaded, but the child rejoins successfully
+    # up to a certain number of times
+    want_fails = String.to_integer(want_fails)
+    {:ok, assign(socket, child: true, want_fails: want_fails, have_fails: 0)}
+  end
+
+  def mount(%{"child" => _}, _session, socket) do
+    {:ok, assign(socket, child: true, want_fails: 0, have_fails: 0)}
+  end
+
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_info({:child_mounted, pid}, socket) do
+    if socket.assigns[:have_fails] < socket.assigns[:want_fails] do
+      send(pid, (socket.assigns[:link] && :boom_link) || :boom)
+      {:noreply, assign(socket, have_fails: socket.assigns[:have_fails] + 1)}
+    else
+      send(pid, (socket.assigns[:link] && :ok_link) || :ok)
+      {:noreply, socket}
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("boom", _params, _socket) do
+    raise "boom"
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <p id="render-time">main rendered at: <%= DateTime.utc_now() %></p>
+
+    <button phx-click="boom">Crash main</button>
+
+    <p class="if-phx-error">Error</p>
+    <p class="if-phx-client-error">Client Error</p>
+    <p class="if-phx-server-error">Server Error</p>
+    <p class="if-phx-disconnected">Disconnected</p>
+    <p class="if-phx-loading">Loading</p>
+
+    <div style="border: 1px solid lightgray; padding: 4px; margin-top: 16px;">
+      <%= if assigns[:child] do %>
+        <%= live_render(@socket, ChildLive, id: "child") %>
+      <% end %>
+    </div>
+
+    <style>
+      [data-phx-session] .if-phx-error {
+        display: none;
+      }
+
+      [data-phx-session].phx-error > .if-phx-error {
+        display: block;
+      }
+
+      [data-phx-session] .if-phx-client-error {
+        display: none;
+      }
+
+      [data-phx-session].phx-client-error > .if-phx-client-error {
+        display: block;
+      }
+
+      [data-phx-session] .if-phx-server-error {
+        display: none;
+      }
+
+      [data-phx-session].phx-server-error > .if-phx-server-error {
+        display: block;
+      }
+
+      [data-phx-session] .if-phx-disconnected {
+        display: none;
+      }
+
+      [data-phx-session].phx-disconnected > .if-phx-disconnected {
+        display: block;
+      }
+
+      [data-phx-session] .if-phx-loading {
+        display: none;
+      }
+
+      [data-phx-session].phx-loading > .if-phx-loading {
+        display: block;
+      }
+    </style>
+    """
+  end
+end

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -23,6 +23,12 @@ end
 defmodule Phoenix.LiveViewTest.E2E.Layout do
   use Phoenix.Component
 
+  def render("root.html", assigns) do
+    ~H"""
+    <%!-- no doctype -> quirks mode --%> <!DOCTYPE html> <%= @inner_content %>
+    """
+  end
+
   def render("live.html", assigns) do
     ~H"""
     <meta name="csrf-token" content={Plug.CSRFProtection.get_csrf_token()} />
@@ -102,6 +108,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
     plug :accepts, ["html"]
     plug :fetch_session
     plug :protect_from_forgery
+    plug :put_root_layout, html: {Phoenix.LiveViewTest.E2E.Layout, :root}
   end
 
   live_session :default,
@@ -154,6 +161,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
     pipe_through(:browser)
 
     live "/form/feedback", FormFeedbackLive
+    live "/errors", ErrorLive
 
     scope "/issues" do
       live "/2965", Issue2965Live

--- a/test/e2e/tests/errors.spec.js
+++ b/test/e2e/tests/errors.spec.js
@@ -1,0 +1,278 @@
+const { test, expect } = require("../test-fixtures");
+const { syncLV } = require("../utils");
+
+/**
+ * https://hexdocs.pm/phoenix_live_view/error-handling.html
+ */
+test.describe("exception handling", () => {
+  let webSocketEvents = [];
+  let networkEvents = [];
+  let consoleMessages = [];
+
+  test.beforeEach(async ({ page }) => {
+    networkEvents = [];
+    webSocketEvents = [];
+    consoleMessages = [];
+  
+    page.on("request", request => networkEvents.push({ method: request.method(), url: request.url() }));
+  
+    page.on("websocket", ws => {
+      ws.on("framesent", event => webSocketEvents.push({ type: "sent", payload: event.payload }));
+      ws.on("framereceived", event => webSocketEvents.push({ type: "received", payload: event.payload }));
+      ws.on("close", () => webSocketEvents.push({ type: "close" }));
+    });
+
+    page.on("console", msg => consoleMessages.push(msg.text()));
+  });
+
+  test.describe("during HTTP mount", () => {
+    test("500 error when dead mount fails", async ({ page }) => {
+      page.on("response", response => {
+        expect(response.status()).toBe(500);
+      });
+      await page.goto("/errors?dead-mount=raise");
+    });
+  });
+
+  test.describe("during connected mount", () => {
+    /**
+     * When the connected mount fails, the page is reloaded. The hope here is
+     * that the next time the page is loaded, either the connected mount will
+     * succeed, or the same error will be triggered during the dead mount as well,
+     * rendering an error page.
+     * 
+     * In the unlikely case that the dead mount succeeds, but the connected mount
+     * fails repeatedly, the liveSocket enters failsafe mode. This still means that
+     * the page will be reloaded without giving up, but the duration is set to 30s
+     * by default.
+     */
+    test("reloads the page when connected mount fails", async ({ page }) => {
+      await page.goto("/errors?connected-mount=raise");
+  
+      // the page was loaded once
+      await expect(networkEvents).toEqual([
+        { method: "GET", url: "http://localhost:4004/errors?connected-mount=raise" },
+        { method: "GET", url: "http://localhost:4004/assets/phoenix/phoenix.min.js" },
+        { method: "GET", url: "http://localhost:4004/assets/phoenix_live_view/phoenix_live_view.esm.js" },
+      ]);
+  
+      networkEvents = [];
+  
+      await page.waitForTimeout(2000);
+      // the first 5 tries failed, on the 6th we entered failsafe mode
+      // where the reloads only happen every 30 seconds
+      await expect(webSocketEvents.filter((e) => e.type === "sent" && e.payload.indexOf("phx_join"))).toHaveLength(6);
+      await expect(webSocketEvents.filter((e) => e.type === "received" && e.payload.indexOf("join crashed"))).toHaveLength(6);
+  
+      // the page was reloaded 5 times
+      await expect(networkEvents.filter((e) => e.url === "http://localhost:4004/errors?connected-mount=raise")).toHaveLength(5);
+  
+      await expect(consoleMessages).toEqual(expect.arrayContaining([
+        expect.stringMatching(/exceeded 5 consecutive reloads. Entering failsafe mode/)
+      ]));
+    });
+  
+    /**
+     * TBD: if the connected mount of the main LV succeeds, but a child LV fails
+     * on mount, we only try to rejoin the child LV instead of reloading the page.
+     */
+    test("rejoin instead of reload when child LV fails on connected mount", async ({ page }) => {
+      await page.goto("/errors?connected-child-mount-raise=2");
+      await page.waitForTimeout(200);
+  
+      await expect(consoleMessages).toEqual([
+        expect.stringMatching(/mount/),
+        expect.stringMatching(/child error: unable to join/),
+        expect.stringMatching(/child error: unable to join/),
+        // third time's the charm
+        expect.stringMatching(/child mount/),
+      ]);
+  
+      // page was not reloaded
+      await expect(networkEvents).toEqual([
+        { method: "GET", url: "http://localhost:4004/errors?connected-child-mount-raise=2" },
+        { method: "GET", url: "http://localhost:4004/assets/phoenix/phoenix.min.js" },
+        { method: "GET", url: "http://localhost:4004/assets/phoenix_live_view/phoenix_live_view.esm.js" },
+      ]);
+    });
+  
+    /**
+     * TBD: if the connected mount of the main LV succeeds, but a child LV fails
+     * repeatedly, we reload the page. Maybe we should give up without reloading the page?
+     */
+    test("reloads the page if child LV fails multiple times", async ({ page }) => {
+      await page.goto("/errors?connected-child-mount-raise=5");
+      // maybe we can find a better way than waiting for a fixed amount of time
+      await page.waitForTimeout(1000);
+  
+      await expect(consoleMessages).toEqual([
+        expect.stringContaining("mount"),
+        expect.stringContaining("child error: unable to join"),
+        expect.stringContaining("child error: unable to join"),
+        expect.stringContaining("child error: unable to join"),
+        // maxChildJoinTries is 3, we count from 0, so the 4th try is the last
+        expect.stringContaining("child error: unable to join"),
+        expect.stringContaining("child destroyed"),
+        // parent is destroyed as well and logs the remove message
+        expect.stringContaining("the child has been removed from the parent"),
+        expect.stringContaining("join: encountered 0 consecutive reloads"),
+        expect.stringContaining("mount:"),
+        expect.stringContaining("child error: unable to join"),
+        expect.stringContaining("child error: child failed to join consecutively, even after reloading the page. We won't try again"),
+        expect.stringContaining("child destroyed"),
+        // TODO: I think the phoenix socket rejoin is triggered before
+        // the view is fully destroyed, therefore this is logged twice;
+        // it would be nice if we can prevent this
+        expect.stringContaining("child error: unable to join"),
+        expect.stringContaining("child error: child failed to join consecutively, even after reloading the page. We won't try again"),
+        expect.stringContaining("child destroyed"),
+      ]);
+  
+      // page was reloaded once
+      await expect(networkEvents).toEqual([
+        // initial load
+        { method: "GET", url: "http://localhost:4004/errors?connected-child-mount-raise=5" },
+        { method: "GET", url: "http://localhost:4004/assets/phoenix/phoenix.min.js" },
+        { method: "GET", url: "http://localhost:4004/assets/phoenix_live_view/phoenix_live_view.esm.js" },
+        // reload
+        { method: "GET", url: "http://localhost:4004/errors?connected-child-mount-raise=5" },
+        { method: "GET", url: "http://localhost:4004/assets/phoenix/phoenix.min.js" },
+        { method: "GET", url: "http://localhost:4004/assets/phoenix_live_view/phoenix_live_view.esm.js" },
+      ]);
+    });
+  });
+
+  test.describe("after connected mount", () => {
+    /**
+     * When a child LV crashes after the connected mount, the parent LV is not
+     * affected. The child LV is simply remounted.
+     */
+    test("page does not reload if child LV crashes (handle_event)", async ({ page }) => {
+      await page.goto("/errors?child");
+      await syncLV(page);
+  
+      const parentTime = await page.locator("#render-time").innerText();
+      const childTime = await page.locator("#child-render-time").innerText();
+  
+      // both lvs mounted, no other messages
+      await expect(consoleMessages).toEqual([
+        expect.stringMatching(/mount/),
+        expect.stringMatching(/child mount/),
+      ]);
+      consoleMessages = [];
+  
+      await page.getByRole("button", { name: "Crash child" }).click();
+      await syncLV(page);
+  
+      // child crashed and re-rendered
+      const newChildTime = await page.locator("#child-render-time").innerText();
+      expect(newChildTime).not.toEqual(childTime);
+      await expect(consoleMessages).toEqual([
+        expect.stringMatching(/child error: view crashed/),
+        expect.stringMatching(/child mount/),
+      ]);
+  
+      // parent did not re-render
+      const newParentTiem = await page.locator("#render-time").innerText();
+      expect(newParentTiem).toEqual(parentTime);
+  
+      // page was not reloaded
+      await expect(networkEvents).toEqual([
+        { method: "GET", url: "http://localhost:4004/errors?child" },
+        { method: "GET", url: "http://localhost:4004/assets/phoenix/phoenix.min.js" },
+        { method: "GET", url: "http://localhost:4004/assets/phoenix_live_view/phoenix_live_view.esm.js" },
+      ]);
+    });
+  
+    /**
+     * When the main LV crashes after the connected mount, the page is not reloaded.
+     * The main LV is simply remounted over the existing transport.
+     */
+    test("page does not reload if main LV crashes (handle_event)", async ({ page }) => {
+      await page.goto("/errors?child");
+      await syncLV(page);
+  
+      const parentTime = await page.locator("#render-time").innerText();
+      const childTime = await page.locator("#child-render-time").innerText();
+  
+      // both lvs mounted, no other messages
+      await expect(consoleMessages).toEqual([
+        expect.stringMatching(/mount/),
+        expect.stringMatching(/child mount/),
+      ]);
+      consoleMessages = [];
+  
+      await page.getByRole("button", { name: "Crash main" }).click();
+      await syncLV(page);
+  
+      // main and child re-rendered (full page refresh)
+      const newChildTime = await page.locator("#child-render-time").innerText();
+      expect(newChildTime).not.toEqual(childTime);
+      const newParentTiem = await page.locator("#render-time").innerText();
+      expect(newParentTiem).not.toEqual(parentTime);
+  
+      await expect(consoleMessages).toEqual([
+        expect.stringMatching(/child destroyed/),
+        expect.stringMatching(/error: view crashed/),
+        expect.stringMatching(/mount/),
+        expect.stringMatching(/child mount/),
+      ]);
+  
+      // page was not reloaded
+      await expect(networkEvents).toEqual([
+        { method: "GET", url: "http://localhost:4004/errors?child" },
+        { method: "GET", url: "http://localhost:4004/assets/phoenix/phoenix.min.js" },
+        { method: "GET", url: "http://localhost:4004/assets/phoenix_live_view/phoenix_live_view.esm.js" },
+      ]);
+    });
+  
+    /**
+     * When the main LV mounts successfully, but a child LV crashes which is linked
+     * to the parent, the parent LV crashed too, triggering a remount of both.
+     */
+    test("parent crashes and reconnects when linked child LV crashes", async ({ page }) => {
+      await page.goto("/errors?connected-child-mount-raise=link");
+      await syncLV(page);
+  
+      // child crashed on mount, linked to parent -> parent crashed too
+      // second mounts are successful
+      await expect(consoleMessages).toEqual([
+        expect.stringMatching(/mount/),
+        expect.stringMatching(/child error: unable to join/),
+        expect.stringMatching(/child destroyed/),
+        expect.stringMatching(/error: view crashed/),
+        expect.stringMatching(/mount/),
+        expect.stringMatching(/child mount/),
+      ]);
+      consoleMessages = [];
+  
+      const parentTime = await page.locator("#render-time").innerText();
+      const childTime = await page.locator("#child-render-time").innerText();
+  
+      // the processes are still linked, crashing the child again crashes the parent
+      await page.getByRole("button", { name: "Crash child" }).click();
+      await syncLV(page);
+  
+      // main and child re-rendered (full page refresh)
+      const newChildTime = await page.locator("#child-render-time").innerText();
+      expect(newChildTime).not.toEqual(childTime);
+      const newParentTiem = await page.locator("#render-time").innerText();
+      expect(newParentTiem).not.toEqual(parentTime);
+  
+      await expect(consoleMessages).toEqual([
+        expect.stringMatching(/child error: view crashed/),
+        expect.stringMatching(/child destroyed/),
+        expect.stringMatching(/error: view crashed/),
+        expect.stringMatching(/mount/),
+        expect.stringMatching(/child mount/),
+      ]);
+  
+      // page was not reloaded
+      await expect(networkEvents).toEqual([
+        { method: "GET", url: "http://localhost:4004/errors?connected-child-mount-raise=link" },
+        { method: "GET", url: "http://localhost:4004/assets/phoenix/phoenix.min.js" },
+        { method: "GET", url: "http://localhost:4004/assets/phoenix_live_view/phoenix_live_view.esm.js" },
+      ]);
+    });
+  });
+});

--- a/test/e2e/tests/navigation.spec.js
+++ b/test/e2e/tests/navigation.spec.js
@@ -141,7 +141,7 @@ test("restores scroll position after navigation", async ({ page }) => {
 
   await expect(page.locator("#items")).toContainText("Item 42");
 
-  await expect(await page.evaluate(() => document.body.scrollTop)).toEqual(0);
+  await expect(await page.evaluate(() => document.documentElement.scrollTop)).toEqual(0);
   const offset = (await page.locator("#items-item-42").evaluate((el) => el.offsetTop)) - 200;
   await page.evaluate((offset) => window.scrollTo(0, offset), offset);
   // LiveView only updates the scroll position every 100ms
@@ -156,7 +156,7 @@ test("restores scroll position after navigation", async ({ page }) => {
   // scroll position is restored
   await expect.poll(
     async () => {
-      return await page.evaluate(() => document.body.scrollTop);
+      return await page.evaluate(() => document.documentElement.scrollTop);
     },
     { message: 'scrollTop not restored', timeout: 5000 }
   ).toBe(offset);
@@ -199,7 +199,7 @@ test("scrolls hash el into view", async ({ page }) => {
   await page.getByRole("link", { name: "Go to 42" }).click();
   await expect(page).toHaveURL("/navigation/b#items-item-42");
 
-  let scrollTop = await page.evaluate(() => document.body.scrollTop)
+  let scrollTop = await page.evaluate(() => document.documentElement.scrollTop)
   await expect(scrollTop).not.toBe(0);
   await expect(scrollTop).toBeGreaterThanOrEqual(offset - 500);
   await expect(scrollTop).toBeLessThanOrEqual(offset + 500);
@@ -207,7 +207,7 @@ test("scrolls hash el into view", async ({ page }) => {
   await page.goto("/navigation/a");
   await page.goto("/navigation/b#items-item-42");
 
-  scrollTop = await page.evaluate(() => document.body.scrollTop)
+  scrollTop = await page.evaluate(() => document.documentElement.scrollTop)
   await expect(scrollTop).not.toBe(0);
   await expect(scrollTop).toBeGreaterThanOrEqual(offset - 500);
   await expect(scrollTop).toBeLessThanOrEqual(offset + 500);


### PR DESCRIPTION
@chrismccord this definitely needs some work (and probably from you).

References #3257.
References https://github.com/phoenixframework/phoenix_live_view/pull/3279.

Summary of the current state:

1. when a child LV join fails we call reloadWithJitter with the child LV
2. reloadWithJitter calls disconnect on the socket
3. disconnect destroys all child views
4. the timeout in reloadWithJitter runs and checks if the view is destroyed -> yes -> nothing happens, because we just return
5. we are stuck

I think we’ll need to first define the expected behavior, as this is a little bit tricky. If I remove the call to disconnect, the first thing I noticed is that the phoenix channel itself tries to rejoin separately from the LV code (https://github.com/phoenixframework/phoenix/blob/69685f783bc60d2a124fc2fb48028b065bc24b22/assets/js/phoenix/channel.js#L45-L48). So we need to keep the Phoenix Socket retries in mind.

I think it should probably be like this:
A child LV that crashes (on join or whenever) should be rejoined without affecting any other LiveView on the page.
We could keep track of the number of failed joins similar how we keep track of consecutive reloads.
If we reach a number of consecutive child joins with no success we should do a hard refresh (this will then of course kill all other LiveViews as well). After we tried a hard refresh and the child LV still fails, we give up.

This PR tries to implement what was described above. As I'm not 100% sure I've grasped everything happening from Phoenix.Socket to the different considerations for LV, this is still a draft. Some TODOs are in the code. I think the tests are good to have - even if the JS changes are thrown away, those can be kept and adapted accordingly.