### PR TITLE
Add support for function in components attr

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -378,7 +378,8 @@ defmodule Phoenix.Component.Declarative do
   @builtin_types [:boolean, :integer, :float, :string, :atom, :list, :map, :global]
   @valid_types [:any] ++ @builtin_types
 
-  defp validate_attr_type!(module, key, slot, name, type, line, file) when is_atom(type) do
+  defp validate_attr_type!(module, key, slot, name, type, line, file)
+       when is_atom(type) or is_tuple(type) do
     attrs = Module.get_attribute(module, key) || []
 
     cond do
@@ -398,14 +399,28 @@ defmodule Phoenix.Component.Declarative do
         :ok
     end
 
-    case Atom.to_string(type) do
-      "Elixir." <> _ -> {:struct, type}
-      _ when type in @valid_types -> type
-      _ -> bad_type!(slot, name, type, line, file)
+    cond do
+      type in @valid_types -> type
+      is_tuple(type) -> validate_function_attr_type!(slot, name, type, line, file)
+      type |> Atom.to_string() |> String.starts_with?("Elixir.") -> {:struct, type}
+      true -> bad_type!(slot, name, type, line, file)
     end
   end
 
   defp validate_attr_type!(_module, _key, slot, name, type, line, file) do
+    bad_type!(slot, name, type, line, file)
+  end
+
+  defp validate_function_attr_type!(slot, name, {:function, args} = type, line, file) do
+    cond do
+      is_integer(args) -> type
+      Keyword.keyword?(args) and Enum.all?(args, fn {_, v} -> v in @valid_types end) -> type
+      is_list(args) and Enum.all?(args, &(&1 in @valid_types)) -> type
+      true -> bad_type!(slot, name, type, line, file)
+    end
+  end
+
+  defp validate_function_attr_type!(slot, name, type, line, file) do
     bad_type!(slot, name, type, line, file)
   end
 
@@ -416,6 +431,10 @@ defmodule Phoenix.Component.Declarative do
 
       * any Elixir struct, such as URI, MyApp.User, etc
       * one of #{Enum.map_join(@builtin_types, ", ", &inspect/1)}
+      * a function written as:
+          * with specific arity, ex: {:function, 2}
+          * with arguments types, ex: {:function, [:string, :integer]}
+          * with arguments names and types, ex: {:function, [arg_1: :string, arg_2: :integer]}
       * :any for all other types
     """)
   end


### PR DESCRIPTION
This PR adds support for describing functions as a component attr types.

It allows the following syntax:

```elixir
attr :on_cancel, {:function, 2}, required: true
attr :on_complete, {:function, [:string, :integer]}, required: true
attr :on_fail, {:function, [reason: :string]}, required: true
```

The reasoning to add this support is to allow components to be more explicit when using functions as attributes. Currently, the only way to do that is to use the `:any` type, which makes the usage of the component harder since the developer will need to find the attribute usage inside the component code to figure out what arguments that attribute should accept.

This is specially a big issue if you are writing a component library and you want your components usage to be as clear as possible.

Just as an example of usage, we can see this suggestion by Chris in this issue: https://github.com/phoenixframework/phoenix_live_view/issues/1597#issuecomment-1635973838