### PR TITLE
don't use mousedown target for click event

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -671,7 +671,9 @@ export default class LiveSocket {
       // therefore the clickStartedAtTarget is stale
       if(e.detail === 0) this.clickStartedAtTarget = e.target
       let clickStartedAtTarget = this.clickStartedAtTarget || e.target
-      target = closestPhxBinding(clickStartedAtTarget, click)
+      // when searching the target for the click event, we always want to
+      // use the actual event target, see #3372
+      target = closestPhxBinding(e.target, click)
       this.dispatchClickAway(e, clickStartedAtTarget)
       this.clickStartedAtTarget = null
       let phxEvent = target && target.getAttribute(click)


### PR DESCRIPTION
Since https://github.com/phoenixframework/phoenix_live_view/commit/db841e39f8fdeebce93d8978aea4a3d7683a1445 LV uses the mousedown target as the target for the actual click event.

This causes an issue with how clicks are usually handled, for example when clicking on a button but then moving the mouse away. Always using the event target should be the correct way.

Fixes #3363.