### PR TITLE
Clarify that using assign/3 will not break change tracking

### DIFF
--- a/guides/server/assigns-eex.md
+++ b/guides/server/assigns-eex.md
@@ -112,15 +112,15 @@ Instead, use a function:
 ```
 
 Similarly, **do not** define variables at the top of your `render` function
-for LiveViews or LiveComponents. Since LiveView cannot track `sum` or `message`,
+for LiveViews or LiveComponents. Since LiveView cannot track `sum` or `title`,
 if either value changes, both must be re-rendered by LiveView.
 
     def render(assigns) do
       sum = assigns.x + assigns.y
-      message = assigns.message
+      title = assigns.title
 
       ~H"""
-      <%= message %>
+      <h1><%= title %></h1>
 
       <%= sum %>
       """
@@ -128,7 +128,7 @@ if either value changes, both must be re-rendered by LiveView.
 
 Instead use the `assign/2`, `assign/3`, `assign_new/3`, and `update/3`
 functions to compute it. Any assign defined or updated this way will be marked as
-changed, while other assigns like `@message` will still be tracked by LiveView.
+changed, while other assigns like `@title` will still be tracked by LiveView.
 
     assign(assigns, sum: assigns.x + assigns.y)
     
@@ -137,10 +137,13 @@ The same functions can be used inside function components too:
 
     attr :x, :integer, required: true
     attr :y, :integer, required: true
+    attr :title, :string, required: true
     def sum_component(assigns) do
       assigns = assign(assigns, sum: assigns.x + assigns.y)
 
       ~H"""
+      <h1><%= @title %></h1>
+
       <%= @sum %>
       """
     end

--- a/guides/server/assigns-eex.md
+++ b/guides/server/assigns-eex.md
@@ -36,7 +36,8 @@ won't resend the static parts and it will only resend the dynamic
 part if it changes.
 
 The tracking of changes is done via assigns. If the `@title` assign
-changes, then LiveView will execute `expand_title(@title)` and send
+changes, then LiveView will execute the dynamic parts of the template,
+`expand_title(@title)`, and send
 the new content. If `@title` is the same, nothing is executed and
 nothing is sent.
 
@@ -111,20 +112,26 @@ Instead, use a function:
 ```
 
 Similarly, **do not** define variables at the top of your `render` function
-for LiveViews or LiveComponents:
+for LiveViews or LiveComponents. Since LiveView cannot track `sum` or `message`,
+if either value changes, both must be re-rendered by LiveView.
 
     def render(assigns) do
       sum = assigns.x + assigns.y
+      message = assigns.message
 
       ~H"""
-      <%= sum %>
+      <p><%= message %></p>
+
+      <div><%= sum %></div>
       """
     end
 
 Instead use the `assign/2`, `assign/3`, `assign_new/3`, and `update/3`
-functions to compute it, which will maintain change tracking:
+functions to compute it. Any assign defined or updated this way will be marked as
+changed, while other assigns like `@message` will still be tracked by LiveView.
 
     assign(assigns, sum: assigns.x + assigns.y)
+    
 
 The same functions can be used inside function components too:
 

--- a/guides/server/assigns-eex.md
+++ b/guides/server/assigns-eex.md
@@ -122,7 +122,7 @@ for LiveViews or LiveComponents:
     end
 
 Instead use the `assign/2`, `assign/3`, `assign_new/3`, and `update/3`
-functions to compute it:
+functions to compute it, which will maintain change tracking:
 
     assign(assigns, sum: assigns.x + assigns.y)
 

--- a/guides/server/assigns-eex.md
+++ b/guides/server/assigns-eex.md
@@ -120,9 +120,9 @@ if either value changes, both must be re-rendered by LiveView.
       message = assigns.message
 
       ~H"""
-      <p><%= message %></p>
+      <%= message %>
 
-      <div><%= sum %></div>
+      <%= sum %>
       """
     end
 

--- a/guides/server/assigns-eex.md
+++ b/guides/server/assigns-eex.md
@@ -131,7 +131,6 @@ functions to compute it. Any assign defined or updated this way will be marked a
 changed, while other assigns like `@title` will still be tracked by LiveView.
 
     assign(assigns, sum: assigns.x + assigns.y)
-    
 
 The same functions can be used inside function components too:
 


### PR DESCRIPTION
I was under the impression that using `assign/3` and friends inside of a function would break change tracking, which is *not* the case.

A quick note to clarify this behavior