### PR TITLE
Keep all old values in `__changed__` when using `assign/3` instead of only maps

### DIFF
--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -96,13 +96,11 @@ defmodule Phoenix.LiveView.Utils do
   def force_assign(assigns, nil, key, val), do: Map.put(assigns, key, val)
 
   def force_assign(assigns, changed, key, val) do
-    # If the current value is a map, we store it in changed so
-    # we can perform nested change tracking. Also note the use
-    # of put_new is important. We want to keep the original value
+    # We store old value in changed so we can perform nested change tracking.
+    # Also note the use of put_new is important. We want to keep the original value
     # from assigns and not any intermediate ones that may appear.
     current_val = Map.get(assigns, key)
-    changed_val = if is_map(current_val), do: current_val, else: true
-    changed = Map.put_new(changed, key, changed_val)
+    changed = Map.put_new(changed, key, current_val)
     Map.put(%{assigns | __changed__: changed}, key, val)
   end
 

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -50,6 +50,23 @@ defmodule Phoenix.ComponentUnitTest do
       assert socket.assigns.existing == %{foo: :bam}
       assert socket.assigns.__changed__.existing == %{foo: :bar}
     end
+
+    test "keeps whole lists in changes" do
+      socket = assign(@socket, existing: [:foo, :bar])
+      socket = Utils.clear_changed(socket)
+
+      socket = assign(socket, existing: [:foo, :baz])
+      assert socket.assigns.existing == [:foo, :baz]
+      assert socket.assigns.__changed__.existing == [:foo, :bar]
+
+      socket = assign(socket, existing: [:foo, :bat])
+      assert socket.assigns.existing == [:foo, :bat]
+      assert socket.assigns.__changed__.existing == [:foo, :bar]
+
+      socket = assign(socket, %{existing: [:foo, :bam]})
+      assert socket.assigns.existing == [:foo, :bam]
+      assert socket.assigns.__changed__.existing == [:foo, :bar]
+    end
   end
 
   describe "assign with assigns" do
@@ -102,7 +119,7 @@ defmodule Phoenix.ComponentUnitTest do
                notexisting: "new-notexisting",
                live_action: nil,
                flash: %{},
-               __changed__: %{existing: true, notexisting: true}
+               __changed__: %{existing: nil, notexisting: nil}
              }
     end
 
@@ -120,7 +137,7 @@ defmodule Phoenix.ComponentUnitTest do
                notexisting: "new-notexisting",
                live_action: nil,
                flash: %{},
-               __changed__: %{existing: true, notexisting: true, existing2: true}
+               __changed__: %{existing: nil, notexisting: nil, existing2: nil}
              }
     end
 
@@ -143,11 +160,11 @@ defmodule Phoenix.ComponentUnitTest do
                live_action: nil,
                flash: %{},
                __changed__: %{
-                 existing: true,
-                 existing2: true,
-                 notexisting: true,
-                 notexisting2: true,
-                 notexisting3: true
+                 existing: nil,
+                 existing2: nil,
+                 notexisting: nil,
+                 notexisting2: nil,
+                 notexisting3: nil
                }
              }
     end


### PR DESCRIPTION
This PR is a prerequisite to perform nested change tracking of other types of data than maps, eg. lists or tuples. It was mentioned in a discussed with @josevalim on [Elixir forum](https://elixirforum.com/t/possible-payload-size-improvement-to-heex-list-comprehensions/64986) and on Twitter DM 

<img width="594" alt="image" src="https://github.com/user-attachments/assets/39469a19-6f52-422b-9740-49db22946171">

The end goal is to optimize lists payload and enable nested change tracking. 

## Change

Currently `socket.assigns.__changed__` keep old versions of maps for nested change tracking and `true` for all other types of props. This PR introduces a small change to keep old versions of all the props regardless of type. 

IMO this is not a breaking change. `changed?/2` is simply checking if key is in the `__changed__` map, value itself is not used. And structure of `__changed__` is a private api.

I also though if it could have any memory impact, but I believe it shouldn't be the case. Old assigns are likely still in memory before `clear_changed/1` is called after render, ie. no GC kicks in between assigning and cleaning up `__changed__`. 

## Other reasons why I want this

I'm the author of [live_vue](https://github.com/Valian/live_vue) library that makes it easy to render and keep in sync props of a Vue component from LiveView. Props are passed as `data-props` attribute. 

I'm trying to minimize the diff sent over the wire without changing user-facing API. [I can do it for maps, but not for lists](https://github.com/Valian/live_vue/blob/diff-optimization/lib/live_vue.ex#L78).  This change should make it possible! 🤗

