### PR TITLE
mix format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,9 @@ jobs:
 
           - elixir: 1.15.4
             otp: 25.3
-            lint: lint
 
           - elixir: 1.16.3
             otp: 26.2
-            lint: lint
 
           # update coverage report as well
           - elixir: 1.17.2
@@ -58,10 +56,6 @@ jobs:
     - name: Install dependencies
       run: mix deps.get --only test
 
-    #- name: Check source code format
-    #  run: mix format --check-formatted
-    #  if: ${{ matrix.lint }}
-
     - name: Remove compiled application files
       run: mix clean
 
@@ -73,6 +67,12 @@ jobs:
 
     - name: Compile & lint dependencies
       run: mix compile --warnings-as-errors
+      if: ${{ matrix.lint }}
+      env:
+        MIX_ENV: test
+
+    - name: Check if formatted
+      run: mix format --check-formatted
       if: ${{ matrix.lint }}
       env:
         MIX_ENV: test

--- a/config/config.exs
+++ b/config/config.exs
@@ -16,10 +16,22 @@ if Mix.env() == :dev do
 
   config :esbuild,
     version: "0.20.2",
-    module: esbuild.(~w(--format=esm --sourcemap --define:LV_VSN="#{lv_vsn}" --outfile=../priv/static/phoenix_live_view.esm.js)),
-    main: esbuild.(~w(--format=cjs --sourcemap --define:LV_VSN="#{lv_vsn}" --outfile=../priv/static/phoenix_live_view.cjs.js)),
-    cdn: esbuild.(~w(--format=iife --target=es2016 --global-name=LiveView --define:LV_VSN="#{lv_vsn}" --outfile=../priv/static/phoenix_live_view.js)),
-    cdn_min: esbuild.(~w(--format=iife --target=es2016 --global-name=LiveView --minify --define:LV_VSN="#{lv_vsn}" --outfile=../priv/static/phoenix_live_view.min.js))
+    module:
+      esbuild.(
+        ~w(--format=esm --sourcemap --define:LV_VSN="#{lv_vsn}" --outfile=../priv/static/phoenix_live_view.esm.js)
+      ),
+    main:
+      esbuild.(
+        ~w(--format=cjs --sourcemap --define:LV_VSN="#{lv_vsn}" --outfile=../priv/static/phoenix_live_view.cjs.js)
+      ),
+    cdn:
+      esbuild.(
+        ~w(--format=iife --target=es2016 --global-name=LiveView --define:LV_VSN="#{lv_vsn}" --outfile=../priv/static/phoenix_live_view.js)
+      ),
+    cdn_min:
+      esbuild.(
+        ~w(--format=iife --target=es2016 --global-name=LiveView --minify --define:LV_VSN="#{lv_vsn}" --outfile=../priv/static/phoenix_live_view.min.js)
+      )
 end
 
 import_config "#{config_env()}.exs"

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -788,7 +788,7 @@ defmodule Phoenix.Component do
   for more information.
   '''
   @doc type: :macro
-  defmacro sigil_H({:<<>>, meta, [expr]}, []) do
+  defmacro sigil_H({:<<>>, meta, [expr]}, _modifiers) do
     unless Macro.Env.has_var?(__CALLER__, {:assigns, nil}) do
       raise "~H requires a variable named \"assigns\" to exist and be set to a map"
     end
@@ -1019,7 +1019,7 @@ defmodule Phoenix.Component do
 
     ~H"""
     <%= for entry <- @entries do %><%= call_inner_block!(entry, @changed, @argument) %><% end %>
-    """
+    """noformat
   end
 
   def __render_slot__(changed, entry, argument) when is_map(entry) do
@@ -3101,7 +3101,7 @@ defmodule Phoenix.Component do
         render_slot(@inner_block, item)
       end
     %><% end %>
-    """
+    """noformat
   end
 
   @doc """

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -788,7 +788,8 @@ defmodule Phoenix.Component do
   for more information.
   '''
   @doc type: :macro
-  defmacro sigil_H({:<<>>, meta, [expr]}, _modifiers) do
+  defmacro sigil_H({:<<>>, meta, [expr]}, modifiers)
+           when modifiers == [] or modifiers == ~c"noformat" do
     unless Macro.Env.has_var?(__CALLER__, {:assigns, nil}) do
       raise "~H requires a variable named \"assigns\" to exist and be set to a map"
     end

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2078,7 +2078,7 @@ defmodule Phoenix.Component do
 
   def live_title(assigns) do
     ~H"""
-    <title data-prefix={@prefix} data-suffix={@suffix}><%= @prefix %><%= render_slot(@inner_block) %><%= @suffix %></title>
+    <title data-prefix={@prefix} data-suffix={@suffix} phx-no-format><%= @prefix %><%= render_slot(@inner_block) %><%= @suffix %></title>
     """
   end
 
@@ -2787,6 +2787,7 @@ defmodule Phoenix.Component do
       href={@navigate}
       data-phx-link="redirect"
       data-phx-link-state={if @replace, do: "replace", else: "push"}
+      phx-no-format
       {@rest}
     ><%= render_slot(@inner_block) %></a>
     """
@@ -2925,7 +2926,8 @@ defmodule Phoenix.Component do
 
     if assigns.inner_block != [] do
       ~H"""
-      <%= {:safe, [?<, @tag]} %><%= @escaped_attrs %><%= {:safe, [?>]} %><%= render_slot(@inner_block) %><%= {:safe, [?<, ?/, @tag, ?>]} %>
+      <%= {:safe, [?<, @tag]} %><%= @escaped_attrs %><%= {:safe, [?>]} %><%= render_slot(@inner_block) %><%= {:safe,
+       [?<, ?/, @tag, ?>]} %>
       """
     else
       ~H"""
@@ -2998,7 +3000,9 @@ defmodule Phoenix.Component do
       data-phx-upload-ref={@upload.ref}
       data-phx-active-refs={join_refs(for(entry <- @upload.entries, do: entry.ref))}
       data-phx-done-refs={join_refs(for(entry <- @upload.entries, entry.done?, do: entry.ref))}
-      data-phx-preflighted-refs={join_refs(for(entry <- @upload.entries, entry.preflighted?, do: entry.ref))}
+      data-phx-preflighted-refs={
+        join_refs(for(entry <- @upload.entries, entry.preflighted?, do: entry.ref))
+      }
       data-phx-auto-upload={@upload.auto_upload?}
       {if @upload.max_entries > 1, do: Map.put(@rest, :multiple, true), else: @rest}
     />
@@ -3056,7 +3060,8 @@ defmodule Phoenix.Component do
       data-phx-hook="Phoenix.LiveImgPreview"
       data-phx-update="ignore"
       phx-no-format
-      {@rest} />
+      {@rest}
+    />
     """
   end
 

--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -1118,7 +1118,9 @@ defmodule Phoenix.Component.Declarative do
 
     undefined_slots =
       Enum.reduce(slots_defs, slots, fn slot_def, slots ->
-        %{name: slot_name, required: required, attrs: attrs, validate_attrs: validate_attrs} = slot_def
+        %{name: slot_name, required: required, attrs: attrs, validate_attrs: validate_attrs} =
+          slot_def
+
         {slot_values, slots} = Map.pop(slots, slot_name)
 
         case slot_values do
@@ -1185,9 +1187,11 @@ defmodule Phoenix.Component.Declarative do
                 # undefined slot attr
                 %{} ->
                   cond do
-                    attr_name == :inner_block -> :ok
+                    attr_name == :inner_block ->
+                      :ok
 
-                    attrs == [] and not validate_attrs -> :ok
+                    attrs == [] and not validate_attrs ->
+                      :ok
 
                     true ->
                       message =

--- a/lib/phoenix_live_view/html_formatter.ex
+++ b/lib/phoenix_live_view/html_formatter.ex
@@ -225,30 +225,34 @@ defmodule Phoenix.LiveView.HTMLFormatter do
 
   @impl Mix.Tasks.Format
   def format(source, opts) do
-    line_length = opts[:heex_line_length] || opts[:line_length] || @default_line_length
-    newlines = :binary.matches(source, ["\r\n", "\n"])
-
-    formatted =
+    if opts[:sigil] === :H and opts[:modifiers] === ~c"noformat" do
       source
-      |> tokenize()
-      |> to_tree([], [], {source, newlines})
-      |> case do
-        {:ok, nodes} ->
-          nodes
-          |> HTMLAlgebra.build(opts)
-          |> Inspect.Algebra.format(line_length)
+    else
+      line_length = opts[:heex_line_length] || opts[:line_length] || @default_line_length
+      newlines = :binary.matches(source, ["\r\n", "\n"])
 
-        {:error, line, column, message} ->
-          file = opts[:file] || "nofile"
-          raise ParseError, line: line, column: column, file: file, description: message
-      end
+      formatted =
+        source
+        |> tokenize()
+        |> to_tree([], [], {source, newlines})
+        |> case do
+          {:ok, nodes} ->
+            nodes
+            |> HTMLAlgebra.build(opts)
+            |> Inspect.Algebra.format(line_length)
 
-    # If the opening delimiter is a single character, such as ~H"...", or the formatted code is empty,
-    # do not add trailing newline.
-    newline = if match?(<<_>>, opts[:opening_delimiter]) or formatted == [], do: [], else: ?\n
+          {:error, line, column, message} ->
+            file = opts[:file] || "nofile"
+            raise ParseError, line: line, column: column, file: file, description: message
+        end
 
-    # TODO: Remove IO.iodata_to_binary/1 call on Elixir v1.14+
-    IO.iodata_to_binary([formatted, newline])
+      # If the opening delimiter is a single character, such as ~H"...", or the formatted code is empty,
+      # do not add trailing newline.
+      newline = if match?(<<_>>, opts[:opening_delimiter]) or formatted == [], do: [], else: ?\n
+
+      # TODO: Remove IO.iodata_to_binary/1 call on Elixir v1.14+
+      IO.iodata_to_binary([formatted, newline])
+    end
   end
 
   # Tokenize contents using EEx.tokenize and Phoenix.Live.Tokenizer respectively.

--- a/lib/phoenix_live_view/tag_engine.ex
+++ b/lib/phoenix_live_view/tag_engine.ex
@@ -1246,7 +1246,8 @@ defmodule Phoenix.LiveView.TagEngine do
           meta
         )
 
-      _ -> :ok
+      _ ->
+        :ok
     end
   end
 

--- a/lib/phoenix_live_view/tokenizer.ex
+++ b/lib/phoenix_live_view/tokenizer.ex
@@ -182,7 +182,11 @@ defmodule Phoenix.LiveView.Tokenizer do
   end
 
   defp handle_doctype(<<>>, line, column, _buffer, _acc, state) do
-    raise_syntax_error!("unexpected end of string inside tag", %{line: line, column: column}, state)
+    raise_syntax_error!(
+      "unexpected end of string inside tag",
+      %{line: line, column: column},
+      state
+    )
   end
 
   ## handle_script

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -341,10 +341,11 @@ defmodule Phoenix.LiveView.Upload do
     %UploadConfig{} = conf = Map.fetch!(socket.assigns.uploads, name)
 
     # don't send more than max_entries preflight responses
-    refs = for {entry, i} <- Enum.with_index(conf.entries),
-      entry.ref in refs,
-      i < conf.max_entries && not entry.preflighted?,
-      do: entry.ref
+    refs =
+      for {entry, i} <- Enum.with_index(conf.entries),
+          entry.ref in refs,
+          i < conf.max_entries && not entry.preflighted?,
+          do: entry.ref
 
     client_meta = %{
       max_file_size: conf.max_file_size,

--- a/lib/phoenix_live_view/upload_config.ex
+++ b/lib/phoenix_live_view/upload_config.ex
@@ -122,9 +122,8 @@ defmodule Phoenix.LiveView.UploadConfig do
           errors: list(),
           ref: String.t(),
           auto_upload?: boolean(),
-          writer:
-            (name :: atom() | String.t(), UploadEntry.t(), Phoenix.LiveView.Socket.t() ->
-               {module(), term()}),
+          writer: (name :: atom() | String.t(), UploadEntry.t(), Phoenix.LiveView.Socket.t() ->
+                     {module(), term()}),
           progress_event:
             (name :: atom() | String.t(), UploadEntry.t(), Phoenix.LiveView.Socket.t() ->
                {:noreply, Phoenix.LiveView.Socket.t()})

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -6,7 +6,7 @@ Application.put_env(:phoenix_live_view, Phoenix.LiveViewTest.E2E.Endpoint,
   secret_key_base: String.duplicate("a", 64),
   render_errors: [
     formats: [
-      html: Phoenix.LiveViewTest.E2E.ErrorHTML,
+      html: Phoenix.LiveViewTest.E2E.ErrorHTML
     ],
     layout: false
   ],

--- a/test/phoenix_component/components_test.exs
+++ b/test/phoenix_component/components_test.exs
@@ -191,7 +191,7 @@ defmodule Phoenix.LiveView.ComponentsTest do
       assigns = %{}
 
       assert_raise ArgumentError, ~r/expected dynamic_tag name to be safe HTML/, fn ->
-        t2h(~H|<.dynamic_tag name="p><script>alert('nice try');</script>"/>|)
+        t2h(~H|<.dynamic_tag name="p><script>alert('nice try');</script>" />|)
       end
     end
 
@@ -232,14 +232,14 @@ defmodule Phoenix.LiveView.ComponentsTest do
     test "self closing without inner block" do
       assigns = %{}
 
-      assert t2h(~H|<.dynamic_tag name="br"/>|) == ~X|<br/>|
-      assert t2h(~H|<.dynamic_tag name="input" type="text"/>|) == ~X|<input type="text"/>|
+      assert t2h(~H|<.dynamic_tag name="br" />|) == ~X|<br/>|
+      assert t2h(~H|<.dynamic_tag name="input" type="text" />|) == ~X|<input type="text"/>|
     end
 
     test "keeps underscores in attributes" do
       assigns = %{}
 
-      assert t2h(~H|<.dynamic_tag name="br" foo_bar="baz"/>|) == ~X|<br foo_bar="baz"/>|
+      assert t2h(~H|<.dynamic_tag name="br" foo_bar="baz" />|) == ~X|<br foo_bar="baz"/>|
     end
   end
 
@@ -327,8 +327,7 @@ defmodule Phoenix.LiveView.ComponentsTest do
       assigns = %{}
 
       template = ~H"""
