### PR TITLE
Upload documentation improvements

### DIFF
--- a/guides/server/uploads.md
+++ b/guides/server/uploads.md
@@ -21,7 +21,11 @@ both direct to server uploads as well as direct-to-cloud
 
 ## Allow uploads
 
-You enable an upload, typically on mount, via [`allow_upload/3`]:
+You enable an upload, typically on mount, via [`allow_upload/3`].
+
+For this example, we will also keep a list of uploaded files in
+a new assign named `uploaded_files`, but you could name it
+something else if you wanted.
 
 ```elixir
 @impl Phoenix.LiveView

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -894,6 +894,9 @@ defmodule Phoenix.LiveView do
   `{:postpone, my_result}` to collect results, but postpone the file
   consumption to be performed later.
 
+  A list of all `my_result` values produced by the passed function is
+  returned, regardless of whether they were consumed or postponed.
+
   ## Examples
 
       def handle_event("save", _params, socket) do


### PR DESCRIPTION
1. Document return value for consume_uploaded_entries/3 explicitly
2. Demystify the magic variable `uploaded_files` in the uploads guide