### PR TITLE
check if child id exists in children list

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -581,7 +581,7 @@ export default class View {
     if(el.id === this.id){
       return this
     } else {
-      return this.children[el.getAttribute(PHX_PARENT_ID)][el.id]
+      return this.children[el.getAttribute(PHX_PARENT_ID)]?.[el.id]
     }
   }
 

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -125,6 +125,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/3200/settings", Issue3200.PanelLive, :settings_tab
       live "/3194", Issue3194Live
       live "/3194/other", Issue3194Live.OtherLive
+      live "/3378", Issue3378.HomeLive
     end
   end
 

--- a/test/e2e/tests/issues/3378.spec.js
+++ b/test/e2e/tests/issues/3378.spec.js
@@ -1,0 +1,21 @@
+const { test, expect } = require("../../test-fixtures");
+const { syncLV } = require("../../utils");
+
+test("can rejoin with nested streams without errors", async ({ page }) => {
+  const errors = [];
+  page.on("pageerror", (err) => {
+    errors.push(err);
+  });
+
+  await page.goto("/issues/3378");
+  await syncLV(page);
+
+  await expect(page.locator("#notifications")).toContainText("big");
+  await page.evaluate(() => new Promise((resolve) => window.liveSocket.disconnect(resolve)));
+
+  await page.evaluate(() => window.liveSocket.connect());
+  await syncLV(page);
+
+  // no js errors should be thrown
+  await expect(errors).toEqual([]);
+});

--- a/test/support/e2e/issues/issue_3378.ex
+++ b/test/support/e2e/issues/issue_3378.ex
@@ -1,0 +1,61 @@
+defmodule Phoenix.LiveViewTest.E2E.Issue3378.NotificationsLive do
+  use Phoenix.LiveView, layout: {__MODULE__, :live}
+
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> stream(:notifications, [%{id: 1, message: "Hello"}])}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div>
+      <ul id="notifications_list" phx-update="stream">
+        <div :for={{dom_id, _notification} <- @streams.notifications} id={dom_id}>
+          <p>big!</p>
+        </div>
+      </ul>
+    </div>
+    """
+  end
+end
+
+defmodule Phoenix.LiveViewTest.E2E.Issue3378.AppBarLive do
+  use Phoenix.LiveView, layout: {__MODULE__, :live}
+
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div>
+      <%= live_render(
+        @socket,
+        Phoenix.LiveViewTest.E2E.Issue3378.NotificationsLive,
+        session: %{},
+        id: :notifications
+      ) %>
+    </div>
+    """
+  end
+end
+
+defmodule Phoenix.LiveViewTest.E2E.Issue3378.HomeLive do
+  use Phoenix.LiveView, layout: {__MODULE__, :live}
+
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <%= live_render(
+      @socket,
+      Phoenix.LiveViewTest.E2E.Issue3378.AppBarLive,
+      session: %{},
+      id: :appbar
+    ) %>
+    """
+  end
+end


### PR DESCRIPTION
Fixes #3378

@chrismccord I'm not 100% sure on this one. Because of the fallback here

https://github.com/phoenixframework/phoenix_live_view/blob/2bb4564ec872e6e544b997a0f38151c58b696827/assets/js/phoenix_live_view/live_socket.js#L474

it can happen that we return the main view instead of the actual owner when a nested LV is not yet joined. Maybe it's not a problem?