### PR TITLE
Docs: replace call to `path/2` with `sigil_p`

### DIFF
--- a/guides/server/live-navigation.md
+++ b/guides/server/live-navigation.md
@@ -76,7 +76,7 @@ the system and you define it in the router as:
 Now to add live sorting, you could do:
 
 ```heex
-<.link patch={~p"/users?#{[sort_by: "name"]}"} }>Sort by name</.link>
+<.link patch={~p"/users?sort_by=name"}>Sort by name</.link>
 ```
 
 When clicked, since we are navigating to the current LiveView,

--- a/guides/server/live-navigation.md
+++ b/guides/server/live-navigation.md
@@ -76,7 +76,7 @@ the system and you define it in the router as:
 Now to add live sorting, you could do:
 
 ```heex
-<.link patch={path(~p"/users", sort_by: "name")}>Sort by name</.link>
+<.link patch={~p"/users?#{[sort_by: "name"]}"} }>Sort by name</.link>
 ```
 
 When clicked, since we are navigating to the current LiveView,


### PR DESCRIPTION
The call to [`path/2`](https://hexdocs.pm/phoenix/Phoenix.VerifiedRoutes.html#path/2) does not work in the current version of Elixir. This commit replaces it with `sigil_p`, passing the query parameter as a keyword list.