### PR TITLE
avoid compile dependency in some cases on `on_mount`

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -537,10 +537,10 @@ defmodule Phoenix.LiveView do
 
   """
   defmacro on_mount(mod_or_mod_arg) do
+    # While we could pass `mod_or_mod_arg` as a whole to
+    # expand_literals, we want to also be able to expand only
+    # the first element, even if the second element is not a literal.
     mod_or_mod_arg =
-      # While we could pass `mod_or_mod_arg` as a whole to
-      # expand_literals, we want to also be able to expand only
-      # the first element, even if the second element is not a literal.
       case mod_or_mod_arg do
         {mod, arg} ->
           {expand_literals(mod, __CALLER__), expand_literals(arg, __CALLER__)}

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -538,10 +538,12 @@ defmodule Phoenix.LiveView do
   """
   defmacro on_mount(mod_or_mod_arg) do
     mod_or_mod_arg =
-      if Macro.quoted_literal?(mod_or_mod_arg) do
-        Macro.prewalk(mod_or_mod_arg, &expand_alias(&1, __CALLER__))
-      else
-        mod_or_mod_arg
+      case mod_or_mod_arg do
+        {mod, arg} ->
+          {expand_literals(mod, __CALLER__), expand_literals(arg, __CALLER__)}
+
+        mod_or_mod_arg ->
+          expand_literals(mod_or_mod_arg, __CALLER__)
       end
 
     quote do
@@ -550,6 +552,14 @@ defmodule Phoenix.LiveView do
         :phoenix_live_mount,
         Phoenix.LiveView.Lifecycle.validate_on_mount!(__MODULE__, unquote(mod_or_mod_arg))
       )
+    end
+  end
+
+  defp expand_literals(ast, env) do
+    if Macro.quoted_literal?(ast) do
+      Macro.prewalk(ast, &expand_alias(&1, env))
+    else
+      ast
     end
   end
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -538,6 +538,9 @@ defmodule Phoenix.LiveView do
   """
   defmacro on_mount(mod_or_mod_arg) do
     mod_or_mod_arg =
+      # While we could pass `mod_or_mod_arg` as a whole to
+      # expand_literals, we want to also be able to expand only
+      # the first element, even if the second element is not a literal.
       case mod_or_mod_arg do
         {mod, arg} ->
           {expand_literals(mod, __CALLER__), expand_literals(arg, __CALLER__)}


### PR DESCRIPTION
In our project, we have a bit of a corner case when using `on_mount/1`. It's used like that:
```
on_mount {MyAppWeb.EnsureFeature, features: [FeatureTypes.my_feature()]}
```

`FeatureTypes.my_feature()` is a macro, we use macro as constants so we can use then in pattern-matching and other place - I know that's a bit unexpected, but well, it works 😄
The problem here is that this macro call makes the whole expression not a quoted literal, preventing LiveView from expanding it (see [on_mount](https://github.com/phoenixframework/phoenix_live_view/blob/f778e5bb1a4b0a29f8d688bbc6c0b7182dea51ca/lib/phoenix_live_view.ex#L538) implementation), creating a compile dependency to both `MyAppWeb.EnsureFeature` and `FeatureTypes.my_feature()`.

The dependency to `FeatureTypes.my_feature()` is expected, there's no way to remove it, but the one on `MyAppWeb.EnsureFeature` isn't.
In this PR, I'm expanding the mod and the arg individually, to remove the compile dependency of the first module. 
