### PR TITLE
Throw error when dispatching input on invalid targets

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -878,6 +878,9 @@ export default class LiveSocket {
 
     for(let type of ["change", "input"]){
       this.on(type, e => {
+        if(e instanceof CustomEvent && e.target.form === undefined){
+          throw new Error(`dispatching a custom ${type} event is only supported on input elements inside a form`)
+        }
         let phxChange = this.binding("change")
         let input = e.target
         let inputEvent = input.getAttribute(phxChange)


### PR DESCRIPTION
Using `JS.dispatch` to trigger an input event only works when targeting an input element (input, select, textarea), not the form element itself. This commit throws a useful error in the case of an invalid target.

References #3328