### PR TITLE
Improve docs of used_input?/1 (returns a boolean, not the errors)

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1538,7 +1538,7 @@ defmodule Phoenix.Component do
   end
 
   @doc """
-  Returns the errors for the form field if the field was used by the client.
+  Checks if the input field was used by the client.
 
   Used inputs are only those inputs that have been focused, interacted with, or
   submitted by the client. For LiveView, this is used to filter errors from the


### PR DESCRIPTION
Better description of what is returned by the `used_input?/1` function. It _doesn't_ return the errors as such, but rather indicates whether the input field is being used (which can then be used to control whether to show errors or not).