### PR TITLE
Force assign ID on LiveComponents to re-render during :phoenix_live_reload

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -347,6 +347,22 @@ defmodule Phoenix.LiveView.Channel do
     {mod, fun, args} = socket.private.phoenix_reloader
     apply(mod, fun, [socket.endpoint | args])
 
+    {components, _, _} = state.components
+
+    state =
+      Enum.reduce(components, state, fn component, state ->
+        {_, {mod, cid, assigns, _, _}} = component
+        assigns = %{id: assigns.id, __changed__: %{id: assigns.id}}
+
+        case Diff.update_component(state.socket, state.components, {{mod, cid}, assigns}) do
+          {diff, new_components} ->
+            push_diff(%{state | components: new_components}, diff, nil)
+
+          :noop ->
+            state
+        end
+      end)
+
     new_socket =
       Enum.reduce(socket.assigns, socket, fn {key, val}, socket ->
         Utils.force_assign(socket, key, val)

--- a/test/support/live_views/reload_component_live.ex
+++ b/test/support/live_views/reload_component_live.ex
@@ -1,0 +1,35 @@
+defmodule Phoenix.LiveViewTest.LiveComponent do
+  use Phoenix.LiveComponent
+
+  @impl true
+  def render(assigns) do
+    {:ok, version} = Application.fetch_env(:phoenix_live_view, :vsn)
+    assigns = assign(assigns, version: version)
+
+    ~H"""
+    <div>
+      <div>Version <%= @version %></div>
+    </div>
+    """
+  end
+end
+
+defmodule Phoenix.LiveViewTest.ReloadComponentLive do
+  use Phoenix.LiveView
+
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @spec render(any()) :: Phoenix.LiveView.Rendered.t()
+  def render(assigns) do
+    ~H"""
+    <div>
+      <Phoenix.Component.live_component
+        id="live-component"
+        module={Phoenix.LiveViewTest.LiveComponent}
+      />
+    </div>
+    """
+  end
+end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -45,6 +45,7 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/log-disabled", WithLogDisabled
     live "/errors", ErrorsLive
     live "/live-reload", ReloadLive
+    live "/live-component-reload", ReloadComponentLive
     live "/assign_async", AssignAsyncLive
     live "/start_async", StartAsyncLive
 


### PR DESCRIPTION
Live reloading does not currently work with live_components, as described in https://github.com/phoenixframework/phoenix_live_reload/issues/162.

This PR adds support for live reloading of live_components by force re-assigning the live component’s ID field when processing the :phoenix_live_reload message. 

I’m not familiar enough with the LiveView internals to know if this is the correct approach, but it’s working well for me in testing - please let me know if there’s a better way to accomplish this.