-      <.form for={%{}} action="/">
-      </.form>
+      <.form for={%{}} action="/"></.form>
       """
 
       csrf_token = Plug.CSRFProtection.get_csrf_token_for("/")
@@ -391,7 +390,8 @@ defmodule Phoenix.LiveView.ComponentsTest do
       assigns = %{}
 
       template = ~H"""
-      <.form :let={user_form}
+      <.form
+        :let={user_form}
         for={%{}}
         id="form"
         action="/"
@@ -435,12 +435,12 @@ defmodule Phoenix.LiveView.ComponentsTest do
       assigns = %{}
 
       template = ~H"""
-        <.form :let={f} as={:myform}>
-          <.inputs_for :let={finner} field={f[:inner]}}>
-            <% 0 = finner.index %>
-            <input id={finner[:foo].id} name={finner[:foo].name} type="text" />
-          </.inputs_for>
-        </.form>
+      <.form :let={f} as={:myform}>
+        <.inputs_for :let={finner} field={f[:inner]} }>
+          <% 0 = finner.index %>
+          <input id={finner[:foo].id} name={finner[:foo].name} type="text" />
+        </.inputs_for>
+      </.form>
       """
 
       assert t2h(template) ==
@@ -456,11 +456,11 @@ defmodule Phoenix.LiveView.ComponentsTest do
       assigns = %{}
 
       template = ~H"""
-        <.form :let={f} as={:myform}>
-          <.inputs_for :let={finner} field={f[:inner]}} id="test" as={:name}>
-            <input id={finner[:foo].id} name={finner[:foo].name} type="text" />
-          </.inputs_for>
-        </.form>
+      <.form :let={f} as={:myform}>
+        <.inputs_for :let={finner} field={f[:inner]} } id="test" as={:name}>
+          <input id={finner[:foo].id} name={finner[:foo].name} type="text" />
+        </.inputs_for>
+      </.form>
       """
 
       assert t2h(template) ==
@@ -476,11 +476,11 @@ defmodule Phoenix.LiveView.ComponentsTest do
       assigns = %{}
 
       template = ~H"""
-        <.form :let={f} as={:myform}>
-          <.inputs_for :let={finner} field={f[:inner]}} default={%{foo: "123"}}>
-            <input id={finner[:foo].id} name={finner[:foo].name} type="text" value={finner[:foo].value} />
-          </.inputs_for>
-        </.form>
+      <.form :let={f} as={:myform}>
+        <.inputs_for :let={finner} field={f[:inner]} } default={%{foo: "123"}}>
+          <input id={finner[:foo].id} name={finner[:foo].name} type="text" value={finner[:foo].value} />
+        </.inputs_for>
+      </.form>
       """
 
       assert t2h(template) ==
@@ -496,17 +496,18 @@ defmodule Phoenix.LiveView.ComponentsTest do
       assigns = %{}
 
       template = ~H"""
-        <.form :let={f} as={:myform}>
-          <.inputs_for
-            :let={finner}
-            field={f[:inner]}}
-            default={[%{foo: "456"}]}
-            prepend={[%{foo: "123"}]}
-            append={[%{foo: "789"}]}
-          >
-            <input id={finner[:foo].id} name={finner[:foo].name} type="text" value={finner[:foo].value} />
-          </.inputs_for>
-        </.form>
+      <.form :let={f} as={:myform}>
+        <.inputs_for
+          :let={finner}
+          field={f[:inner]}
+          }
+          default={[%{foo: "456"}]}
+          prepend={[%{foo: "123"}]}
+          append={[%{foo: "789"}]}
+        >
+          <input id={finner[:foo].id} name={finner[:foo].name} type="text" value={finner[:foo].value} />
+        </.inputs_for>
+      </.form>
       """
 
       assert t2h(template) ==
@@ -526,15 +527,11 @@ defmodule Phoenix.LiveView.ComponentsTest do
       assigns = %{}
 
       template = ~H"""
-        <.form :let={f} as={:myform}>
-          <.inputs_for
-            :let={finner}
-            field={f[:inner]}}
-            options={[foo: "bar"]}
-          >
-            <p><%= finner.options[:foo] %></p>
-          </.inputs_for>
-        </.form>
+      <.form :let={f} as={:myform}>
+        <.inputs_for :let={finner} field={f[:inner]} } options={[foo: "bar"]}>
+          <p><%= finner.options[:foo] %></p>
+        </.inputs_for>
+      </.form>
       """
 
       html = t2h(template)
@@ -553,7 +550,7 @@ defmodule Phoenix.LiveView.ComponentsTest do
       }
 
       assert t2h(
-               ~H|<.live_file_input upload={@conf} class={"<script>alert('nice try');</script>"} />|
+               ~H|<.live_file_input upload={@conf} class="<script>alert('nice try');</script>" />|
              ) ==
                ~X|<input type="file" accept="" data-phx-hook="Phoenix.LiveFileUpload" data-phx-update="ignore" data-phx-active-refs="foo" data-phx-done-refs="" data-phx-preflighted-refs="" data-phx-auto-upload class="&lt;script&gt;alert(&#39;nice try&#39;);&lt;/script&gt;">|
     end

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -54,15 +54,15 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
 
     def with_global_line, do: __ENV__.line
     attr :id, :string, default: "container"
-    def with_global(assigns), do: ~H[<.button id={@id} class="btn" aria-hidden="true"/>]
+    def with_global(assigns), do: ~H[<.button id={@id} class="btn" aria-hidden="true" />]
 
     attr :id, :string, required: true
     attr :rest, :global
-    def button(assigns), do: ~H[<button id={@id} {@rest}/>]
+    def button(assigns), do: ~H[<button id={@id} {@rest} />]
 
     def button_with_defaults_line, do: __ENV__.line
     attr :rest, :global, default: %{class: "primary"}
-    def button_with_defaults(assigns), do: ~H[<button {@rest}/>]
+    def button_with_defaults(assigns), do: ~H[<button {@rest} />]
 
     def button_with_values_line, do: __ENV__.line
     attr :text, :string, values: ["Save", "Cancel"]
@@ -85,17 +85,17 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     def render(assigns) do
       ~H"""
       <!-- local -->
-      <.func1 id="1"/>
+      <.func1 id="1" />
       <!-- local with inner content -->
       <.func1 id="2" email="foo@bar">CONTENT</.func1>
       <!-- imported -->
-      <.remote id="3"/>
+      <.remote id="3" />
       <!-- remote -->
-      <RemoteFunctionComponentWithAttrs.remote id="4"/>
+      <RemoteFunctionComponentWithAttrs.remote id="4" />
       <!-- remote with inner content -->
       <RemoteFunctionComponentWithAttrs.remote id="5">CONTENT</RemoteFunctionComponentWithAttrs.remote>
       <!-- remote and aliased -->
-      <Remote.remote id="6" {[dynamic: :values]}/>
+      <Remote.remote id="6" {[dynamic: :values]} />
       """
     end
   end
@@ -380,9 +380,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
         <:header>
           This is a header.
         </:header>
-
         Hello, World
-
         <:footer>
           This is a footer.
         </:footer>
@@ -603,10 +601,10 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       end
 
       attr :nil_default, :string, default: nil
-      def example(assigns), do: ~H[<%= inspect @nil_default %>]
+      def example(assigns), do: ~H[<%= inspect(@nil_default) %>]
 
       attr :value, :string
-      def no_default(assigns), do: ~H[<%= inspect @value %>]
+      def no_default(assigns), do: ~H[<%= inspect(@value) %>]
 
       attr :id, :any
       attr :errors, :list, default: []
@@ -662,7 +660,9 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
         ~H"""
         <div {@rest}>
           <%= render_slot(@inner_block) %>
-          <%= for col <- @col do %><%= render_slot(col) %>,<% end %>
+          <%= for col <- @col do %>
+            <%= render_slot(col) %>,
+          <% end %>
         </div>
         """
       end
@@ -680,7 +680,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       """
 
     assert Phoenix.LiveViewTest.rendered_to_string(template) ==
-             ~s|<div class="my-class">\n  \n  block\n  \n  col1,col2,\n</div>|
+             ~s|<div class=\"my-class\">\n  \n  block\n  \n  \n    col1,\n  \n    col2,\n  \n</div>|
   end
 
   defp lookup(_key \\ :one)

--- a/test/phoenix_component/rendering_test.exs
+++ b/test/phoenix_component/rendering_test.exs
@@ -263,19 +263,27 @@ defmodule Phoenix.ComponentRenderingTest do
       assert eval(~H|<.inner_changed :let={_foo} foo={@foo}></.inner_changed>|) ==
                [["%{foo: true}", nil]]
 
-      assert eval(
-               ~H|<.inner_changed :let={_foo} foo={@foo}><%= inspect(Map.get(assigns, :__changed__)) %></.inner_changed>|
-             ) ==
+      assert eval(~H"""
+             <.inner_changed :let={_foo} foo={@foo}>
+               <%= inspect(Map.get(assigns, :__changed__)) %>
+             </.inner_changed>
+             """) ==
                [["%{foo: true, inner_block: true}", ["%{foo: true}"]]]
 
-      assert eval(
-               ~H|<.inner_changed :let={_foo} foo={@foo}><%= "constant" %><%= inspect(Map.get(assigns, :__changed__)) %></.inner_changed>|
-             ) ==
+      assert eval(~H"""
+             <.inner_changed :let={_foo} foo={@foo}>
+               <%= "constant" %><%= inspect(Map.get(assigns, :__changed__)) %>
+             </.inner_changed>
+             """) ==
                [["%{foo: true, inner_block: true}", [nil, "%{foo: true}"]]]
 
-      assert eval(
-               ~H|<.inner_changed :let={foo} foo={@foo}><.inner_changed :let={_bar} bar={foo}><%= "constant" %><%= inspect(Map.get(assigns, :__changed__)) %></.inner_changed></.inner_changed>|
-             ) ==
+      assert eval(~H"""
+             <.inner_changed :let={foo} foo={@foo}>
+               <.inner_changed :let={_bar} bar={foo}>
+                 <%= "constant" %><%= inspect(Map.get(assigns, :__changed__)) %>
+               </.inner_changed>
+             </.inner_changed>
+             """) ==
                [
                  [
                    "%{foo: true, inner_block: true}",
@@ -283,14 +291,20 @@ defmodule Phoenix.ComponentRenderingTest do
                  ]
                ]
 
-      assert eval(
-               ~H|<.inner_changed :let={foo} foo={@foo}><%= foo %><%= inspect(Map.get(assigns, :__changed__)) %></.inner_changed>|
-             ) ==
+      assert eval(~H"""
+             <.inner_changed :let={foo} foo={@foo}>
+               <%= foo %><%= inspect(Map.get(assigns, :__changed__)) %>
+             </.inner_changed>
+             """) ==
                [["%{foo: true, inner_block: true}", ["var", "%{foo: true}"]]]
 
-      assert eval(
-               ~H|<.inner_changed :let={foo} foo={@foo}><.inner_changed :let={bar} bar={foo}><%= bar %><%= inspect(Map.get(assigns, :__changed__)) %></.inner_changed></.inner_changed>|
-             ) ==
+      assert eval(~H"""
+             <.inner_changed :let={foo} foo={@foo}>
+               <.inner_changed :let={bar} bar={foo}>
+                 <%= bar %><%= inspect(Map.get(assigns, :__changed__)) %>
+               </.inner_changed>
+             </.inner_changed>
+             """) ==
                [
                  [
                    "%{foo: true, inner_block: true}",
@@ -305,7 +319,7 @@ defmodule Phoenix.ComponentRenderingTest do
       assert eval(~H"""
              <.wrapper>
                <%= @foo %>
