### PR TITLE
Fix using named form inputs with put_submitter/2

### DIFF
--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -885,6 +885,15 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
 
   defp root(state, view), do: DOM.by_id!(state.html, view.id)
 
+  defp select_node_from_list(node_list, %Element{selector: selector, text_filter: nil}) do
+    DOM.maybe_one(node_list, selector)
+  end
+
+  defp select_node_from_list(node_list, %Element{selector: selector, text_filter: text_filter}) do
+    nodes = DOM.all(node_list, selector)
+    select_node_by_text(node_list, nodes, text_filter, selector)
+  end
+
   defp select_node(root, %Element{selector: selector, text_filter: nil}) do
     root
     |> DOM.child_nodes()
@@ -897,6 +906,18 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
       |> DOM.child_nodes()
       |> DOM.all(selector)
 
+    select_node_by_text(root, nodes, text_filter, selector)
+  end
+
+  defp select_node(root, {_, _, selector}) do
+    if selector do
+      root |> DOM.child_nodes() |> DOM.maybe_one(selector)
+    else
+      {:ok, root}
+    end
+  end
+
+  defp select_node_by_text(root, nodes, text_filter, selector) do
     filtered_nodes = Enum.filter(nodes, &(DOM.to_text(&1) =~ text_filter))
 
     case {nodes, filtered_nodes} do
@@ -924,14 +945,6 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
          "selector #{inspect(selector)} returned #{length(nodes)} elements " <>
            "and #{length(filtered_nodes)} of them matched the text filter #{inspect(text_filter)}: \n\n " <>
            DOM.inspect_html(filtered_nodes)}
-    end
-  end
-
-  defp select_node(root, {_, _, selector}) do
-    if selector do
-      root |> DOM.child_nodes() |> DOM.maybe_one(selector)
-    else
-      {:ok, root}
     end
   end
 
@@ -1093,24 +1106,31 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
        when type in [:change, :submit] do
     cond do
       tag == "form" ->
-        named_fields =
+        form_inputs = filtered_inputs(node)
+
+        named_inputs =
           case Enum.into(attrs, %{}) do
             %{"id" => id} -> Floki.find(root, "[form=#{id}]")
             _ -> []
           end
 
-        fields =
-          (named_fields ++ node)
-          |> DOM.filter(fn node ->
-            DOM.tag(node) in ~w(input textarea select) and
-              is_nil(DOM.attribute(node, "disabled"))
-          end)
-          |> Enum.uniq()
+        named_btns = DOM.filter(named_inputs, fn node -> DOM.tag(node) == "button" end)
+        named_inputs = filtered_inputs(named_inputs)
 
-        defaults = Enum.reduce(fields, Query.decode_init(), &form_defaults/2)
+        # All inputs including buttons
+        # Remove the named inputs first to remove any possible
+        # duplicates if the child inputs also had a form attribite.
+        all_inputs = (form_inputs -- named_inputs) ++ named_inputs
+        all_inputs = (all_inputs -- named_btns) ++ named_btns
 
