### PR TITLE
Fix: Links to server and client pages from welcome guide

### DIFF
--- a/guides/introduction/welcome.md
+++ b/guides/introduction/welcome.md
@@ -299,7 +299,7 @@ These guides focus on server-side functionality:
 
 These guides focus on LiveView bindings and client-side integration:
 
-* [Bindings](bindings.md)
-* [Form bindings](form-bindings.md)
-* [JavaScript interoperability](js-interop.md)
-* [External uploads](uploads-external.md)
+* [Bindings](../client/bindings.md)
+* [Form bindings](../client/form-bindings.md)
+* [JavaScript interoperability](../client/js-interop.md)
+* [External uploads](../client/uploads-external.md)

--- a/guides/introduction/welcome.md
+++ b/guides/introduction/welcome.md
@@ -285,15 +285,15 @@ split on server-side and client-side:
 
 These guides focus on server-side functionality:
 
-* [Assigns and HEEx templates](assigns-eex.md)
-* [Deployments](deployments.md)
-* [Error and exception handling](error-handling.md)
-* [Live layouts](live-layouts.md)
-* [Live navigation](live-navigation.md)
-* [Security considerations](security-model.md)
-* [Telemetry](telemetry.md)
-* [Uploads](uploads.md)
-* [Gettext for internationalization](using-gettext.md)
+* [Assigns and HEEx templates](../server/assigns-eex.md)
+* [Deployments](../server/deployments.md)
+* [Error and exception handling](../server/error-handling.md)
+* [Live layouts](../server/live-layouts.md)
+* [Live navigation](../server/live-navigation.md)
+* [Security considerations](../server/security-model.md)
+* [Telemetry](../server/telemetry.md)
+* [Uploads](../server/uploads.md)
+* [Gettext for internationalization](../server/using-gettext.md)
 
 ### Client-side
 


### PR DESCRIPTION
This pull request fixes the client and server links on the `welcome.md` page to point to the corresponding client and server pages