### PR TITLE
Remove focusMain from aria.js because it doesn't seem to be used

### DIFF
--- a/assets/js/phoenix_live_view/aria.js
+++ b/assets/js/phoenix_live_view/aria.js
@@ -1,14 +1,4 @@
 let ARIA = {
-  focusMain(){
-    let target = document.querySelector("main h1, main, h1")
-    if(target){
-      let origTabIndex = target.tabIndex
-      target.tabIndex = -1
-      target.focus()
-      target.tabIndex = origTabIndex
-    }
-  },
-
   anyOf(instance, classes){ return classes.find(name => instance instanceof name) },
 
   isFocusable(el, interactiveOnly){


### PR DESCRIPTION
I can't find it used anywhere in the project and no references online, so it doesn't seem to be used by applications, as far as I can tell