### PR TITLE
Clarify the role of `phx-update`

### DIFF
--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -21,7 +21,7 @@ callback, for example:
 | [Focus Events](#focus-and-blur-events) | `phx-blur`, `phx-focus`, `phx-window-blur`, `phx-window-focus` |
 | [Key Events](#key-events) | `phx-keydown`, `phx-keyup`, `phx-window-keydown`, `phx-window-keyup`, `phx-key` |
 | [Scroll Events](#scroll-events-and-infinite-pagination) | `phx-viewport-top`, `phx-viewport-bottom` |
-| [DOM Patching](#dom-patching) | `phx-mounted`, `phx-update`, `phx-remove` |
+| [DOM Patching](#dom-patching) | `phx-update`, `phx-mounted`, `phx-remove` |
 | [JS Interop](js-interop.md#client-hooks-via-phx-hook) | `phx-hook` |
 | [Lifecycle Events](#lifecycle-events) | `phx-connected`, `phx-disconnected` |
 | [Rate Limiting](#rate-limiting-events-with-debounce-and-throttle) | `phx-debounce`, `phx-throttle` |
@@ -340,6 +340,10 @@ To react to elements being removed from the DOM, the `phx-remove` binding
 may be specified, which can contain a `Phoenix.LiveView.JS` command to execute.
 The `phx-remove` command is only executed for the removed parent element.
 It does not cascade to children.
+
+To react to elements being updated in the DOM, you'll need to use a
+[hook](js-interop.md#client-hooks-via-phx-hook), which gives you full access
+to the element life-cycle.
 
 ## Lifecycle events
 


### PR DESCRIPTION
Hi folks 💜 

I was confused about the role of `phx-update` earlier. Because of how it's presented in the documentation, I thought it was a counterpart to `phx-mounted` and `phx-remove` and didn't understand why I couldn't do e.g.

```html
<div id="my-div" phx-update={JS.transition(...)}>
```

To address this, I've changed the order of bindings listed under DOM Patching to mirror the explanation and avoid implying a life-cycle. I've also added a note at the bottom of the explanation to explicitly direct people to use `phx-hook` instead. Both of these would have helped me avoid confusion. 🙂 

Hope this helps!