### PR TITLE
Update socket lifecycle docs s/events/bindings

### DIFF
--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -344,8 +344,10 @@ It does not cascade to children.
 
 ## Lifecycle Events
 
-LiveView supports the `phx-connected`, and `phx-disconnected` events to react to
-connection lifecycle events with JS commands. For example, to show an element when the LiveView has lost its connection and hide it when the connection recovers:
+LiveView supports the `phx-connected` and `phx-disconnected` bindings to react
+to connection lifecycle events with JS commands. For example, to show an element
+when the LiveView has lost its connection and hide it when the connection
+recovers:
 
 ```heex
 <div id="status" class="hidden" phx-disconnected={JS.show()} phx-connected={JS.hide()}>


### PR DESCRIPTION
In the given context, `phx-connect` and `phx-disconnected` are bindings (a.k.a. "event bindings") and not events themselves, which could confuse readers thinking about JavaScript events or LiveView socket events.