-               <.inner_changed foo={@bar} :let={var}>
+               <.inner_changed :let={var} foo={@bar}>
                  <%= var %>
                </.inner_changed>
              </.wrapper>

--- a/test/phoenix_component/verify_test.exs
+++ b/test/phoenix_component/verify_test.exs
@@ -20,7 +20,7 @@ defmodule Phoenix.ComponentVerifyTest do
 
           def render(assigns) do
             ~H"""
-            <.func/>
+            <.func />
             """
           end
         end
@@ -101,7 +101,7 @@ defmodule Phoenix.ComponentVerifyTest do
           def render(assigns) do
             ~H"""
             <External.render>
-            <:named />
+              <:named />
             </External.render>
             """
           end
@@ -148,7 +148,7 @@ defmodule Phoenix.ComponentVerifyTest do
           def global_render(assigns) do
             ~H"""
             <.func global="global" />
-            <.func phx-click="click" id="id"/>
+            <.func phx-click="click" id="id" />
             """
           end
 
@@ -478,7 +478,7 @@ defmodule Phoenix.ComponentVerifyTest do
             <.func_string attr="boom" />
             <.func_atom attr={:boom} />
             <.func_integer attr={11} />
-            <.func_string attr={"bar"} />
+            <.func_string attr="bar" />
             <.func_string attr={@string} />
             <.func_atom attr={:bar} />
             <.func_atom attr={@atom} />
@@ -574,9 +574,9 @@ defmodule Phoenix.ComponentVerifyTest do
       end)
 
     assert warnings =~ """
-    undefined attribute "class" in slot "item" for component \
-    Phoenix.ComponentVerifyTest.SlotWithoutDoBlock.func_slot_wo_do_block/1
-    """
+           undefined attribute "class" in slot "item" for component \
+           Phoenix.ComponentVerifyTest.SlotWithoutDoBlock.func_slot_wo_do_block/1
+           """
   end
 
   test "validates slot attr values" do
@@ -598,9 +598,9 @@ defmodule Phoenix.ComponentVerifyTest do
           def render(assigns) do
             ~H"""
             <.func>
-              <:named string="boom" atom={:boom} integer={11}/>
-              <:named string={@string} atom={@atom} integer={@integer}/>
-              <:named string="bar" atom={:bar} integer={5}/>
+              <:named string="boom" atom={:boom} integer={11} />
+              <:named string={@string} atom={@atom} integer={@integer} />
+              <:named string="bar" atom={:bar} integer={5} />
             </.func>
             """
           end
@@ -655,29 +655,23 @@ defmodule Phoenix.ComponentVerifyTest do
           def render(assigns) do
             ~H"""
             <!-- no default slot provided -->
-            <.func/>
-
+            <.func />
             <!-- with an empty default slot -->
             <.func></.func>
-
             <!-- with content in the default slot -->
             <.func>Hello!</.func>
-
             <!-- no named slots provided -->
-            <.func_named_slot/>
-
+            <.func_named_slot />
             <!-- with an empty named slot -->
             <.func_named_slot>
               <:named />
             </.func_named_slot>
-
             <!-- with content in the named slots -->
             <.func_named_slot>
               <:named>
                 Hello!
               </:named>
             </.func_named_slot>
-
             <!-- with entries for the named slot -->
             <.func_named_slot>
               <:named>
@@ -706,7 +700,7 @@ defmodule Phoenix.ComponentVerifyTest do
            Phoenix.ComponentVerifyTest.RequiredSlots.func_named_slot/1
            """
 
-    assert warnings =~ "test/phoenix_component/verify_test.exs:#{line + 12}: (file)"
+    assert warnings =~ "test/phoenix_component/verify_test.exs:#{line + 9}: (file)"
   end
 
   test "validate slot attr types" do
@@ -973,7 +967,7 @@ defmodule Phoenix.ComponentVerifyTest do
           def func(assigns) do
             ~H"""
             <div>
-            <%= render_slot(@slot) %>
+              <%= render_slot(@slot) %>
             </div>
             """
           end
@@ -983,15 +977,15 @@ defmodule Phoenix.ComponentVerifyTest do
           def render(assigns) do
             ~H"""
             <.func>
-            <:slot />
-            <:slot attr="foo" />
-            <:slot>
-            foo
-            </:slot>
-            <:slot attr="bar">
-            bar
-            </:slot>
-            <:slot {[attr: "bar"]} />
+              <:slot />
+              <:slot attr="foo" />
+              <:slot>
+                foo
+              </:slot>
+              <:slot attr="bar">
+                bar
+              </:slot>
+              <:slot {[attr: "bar"]} />
             </.func>
             """
           end
@@ -1045,16 +1039,14 @@ defmodule Phoenix.ComponentVerifyTest do
             <.fun_no_slots>
               hello
             </.fun_no_slots>
-
             <!-- undefined named slot -->
             <.func>
-            <:undefined />
+              <:undefined />
             </.func>
-
             <!-- named slot with undefined attrs -->
             <.func_undefined_slot_attrs>
-            <:named undefined />
-            <:named undefined="undefined" />
+              <:named undefined />
+              <:named undefined="undefined" />
             </.func_undefined_slot_attrs>
             """
           end
@@ -1075,7 +1067,7 @@ defmodule Phoenix.ComponentVerifyTest do
            Phoenix.ComponentVerifyTest.UndefinedSlots.func/1
            """
 
-    assert warnings =~ "test/phoenix_component/verify_test.exs:#{line + 9}: (file)"
+    assert warnings =~ "test/phoenix_component/verify_test.exs:#{line + 8}: (file)"
 
     assert warnings =~ """
            undefined attribute "undefined" \
@@ -1084,7 +1076,7 @@ defmodule Phoenix.ComponentVerifyTest do
            Phoenix.ComponentVerifyTest.UndefinedSlots.func_undefined_slot_attrs/1
            """
 
-    assert warnings =~ "test/phoenix_component/verify_test.exs:#{line + 14}: (file)"
+    assert warnings =~ "test/phoenix_component/verify_test.exs:#{line + 12}: (file)"
 
     assert warnings =~ """
            undefined attribute "undefined" \
@@ -1093,7 +1085,7 @@ defmodule Phoenix.ComponentVerifyTest do
            Phoenix.ComponentVerifyTest.UndefinedSlots.func_undefined_slot_attrs/1
            """
 
-    assert warnings =~ "test/phoenix_component/verify_test.exs:#{line + 15}: (file)"
+    assert warnings =~ "test/phoenix_component/verify_test.exs:#{line + 13}: (file)"
   end
 
   test "validates calls for locally defined components" do

--- a/test/phoenix_live_view/async_test.exs
+++ b/test/phoenix_live_view/async_test.exs
@@ -11,15 +11,17 @@ defmodule Phoenix.LiveView.AsyncTest do
           capture_io(:stderr, fn ->
             fun = unquote(fun)
 
-            Code.eval_quoted(quote do
-              require Phoenix.LiveView
+            Code.eval_quoted(
+              quote do
+                require Phoenix.LiveView
 
-              socket = %Phoenix.LiveView.Socket{assigns: %{__changed__: %{}, bar: :baz}}
+                socket = %Phoenix.LiveView.Socket{assigns: %{__changed__: %{}, bar: :baz}}
 
-              Phoenix.LiveView.unquote(fun)(socket, :foo, fn ->
-                socket.assigns.bar
-              end)
-            end)
+                Phoenix.LiveView.unquote(fun)(socket, :foo, fn ->
+                  socket.assigns.bar
+                end)
+              end
+            )
           end)
 
         assert warnings =~
@@ -31,16 +33,18 @@ defmodule Phoenix.LiveView.AsyncTest do
           capture_io(:stderr, fn ->
             fun = unquote(fun)
 
-            Code.eval_quoted(quote do
-              require Phoenix.LiveView
+            Code.eval_quoted(
+              quote do
+                require Phoenix.LiveView
 
-              socket = %Phoenix.LiveView.Socket{assigns: %{__changed__: %{}, bar: :baz}}
-              bar = socket.assigns.bar
+                socket = %Phoenix.LiveView.Socket{assigns: %{__changed__: %{}, bar: :baz}}
+                bar = socket.assigns.bar
 
-              Phoenix.LiveView.unquote(fun)(socket, :foo, fn ->
-                bar
-              end)
-            end)
+                Phoenix.LiveView.unquote(fun)(socket, :foo, fn ->
+                  bar
+                end)
+              end
+            )
           end)
 
         refute warnings =~
@@ -58,9 +62,10 @@ defmodule Phoenix.LiveView.AsyncTest do
               use Phoenix.LiveView
 
               def mount(_params, _session, socket) do
-                {:ok, unquote(fun)(socket, :foo, fn ->
-                  do_something(socket.assigns)
-                end)}
+                {:ok,
+                 unquote(fun)(socket, :foo, fn ->
+                   do_something(socket.assigns)
+                 end)}
               end
 
               defp do_something(_socket), do: :ok
@@ -71,7 +76,9 @@ defmodule Phoenix.LiveView.AsyncTest do
                  "you are accessing the LiveView Socket inside a function given to #{unquote(fun)}"
       end
 
-      test "does not warn when accessing socket outside of function passed to #{fun}", %{test: test} do
+      test "does not warn when accessing socket outside of function passed to #{fun}", %{
+        test: test
+      } do
         warnings =
           capture_io(:stderr, fn ->
             defmodule Module.concat(AssignAsyncSocket, "Test#{:erlang.phash2(test)}") do
@@ -81,9 +88,10 @@ defmodule Phoenix.LiveView.AsyncTest do
                 socket = assign(socket, :foo, :bar)
                 foo = socket.assigns.foo
 
-                {:ok, unquote(fun)(socket, :foo, fn ->
-                  do_something(foo)
-                end)}
+                {:ok,
+                 unquote(fun)(socket, :foo, fn ->
+                   do_something(foo)
+                 end)}
               end
 
               defp do_something(assigns), do: :ok

--- a/test/phoenix_live_view/controller_test.exs
+++ b/test/phoenix_live_view/controller_test.exs
@@ -32,9 +32,10 @@ defmodule Phoenix.LiveView.ControllerTest do
 
   test "renders function components from dead layout", %{conn: conn} do
     conn = get(conn, "/controller/render-layout-with-function-component")
+
     assert html_response(conn, 200) =~ """
-    LAYOUT:COMPONENT:from layout
-    Hello\
-    """
+           LAYOUT:COMPONENT:from layout
+           Hello\
+           """
   end
 end

--- a/test/phoenix_live_view/diff_test.exs
+++ b/test/phoenix_live_view/diff_test.exs
@@ -29,7 +29,7 @@ defmodule Phoenix.LiveView.DiffTest do
     <div>
       <h1><%= @title %></h1>
       <%= for name <- @names do %>
-        <br/><%= name %>
+        <br /><%= name %>
       <% end %>
     </div>
     """
@@ -40,9 +40,9 @@ defmodule Phoenix.LiveView.DiffTest do
     <div>
       <h1><%= @title %></h1>
       <%= for name <- @names do %>
-        <br/><%= name %>
+        <br /><%= name %>
         <%= for score <- @scores do %>
-          <br/><%= score %>
+          <br /><%= score %>
         <% end %>
       <% end %>
     </div>
@@ -435,8 +435,10 @@ defmodule Phoenix.LiveView.DiffTest do
     def render(assigns) do
       ~H"""
       <div>
