### PR TITLE
[docs] JS.transition/1-2-3 `duration-300` matches `time: 300` example

### DIFF
--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -593,6 +593,10 @@ defmodule Phoenix.LiveView.JS do
 
       <div id="item">My Item</div>
       <button phx-click={JS.transition("shake", to: "#item")}>Shake!</button>
+
+      <div phx-mounted={JS.transition({"ease-out duration-300", "opacity-0", "opacity-100"}, time: 300)}>
+         duration-300 milliseconds matches time: 300 milliseconds
+      <div>
   """
   def transition(transition) when is_binary(transition) or is_tuple(transition) do
     transition(%JS{}, transition, [])


### PR DESCRIPTION
Add example where `duration-300` and `time:` are the same otherwise the transition will be cut short as the default `time:` is 200 milliseconds.