### PR TITLE
document form method default

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2276,7 +2276,8 @@ defmodule Phoenix.Component do
     The HTTP method.
     It is only used if an `:action` is given. If the method is not `get` nor `post`,
     an input tag with name `_method` is generated alongside the form tag.
-    If an `:action` is given with no method, the method will default to `post`.
+    If an `:action` is given with no method, the method will default to the return value
+    of `Phoenix.HTML.FormData.to_form/2` (usually `post`).
     """
   )
 


### PR DESCRIPTION
The docs for the `<.form>` component currently state "If an :action is given with no method, the method will default to post". However, this is incorrect because if `Phoenix.HTML.FormData.to_form/2` can also return `:put`. This PR updates the doc to make it more clear that `Phoenix.HTML.FormData.to_form/2` determines the default.

Here is what it looks like rendered in html:
![Screenshot 2024-08-24 07-01-50@2x](https://github.com/user-attachments/assets/2f78ac2d-0c51-4f26-91b7-40d8fe0e45d1)

Background: I just spent a bunch of time trying to determine why when I changed my changeset, suddenly when my form resulted in a `no route found for POST` exception. It turns out it's because `phoenix_html`'s `Phoenix.HTML.FormData.to_form/2` calls `phoenix_ecto`'s `defimpl Phoenix.HTML.FormData, for: Ecto.Changeset` which looks for `state: :loaded` in the changeset data. Hopefully this documentation fix will make it easier to track down for the next person! This was also hard to track down since the default `Inspect` implementation of `Ecto.Changeset` doesn't print out the `data.__meta__` which has the `:state`.