-        HELLO <%= @id %> <%= render_slot(@inner_block, %{value: 1}) %>
-        HELLO <%= @id %> <%= render_slot(@inner_block, %{value: 2}) %>
+        HELLO <%= @id %> <%= render_slot(@inner_block, %{value: 1}) %> HELLO <%= @id %> <%= render_slot(
+          @inner_block,
+          %{value: 2}
+        ) %>
       </div>
       """
     end
@@ -452,8 +454,7 @@ defmodule Phoenix.LiveView.DiffTest do
     def render_inner_block_no_args(assigns) do
       ~H"""
       <div>
-        HELLO <%= @id %> <%= render_slot(@inner_block) %>
-        HELLO <%= @id %> <%= render_slot(@inner_block) %>
+        HELLO <%= @id %> <%= render_slot(@inner_block) %> HELLO <%= @id %> <%= render_slot(@inner_block) %>
       </div>
       """
     end
@@ -461,8 +462,7 @@ defmodule Phoenix.LiveView.DiffTest do
     def render_with_slot_no_args(assigns) do
       ~H"""
       <div>
-        HELLO <%= @id %> <%= render_slot(@sample) %>
-        HELLO <%= @id %> <%= render_slot(@sample) %>
+        HELLO <%= @id %> <%= render_slot(@sample) %> HELLO <%= @id %> <%= render_slot(@sample) %>
       </div>
       """
     end
@@ -470,8 +470,10 @@ defmodule Phoenix.LiveView.DiffTest do
     def render_inner_block(assigns) do
       ~H"""
       <div>
-        HELLO <%= @id %> <%= render_slot(@inner_block, 1) %>
-        HELLO <%= @id %> <%= render_slot(@inner_block, 2) %>
+        HELLO <%= @id %> <%= render_slot(@inner_block, 1) %> HELLO <%= @id %> <%= render_slot(
+          @inner_block,
+          2
+        ) %>
       </div>
       """
     end
@@ -479,7 +481,7 @@ defmodule Phoenix.LiveView.DiffTest do
     def render_with_live_component(assigns) do
       ~H"""
       COMPONENT
-      <.live_component module={SlotComponent} :let={%{value: value}} id="WORLD">
+      <.live_component :let={%{value: value}} module={SlotComponent} id="WORLD">
         WITH VALUE <%= value %>
       </.live_component>
       """
@@ -538,7 +540,7 @@ defmodule Phoenix.LiveView.DiffTest do
 
         :b ->
           ~H"""
-          <%= %>
+          <%=  %>
           """
 
         :c ->
@@ -637,7 +639,7 @@ defmodule Phoenix.LiveView.DiffTest do
                  1 => %{s: ["\n  INSIDE BLOCK\n"]},
                  2 => "DEFAULT",
                  3 => %{s: ["\n  INSIDE BLOCK\n"]},
-                 :s => ["<div>\n  HELLO ", " ", "\n  HELLO ", " ", "\n</div>"],
+                 :s => ["<div>\n  HELLO ", " ", " HELLO ", " ", "\n</div>"],
                  :r => 1
                },
                :s => ["", ""]
@@ -666,7 +668,7 @@ defmodule Phoenix.LiveView.DiffTest do
                  1 => %{s: ["\n    INSIDE SLOT\n  "]},
                  2 => "MY ID",
                  3 => %{s: ["\n    INSIDE SLOT\n  "]},
-                 :s => ["<div>\n  HELLO ", " ", "\n  HELLO ", " ", "\n</div>"],
+                 :s => ["<div>\n  HELLO ", " ", " HELLO ", " ", "\n</div>"],
                  :r => 1
                },
                :s => ["", ""]
@@ -695,7 +697,7 @@ defmodule Phoenix.LiveView.DiffTest do
                  1 => %{0 => "1", :s => ["\n  WITH VALUE ", " - ", "\n"], 1 => "123"},
                  2 => "DEFAULT",
                  3 => %{0 => "2", :s => ["\n  WITH VALUE ", " - ", "\n"], 1 => "123"},
-                 :s => ["<div>\n  HELLO ", " ", "\n  HELLO ", " ", "\n</div>"],
+                 :s => ["<div>\n  HELLO ", " ", " HELLO ", " ", "\n</div>"],
                  :r => 1
                },
                :s => ["", ""]
@@ -748,8 +750,7 @@ defmodule Phoenix.LiveView.DiffTest do
     def render_multiple_slots(assigns) do
       ~H"""
       <div>
-        HEADER: <%= render_slot(@header) %>
-        FOOTER: <%= render_slot(@footer) %>
+        HEADER: <%= render_slot(@header) %> FOOTER: <%= render_slot(@footer) %>
       </div>
       """
     end
@@ -776,7 +777,7 @@ defmodule Phoenix.LiveView.DiffTest do
                0 => %{
                  0 => %{0 => "H", 1 => "B", :s => ["\n    ", "", "\n  "]},
                  1 => %{0 => "F", 1 => "B", :s => ["\n    ", "", "\n  "]},
-                 :s => ["<div>\n  HEADER: ", "\n  FOOTER: ", "\n</div>"],
+                 :s => ["<div>\n  HEADER: ", " FOOTER: ", "\n</div>"],
                  :r => 1
                },
                :s => ["", ""]
@@ -866,7 +867,7 @@ defmodule Phoenix.LiveView.DiffTest do
                    1 => %{0 => "1", :s => ["\n  WITH VALUE ", "\n"]},
                    2 => "WORLD",
                    3 => %{0 => "2", :s => ["\n  WITH VALUE ", "\n"]},
-                   :s => ["<div>\n  HELLO ", " ", "\n  HELLO ", " ", "\n</div>"],
+                   :s => ["<div>\n  HELLO ", " ", " HELLO ", " ", "\n</div>"],
                    :r => 1
                  }
                },
@@ -1555,7 +1556,9 @@ defmodule Phoenix.LiveView.DiffTest do
         rendered = ~H"""
         <div>
           <%= for {component, index} <- Enum.with_index(@components, 1) do %>
-            <%= if index > 1 do %><%= index %>: <%= component %><% end %>
+            <%= if index > 1 do %>
+              <%= index %>: <%= component %>
+            <% end %>
           <% end %>
         </div>
         """
@@ -1566,7 +1569,7 @@ defmodule Phoenix.LiveView.DiffTest do
                0 => %{
                  d: [[""], [%{0 => "2", 1 => 1, :s => 0}]],
                  s: ["\n    ", "\n  "],
-                 p: %{0 => ["", ": ", ""]}
+                 p: %{0 => ["\n      ", ": ", "\n    "]}
                },
                :c => %{
                  1 => %{
@@ -1625,9 +1628,8 @@ defmodule Phoenix.LiveView.DiffTest do
 
     defp tracking(assigns) do
       ~H"""
-      <.live_component module={SlotComponent} :let={%{value: value}} id="TRACKING">
-        WITH PARENT VALUE <%= @parent_value %>
-        WITH VALUE <%= value %>
+      <.live_component :let={%{value: value}} module={SlotComponent} id="TRACKING">
+        WITH PARENT VALUE <%= @parent_value %> WITH VALUE <%= value %>
       </.live_component>
       """
     end
@@ -1644,15 +1646,15 @@ defmodule Phoenix.LiveView.DiffTest do
                    1 => %{
                      0 => "123",
                      1 => "1",
-                     :s => ["\n  WITH PARENT VALUE ", "\n  WITH VALUE ", "\n"]
+                     :s => ["\n  WITH PARENT VALUE ", " WITH VALUE ", "\n"]
                    },
                    2 => "TRACKING",
                    3 => %{
                      0 => "123",
                      1 => "2",
-                     :s => ["\n  WITH PARENT VALUE ", "\n  WITH VALUE ", "\n"]
+                     :s => ["\n  WITH PARENT VALUE ", " WITH VALUE ", "\n"]
                    },
-                   :s => ["<div>\n  HELLO ", " ", "\n  HELLO ", " ", "\n</div>"],
+                   :s => ["<div>\n  HELLO ", " ", " HELLO ", " ", "\n</div>"],
                    :r => 1
                  }
                },

--- a/test/phoenix_live_view/heex_extension_test.exs
+++ b/test/phoenix_live_view/heex_extension_test.exs
@@ -25,76 +25,85 @@ defmodule Phoenix.LiveView.HEExExtensionTest do
 
   test "renders live engine with live engine to string" do
     assert Phoenix.View.render_to_string(View, "live_with_live.html", @assigns) ==
-              "pre: pre\nlive: inner\npost: post"
+             "pre: pre\nlive: inner\npost: post"
   end
 
   test "renders live engine with comprehension to string" do
     assigns = Map.put(@assigns, :points, [])
 
     assert Phoenix.View.render_to_string(View, "live_with_comprehension.html", assigns) ==
-              "pre: pre\n\npost: post"
+             "pre: pre\n\npost: post"
 
     assigns = Map.put(@assigns, :points, [%{x: 1, y: 2}, %{x: 3, y: 4}])
 
     assert Phoenix.View.render_to_string(View, "live_with_comprehension.html", assigns) ==
-              "pre: pre\n\n  x: 1\n  live: inner\n  y: 2\n\n  x: 3\n  live: inner\n  y: 4\n\npost: post"
+             "pre: pre\n\n  x: 1\n  live: inner\n  y: 2\n\n  x: 3\n  live: inner\n  y: 4\n\npost: post"
   end
 
   test "renders live engine as is" do
     assert %Rendered{static: ["live: ", ""], dynamic: ["inner"]} =
-              Phoenix.View.render(View, "inner_live.html", @assigns) |> expand_rendered(true)
+             Phoenix.View.render(View, "inner_live.html", @assigns) |> expand_rendered(true)
   end
 
   test "renders live engine with nested live view" do
     assert %Rendered{
-              static: ["pre: ", "\n", "\npost: ", ""],
-              dynamic: [
-                "pre",
-                %Rendered{dynamic: ["inner"], static: ["live: ", ""]},
-                "post"
-              ]
-            } =
-              Phoenix.View.render(View, "live_with_live.html", @assigns) |> expand_rendered(true)
+             static: ["pre: ", "\n", "\npost: ", ""],
+             dynamic: [
+               "pre",
+               %Rendered{dynamic: ["inner"], static: ["live: ", ""]},
+               "post"
+             ]
+           } =
+             Phoenix.View.render(View, "live_with_live.html", @assigns) |> expand_rendered(true)
   end
 
   test "renders live engine with nested dead view" do
     assert %Rendered{
-              static: ["pre: ", "\n", "\npost: ", ""],
-              dynamic: ["pre", ["dead: ", "inner"], "post"]
-            } =
-              Phoenix.View.render(View, "live_with_dead.html", @assigns) |> expand_rendered(true)
+             static: ["pre: ", "\n", "\npost: ", ""],
+             dynamic: ["pre", ["dead: ", "inner"], "post"]
+           } =
+             Phoenix.View.render(View, "live_with_dead.html", @assigns) |> expand_rendered(true)
   end
 
   test "renders dead engine with nested live view" do
     assert Phoenix.View.render(View, "dead_with_live.html", @assigns) ==
-              {:safe, ["pre: ", "pre", "\n", ["live: ", "inner", ""], "\npost: ", "post"]}
+             {:safe, ["pre: ", "pre", "\n", ["live: ", "inner", ""], "\npost: ", "post"]}
   end
 
   test "renders dead engine with function component" do
     assert %Rendered{
-              static: ["pre: ", "\n", "\npost: ", ""],
-              dynamic: ["pre", %Rendered{dynamic: ["the value"], static: ["COMPONENT:", ""]}, "post"]
-            } =
-              Phoenix.View.render(View, "dead_with_function_component.html", @assigns) |> expand_rendered(true)
+             static: ["pre: ", "\n", "\npost: ", ""],
+             dynamic: [
+               "pre",
+               %Rendered{dynamic: ["the value"], static: ["COMPONENT:", ""]},
+               "post"
+             ]
+           } =
+             Phoenix.View.render(View, "dead_with_function_component.html", @assigns)
+             |> expand_rendered(true)
   end
 
   test "renders dead engine with function component with inner content" do
     assert %Rendered{
-              static: ["pre: ", "\n", "\npost: ", ""],
-              dynamic: [
-                "pre",
-                %Rendered{
-                  dynamic: [
-                    "the value",
-                    %Rendered{dynamic: [], static: ["\n  The inner content\n"]}
-                  ],
-                  static: ["COMPONENT:", ", Content: ", ""]
-                },
-                "post"
-              ]
-            } =
-              Phoenix.View.render(View, "dead_with_function_component_with_inner_content.html", @assigns)
-              |> expand_rendered(true)
+             static: ["pre: ", "\n", "\npost: ", ""],
+             dynamic: [
+               "pre",
+               %Rendered{
+                 dynamic: [
+                   "the value",
+                   %Rendered{dynamic: [], static: ["\n  The inner content\n"]}
+                 ],
+                 static: ["COMPONENT:", ", Content: ", ""]
+               },
+               "post"
+             ]
+           } =
+             Phoenix.View.render(
+               View,
+               "dead_with_function_component_with_inner_content.html",
+               @assigns
+             )
+             |> expand_rendered(true)
   end
 
   defp expand_dynamic(dynamic, track_changes?) do

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -773,7 +773,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
       BEFORE SLOT
       <%= render_slot(@sample) %>
       AFTER SLOT
-      """
+      """noformat
     end
 
     def function_component_with_slots(assigns) do
@@ -783,7 +783,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
       TEXT
       <%= render_slot(@footer) %>
       AFTER FOOTER
-      """
+      """noformat
     end
 
     def function_component_with_slots_and_default(assigns) do
@@ -793,7 +793,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
       TEXT:<%= render_slot(@inner_block) %>:TEXT
       <%= render_slot(@footer) %>
       AFTER FOOTER
-      """
+      """noformat
     end
 
     def function_component_with_slots_and_args(assigns) do
@@ -801,7 +801,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
       BEFORE SLOT
       <%= render_slot(@sample, 1) %>
       AFTER SLOT
-      """
+      """noformat
     end
 
     def function_component_with_slot_attrs(assigns) do
@@ -811,7 +811,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
       <%= render_slot(entry) %>
       <%= entry.b %>
       <% end %>
-      """
+      """noformat
     end
 
     def function_component_with_multiple_slots_entries(assigns) do
@@ -819,7 +819,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
       <%= for entry <- @sample do %>
         <%= entry.id %>: <%= render_slot(entry, %{}) %>
       <% end %>
-      """
+      """noformat
     end
 
     def function_component_with_self_close_slots(assigns) do
@@ -827,15 +827,15 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
       <%= for entry <- @sample do %>
         <%= entry.id %>
       <% end %>
-      """
+      """noformat
     end
 
     def render_slot_name(assigns) do
-      ~H"<%= for entry <- @sample do %>[<%= entry.__slot__ %>]<% end %>"
+      ~H"<%= for entry <- @sample do %>[<%= entry.__slot__ %>]<% end %>"noformat
     end
 
     def render_inner_block_slot_name(assigns) do
-      ~H"<%= for entry <- @inner_block do %>[<%= entry.__slot__ %>]<% end %>"
+      ~H"<%= for entry <- @inner_block do %>[<%= entry.__slot__ %>]<% end %>"noformat
     end
 
     test "single slot" do
@@ -2073,7 +2073,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
     def slot_if_self_close(assigns) do
       ~H"""
       <div><%= @value %>-<%= for slot <- @slot do %><%= slot.val %>-<% end %></div>
