### PR TITLE
Consider more possible characters when prefixing unused form data key

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -60,7 +60,7 @@ export let prependFormDataKey = (key, prefix) => {
   // Remove the "[]" if it's an array
   let baseKey = isArray ? key.slice(0, -2) : key
   // Replace last occurrence of key before a closing bracket or the end with key plus suffix
-  baseKey = baseKey.replace(/(\w+)(\]?$)/, `${prefix}$1$2`)
+  baseKey = baseKey.replace(/([^\[\]]+)(\]?$)/, `${prefix}$1$2`)
   // Add back the "[]" if it was an array
   if(isArray){ baseKey += "[]" }
   return baseKey


### PR DESCRIPTION
> Even though `-` is rarely used as key in Elixir, there are instances when it is used, so it's better to consider it.

[Current implementation of `prependFormDataKey`](https://github.com/phoenixframework/phoenix_live_view/blob/02bc543fc2602a1de3f53dbfe2bbdfef443806ac/assets/js/phoenix_live_view/view.js#L58) fails to handle the key containing `-`:
```
prependFormDataKey('en', '_unused_')    // '_unused_en'    - good
prependFormDataKey('en-US', '_unused_') // 'en-_unused_US' - bad
```

This PR aims to fix above issue by considering more possible characters. The result:
```
prependFormDataKey('en', '_unused_')    // '_unused_en'    - good
prependFormDataKey('en-US', '_unused_') // '_unused_en-US' - good
```

