### PR TITLE
Fix code example: `#` should not be escaped

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -94,7 +94,7 @@ defmodule Phoenix.LiveComponent do
 
         def render(assigns) do
           ~H"""
-          <div id={"user-\#{@id}"} class="user">
+          <div id={"user-#{@id}"} class="user">
             <%= @user.name %>
           </div>
           """


### PR DESCRIPTION
Fixes the code example so `@id` is rendered instead of being escaped.