-      """
+      """noformat
     end
 
     test ":if in slots" do

--- a/test/phoenix_live_view/integrations/hooks_test.exs
+++ b/test/phoenix_live_view/integrations/hooks_test.exs
@@ -149,7 +149,7 @@ defmodule Phoenix.LiveView.HooksTest do
 
   test "handle_params/3 attached after connected", %{conn: conn} do
     {:ok, lv, html} = live(conn, "/lifecycle")
-    assert html =~ "params_hook:\n"
+    assert html =~ "params_hook:</p>"
 
     HooksLive.attach_hook(lv, :hook, :handle_params, fn
       _params, _uri, %{assigns: %{params_hook_ref: _}} = socket ->
@@ -174,7 +174,7 @@ defmodule Phoenix.LiveView.HooksTest do
 
   test "handle_params/3 when callback is not exported raises without halt", %{conn: conn} do
     {:ok, lv, html} = live(conn, "/lifecycle")
-    assert html =~ "params_hook:\n"
+    assert html =~ "params_hook:</p>"
 
     HooksLive.attach_hook(lv, :hook, :handle_params, fn
       _params, _uri, %{assigns: %{params_hook_ref: 0}} = socket ->
@@ -271,12 +271,12 @@ defmodule Phoenix.LiveView.HooksTest do
     end)
 
     lv |> element("#async") |> render_click()
-    assert render_async(lv) =~ "task:o.\n"
+    assert render_async(lv) =~ "task:o.</p>"
 
     HooksLive.detach_hook(lv, :hook, :handle_async)
 
     lv |> element("#async") |> render_click()
-    assert render_async(lv) =~ "task:o..\n"
+    assert render_async(lv) =~ "task:o..</p>"
   end
 
   test "handle_async/3 halts", %{conn: conn} do
@@ -287,12 +287,12 @@ defmodule Phoenix.LiveView.HooksTest do
     end)
 
     lv |> element("#async") |> render_click()
-    assert render_async(lv) =~ "task:o\n"
+    assert render_async(lv) =~ "task:o</p>"
 
     HooksLive.detach_hook(lv, :hook, :handle_async)
 
     lv |> element("#async") |> render_click()
-    assert render_async(lv) =~ "task:o.\n"
+    assert render_async(lv) =~ "task:o.</p>"
   end
 
   test "attach/detach_hook with a handle_event live component socket", %{conn: conn} do

--- a/test/phoenix_live_view/integrations/live_view_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test.exs
@@ -94,7 +94,7 @@ defmodule Phoenix.LiveView.LiveViewTest do
       html = html_response(conn, 200)
 
       assert html =~ """
-             The temp is: 0
+             <p>The temp is: 0</p>
              <button phx-click="dec">-</button>
              <button phx-click="inc">+</button>
              """
@@ -104,7 +104,8 @@ defmodule Phoenix.LiveView.LiveViewTest do
       {_tag, _attrs, children} = html |> DOM.parse() |> DOM.by_id!(view.id)
 
       assert children == [
-               "Redirect: none\nThe temp is: 1\n",
+               {"p", [], ["Redirect: none"]},
+               {"p", [], ["The temp is: 1"]},
                {"button", [{"phx-click", "dec"}], ["-"]},
                {"button", [{"phx-click", "inc"}], ["+"]}
              ]
@@ -224,7 +225,8 @@ defmodule Phoenix.LiveView.LiveViewTest do
                     {"class", "thermo"}
                   ],
                   [
-                    _text,
+                    _p1,
+                    _p2,
                     _btn_down,
                     _btn_up,
                     {"section",
@@ -265,7 +267,8 @@ defmodule Phoenix.LiveView.LiveViewTest do
                     {"style", "thermo-flex<script>"}
                   ],
                   [
-                    _text,
+                    _p1,
+                    _p2,
                     _btn_down,
                     _btn_up,
                     {"p",
@@ -304,14 +307,16 @@ defmodule Phoenix.LiveView.LiveViewTest do
 
       assert DOM.parse(render_click(view, :inc)) ==
                DOM.parse("""
-               Redirect: none\nThe temp is: 4
+               <p>Redirect: none</p>
+               <p>The temp is: 4</p>
                <button phx-click="dec">-</button>
                <button phx-click="inc">+</button>
                """)
 
       assert DOM.parse(render_click(view, :dec)) ==
                DOM.parse("""
-               Redirect: none\nThe temp is: 3
+               <p>Redirect: none</p>
+               <p>The temp is: 3</p>
                <button phx-click="dec">-</button>
                <button phx-click="inc">+</button>
                """)
@@ -320,7 +325,8 @@ defmodule Phoenix.LiveView.LiveViewTest do
 
       assert child_nodes ==
                DOM.parse("""
-               Redirect: none\nThe temp is: 3
+               <p>Redirect: none</p>
+               <p>The temp is: 3</p>
                <button phx-click="dec">-</button>
                <button phx-click="inc">+</button>
                """)

--- a/test/phoenix_live_view/integrations/navigation_test.exs
+++ b/test/phoenix_live_view/integrations/navigation_test.exs
@@ -178,8 +178,11 @@ defmodule Phoenix.LiveView.NavigationTest do
         assert str =~ "The temp is"
       end
 
-      assert {:ok, thermo_live3, _html} = live_redirect(thermo_live2, to: "/thermo-live-session/nested-thermo")
-      assert {:ok, _thermo_live4, _html} = live_redirect(thermo_live3, to: "/thermo-live-session/nested-thermo")
+      assert {:ok, thermo_live3, _html} =
+               live_redirect(thermo_live2, to: "/thermo-live-session/nested-thermo")
+
+      assert {:ok, _thermo_live4, _html} =
+               live_redirect(thermo_live3, to: "/thermo-live-session/nested-thermo")
     end
 
     test "refused with mismatched live session", %{conn: conn} do

--- a/test/phoenix_live_view/integrations/nested_test.exs
+++ b/test/phoenix_live_view/integrations/nested_test.exs
@@ -77,7 +77,8 @@ defmodule Phoenix.LiveView.NestedTest do
 
     html_without_nesting =
       DOM.parse("""
-      Redirect: none\nThe temp is: 1
+      <p>Redirect: none</p>
+      <p>The temp is: 1</p>
       <button phx-click="dec">-</button>
       <button phx-click="inc">+</button>
       """)

--- a/test/phoenix_live_view/integrations/params_test.exs
+++ b/test/phoenix_live_view/integrations/params_test.exs
@@ -261,7 +261,7 @@ defmodule Phoenix.LiveView.ParamsTest do
                  {"data-phx-session", _},
                  {"data-phx-static", _}
                ],
-               ["The value is: 1" <> _]
+               [{"p", [], ["The value is: 1"]} | _]
              } = container
     end
 

--- a/test/phoenix_live_view/js_test.exs
+++ b/test/phoenix_live_view/js_test.exs
@@ -346,7 +346,6 @@ defmodule Phoenix.LiveView.JSTest do
                ]
              }
 
