### PR TITLE
Formatter | Doesn't convert <%= to <%

### DIFF
--- a/lib/phoenix_live_view/html_algebra.ex
+++ b/lib/phoenix_live_view/html_algebra.ex
@@ -279,7 +279,7 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
   end
 
   # Handle EEX blocks
-  defp to_algebra({:eex_block, expr, block}, context) do
+  defp to_algebra({:eex_block, expr, block, meta}, context) do
     {doc, _stab} =
       Enum.reduce(block, {empty(), false}, fn {block, expr}, {doc, stab?} ->
         {block, _force_newline?} = trim_block_newlines(block)
@@ -287,7 +287,7 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
         {concat(doc, force_unfit(next_doc)), stab?}
       end)
 
-    {:block, group(concat("<%= #{expr} %>", doc))}
+    {:block, group(concat("<%#{meta.opt} #{expr} %>", doc))}
   end
 
   defp to_algebra({:eex_comment, text}, _context) do

--- a/lib/phoenix_live_view/html_formatter.ex
+++ b/lib/phoenix_live_view/html_formatter.ex
@@ -501,48 +501,48 @@ defmodule Phoenix.LiveView.HTMLFormatter do
     to_tree(tokens, [{:eex_comment, text} | buffer], stack, source)
   end
 
-  defp to_tree([{:eex, :start_expr, expr, _meta} | tokens], buffer, stack, source) do
-    to_tree(tokens, [], [{:eex_block, expr, buffer} | stack], source)
+  defp to_tree([{:eex, :start_expr, expr, meta} | tokens], buffer, stack, source) do
+    to_tree(tokens, [], [{:eex_block, expr, meta, buffer} | stack], source)
   end
 
   defp to_tree(
          [{:eex, :middle_expr, middle_expr, _meta} | tokens],
          buffer,
-         [{:eex_block, expr, upper_buffer, middle_buffer} | stack],
+         [{:eex_block, expr, meta, upper_buffer, middle_buffer} | stack],
          source
        ) do
     middle_buffer = [{Enum.reverse(buffer), middle_expr} | middle_buffer]
-    to_tree(tokens, [], [{:eex_block, expr, upper_buffer, middle_buffer} | stack], source)
+    to_tree(tokens, [], [{:eex_block, expr, meta, upper_buffer, middle_buffer} | stack], source)
   end
 
   defp to_tree(
          [{:eex, :middle_expr, middle_expr, _meta} | tokens],
          buffer,
-         [{:eex_block, expr, upper_buffer} | stack],
+         [{:eex_block, expr, meta, upper_buffer} | stack],
          source
        ) do
     middle_buffer = [{Enum.reverse(buffer), middle_expr}]
-    to_tree(tokens, [], [{:eex_block, expr, upper_buffer, middle_buffer} | stack], source)
+    to_tree(tokens, [], [{:eex_block, expr, meta, upper_buffer, middle_buffer} | stack], source)
   end
 
   defp to_tree(
          [{:eex, :end_expr, end_expr, _meta} | tokens],
          buffer,
-         [{:eex_block, expr, upper_buffer, middle_buffer} | stack],
+         [{:eex_block, expr, meta, upper_buffer, middle_buffer} | stack],
          source
        ) do
     block = Enum.reverse([{Enum.reverse(buffer), end_expr} | middle_buffer])
-    to_tree(tokens, [{:eex_block, expr, block} | upper_buffer], stack, source)
+    to_tree(tokens, [{:eex_block, expr, block, meta} | upper_buffer], stack, source)
   end
 
   defp to_tree(
          [{:eex, :end_expr, end_expr, _meta} | tokens],
          buffer,
-         [{:eex_block, expr, upper_buffer} | stack],
+         [{:eex_block, expr, meta, upper_buffer} | stack],
          source
        ) do
     block = [{Enum.reverse(buffer), end_expr}]
-    to_tree(tokens, [{:eex_block, expr, block} | upper_buffer], stack, source)
+    to_tree(tokens, [{:eex_block, expr, block, meta} | upper_buffer], stack, source)
   end
 
   defp to_tree([{:eex, _type, expr, meta} | tokens], buffer, stack, source) do

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -2066,6 +2066,14 @@ defmodule Phoenix.LiveView.HTMLFormatterTest do
     assert_formatter_doesnt_change("", opening_delimiter: "\"\"\"")
   end
 
+  test "doesn't convert <% to <%=" do
+    assert_formatter_doesnt_change("""
+    <% fun = fn assigns -> %>
+      <hr />
+    <% end %>
+    """)
+  end
+
   # TODO: Remove this `if` when we require Elixir 1.14+
   if function_exported?(EEx, :tokenize, 2) do
     test "handle EEx comments" do


### PR DESCRIPTION
Fixes https://github.com/phoenixframework/phoenix_live_view/issues/3289

So that Formatter doesn't force `<%=`. It should relies on `opt` metadata ommited by EEx tokenizer instead.