### PR TITLE
validate slot options

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -290,6 +290,14 @@ defmodule Phoenix.Component.Declarative do
       cannot define attributes in a slot with name #{inspect(slot.name)}
       """)
     end
+
+    if slot.opts != [] do
+      compile_error!(
+        line,
+        file,
+        "invalid options #{inspect(slot.opts)} for slot #{inspect(slot.name)}. The supported options are: [:required, :doc, :validate_attrs]"
+      )
+    end
   end
 
   @doc false

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -1638,4 +1638,17 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       end
     end
   end
+
+  test "raise if slot attribute is not supported" do
+    msg = ~r"invalid options .* for slot :foo. The supported options are"
+
+    assert_raise CompileError, msg, fn ->
+      defmodule Phoenix.ComponentTest.InvalidSlotAttr do
+        use Elixir.Phoenix.Component
+
+        slot :foo, require: true
+        def func(assigns), do: ~H[]
+      end
+    end
+  end
 end


### PR DESCRIPTION
Previously, having a typo when defining slot options did not warn, so you could write `slot :myslot, requird: true` and it would be silently ignored. This PR adds a compile time warning if any other option than `required`, `doc`, or `validate_attrs` is passed to `slot`.