-
       assert JS.toggle_class("c", transition: "a b") == %JS{
                ops: [
                  [

--- a/test/support/e2e/form_live.ex
+++ b/test/support/e2e/form_live.ex
@@ -160,11 +160,13 @@ defmodule Phoenix.LiveViewTest.E2E.FormStreamLive do
     ~H"""
     <%= @count %>
     <form id="test-form" phx-change="validate" phx-submit="save">
-      <input name="myname" value={@count}>
-      <input id="other" name="other" value={@count}>
+      <input name="myname" value={@count} />
+      <input id="other" name="other" value={@count} />
       <div id="form-stream-hook" phx-hook="FormHook" phx-update="ignore"></div>
       <ul id="form-stream" phx-update="stream">
-        <li :for={{id, item} <- @streams.items} id={id} phx-hook="FormStreamHook">*<%= inspect(item) %></li>
+        <li :for={{id, item} <- @streams.items} id={id} phx-hook="FormStreamHook">
+          *<%= inspect(item) %>
+        </li>
       </ul>
       <button id="submit" phx-disable-with="Saving...">Submit</button>
     </form>

--- a/test/support/e2e/issues/issue_3026.ex
+++ b/test/support/e2e/issues/issue_3026.ex
@@ -10,7 +10,6 @@ defmodule Phoenix.LiveViewTest.E2E.Issue3026Live do
       ~H"""
       <div>
         Example form
-
         <.form for={to_form(%{})} phx-change="validate" phx-submit="submit">
           <input label="Name" name="name" type="text" value={@name} />
           <input label="Email" name="email" type="text" value={@email} />

--- a/test/support/e2e/issues/issue_3040.ex
+++ b/test/support/e2e/issues/issue_3040.ex
@@ -31,7 +31,7 @@ defmodule Phoenix.LiveViewTest.E2E.Issue3040Live do
       <%= style() %>
     </style>
 
-    <.link patch={"/issues/3040?modal=true"}>Add new</.link>
+    <.link patch="/issues/3040?modal=true">Add new</.link>
 
     <.modal :if={@modal_open} id="my-modal" show on_cancel={JS.patch("/issues/3040")}>
       <.form for={%{}} phx-submit="submit">

--- a/test/support/e2e/issues/issue_3047.ex
+++ b/test/support/e2e/issues/issue_3047.ex
@@ -3,14 +3,17 @@ defmodule Phoenix.LiveViewTest.E2E.Issue3047ALive do
 
   def render("live.html", assigns) do
     ~H"""
-    <%= apply(Phoenix.LiveViewTest.E2E.Layout, :render, ["live.html", Map.put(assigns, :inner_content, [])]) %>
+    <%= apply(Phoenix.LiveViewTest.E2E.Layout, :render, [
+      "live.html",
+      Map.put(assigns, :inner_content, [])
+    ]) %>
 
     <div class="flex flex-col items-center justify-center">
       <div class="flex flex-row gap-3">
-        <.link class="border rounded bg-blue-700 w-fit px-2 text-white" navigate={"/issues/3047/a"}>
+        <.link class="border rounded bg-blue-700 w-fit px-2 text-white" navigate="/issues/3047/a">
           Page A
         </.link>
-        <.link class="border rounded bg-blue-700 w-fit px-2 text-white" navigate={"/issues/3047/b"}>
+        <.link class="border rounded bg-blue-700 w-fit px-2 text-white" navigate="/issues/3047/b">
           Page B
         </.link>
       </div>

--- a/test/support/e2e/issues/issue_3169.ex
+++ b/test/support/e2e/issues/issue_3169.ex
@@ -22,8 +22,7 @@ defmodule Phoenix.LiveViewTest.E2E.Issue3169Live.Components do
 
   def test(assigns) do
     ~H"""
-    This is a test!
-    <%= @var %>
+    This is a test! <%= @var %>
     """
   end
 end
@@ -35,8 +34,7 @@ defmodule Phoenix.LiveViewTest.E2E.Issue3169Live.FormColumn do
   def render(assigns) do
     ~H"""
     <div>
-      FormColumn (c3)
-      <input type="text" value={@form[:name].value} />
+      FormColumn (c3) <input type="text" value={@form[:name].value} />
       <.input field={@form[:name]} />
       <.test var="foo" />
     </div>
@@ -68,7 +66,6 @@ defmodule Phoenix.LiveViewTest.E2E.Issue3169Live.FormCore do
     """
   end
 end
-
 
 defmodule Phoenix.LiveViewTest.E2E.Issue3169Live.FormComponent do
   use Phoenix.LiveComponent
@@ -107,7 +104,6 @@ defmodule Phoenix.LiveViewTest.E2E.Issue3169Live.FormComponent do
   end
 end
 
-
 defmodule Phoenix.LiveViewTest.E2E.Issue3169Live do
   use Phoenix.LiveView, layout: {__MODULE__, :live}
 
@@ -132,8 +128,7 @@ defmodule Phoenix.LiveViewTest.E2E.Issue3169Live do
 
   def render(assigns) do
     ~H"""
-    HomeLive
-    <.live_component module={FormComponent} id="form_view" selected={@selected}/>
+    HomeLive <.live_component module={FormComponent} id="form_view" selected={@selected} />
     <button id="select-a" phx-click="select" phx-value-name="a">Select A</button>
     <button id="select-b" phx-click="select" phx-value-name="b">Select B</button>
     <button id="select-z" phx-click="select" phx-value-name="z">Select Z</button>

--- a/test/support/e2e/issues/issue_3194.ex
+++ b/test/support/e2e/issues/issue_3194.ex
@@ -11,11 +11,7 @@ defmodule Phoenix.LiveViewTest.E2E.Issue3194Live do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <.form
-      for={@form}
-      phx-change="validate"
-      phx-submit="submit"
-    >
+    <.form for={@form} phx-change="validate" phx-submit="submit">
       <input
         id={@form[:store_number].id}
         name={@form[:store_number].name}

--- a/test/support/e2e/issues/issue_3200.ex
+++ b/test/support/e2e/issues/issue_3200.ex
@@ -18,10 +18,16 @@ defmodule Phoenix.LiveViewTest.E2E.Issue3200 do
           <aside>
             <div>
               <div :if={@live_action == :messages_tab}>
-                <.live_component module={Phoenix.LiveViewTest.E2E.Issue3200.MessagesTab} id="messages_tab" />
+                <.live_component
+                  module={Phoenix.LiveViewTest.E2E.Issue3200.MessagesTab}
+                  id="messages_tab"
+                />
               </div>
               <div :if={@live_action == :settings_tab}>
-                <.live_component module={Phoenix.LiveViewTest.E2E.Issue3200.SettingsTab} id="settings_tab" />
+                <.live_component
+                  module={Phoenix.LiveViewTest.E2E.Issue3200.SettingsTab}
+                  id="settings_tab"
+                />
               </div>
             </div>
           </aside>

--- a/test/support/e2e/upload_live.ex
+++ b/test/support/e2e/upload_live.ex
@@ -61,7 +61,12 @@ defmodule Phoenix.LiveViewTest.E2E.UploadLive do
             <figcaption><%= entry.client_name %></figcaption>
           </figure>
           <progress value={entry.progress} max="100"><%= entry.progress %>%</progress>
-          <button type="button" phx-click="cancel-upload" phx-value-ref={entry.ref} aria-label="cancel">
+          <button
+            type="button"
+            phx-click="cancel-upload"
+            phx-value-ref={entry.ref}
+            aria-label="cancel"
+          >
             &times;
           </button>
           <p :for={err <- upload_errors(@uploads.avatar, entry)} class="alert alert-danger">

--- a/test/support/live_views/component_and_nested_in_live.ex
+++ b/test/support/live_views/component_and_nested_in_live.ex
@@ -36,10 +36,10 @@ defmodule Phoenix.LiveViewTest.ComponentAndNestedInLive do
 
   def render(assigns) do
     ~H"""
-      <%= if @enabled do %>
-        <%= live_render @socket, NestedLive, id: :nested_live %>
-        <.live_component module={NestedComponent} id={:_component} />
-      <% end %>
+    <%= if @enabled do %>
+      <%= live_render(@socket, NestedLive, id: :nested_live) %>
+      <.live_component module={NestedComponent} id={:_component} />
+    <% end %>
     """
   end
 

--- a/test/support/live_views/component_in_live.ex
+++ b/test/support/live_views/component_in_live.ex
@@ -6,7 +6,7 @@ defmodule Phoenix.LiveViewTest.ComponentInLive.Root do
   end
 
   def render(assigns) do
-    ~H"<%= @enabled && live_render @socket, Phoenix.LiveViewTest.ComponentInLive.Live, id: :nested_live %>"
+    ~H"<%= @enabled && live_render(@socket, Phoenix.LiveViewTest.ComponentInLive.Live, id: :nested_live) %>"
   end
 
   def handle_info(:disable, socket) do
@@ -22,7 +22,7 @@ defmodule Phoenix.LiveViewTest.ComponentInLive.Live do
   end
 
   def render(assigns) do
-    ~H"<.live_component module={Phoenix.LiveViewTest.ComponentInLive.Component} id={ :nested_component} />"
+    ~H"<.live_component module={Phoenix.LiveViewTest.ComponentInLive.Component} id={:nested_component} />"
   end
 
   def handle_event("disable", _params, socket) do

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -258,8 +258,14 @@ defmodule Phoenix.LiveViewTest.WithComponentLive do
     ~H"""
     Redirect: <%= @redirect %>
     <%= for name <- @names do %>
-      <.live_component module={Phoenix.LiveViewTest.StatefulComponent}
-          id={name} name={name} from={@from} disabled={name in @disabled} parent_id={nil} />
+      <.live_component
+        module={Phoenix.LiveViewTest.StatefulComponent}
+        id={name}
+        name={name}
+        from={@from}
+        disabled={name in @disabled}
+        parent_id={nil}
+      />
     <% end %>
     """
   end
@@ -313,8 +319,14 @@ defmodule Phoenix.LiveViewTest.WithMultipleTargets do
     <div id="parent_id" class="parent">
       <%= @message %>
       <%= for name <- @names do %>
-        <.live_component module={Phoenix.LiveViewTest.StatefulComponent}
-            id={name} name={name} from={@from} disabled={name in @disabled} parent_id={@parent_selector} />
+        <.live_component
+          module={Phoenix.LiveViewTest.StatefulComponent}
+          id={name}
+          name={name}
+          from={@from}
+          disabled={name in @disabled}
+          parent_id={@parent_selector}
+        />
       <% end %>
     </div>
     """

--- a/test/support/live_views/connect.ex
+++ b/test/support/live_views/connect.ex
@@ -3,12 +3,12 @@ defmodule Phoenix.LiveViewTest.ConnectLive do
 
   def render(assigns) do
     ~H"""
-    params: <%= inspect(@params) %>
-    uri: <%= URI.to_string(@uri) %>
-    trace: <%= inspect(@trace) %>
-    peer: <%= inspect(@peer, custom_options: [sort_maps: true]) %>
-    x-headers: <%= inspect(@x_headers) %>
-    user-agent: <%= inspect(@user_agent) %>
+    <p>params: <%= inspect(@params) %></p>
+    <p>uri: <%= URI.to_string(@uri) %></p>
+    <p>trace: <%= inspect(@trace) %></p>
+    <p>peer: <%= inspect(@peer, custom_options: [sort_maps: true]) %></p>
+    <p>x-headers: <%= inspect(@x_headers) %></p>
+    <p>user-agent: <%= inspect(@user_agent) %></p>
     """
   end
 

--- a/test/support/live_views/elements.ex
+++ b/test/support/live_views/elements.ex
@@ -9,35 +9,78 @@ defmodule Phoenix.LiveViewTest.ElementsLive do
     <div id="last-event"><%= @event %></div>
     <div id="scoped-render"><span>This</span> is a div</div>
     <div>This</div>
-    <div id="child-component"><.live_component module={Phoenix.LiveViewTest.ElementsComponent} id={1} /></div>
+    <div id="child-component">
+      <.live_component module={Phoenix.LiveViewTest.ElementsComponent} id={1} />
+    </div>
 
     <% # basic render_* %>
     <span id="span-no-attr">This is a span</span>
 
     <span id="span-blur-no-value" phx-blur="span-blur">This is a span</span>
-    <span id="span-blur-value" phx-blur="span-blur" value="123" phx-value-extra="456">This is a span</span>
-    <span id="span-blur-phx-value" phx-blur="span-blur" phx-value-foo="123" phx-value-bar="456">This is a span</span>
+    <span id="span-blur-value" phx-blur="span-blur" value="123" phx-value-extra="456">
+      This is a span
+    </span>
+    <span id="span-blur-phx-value" phx-blur="span-blur" phx-value-foo="123" phx-value-bar="456">
+      This is a span
+    </span>
 
     <span id="span-focus-no-value" phx-focus="span-focus">This is a span</span>
-    <span id="span-focus-value" phx-focus="span-focus" value="123" phx-value-extra="456">This is a span</span>
-    <span id="span-focus-phx-value" phx-focus="span-focus" phx-value-foo="123" phx-value-bar="456">This is a span</span>
+    <span id="span-focus-value" phx-focus="span-focus" value="123" phx-value-extra="456">
+      This is a span
+    </span>
+    <span id="span-focus-phx-value" phx-focus="span-focus" phx-value-foo="123" phx-value-bar="456">
+      This is a span
+    </span>
 
     <span id="span-keyup-no-value" phx-keyup="span-keyup">This is a span</span>
-    <span id="span-keyup-value" phx-keyup="span-keyup" value="123" phx-value-extra="456">This is a span</span>
-    <span id="span-keyup-phx-value" phx-keyup="span-keyup" phx-value-foo="123" phx-value-bar="456">This is a span</span>
-    <span id="span-window-keyup-phx-value" phx-window-keyup="span-window-keyup" phx-value-foo="123" phx-value-bar="456">This is a span</span>
+    <span id="span-keyup-value" phx-keyup="span-keyup" value="123" phx-value-extra="456">
+      This is a span
+    </span>
+    <span id="span-keyup-phx-value" phx-keyup="span-keyup" phx-value-foo="123" phx-value-bar="456">
+      This is a span
+    </span>
+    <span
+      id="span-window-keyup-phx-value"
+      phx-window-keyup="span-window-keyup"
+      phx-value-foo="123"
+      phx-value-bar="456"
+    >
+      This is a span
+    </span>
 
     <span id="span-keydown-no-value" phx-keydown="span-keydown">This is a span</span>
-    <span id="span-keydown-value" phx-keydown="span-keydown" value="123" phx-value-extra="456">This is a span</span>
-    <span id="span-keydown-phx-value" phx-keydown="span-keydown" phx-value-foo="123" phx-value-bar="456">This is a span</span>
-    <span id="span-window-keydown-phx-value" phx-window-keydown="span-window-keydown" phx-value-foo="123" phx-value-bar="456">This is a span</span>
+    <span id="span-keydown-value" phx-keydown="span-keydown" value="123" phx-value-extra="456">
+      This is a span
+    </span>
+    <span
+      id="span-keydown-phx-value"
+      phx-keydown="span-keydown"
+      phx-value-foo="123"
+      phx-value-bar="456"
+    >
+      This is a span
+    </span>
+    <span
+      id="span-window-keydown-phx-value"
+      phx-window-keydown="span-window-keydown"
+      phx-value-foo="123"
+      phx-value-bar="456"
+    >
+      This is a span
+    </span>
 
     <button id="button-js-click" phx-click={JS.push("button-click")}>This is a JS button</button>
-    <button id="button-js-click-value" phx-click={JS.push("button-click", value: %{one: 1})}>This is a JS button with a value</button>
+    <button id="button-js-click-value" phx-click={JS.push("button-click", value: %{one: 1})}>
+      This is a JS button with a value
+    </button>
     <button id="button-disabled-click" phx-click="button-click" disabled>This is a button</button>
     <span id="span-click-no-value" phx-click="span-click">This is a span</span>
-    <span id="span-click-value" phx-click="span-click" value="123" phx-value-extra="&lt;456&gt;">This is a span</span>
-    <span id="span-click-phx-value" phx-click="span-click" phx-value-foo="123" phx-value-bar="456">This is a span</span>
+    <span id="span-click-value" phx-click="span-click" value="123" phx-value-extra="&lt;456&gt;">
+      This is a span
+    </span>
+    <span id="span-click-phx-value" phx-click="span-click" phx-value-foo="123" phx-value-bar="456">
+      This is a span
+    </span>
 
     <% # link handling %>
     <a id="a-no-attr">No href link</a>
@@ -46,13 +89,37 @@ defmodule Phoenix.LiveViewTest.ElementsLive do
     <.link navigate="/example" id="live-redirect-a">Live redirect</.link>
     <.link navigate="/example" id="live-redirect-replace-a" replace>Live redirect</.link>
     <% # unrelated phx-click does not disable patching %>
-    <.link patch="/elements?from=uri" id="live-patch-a" phx-click={JS.dispatch("noop")}>Live patch</.link>
+    <.link patch="/elements?from=uri" id="live-patch-a" phx-click={JS.dispatch("noop")}>
+      Live patch
+    </.link>
 
-    <button type="button" id="live-patch-button" phx-click={JS.patch("/elements?from=uri")}>Live patch button</button>
-    <button type="button" id="live-push-patch-button" phx-click={JS.push("foo") |> JS.patch("/elements?from=uri")}>Live push patch button</button>
-    <button type="button" id="live-redirect-push-button" phx-click={JS.navigate("/example")}>Live redirect</button>
-    <button type="button" id="live-redirect-replace-button" phx-click={JS.navigate("/example", replace: true)}>Live redirect</button>
-    <button type="button" id="live-redirect-patch-button" phx-click={JS.navigate("/example", replace: true) |> JS.patch("/elements?from=uri")}>Last one wins</button>
+    <button type="button" id="live-patch-button" phx-click={JS.patch("/elements?from=uri")}>
+      Live patch button
+    </button>
+    <button
+      type="button"
+      id="live-push-patch-button"
+      phx-click={JS.push("foo") |> JS.patch("/elements?from=uri")}
+    >
+      Live push patch button
+    </button>
+    <button type="button" id="live-redirect-push-button" phx-click={JS.navigate("/example")}>
+      Live redirect
+    </button>
+    <button
+      type="button"
+      id="live-redirect-replace-button"
+      phx-click={JS.navigate("/example", replace: true)}
+    >
+      Live redirect
+    </button>
+    <button
+      type="button"
+      id="live-redirect-patch-button"
+      phx-click={JS.navigate("/example", replace: true) |> JS.patch("/elements?from=uri")}
+    >
+      Last one wins
+    </button>
 
     <% # hooks %>
     <section phx-hook="Example" id="hook-section" phx-value-foo="ignore">Section</section>
@@ -60,34 +127,39 @@ defmodule Phoenix.LiveViewTest.ElementsLive do
 
     <% # forms %>
     <a id="a-no-form" phx-change="hello" phx-submit="world">Change</a>
-    <form id="empty-form" phx-change="form-change" phx-submit="form-submit">
-    </form>
-    <form id="phx-value-form" phx-change="form-change" phx-submit="form-submit" phx-value-key="val" phx-value-foo="bar">
+    <form id="empty-form" phx-change="form-change" phx-submit="form-submit"></form>
+    <form
+      id="phx-value-form"
+      phx-change="form-change"
+      phx-submit="form-submit"
+      phx-value-key="val"
+      phx-value-foo="bar"
+    >
     </form>
     <form id="form" phx-change="form-change" phx-submit="form-submit" phx-value-key="value">
-      <input value="no-name">
-      <input name="hello[disabled]" value="value" disabled>
-      <input name="hello[no-type]" value="value">
-      <input name="hello[latest]" type="text" value="old">
-      <input name="hello[latest]" type="text" value="new">
-      <input name="hello[hidden]" type="hidden" value="hidden">
-      <input name="hello[hidden_or_checkbox]" type="hidden" value="false">
-      <input name="hello[hidden_or_checkbox]" type="checkbox" value="true">
-      <input name="hello[hidden_or_text]" type="hidden" value="false">
-      <input name="hello[hidden_or_text]" type="text" value="true">
-      <input name="hello[radio]" type="radio" value="1">
-      <input name="hello[radio]" type="radio" value="2" checked>
-      <input name="hello[radio]" type="radio" value="3">
-      <input name="hello[not-checked-radio]" type="radio" value="1">
-      <input name="hello[disabled-radio]" type="radio" value="1" checked disabled>
-      <input name="hello[checkbox]" type="checkbox" value="1">
-      <input name="hello[checkbox]" type="checkbox" value="2" checked>
-      <input name="hello[checkbox]" type="checkbox" value="3">
-      <input name="hello[not-checked-checkbox]" type="checkbox" value="1">
-      <input name="hello[disabled-checkbox]" type="checkbox" value="1" checked disabled>
-      <input name="hello[multiple-checkbox][]" type="checkbox" value="1">
-      <input name="hello[multiple-checkbox][]" type="checkbox" value="2" checked>
-      <input name="hello[multiple-checkbox][]" type="checkbox" value="3" checked>
+      <input value="no-name" />
+      <input name="hello[disabled]" value="value" disabled />
+      <input name="hello[no-type]" value="value" />
+      <input name="hello[latest]" type="text" value="old" />
+      <input name="hello[latest]" type="text" value="new" />
+      <input name="hello[hidden]" type="hidden" value="hidden" />
+      <input name="hello[hidden_or_checkbox]" type="hidden" value="false" />
+      <input name="hello[hidden_or_checkbox]" type="checkbox" value="true" />
+      <input name="hello[hidden_or_text]" type="hidden" value="false" />
+      <input name="hello[hidden_or_text]" type="text" value="true" />
+      <input name="hello[radio]" type="radio" value="1" />
+      <input name="hello[radio]" type="radio" value="2" checked />
+      <input name="hello[radio]" type="radio" value="3" />
+      <input name="hello[not-checked-radio]" type="radio" value="1" />
+      <input name="hello[disabled-radio]" type="radio" value="1" checked disabled />
+      <input name="hello[checkbox]" type="checkbox" value="1" />
+      <input name="hello[checkbox]" type="checkbox" value="2" checked />
+      <input name="hello[checkbox]" type="checkbox" value="3" />
+      <input name="hello[not-checked-checkbox]" type="checkbox" value="1" />
+      <input name="hello[disabled-checkbox]" type="checkbox" value="1" checked disabled />
+      <input name="hello[multiple-checkbox][]" type="checkbox" value="1" />
+      <input name="hello[multiple-checkbox][]" type="checkbox" value="2" checked />
+      <input name="hello[multiple-checkbox][]" type="checkbox" value="3" checked />
       <select name="hello[not-selected]">
         <option value="" disabled>Disabled Prompt</option>
         <option value="blank">None</option>
@@ -127,40 +199,50 @@ defmodule Phoenix.LiveViewTest.ElementsLive do
       <!-- Mimic textarea from Phoenix.HTML -->
       <textarea name="hello[textarea_nl]">
     Text</textarea>
-      <input name="hello[ignore-submit]" type="submit" value="ignored">
-      <input name="hello[ignore-image]" type="image" value="ignored">
-      <input name="hello[date_text]" type="text">
-      <%= PhoenixHTMLHelpers.Form.date_select :hello, :date_select %>
-      <input name="hello[time_text]" type="text">
-      <%= PhoenixHTMLHelpers.Form.time_select :hello, :time_select %>
-      <input name="hello[naive_text]" type="text">
-      <%= PhoenixHTMLHelpers.Form.datetime_select :hello, :naive_select %>
-      <input name="hello[utc_text]" type="text">
-      <%= PhoenixHTMLHelpers.Form.datetime_select :hello, :utc_select, second: [] %>
-      <input name="hello[individual]" type="text" phx-change="individual-changed"/>
+      <input name="hello[ignore-submit]" type="submit" value="ignored" />
+      <input name="hello[ignore-image]" type="image" value="ignored" />
+      <input name="hello[date_text]" type="text" />
+      <%= PhoenixHTMLHelpers.Form.date_select(:hello, :date_select) %>
+      <input name="hello[time_text]" type="text" />
+      <%= PhoenixHTMLHelpers.Form.time_select(:hello, :time_select) %>
+      <input name="hello[naive_text]" type="text" />
+      <%= PhoenixHTMLHelpers.Form.datetime_select(:hello, :naive_select) %>
+      <input name="hello[utc_text]" type="text" />
+      <%= PhoenixHTMLHelpers.Form.datetime_select(:hello, :utc_select, second: []) %>
+      <input name="hello[individual]" type="text" phx-change="individual-changed" />
     </form>
 
     <form id="submitter-form" phx-submit="form-submit">
-      <input name="data[a]" type="hidden" value="b">
-      <input name="input" type="submit" value="yes">
-      <input name="input_disabled" type="submit" value="yes" disabled>
-      <input name="data[nested]" id="data-nested" type="submit" value="yes">
-      <input id="input_no_name" type="submit" value="yes">
+      <input name="data[a]" type="hidden" value="b" />
+      <input name="input" type="submit" value="yes" />
+      <input name="input_disabled" type="submit" value="yes" disabled />
+      <input name="data[nested]" id="data-nested" type="submit" value="yes" />
+      <input id="input_no_name" type="submit" value="yes" />
       <button name="button" type="submit" value="yes">button</button>
       <button name="button_disabled" type="submit" value="yes" disabled />
-      <button name="button_no_submit" type="button" value="this_value_should_never_appear">button_no_submit</button>
+      <button name="button_no_submit" type="button" value="this_value_should_never_appear">
+        button_no_submit
+      </button>
       <button name="button_no_type" value="yes">button_no_type</button>
       <button name="button_no_value">Button No Value</button>
     </form>
 
-    <form id="trigger-form-default" phx-submit="form-submit-trigger"
-          phx-trigger-action={@trigger_action}>
+    <form
+      id="trigger-form-default"
+      phx-submit="form-submit-trigger"
+      phx-trigger-action={@trigger_action}
+    >
     </form>
 
     <form id="submit-form-default" action="/not_found"></form>
 
-    <form id="trigger-form-value" action="/not_found" method="POST" phx-submit="form-submit-trigger"
-          phx-trigger-action={@trigger_action}>
+    <form
+      id="trigger-form-value"
+      action="/not_found"
+      method="POST"
+      phx-submit="form-submit-trigger"
+      phx-trigger-action={@trigger_action}
+    >
     </form>
 
     <form id="named" phx-submit="form-submit-named">
@@ -168,11 +250,15 @@ defmodule Phoenix.LiveViewTest.ElementsLive do
     </form>
     <input form="named" name="foo" />
     <textarea form="named" name="bar" />
-    <select form="named" name="baz"><option value="c">c</option></select>
+    <select form="named" name="baz">
+      <option value="c">c</option>
+    </select>
     <button form="named" name="btn" type="submit" value="x">Submit</button>
 
     <% # @page_title assign is unique %>
-    <svg><title>SVG with title</title></svg>
+    <svg>
+      <title>SVG with title</title>
+    </svg>
     """
   end
 
@@ -208,7 +294,12 @@ defmodule Phoenix.LiveViewTest.ElementsComponent do
     <div>
       <div id="component-last-event"><%= @event %></div>
 
-      <button id="component-button-js-click-target" phx-click={JS.push("button-click", target: @myself)}>button</button>
+      <button
+        id="component-button-js-click-target"
+        phx-click={JS.push("button-click", target: @myself)}
+      >
+        button
+      </button>
     </div>
     """
   end

--- a/test/support/live_views/events.ex
+++ b/test/support/live_views/events.ex
@@ -93,7 +93,8 @@ defmodule Phoenix.LiveViewTest.EventsInComponentMultiJSLive do
           id="push-to-self"
           phx-click={
             JS.push("inc", target: "#child_1", value: %{inc: 1})
-            |> JS.push("inc", target: "#child_1", value: %{inc: 10})}
+            |> JS.push("inc", target: "#child_1", value: %{inc: 10})
+          }
         >
           Both to self
         </button>
@@ -118,8 +119,7 @@ defmodule Phoenix.LiveViewTest.EventsInComponentMultiJSLive do
   def render(assigns) do
     ~H"""
     <.live_component module={Child} id={:child_1} />
-    <.live_component module={Child} id={:child_2} />
-    root count: <%= @count %>
+    <.live_component module={Child} id={:child_2} /> root count: <%= @count %>
     """
   end
 
@@ -153,7 +153,7 @@ defmodule Phoenix.LiveViewTest.EventsInMountLive do
   end
 
   def render(assigns) do
-    ~H"<%= live_render @socket, Child, id: :child_live %>"
+    ~H"<%= live_render(@socket, Child, id: :child_live) %>"
   end
 
   def mount(_params, _session, socket) do
@@ -175,15 +175,11 @@ defmodule Phoenix.LiveViewTest.EventsInComponentLive do
     def render(assigns) do
       ~H"""
       <div>
-        <button id="comp-reply"
-                phx-click="reply"
-                phx-target={@myself}>
+        <button id="comp-reply" phx-click="reply" phx-target={@myself}>
           bump reply!
         </button>
 
-        <button id="comp-noreply"
-                phx-click="noreply"
-                phx-target={@myself}>
+        <button id="comp-noreply" phx-click="noreply" phx-target={@myself}>
           bump no reply!
         </button>
       </div>

--- a/test/support/live_views/flash.ex
+++ b/test/support/live_views/flash.ex
@@ -7,7 +7,7 @@ defmodule Phoenix.LiveViewTest.FlashLive do
     root[<%= Phoenix.Flash.get(@flash, :info) %>]:info
     root[<%= Phoenix.Flash.get(@flash, :error) %>]:error
     <.live_component module={Phoenix.LiveViewTest.FlashComponent} id="flash-component" />
-    child[<%= live_render @socket, Phoenix.LiveViewTest.FlashChildLive, id: "flash-child" %>]
+    child[<%= live_render(@socket, Phoenix.LiveViewTest.FlashChildLive, id: "flash-child") %>]
     """
   end
 
@@ -48,9 +48,13 @@ defmodule Phoenix.LiveViewTest.FlashComponent do
   def render(assigns) do
     ~H"""
     <div id={@id} phx-target={@myself} phx-click="click">
-    <span phx-target={@myself} phx-click="lv:clear-flash">Clear all</span>
-    <span phx-target={@myself} phx-click="lv:clear-flash" phx-value-key="info">component[<%= Phoenix.Flash.get(@flash, :info) %>]:info</span>
-    <span phx-target={@myself} phx-click="lv:clear-flash" phx-value-key="error">component[<%= Phoenix.Flash.get(@flash, :error) %>]:error</span>
+      <span phx-target={@myself} phx-click="lv:clear-flash">Clear all</span>
+      <span phx-target={@myself} phx-click="lv:clear-flash" phx-value-key="info">
+        component[<%= Phoenix.Flash.get(@flash, :info) %>]:info
+      </span>
+      <span phx-target={@myself} phx-click="lv:clear-flash" phx-value-key="error">
+        component[<%= Phoenix.Flash.get(@flash, :error) %>]:error
+      </span>
     </div>
     """
   end

--- a/test/support/live_views/general.ex
+++ b/test/support/live_views/general.ex
@@ -10,8 +10,8 @@ defmodule Phoenix.LiveViewTest.ThermostatLive do
 
   def render(assigns) do
     ~H"""
-    Redirect: <%= @redirect %>
-    The temp is: <%= @val %><%= @greeting %>
+    <p>Redirect: <%= @redirect %></p>
+    <p>The temp is: <%= @val %><%= @greeting %></p>
     <button phx-click="dec">-</button>
     <button phx-click="inc">+</button>
     <%= if @nest do %>
@@ -92,7 +92,10 @@ defmodule Phoenix.LiveViewTest.ClockLive do
   def render(assigns) do
     ~H"""
     time: <%= @time %> <%= @name %>
-    <%= live_render(@socket, ClockControlsLive, id: :"#{String.replace(@name, " ", "-")}-controls", sticky: @sticky) %>
+    <%= live_render(@socket, ClockControlsLive,
+      id: :"#{String.replace(@name, " ", "-")}-controls",
+      sticky: @sticky
+    ) %>
     """
   end
 
@@ -136,7 +139,7 @@ defmodule Phoenix.LiveViewTest.DashboardLive do
 
   def render(assigns) do
     ~H"""
-    session: <%= Phoenix.HTML.raw inspect(@session) %>
+    session: <%= Phoenix.HTML.raw(inspect(@session)) %>
     """
   end
 
@@ -555,7 +558,7 @@ defmodule Phoenix.LiveViewTest.StartAsyncLive do
     <.live_component :if={@lc} module={Phoenix.LiveViewTest.StartAsyncLive.LC} test={@lc} id="lc" />
     result: <%= inspect(@result) %>
     <%= if flash = @flash["info"] do %>
-    flash: <%= flash %>
+      flash: <%= flash %>
     <% end %>
     """
   end

--- a/test/support/live_views/host.ex
+++ b/test/support/live_views/host.ex
@@ -8,10 +8,12 @@ defmodule Phoenix.LiveViewTest.HostLive do
 
   def render(assigns) do
     ~H"""
-    URI: <%= @uri %>
-    LiveAction: <%= @live_action %>
+    <p>URI: <%= @uri %></p>
+    <p>LiveAction: <%= @live_action %></p>
     <.link id="path" patch={Routes.host_path(@socket, :path)}>Path</.link>
-    <.link id="full" patch={"https://app.example.com" <> Routes.host_path(@socket, :full)}>Full</.link>
+    <.link id="full" patch={"https://app.example.com" <> Routes.host_path(@socket, :full)}>
+      Full
+    </.link>
     """
   end
 end

--- a/test/support/live_views/layout.ex
+++ b/test/support/live_views/layout.ex
@@ -3,7 +3,7 @@ defmodule Phoenix.LiveViewTest.ParentLayoutLive do
 
   def render(assigns) do
     ~H"""
-    <%= live_render @socket, Phoenix.LiveViewTest.LayoutLive, session: @session, id: "layout" %>
+    <%= live_render(@socket, Phoenix.LiveViewTest.LayoutLive, session: @session, id: "layout") %>
     """
   end
 

--- a/test/support/live_views/lifecycle.ex
+++ b/test/support/live_views/lifecycle.ex
@@ -54,10 +54,10 @@ defmodule Phoenix.LiveViewTest.HooksLive do
 
   def render(assigns) do
     ~H"""
-    last_on_mount:<%= inspect(assigns[:last_on_mount]) %>
-    params_hook:<%= assigns[:params_hook_ref] %>
-    count:<%= @count %>
-    task:<%= @task %>
+    <p>last_on_mount:<%= inspect(assigns[:last_on_mount]) %></p>
+    <p>params_hook:<%= assigns[:params_hook_ref] %></p>
+    <p>count:<%= @count %></p>
+    <p>task:<%= @task %></p>
     <button id="dec" phx-click="dec">-</button>
     <button id="inc" phx-click="inc">+</button>
     <button id="patch" phx-click="patch">?</button>

--- a/test/support/live_views/live_in_component.ex
+++ b/test/support/live_views/live_in_component.ex
@@ -16,7 +16,7 @@ defmodule Phoenix.LiveViewTest.LiveInComponent.Component do
   def render(assigns) do
     ~H"""
     <div>
-      <%= live_render @socket, Phoenix.LiveViewTest.LiveInComponent.Live, id: :nested_live %>"
+      <%= live_render(@socket, Phoenix.LiveViewTest.LiveInComponent.Live, id: :nested_live) %>"
     </div>
     """
   end

--- a/test/support/live_views/params.ex
+++ b/test/support/live_views/params.ex
@@ -3,9 +3,9 @@ defmodule Phoenix.LiveViewTest.ParamCounterLive do
 
   def render(assigns) do
     ~H"""
-    The value is: <%= @val %>
-    mount: <%= inspect(@mount_params) %>
-    params: <%= inspect(@params) %>
+    <p>The value is: <%= @val %></p>
+    <p>mount: <%= inspect(@mount_params) %></p>
+    <p>params: <%= inspect(@params) %></p>
     """
   end
 
@@ -73,9 +73,9 @@ defmodule Phoenix.LiveViewTest.ActionLive do
 
   def render(assigns) do
     ~H"""
-    Live action: <%= inspect @live_action %>
-    Mount action: <%= inspect @mount_action %>
-    Params: <%= inspect @params %>
+    <p>Live action: <%= inspect(@live_action) %></p>
+    <p>Mount action: <%= inspect(@mount_action) %></p>
+    <p>Params: <%= inspect(@params) %></p>
     """
   end
 

--- a/test/support/live_views/reload_live.ex
+++ b/test/support/live_views/reload_live.ex
@@ -7,15 +7,8 @@ defmodule Phoenix.LiveViewTest.ReloadLive do
 
   def render(assigns) do
     case Application.fetch_env(:phoenix_live_view, :vsn) do
-      {:ok, 1} ->
-        ~H"""
-         <div>Version 1</div>
-        """
-
-      {:ok, 2} ->
-        ~H"""
-         <div>Version 2</div>
-        """
+      {:ok, 1} -> ~H"<div>Version 1</div>"
+      {:ok, 2} -> ~H"<div>Version 2</div>"
     end
   end
 end

--- a/test/support/live_views/update.ex
+++ b/test/support/live_views/update.ex
@@ -19,7 +19,10 @@ defmodule Phoenix.LiveViewTest.ShuffleLive do
     ~H"""
     <%= for zone <- @time_zones do %>
       <div id={"score-" <> zone["id"]}>
-        <%= live_render(@socket, Phoenix.LiveViewTest.TZLive, id: "tz-#{zone["id"]}", session: %{"name" => zone["name"]}) %>
+        <%= live_render(@socket, Phoenix.LiveViewTest.TZLive,
+          id: "tz-#{zone["id"]}",
+          session: %{"name" => zone["name"]}
+        ) %>
       </div>
     <% end %>
     """

--- a/test/support/live_views/upload_live.ex
+++ b/test/support/live_views/upload_live.ex
@@ -126,7 +126,8 @@ defmodule Phoenix.LiveViewTest.UploadComponent do
         nil ->
           socket
 
-        other -> {:other, other}
+        other ->
+          {:other, other}
       end
 
     {:ok,

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -130,7 +130,10 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/stream/reset-lc", StreamResetLCLive
     live "/stream/limit", StreamLimitLive
     live "/stream/nested", StreamNestedLive
-    live "/stream/high-frequency-stream-and-non-stream-updates", HighFrequencyStreamAndNoStreamUpdatesLive
+
+    live "/stream/high-frequency-stream-and-non-stream-updates",
+         HighFrequencyStreamAndNoStreamUpdatesLive
+
     live "/stream/nested-component-reset", StreamNestedComponentResetLive
     live "/stream/inside-for", StreamInsideForLive
 


### PR DESCRIPTION
There are still two files left that cannot easily be formatted currently.

One is the slot declaration in phoenix_component, where we don't want extra newlines, but there's not way to tell the formatter to omit them.

https://github.com/phoenixframework/phoenix_live_view/blob/f6e24c5bd7fc50fcb6dc74ac9d3df4c76bde7bd0/lib/phoenix_component.ex#L1017-L1023

The other is the html_engine_test file where we want to keep newlines that the formatter does not like.

Could we have a sigil_H modifier to prevent formatting? @josevalim 