### PR TITLE
Fix unnecessary remount when navigating back

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -308,6 +308,9 @@ export default class View {
     if(this.root === this){
       this.formsForRecovery = this.getFormsForRecovery()
     }
+    if(this.isMain()){
+      this.liveSocket.replaceRootHistory()
+    }
 
     if(liveview_version !== this.liveSocket.version()){
       console.error(`LiveView asset version mismatch. JavaScript version ${this.liveSocket.version()} vs. server ${liveview_version}. To avoid issues, please ensure that your assets use the same version as the server.`)

--- a/test/e2e/tests/navigation.spec.js
+++ b/test/e2e/tests/navigation.spec.js
@@ -212,3 +212,18 @@ test("scrolls hash el into view", async ({ page }) => {
   await expect(scrollTop).toBeGreaterThanOrEqual(offset - 500);
   await expect(scrollTop).toBeLessThanOrEqual(offset + 500);
 });
+
+test("navigating all the way back works without remounting (only patching)", async ({ page }) => {
+  await page.goto("/navigation/a");
+  await syncLV(page);
+  networkEvents = [];
+  await page.getByRole("link", { name: "Patch this LiveView" }).click();
+  await syncLV(page);
+  await page.goBack();
+  await syncLV(page);
+  await expect(networkEvents).toEqual([]);
+  // we only expect patch navigation
+  await expect(webSocketEvents.filter(e => e.payload.indexOf("phx_leave") !== -1)).toHaveLength(0);
+  // we patched 2 times
+  await expect(webSocketEvents.filter(e => e.payload.indexOf("live_patch") !== -1)).toHaveLength(2);
+});


### PR DESCRIPTION
Initially reported here: https://elixirforum.com/t/navigating-using-patch-causes-liveview-to-re-mount-when-using-browser-back-button/62595

In the popstate event LV compares the id in the history with the id of the main view id. But on the initial navigation, the history state is never set, so navigating all the way back causes an unnecessary remount.

This is fixed by using replaceRootHistory when joining the main view.