### PR TITLE
Allow disabling verification of `:global` attributes

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -325,6 +325,10 @@ defmodule Phoenix.Component.Declarative do
       compile_error!(line, file, ":include is only supported for :global attributes")
     end
 
+    if type != :global and Keyword.has_key?(opts, :verify) do
+      compile_error!(line, file, ":verify is only supported for :global attributes")
+    end
+
     {doc, opts} = Keyword.pop(opts, :doc, nil)
 
     unless is_binary(doc) or is_nil(doc) or doc == false do
@@ -523,9 +527,10 @@ defmodule Phoenix.Component.Declarative do
   defp invalid_attr_message(:required, _), do: nil
   defp invalid_attr_message(:values, _), do: nil
   defp invalid_attr_message(:examples, _), do: nil
+  defp invalid_attr_message(:verify, _), do: nil
 
   defp invalid_attr_message(_key, nil),
-    do: "The supported options are: [:required, :default, :values, :examples, :include]"
+    do: "The supported options are: [:required, :default, :values, :examples, :include, :verify]"
 
   defp invalid_attr_message(_key, _slot),
     do: "The supported options inside slots are: [:required]"
@@ -1111,7 +1116,7 @@ defmodule Phoenix.Component.Declarative do
       end)
 
     for {name, {line, _column, _type_value}} <- attrs,
-        !(global_attr && __global__?(caller_module, Atom.to_string(name), global_attr)) do
+        !global_attr || (global_attr && Keyword.get(global_attr.opts, :verify, true) && !__global__?(caller_module, Atom.to_string(name), global_attr)) do
       message = "undefined attribute \"#{name}\" for component #{component_fa(call)}"
       warn(message, call.file, line)
     end

--- a/test/phoenix_component/verify_test.exs
+++ b/test/phoenix_component/verify_test.exs
@@ -78,6 +78,28 @@ defmodule Phoenix.ComponentVerifyTest do
 
     assert warnings =~ "test/phoenix_component/verify_test.exs:#{line}: (file)"
   end
+  
+  test "allow any attributes when :verify is set to false" do
+    warnings =
+      capture_io(:stderr, fn ->
+        defmodule UndefinedAttrs do
+          use Phoenix.Component
+
+          attr :rest, :global, verify: false
+          def func(assigns), do: ~H[]
+
+          def line, do: __ENV__.line + 4
+
+          def render(assigns) do
+            ~H"""
+            <.func width="btn" size={@size} phx-no-format />
+            """
+          end
+        end
+      end)
+
+    assert warnings == ""
+  end
 
   test "validates attrs and slots for external function components" do
     warnings =


### PR DESCRIPTION
# Context

When building a component library, we might want to build components that add state and functionality, but leave the rendering to the user. This is typically exposed as the `as` prop in headless libraries for the JavaScript ecosystem:

ChakraUI: https://v2.chakra-ui.com/docs/components/box/usage#as-prop
HeadlessUI: https://headlessui.com/react/menu#menu

In my use case, I want to give the users of my library the ability to pass either strings, representing HTML elements (such as `"button"`, "`div`") _or_ captured function components (such as `&button/1`) as the render target.
For basic HTML elements that's a non-issue, but for function components, it should allow passing the attributes of the captured component as well.  
In usage, this might look like

```
<Tooltip.trigger as={&button/1} icon_left="i-ph-circle">Hover</Tooltip.trigger>
```

The `trigger/1` component handles the aria attributes, state management through Phoenix Hooks, and the `button/1` component handles the styling. In this case `icon_left` is an attribute on `button/1` and _not_ on `trigger`.  
While it renders just fine and has all the functionality and styling I need, the attribute verification throws out a warning since `icon_left` is an attribute of the passed-down component.

This PR allows setting `attr :rest, :global, verify: false` to silence all global attribute warnings and essentially allow _any_ attribute.

# Full example of usage

```elixir
defmodule Tooltip do
  # ...
  attr :as, :any, default: "button"
  attr :rest, :global, verify: false
  slot :inner_block

  def trigger(assigns) do
    render_as_tag_or_component(assigns, %{"data-part" => "trigger"})
  end
end

defmodule Utilities do
  # ...
  def render_as_tag_or_component(assigns, extra_assigns) do
    assigns =
      assigns
      |> Map.get(:rest, %{})
      |> Enum.reduce(assigns, fn {k, v}, acc -> assign(acc, k, v) end)
      |> Map.delete(:rest)
      |> Map.merge(extra_assigns)

    ~H"""
    <%= if is_function(@as) do %>
      <%= Phoenix.LiveView.TagEngine.component(
        @as,
        Map.delete(assigns, :as),
        {__ENV__.module, __ENV__.function, __ENV__.file, __ENV__.line}
      ) %>
    <% end %>

    <%= if is_binary(@as) do %>
      <.dynamic_tag name={@as} {Map.delete(assigns, :as)} />
    <% end %>
    """
  end
end
```

Cheers!