### PR TITLE
Add compile time warnings for attr arity mismatch

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -1248,6 +1248,9 @@ defmodule Phoenix.Component.Declarative do
   defp type_mismatch(type, {type, _value}), do: nil
   defp type_mismatch(:atom, {:boolean, _value}), do: nil
   defp type_mismatch({:struct, _}, {:map, {:%{}, _, [{:|, _, [_, _]}]}}), do: nil
+  defp type_mismatch(:fun, {:fun, _}), do: nil
+  defp type_mismatch({:fun, arity}, {:fun, arity}), do: nil
+  defp type_mismatch({:fun, _arity}, {:fun, arity}), do: type_with_article({:fun, arity})
   defp type_mismatch(_type, {_, value}), do: Macro.to_string(value)
 
   defp component_fa(%{component: {mod, fun}}) do
@@ -1257,6 +1260,8 @@ defmodule Phoenix.Component.Declarative do
   ## Shared helpers
 
   defp type_with_article({:struct, struct}), do: "a #{inspect(struct)} struct"
+  defp type_with_article(:fun), do: "a function"
+  defp type_with_article({:fun, arity}), do: "a function of arity #{arity}"
   defp type_with_article(type) when type in [:atom, :integer], do: "an #{inspect(type)}"
   defp type_with_article(type), do: "a #{inspect(type)}"
 

--- a/lib/phoenix_live_view/tag_engine.ex
+++ b/lib/phoenix_live_view/tag_engine.ex
@@ -1206,25 +1206,15 @@ defmodule Phoenix.LiveView.TagEngine do
   # this could be a &myfun(&1, &2)
   defp attr_type({:&, _, args}) do
     {_ast, arity} =
-      Macro.traverse(
-        args,
-        nil,
-        fn
-          {:&, _, [n]} = ast, acc ->
-            # we found a &1, &2, etc, keep the largest one
-            if n > acc || is_nil(acc) do
-              {ast, n}
-            else
-              {ast, acc}
-            end
+      Macro.prewalk(args, 0, fn
+        {:&, _, [n]} = ast, acc when is_integer(n) ->
+          {ast, max(n, acc)}
 
-          ast, acc ->
-            {ast, acc}
-        end,
-        fn ast, acc -> {ast, acc} end
-      )
+        ast, acc ->
+          {ast, acc}
+      end)
 
-    (is_number(arity) && {:fun, arity}) || :any
+    (arity > 0 && {:fun, arity}) || :any
   end
 
   defp attr_type(_value), do: :any

--- a/test/phoenix_component/verify_test.exs
+++ b/test/phoenix_component/verify_test.exs
@@ -466,6 +466,10 @@ defmodule Phoenix.ComponentVerifyTest do
           attr :arity_1, {:fun, 1}
           attr :arity_2, {:fun, 2}
 
+          slot :myslot do
+            attr :arity_1, {:fun, 1}
+          end
+
           def func(assigns), do: ~H[]
 
           def line, do: __ENV__.line + 4
@@ -496,6 +500,10 @@ defmodule Phoenix.ComponentVerifyTest do
             <.func arity_2={&Function.identity/1} />
             <.func arity_2={&Phoenix.LiveView.send_update(@myself, completed: &1)} />
             <.func arity_2="foo" />
+            <%!-- also works for slots --%>
+            <.func>
+              <:myslot arity_1={fn _, _ -> nil end} />
+            </.func>
             """
           end
         end
@@ -533,6 +541,13 @@ defmodule Phoenix.ComponentVerifyTest do
     assert warnings =~ "test/phoenix_component/verify_test.exs:#{line + 21}: (file)"
     assert warnings =~ "test/phoenix_component/verify_test.exs:#{line + 22}: (file)"
     assert warnings =~ "test/phoenix_component/verify_test.exs:#{line + 23}: (file)"
+
+    assert warnings =~ """
+           attribute "arity_1" in slot "myslot" for component Phoenix.ComponentVerifyTest.FunAttrs.func/1 \
+           must be a function of arity 1, got: a function of arity 2
+           """
+
+    assert warnings =~ "test/phoenix_component/verify_test.exs:#{line + 26}: (file)"
   end
 
   test "validates attr values" do


### PR DESCRIPTION
This commit introduces compile time warnings for component attributes that are defined using `{:fun, arity}`. In the cases that we can detect the arity at compile time, we will warn the user if the arity of the passed function does not match the arity declared for the attribute.

Relates to #3355.