-        with {:ok, defaults} <- maybe_submitter(defaults, type, {root, node}, element),
-             {:ok, value} <- fill_in_map(Enum.to_list(element.form_data || %{}), "", fields, []) do
+        # All inputs excluding buttons
+        value_inputs = (form_inputs -- named_inputs) ++ named_inputs
+
+        defaults = Enum.reduce(value_inputs, Query.decode_init(), &form_defaults/2)
+
+        with {:ok, defaults} <- maybe_submitter(defaults, type, {node, all_inputs}, element),
+             {:ok, value} <-
+               fill_in_map(Enum.to_list(element.form_data || %{}), "", value_inputs, []) do
           {:ok,
            defaults
            |> Query.decode_done()
@@ -1132,13 +1152,20 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
     {:ok, DOM.all_values(node)}
   end
 
-  defp maybe_submitter(defaults, :submit, {root, form}, %Element{meta: %{submitter: element}}) do
-    collect_submitter({root, form}, element, defaults)
+  defp filtered_inputs(nodes) do
+    DOM.filter(nodes, fn node ->
+      DOM.tag(node) in ~w(input textarea select) and
+        is_nil(DOM.attribute(node, "disabled"))
+    end)
+  end
+
+  defp maybe_submitter(defaults, :submit, {form, inputs}, %Element{meta: %{submitter: element}}) do
+    collect_submitter({form, inputs}, element, defaults)
   end
 
   defp maybe_submitter(defaults, _, _, _), do: {:ok, defaults}
 
-  defp collect_submitter({root, form}, element, defaults) do
+  defp collect_submitter({form, inputs}, element, defaults) do
     # Check the form for the submitter first
     case select_node(form, element) do
       {:ok, node} ->
@@ -1146,10 +1173,10 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
 
       {:error, _, msg} ->
         # If the form did not have the submitter
-        # then check the rest of the DOM.
-        case select_node(root, element) do
+        # then check the inputs instead.
+        case select_node_from_list(inputs, element) do
           {:ok, node} ->
-            collect_submitter(node, form, element, defaults)
+            collect_submitter(node, inputs, element, defaults)
 
           {:error, _, _} ->
             {:error, :invalid, "invalid form submitter, " <> msg}
@@ -1158,8 +1185,6 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
   end
 
   defp collect_submitter(node, form, element, defaults) do
-    form_id = DOM.attribute(form, "id")
-    form_name = DOM.attribute(node, "form")
     name = DOM.attribute(node, "name")
 
     cond do
@@ -1167,7 +1192,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
         {:error, :invalid,
          "form submitter selected by #{inspect(element.selector)} must have a name"}
 
-      submitter?(node) and is_nil(DOM.attribute(node, "disabled")) and (!form_name or form_name == form_id) ->
+      submitter?(node) and is_nil(DOM.attribute(node, "disabled")) ->
         {:ok, Plug.Conn.Query.decode_each({name, DOM.attribute(node, "value")}, defaults)}
 
       true ->

--- a/test/phoenix_live_view/integrations/elements_test.exs
+++ b/test/phoenix_live_view/integrations/elements_test.exs
@@ -628,13 +628,18 @@ defmodule Phoenix.LiveView.ElementsTest do
       assert conn.query_string == "foo=bar"
     end
 
-    test "named form", %{live: view, conn: conn} do
-      view |> form("#named", %{foo: "a", bar: "b", baz: "c", child: "cc"}) |> render_submit()
+    test "named form", %{live: view, conn: _conn} do
+      view
+      |> form("#named", %{foo: "a", bar: "b", baz: "c", child: "cc"})
+      |> put_submitter("[name=btn]")
+      |> render_submit()
+
       assert last_event(view) =~ ~s|form-submit-named: %{|
       assert last_event(view) =~ ~s|"foo" => "a"|
       assert last_event(view) =~ ~s|"bar" => "b"|
       assert last_event(view) =~ ~s|"baz" => "c"|
       assert last_event(view) =~ ~s|"child" => "cc"|
+      assert last_event(view) =~ ~s|"btn" => "x"|
     end
   end
 

--- a/test/support/live_views/elements.ex
+++ b/test/support/live_views/elements.ex
@@ -169,6 +169,7 @@ defmodule Phoenix.LiveViewTest.ElementsLive do
     <input form="named" name="foo" />
     <textarea form="named" name="bar" />
     <select form="named" name="baz"><option value="c">c</option></select>
+    <button form="named" name="btn" type="submit" value="x">Submit</button>
 
     <% # @page_title assign is unique %>
     <svg><title>SVG with title</title></svg>


### PR DESCRIPTION
I created a bug in #3298 if you used put_submitter with a button outside the form.

```
** (FunctionClauseError) no function clause matching in Phoenix.LiveViewTest.ClientProxy.form_defaults/3

# 1
{"button", [...], [...]}...
```

So this fixes using `put_submitter/2` with named inputs because before I included buttons in `maybe_submitter/2`.

I'll try and write some extra tests for error/failure cases next week. I've run out of time this weekend.