### PR TITLE
Add missing spots to dynamic form docs

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2437,7 +2437,7 @@ defmodule Phoenix.Component do
     </button>
   </.inputs_for>
 
-  <input type="hidden" name="mailing_list[emails_drop][]" />
+  <input type="hidden" name="mailing_list[emails_drop][]" value="old" />
 
   <button type="button" name="mailing_list[emails_sort][]" value="new" phx-click={JS.dispatch("change")}>
     add more


### PR DESCRIPTION
Currently it is not possible to delete the item if it is the single child in the form.

To keep this working, we need to add a value to the smth[*_drop][] field.