### PR TITLE
Ignore test support files when calculating coverage

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,7 @@ defmodule Phoenix.LiveView.MixProject do
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),
       test_options: [docs: true],
-      test_coverage: [summary: [threshold: 85]],
+      test_coverage: [summary: [threshold: 85], ignore_modules: coverage_ignore_modules()],
       xref: [exclude: [Floki]],
       package: package(),
       deps: deps(),
@@ -197,6 +197,14 @@ defmodule Phoenix.LiveView.MixProject do
     [
       "assets.build": ["esbuild module", "esbuild cdn", "esbuild cdn_min", "esbuild main"],
       "assets.watch": ["esbuild module --watch"]
+    ]
+  end
+
+  defp coverage_ignore_modules do
+    [
+      ~r/Phoenix\.LiveViewTest\.Support\..*/,
+      ~r/Phoenix\.LiveViewTest\.E2E\..*/,
+      ~r/Inspect\..*/
     ]
   end
 end

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -110,13 +110,13 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
     scope "/", Phoenix.LiveViewTest do
       pipe_through(:browser)
 
-      live "/stream", StreamLive
-      live "/stream/reset", StreamResetLive
-      live "/stream/reset-lc", StreamResetLCLive
-      live "/stream/limit", StreamLimitLive
-      live "/stream/nested-component-reset", StreamNestedComponentResetLive
-      live "/stream/inside-for", StreamInsideForLive
-      live "/healthy/:category", HealthyLive
+      live "/stream", Support.StreamLive
+      live "/stream/reset", Support.StreamResetLive
+      live "/stream/reset-lc", Support.StreamResetLCLive
+      live "/stream/limit", Support.StreamLimitLive
+      live "/stream/nested-component-reset", Support.StreamNestedComponentResetLive
+      live "/stream/inside-for", Support.StreamInsideForLive
+      live "/healthy/:category", Support.HealthyLive
 
       live "/upload", E2E.UploadLive
       live "/form", E2E.FormLive

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -862,7 +862,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
 
   test "inserts attr & slot docs into function component @doc string" do
     {_, _, :elixir, "text/markdown", _, _, docs} =
-      Code.fetch_docs(Phoenix.LiveViewTest.FunctionComponentWithAttrs)
+      Code.fetch_docs(Phoenix.LiveViewTest.Support.FunctionComponentWithAttrs)
 
     components = %{
       fun_attr_any: """
@@ -934,7 +934,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       fun_attr_struct: """
       ## Attributes
 
-      * `attr` (`Phoenix.LiveViewTest.FunctionComponentWithAttrs.Struct`)
+      * `attr` (`Phoenix.LiveViewTest.Support.FunctionComponentWithAttrs.Struct`)
       """,
       fun_attr_required: """
       ## Attributes
@@ -1069,7 +1069,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
   end
 
   test "stores correct line number on AST" do
-    module = Phoenix.LiveViewTest.FunctionComponentWithAttrs
+    module = Phoenix.LiveViewTest.Support.FunctionComponentWithAttrs
 
     {^module, binary, _file} = :code.get_object_code(module)
 
@@ -1089,7 +1089,7 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
 
   test "does not override signature of Elixir functions" do
     {:docs_v1, _, :elixir, "text/markdown", _, _, docs} =
-      Code.fetch_docs(Phoenix.LiveViewTest.FunctionComponentWithAttrs)
+      Code.fetch_docs(Phoenix.LiveViewTest.Support.FunctionComponentWithAttrs)
 
     assert {{:function, :identity, 1}, _, ["identity(var)"], _, %{}} =
              List.keyfind(docs, {:function, :identity, 1}, 0)
@@ -1097,8 +1097,10 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     assert {{:function, :map_identity, 1}, _, ["map_identity(map)"], _, %{}} =
              List.keyfind(docs, {:function, :map_identity, 1}, 0)
 
-    assert Phoenix.LiveViewTest.FunctionComponentWithAttrs.identity(:not_a_map) == :not_a_map
-    assert Phoenix.LiveViewTest.FunctionComponentWithAttrs.identity(%{}) == %{}
+    assert Phoenix.LiveViewTest.Support.FunctionComponentWithAttrs.identity(:not_a_map) ==
+             :not_a_map
+
+    assert Phoenix.LiveViewTest.Support.FunctionComponentWithAttrs.identity(%{}) == %{}
   end
 
   test "raise if attr :doc is not a string" do

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -7,13 +7,13 @@ defmodule Phoenix.ComponentUnitTest do
   @socket Utils.configure_socket(
             %Socket{
               endpoint: Endpoint,
-              router: Phoenix.LiveViewTest.Router,
-              view: Phoenix.LiveViewTest.ParamCounterLive
+              router: Phoenix.LiveViewTest.Support.Router,
+              view: Phoenix.LiveViewTest.Support.ParamCounterLive
             },
             %{
               connect_params: %{},
               connect_info: %{},
-              root_view: Phoenix.LiveViewTest.ParamCounterLive,
+              root_view: Phoenix.LiveViewTest.Support.ParamCounterLive,
               __changed__: %{}
             },
             nil,

--- a/test/phoenix_live_view/controller_test.exs
+++ b/test/phoenix_live_view/controller_test.exs
@@ -2,7 +2,7 @@ defmodule Phoenix.LiveView.ControllerTest do
   use ExUnit.Case, async: true
   import Phoenix.ConnTest
 
-  alias Phoenix.LiveViewTest.Endpoint
+  alias Phoenix.LiveViewTest.Support.Endpoint
 
   @endpoint Endpoint
 

--- a/test/phoenix_live_view/hooks_test.exs
+++ b/test/phoenix_live_view/hooks_test.exs
@@ -4,7 +4,7 @@ defmodule Phoenix.LiveView.IntegrationHooksTest do
   alias Phoenix.LiveView
   alias Phoenix.LiveView.Lifecycle
 
-  defp build_socket(router \\ Phoenix.LiveViewTest.Router) do
+  defp build_socket(router \\ Phoenix.LiveViewTest.Support.Router) do
     %LiveView.Socket{
       private: %{lifecycle: %Lifecycle{}},
       router: router

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -378,8 +378,8 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
   end
 
   describe "debug annotations" do
-    alias Phoenix.LiveViewTest.DebugAnno
-    import Phoenix.LiveViewTest.DebugAnno
+    alias Phoenix.LiveViewTest.Support.DebugAnno
+    import Phoenix.LiveViewTest.Support.DebugAnno
 
     test "without root tag" do
       assigns = %{}
@@ -391,17 +391,17 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
       assigns = %{}
 
       assert compile("<DebugAnno.remote_with_root value='1'/>") ==
-               "<!-- <Phoenix.LiveViewTest.DebugAnno.remote_with_root> test/support/live_views/debug_anno.exs:11 () --><div>REMOTE COMPONENT: Value: 1</div><!-- </Phoenix.LiveViewTest.DebugAnno.remote_with_root> -->"
+               "<!-- <Phoenix.LiveViewTest.Support.DebugAnno.remote_with_root> test/support/live_views/debug_anno.exs:11 () --><div>REMOTE COMPONENT: Value: 1</div><!-- </Phoenix.LiveViewTest.Support.DebugAnno.remote_with_root> -->"
 
       assert compile("<.local_with_root value='1'/>") ==
-               "<!-- <Phoenix.LiveViewTest.DebugAnno.local_with_root> test/support/live_views/debug_anno.exs:19 () --><div>LOCAL COMPONENT: Value: 1</div><!-- </Phoenix.LiveViewTest.DebugAnno.local_with_root> -->"
+               "<!-- <Phoenix.LiveViewTest.Support.DebugAnno.local_with_root> test/support/live_views/debug_anno.exs:19 () --><div>LOCAL COMPONENT: Value: 1</div><!-- </Phoenix.LiveViewTest.Support.DebugAnno.local_with_root> -->"
     end
 
     test "nesting" do
       assigns = %{}
 
       assert compile("<DebugAnno.nested value='1'/>") ==
-               "<!-- <Phoenix.LiveViewTest.DebugAnno.nested> test/support/live_views/debug_anno.exs:23 () --><div>\n  <!-- @caller test/support/live_views/debug_anno.exs:25 () --><!-- <Phoenix.LiveViewTest.DebugAnno.local_with_root> test/support/live_views/debug_anno.exs:19 () --><div>LOCAL COMPONENT: Value: local</div><!-- </Phoenix.LiveViewTest.DebugAnno.local_with_root> -->\n</div><!-- </Phoenix.LiveViewTest.DebugAnno.nested> -->"
+               "<!-- <Phoenix.LiveViewTest.Support.DebugAnno.nested> test/support/live_views/debug_anno.exs:23 () --><div>\n  <!-- @caller test/support/live_views/debug_anno.exs:25 () --><!-- <Phoenix.LiveViewTest.Support.DebugAnno.local_with_root> test/support/live_views/debug_anno.exs:19 () --><div>LOCAL COMPONENT: Value: local</div><!-- </Phoenix.LiveViewTest.Support.DebugAnno.local_with_root> -->\n</div><!-- </Phoenix.LiveViewTest.Support.DebugAnno.nested> -->"
     end
   end
 

--- a/test/phoenix_live_view/integrations/assign_async_test.exs
+++ b/test/phoenix_live_view/integrations/assign_async_test.exs
@@ -3,7 +3,7 @@ defmodule Phoenix.LiveView.AssignAsyncTest do
   import Phoenix.ConnTest
 
   import Phoenix.LiveViewTest
-  alias Phoenix.LiveViewTest.Endpoint
+  alias Phoenix.LiveViewTest.Support.Endpoint
 
   @endpoint Endpoint
 
@@ -125,7 +125,7 @@ defmodule Phoenix.LiveView.AssignAsyncTest do
       {:ok, lv, _html} = live(conn, "/assign_async?test=lc_ok")
       assert render_async(lv) =~ "lc_data: 123"
 
-      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.AssignAsyncLive.LC,
+      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.Support.AssignAsyncLive.LC,
         id: "lc",
         action: :assign_async_reset,
         reset: false
@@ -141,7 +141,7 @@ defmodule Phoenix.LiveView.AssignAsyncTest do
       assert rendered =~ "lc_data: 123"
       assert rendered =~ "other_data: 555"
 
-      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.AssignAsyncLive.LC,
+      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.Support.AssignAsyncLive.LC,
         id: "lc",
         action: :assign_async_reset,
         reset: [:other_data]
@@ -159,7 +159,7 @@ defmodule Phoenix.LiveView.AssignAsyncTest do
       {:ok, lv, _html} = live(conn, "/assign_async?test=lc_ok")
       assert render_async(lv) =~ "lc_data: 123"
 
-      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.AssignAsyncLive.LC,
+      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.Support.AssignAsyncLive.LC,
         id: "lc",
         action: :assign_async_reset,
         reset: true
@@ -210,7 +210,7 @@ defmodule Phoenix.LiveView.AssignAsyncTest do
 
       async_ref = Process.monitor(Process.whereis(:lc_cancel))
 
-      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.AssignAsyncLive.LC,
+      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.Support.AssignAsyncLive.LC,
         id: "lc",
         action: :cancel
       )
@@ -219,7 +219,7 @@ defmodule Phoenix.LiveView.AssignAsyncTest do
 
       assert render(lv) =~ "exit: {:shutdown, :cancel}"
 
-      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.AssignAsyncLive.LC,
+      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.Support.AssignAsyncLive.LC,
         id: "lc",
         action: :renew_canceled
       )

--- a/test/phoenix_live_view/integrations/assigns_test.exs
+++ b/test/phoenix_live_view/integrations/assigns_test.exs
@@ -4,7 +4,7 @@ defmodule Phoenix.LiveView.AssignsTest do
   import Phoenix.ConnTest
 
   import Phoenix.LiveViewTest
-  alias Phoenix.LiveViewTest.Endpoint
+  alias Phoenix.LiveViewTest.Support.Endpoint
 
   @endpoint Endpoint
 
@@ -67,7 +67,7 @@ defmodule Phoenix.LiveView.AssignsTest do
 
     test "raises with invalid options", %{conn: conn} do
       assert_raise Plug.Conn.WrapperError,
-                   ~r/invalid option returned from Phoenix.LiveViewTest.OptsLive.mount\/3/,
+                   ~r/invalid option returned from Phoenix.LiveViewTest.Support.OptsLive.mount\/3/,
                    fn ->
                      conn
                      |> put_session(:opts, oops: [:description])

--- a/test/phoenix_live_view/integrations/collocated_test.exs
+++ b/test/phoenix_live_view/integrations/collocated_test.exs
@@ -3,7 +3,7 @@ defmodule Phoenix.LiveView.CollocatedTest do
   import Phoenix.ConnTest
 
   import Phoenix.LiveViewTest
-  alias Phoenix.LiveViewTest.{Endpoint, CollocatedLive, CollocatedComponent}
+  alias Phoenix.LiveViewTest.Support.{Endpoint, CollocatedLive, CollocatedComponent}
 
   @endpoint Endpoint
 

--- a/test/phoenix_live_view/integrations/connect_test.exs
+++ b/test/phoenix_live_view/integrations/connect_test.exs
@@ -3,7 +3,7 @@ defmodule Phoenix.LiveView.ConnectTest do
   import Phoenix.LiveViewTest
   import Phoenix.ConnTest
 
-  @endpoint Phoenix.LiveViewTest.Endpoint
+  @endpoint Phoenix.LiveViewTest.Support.Endpoint
 
   describe "connect_params" do
     test "can be read on mount" do

--- a/test/phoenix_live_view/integrations/elements_test.exs
+++ b/test/phoenix_live_view/integrations/elements_test.exs
@@ -3,7 +3,7 @@ defmodule Phoenix.LiveView.ElementsTest do
   import Phoenix.ConnTest
 
   import Phoenix.LiveViewTest
-  alias Phoenix.LiveViewTest.{Endpoint}
+  alias Phoenix.LiveViewTest.Support.Endpoint
 
   @endpoint Endpoint
 

--- a/test/phoenix_live_view/integrations/event_test.exs
+++ b/test/phoenix_live_view/integrations/event_test.exs
@@ -5,7 +5,7 @@ defmodule Phoenix.LiveView.EventTest do
   import Phoenix.LiveViewTest
 
   alias Phoenix.{Component, LiveView}
-  alias Phoenix.LiveViewTest.{Endpoint}
+  alias Phoenix.LiveViewTest.Support.Endpoint
 
   @endpoint Endpoint
 

--- a/test/phoenix_live_view/integrations/expensive_runtime_checks_test.exs
+++ b/test/phoenix_live_view/integrations/expensive_runtime_checks_test.exs
@@ -8,7 +8,7 @@ defmodule Phoenix.LiveViewTest.ExpensiveRuntimeChecksTest do
   import Phoenix.ConnTest
 
   import Phoenix.LiveViewTest
-  alias Phoenix.LiveViewTest.Endpoint
+  alias Phoenix.LiveViewTest.Support.Endpoint
 
   @endpoint Endpoint
 

--- a/test/phoenix_live_view/integrations/flash_test.exs
+++ b/test/phoenix_live_view/integrations/flash_test.exs
@@ -4,7 +4,7 @@ defmodule Phoenix.LiveView.FlashIntegrationTest do
 
   import Phoenix.LiveViewTest
   alias Phoenix.LiveView
-  alias Phoenix.LiveViewTest.{Endpoint, Router}
+  alias Phoenix.LiveViewTest.Support.{Endpoint, Router}
 
   @endpoint Endpoint
 
@@ -218,14 +218,14 @@ defmodule Phoenix.LiveView.FlashIntegrationTest do
       render_click(flash_child, "redirect", %{"to" => "/flash-root", "info" => "ok!"})
 
       assert_raise ArgumentError,
-                   "expected Phoenix.LiveViewTest.FlashChildLive to redirect to \"/wrong\", but got a redirect to \"/flash-root\"",
+                   "expected Phoenix.LiveViewTest.Support.FlashChildLive to redirect to \"/wrong\", but got a redirect to \"/flash-root\"",
                    fn -> assert_redirect(flash_child, "/wrong") end
 
       {:ok, flash_live, _} = live(conn, "/flash-root")
       render_click(flash_live, "push_patch", %{"to" => "/flash-root?foo", "info" => "ok!"})
 
       assert_raise ArgumentError,
-                   "expected Phoenix.LiveViewTest.FlashLive to redirect to \"/wrong\", but got a patch to \"/flash-root?foo\"",
+                   "expected Phoenix.LiveViewTest.Support.FlashLive to redirect to \"/wrong\", but got a patch to \"/flash-root?foo\"",
                    fn -> assert_redirect(flash_live, "/wrong") end
     end
 
@@ -234,14 +234,14 @@ defmodule Phoenix.LiveView.FlashIntegrationTest do
       render_click(flash_live, "push_patch", %{"to" => "/flash-root?foo", "info" => "ok!"})
 
       assert_raise ArgumentError,
-                   "expected Phoenix.LiveViewTest.FlashLive to patch to \"/wrong\", but got a patch to \"/flash-root?foo\"",
+                   "expected Phoenix.LiveViewTest.Support.FlashLive to patch to \"/wrong\", but got a patch to \"/flash-root?foo\"",
                    fn -> assert_patch(flash_live, "/wrong") end
 
       {:ok, flash_child, _} = live(conn, "/flash-child")
       render_click(flash_child, "redirect", %{"to" => "/flash-root", "info" => "ok!"})
 
       assert_raise ArgumentError,
-                   "expected Phoenix.LiveViewTest.FlashChildLive to patch to \"/wrong\", but got a redirect to \"/flash-root\"",
+                   "expected Phoenix.LiveViewTest.Support.FlashChildLive to patch to \"/wrong\", but got a redirect to \"/flash-root\"",
                    fn -> assert_patch(flash_child, "/wrong") end
     end
   end

--- a/test/phoenix_live_view/integrations/hooks_test.exs
+++ b/test/phoenix_live_view/integrations/hooks_test.exs
@@ -5,7 +5,7 @@ defmodule Phoenix.LiveView.HooksTest do
   import Phoenix.LiveViewTest
 
   alias Phoenix.Component
-  alias Phoenix.LiveViewTest.{Endpoint, HooksLive}
+  alias Phoenix.LiveViewTest.Support.{Endpoint, HooksLive}
 
   @endpoint Endpoint
 
@@ -15,7 +15,7 @@ defmodule Phoenix.LiveView.HooksTest do
 
   test "on_mount hook raises when hook result is invalid", %{conn: conn} do
     assert_raise Plug.Conn.WrapperError,
-                 ~r(invalid return from hook {Phoenix.LiveViewTest.HooksLive.BadMount, :default}),
+                 ~r(invalid return from hook {Phoenix.LiveViewTest.Support.HooksLive.BadMount, :default}),
                  fn ->
                    live(conn, "/lifecycle/bad-mount")
                  end
@@ -33,7 +33,7 @@ defmodule Phoenix.LiveView.HooksTest do
 
   test "on_mount hook raises when :halt is returned without a redirected socket", %{conn: conn} do
     assert_raise Plug.Conn.WrapperError,
-                 ~r(the hook {Phoenix.LiveViewTest.HooksLive.HaltMount, :hook} for lifecycle event :mount attempted to halt without redirecting.),
+                 ~r(the hook {Phoenix.LiveViewTest.Support.HooksLive.HaltMount, :hook} for lifecycle event :mount attempted to halt without redirecting.),
                  fn ->
                    live(conn, "/lifecycle/halt-mount")
                  end
@@ -41,7 +41,7 @@ defmodule Phoenix.LiveView.HooksTest do
 
   test "on_mount hook raises when :cont is returned with a redirected socket", %{conn: conn} do
     assert_raise Plug.Conn.WrapperError,
-                 ~r(the hook {Phoenix.LiveViewTest.HooksLive.RedirectMount, :default} for lifecycle event :mount attempted to redirect without halting.),
+                 ~r(the hook {Phoenix.LiveViewTest.Support.HooksLive.RedirectMount, :default} for lifecycle event :mount attempted to redirect without halting.),
                  fn ->
                    live(conn, "/lifecycle/redirect-cont-mount")
                  end
@@ -201,7 +201,7 @@ defmodule Phoenix.LiveView.HooksTest do
                :exit, _ -> :ok
              end
            end) =~
-             "** (UndefinedFunctionError) function Phoenix.LiveViewTest.HooksLive.handle_params/3 is undefined"
+             "** (UndefinedFunctionError) function Phoenix.LiveViewTest.Support.HooksLive.handle_params/3 is undefined"
   end
 
   test "handle_info/2 raises when hook result is invalid", %{conn: conn} do
@@ -314,7 +314,7 @@ defmodule Phoenix.LiveView.HooksTest do
                :exit, _ -> :ok
              end
            end) =~
-             "** (UndefinedFunctionError) function Phoenix.LiveViewTest.HooksEventComponent.handle_event/3 is undefined"
+             "** (UndefinedFunctionError) function Phoenix.LiveViewTest.Support.HooksEventComponent.handle_event/3 is undefined"
   end
 
   test "attach_hook raises when given a live component socket", %{conn: conn} do

--- a/test/phoenix_live_view/integrations/layout_test.exs
+++ b/test/phoenix_live_view/integrations/layout_test.exs
@@ -3,7 +3,7 @@ defmodule Phoenix.LiveView.LayoutTest do
   import Phoenix.ConnTest
 
   import Phoenix.LiveViewTest
-  alias Phoenix.LiveViewTest.{Endpoint, LayoutView}
+  alias Phoenix.LiveViewTest.Support.{Endpoint, LayoutView}
 
   @endpoint Endpoint
 

--- a/test/phoenix_live_view/integrations/live_components_test.exs
+++ b/test/phoenix_live_view/integrations/live_components_test.exs
@@ -3,7 +3,8 @@ defmodule Phoenix.LiveView.LiveComponentsTest do
   import Phoenix.ConnTest
 
   import Phoenix.LiveViewTest
-  alias Phoenix.LiveViewTest.{Endpoint, DOM, StatefulComponent}
+  alias Phoenix.LiveViewTest.DOM
+  alias Phoenix.LiveViewTest.Support.{Endpoint, StatefulComponent}
 
   @endpoint Endpoint
   @moduletag session: %{names: ["chris", "jose"], from: nil}
@@ -386,7 +387,7 @@ defmodule Phoenix.LiveView.LiveComponentsTest do
                render(view)
                refute_receive {:updated, _}
              end) =~
-               "send_update failed because component Phoenix.LiveViewTest.StatefulComponent with ID \"nemo\" does not exist or it has been removed"
+               "send_update failed because component Phoenix.LiveViewTest.Support.StatefulComponent with ID \"nemo\" does not exist or it has been removed"
 
       # with @myself
       assert ExUnit.CaptureLog.capture_log(fn ->
@@ -535,7 +536,7 @@ defmodule Phoenix.LiveView.LiveComponentsTest do
     end
 
     test "loads unloaded component" do
-      module = Phoenix.LiveViewTest.ComponentInLive.Component
+      module = Phoenix.LiveViewTest.Support.ComponentInLive.Component
       :code.purge(module)
       :code.delete(module)
       assert render_component(module, %{}) =~ "<div>Hello World</div>"

--- a/test/phoenix_live_view/integrations/live_reload_test.exs
+++ b/test/phoenix_live_view/integrations/live_reload_test.exs
@@ -7,7 +7,7 @@ defmodule Phoenix.LiveView.LiveReloadTest do
     socket "/live", Phoenix.LiveView.Socket
     socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
     plug Phoenix.CodeReloader
-    plug Phoenix.LiveViewTest.Router
+    plug Phoenix.LiveViewTest.Support.Router
   end
 
   import Phoenix.ConnTest

--- a/test/phoenix_live_view/integrations/live_view_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test.exs
@@ -6,7 +6,8 @@ defmodule Phoenix.LiveView.LiveViewTest do
 
   alias Phoenix.HTML
   alias Phoenix.LiveView
-  alias Phoenix.LiveViewTest.{Endpoint, DOM}
+  alias Phoenix.LiveViewTest.DOM
+  alias Phoenix.LiveViewTest.Support.Endpoint
 
   @endpoint Endpoint
 
@@ -344,7 +345,9 @@ defmodule Phoenix.LiveView.LiveViewTest do
   describe "live_isolated" do
     test "renders a live view with custom session", %{conn: conn} do
       {:ok, view, _} =
-        live_isolated(conn, Phoenix.LiveViewTest.DashboardLive, session: %{"hello" => "world"})
+        live_isolated(conn, Phoenix.LiveViewTest.Support.DashboardLive,
+          session: %{"hello" => "world"}
+        )
 
       assert render(view) =~ "session: %{&quot;hello&quot; =&gt; &quot;world&quot;}"
     end
@@ -353,7 +356,9 @@ defmodule Phoenix.LiveView.LiveViewTest do
       conn = %Plug.Conn{conn | request_path: "/router/thermo_defaults/123"}
 
       {:ok, view, _} =
-        live_isolated(conn, Phoenix.LiveViewTest.DashboardLive, session: %{"hello" => "world"})
+        live_isolated(conn, Phoenix.LiveViewTest.Support.DashboardLive,
+          session: %{"hello" => "world"}
+        )
 
       assert render(view) =~ "session: %{&quot;hello&quot; =&gt; &quot;world&quot;}"
     end
@@ -361,12 +366,12 @@ defmodule Phoenix.LiveView.LiveViewTest do
     test "raises if handle_params is implemented", %{conn: conn} do
       assert_raise ArgumentError,
                    ~r/it is not mounted nor accessed through the router live\/3 macro/,
-                   fn -> live_isolated(conn, Phoenix.LiveViewTest.ParamCounterLive) end
+                   fn -> live_isolated(conn, Phoenix.LiveViewTest.Support.ParamCounterLive) end
     end
 
     test "works without an initialized session" do
       {:ok, view, _} =
-        live_isolated(Phoenix.ConnTest.build_conn(), Phoenix.LiveViewTest.DashboardLive,
+        live_isolated(Phoenix.ConnTest.build_conn(), Phoenix.LiveViewTest.Support.DashboardLive,
           session: %{"hello" => "world"}
         )
 
@@ -375,7 +380,7 @@ defmodule Phoenix.LiveView.LiveViewTest do
 
     test "raises on session with atom keys" do
       assert_raise ArgumentError, ~r"LiveView :session must be a map with string keys,", fn ->
-        live_isolated(Phoenix.ConnTest.build_conn(), Phoenix.LiveViewTest.DashboardLive,
+        live_isolated(Phoenix.ConnTest.build_conn(), Phoenix.LiveViewTest.Support.DashboardLive,
           session: %{hello: "world"}
         )
       end
@@ -396,7 +401,7 @@ defmodule Phoenix.LiveView.LiveViewTest do
                   header: ~c"Status for generic server " ++ _,
                   data: _gen_server_data,
                   data: [
-                    {~c"LiveView", Phoenix.LiveViewTest.ClockLive},
+                    {~c"LiveView", Phoenix.LiveViewTest.Support.ClockLive},
                     {~c"Parent pid", nil},
                     {~c"Transport pid", _},
                     {~c"Topic", <<_::binary>>},
@@ -434,18 +439,26 @@ defmodule Phoenix.LiveView.LiveViewTest do
 
   describe "connected mount exceptions" do
     test "when disconnected, raises normally per plug wrapper", %{conn: conn} do
-      assert_raise(Plug.Conn.WrapperError, ~r/Phoenix.LiveViewTest.ThermostatLive.Error/, fn ->
-        get(conn, "/thermo?raise_disconnected=500")
-      end)
+      assert_raise(
+        Plug.Conn.WrapperError,
+        ~r/Phoenix.LiveViewTest.Support.ThermostatLive.Error/,
+        fn ->
+          get(conn, "/thermo?raise_disconnected=500")
+        end
+      )
 
-      assert_raise(Plug.Conn.WrapperError, ~r/Phoenix.LiveViewTest.ThermostatLive.Error/, fn ->
-        get(conn, "/thermo?raise_disconnected=404")
-      end)
+      assert_raise(
+        Plug.Conn.WrapperError,
+        ~r/Phoenix.LiveViewTest.Support.ThermostatLive.Error/,
+        fn ->
+          get(conn, "/thermo?raise_disconnected=404")
+        end
+      )
     end
 
     test "when connected, raises and exits for 5xx", %{conn: conn} do
       assert {{exception, _}, _} = catch_exit(live(conn, "/thermo?raise_connected=500"))
-      assert %Phoenix.LiveViewTest.ThermostatLive.Error{plug_status: 500} = exception
+      assert %Phoenix.LiveViewTest.Support.ThermostatLive.Error{plug_status: 500} = exception
     end
 
     test "when connected, raises and wraps 4xx in client response", %{conn: conn} do

--- a/test/phoenix_live_view/integrations/navigation_test.exs
+++ b/test/phoenix_live_view/integrations/navigation_test.exs
@@ -4,7 +4,8 @@ defmodule Phoenix.LiveView.NavigationTest do
   import Phoenix.ConnTest
   import Phoenix.LiveViewTest
 
-  alias Phoenix.LiveViewTest.{Endpoint, DOM}
+  alias Phoenix.LiveViewTest.DOM
+  alias Phoenix.LiveViewTest.Support.Endpoint
 
   @endpoint Endpoint
 

--- a/test/phoenix_live_view/integrations/nested_test.exs
+++ b/test/phoenix_live_view/integrations/nested_test.exs
@@ -6,7 +6,8 @@ defmodule Phoenix.LiveView.NestedTest do
   import Phoenix.LiveViewTest
 
   alias Phoenix.LiveView
-  alias Phoenix.LiveViewTest.{Endpoint, DOM, ClockLive, ClockControlsLive, LiveInComponent}
+  alias Phoenix.LiveViewTest.DOM
+  alias Phoenix.LiveViewTest.Support.{Endpoint, ClockLive, ClockControlsLive, LiveInComponent}
 
   @endpoint Endpoint
 

--- a/test/phoenix_live_view/integrations/params_test.exs
+++ b/test/phoenix_live_view/integrations/params_test.exs
@@ -9,7 +9,8 @@ defmodule Phoenix.LiveView.ParamsTest do
   import Phoenix.LiveView.TelemetryTestHelpers
 
   alias Phoenix.{Component, LiveView}
-  alias Phoenix.LiveViewTest.{Endpoint, DOM}
+  alias Phoenix.LiveViewTest.DOM
+  alias Phoenix.LiveViewTest.Support.Endpoint
 
   @endpoint Endpoint
 

--- a/test/phoenix_live_view/integrations/start_async_test.exs
+++ b/test/phoenix_live_view/integrations/start_async_test.exs
@@ -3,7 +3,7 @@ defmodule Phoenix.LiveView.StartAsyncTest do
   import Phoenix.ConnTest
 
   import Phoenix.LiveViewTest
-  alias Phoenix.LiveViewTest.Endpoint
+  alias Phoenix.LiveViewTest.Support.Endpoint
 
   @endpoint Endpoint
 
@@ -160,7 +160,7 @@ defmodule Phoenix.LiveView.StartAsyncTest do
 
       async_ref = Process.monitor(Process.whereis(:start_async_cancel))
 
-      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.StartAsyncLive.LC,
+      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.Support.StartAsyncLive.LC,
         id: "lc",
         action: :cancel
       )
@@ -169,7 +169,7 @@ defmodule Phoenix.LiveView.StartAsyncTest do
 
       assert render(lv) =~ "lc: {:exit, {:shutdown, :cancel}}"
 
-      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.StartAsyncLive.LC,
+      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.Support.StartAsyncLive.LC,
         id: "lc",
         action: :renew_canceled
       )

--- a/test/phoenix_live_view/integrations/stream_test.exs
+++ b/test/phoenix_live_view/integrations/stream_test.exs
@@ -4,7 +4,8 @@ defmodule Phoenix.LiveView.StreamTest do
   import Phoenix.ConnTest
   import Phoenix.LiveViewTest
 
-  alias Phoenix.LiveViewTest.{StreamLive, DOM, Endpoint}
+  alias Phoenix.LiveViewTest.DOM
+  alias Phoenix.LiveViewTest.Support.{StreamLive, Endpoint}
 
   @endpoint Endpoint
 
@@ -406,14 +407,14 @@ defmodule Phoenix.LiveView.StreamTest do
 
       assert lv |> render() |> users_in_dom("c_users") == [{"c_users-2", "updated"}]
 
-      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.StreamComponent,
+      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.Support.StreamComponent,
         id: "stream-component",
         reset: {:c_users, []}
       )
 
       assert lv |> render() |> users_in_dom("c_users") == []
 
-      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.StreamComponent,
+      Phoenix.LiveView.send_update(lv.pid, Phoenix.LiveViewTest.Support.StreamComponent,
         id: "stream-component",
         send_assigns_to: self()
       )
@@ -526,7 +527,7 @@ defmodule Phoenix.LiveView.StreamTest do
   test "stream raises when attempting to consume ahead of for", %{conn: conn} do
     {:ok, lv, _html} = live(conn, "/stream")
 
-    assert Phoenix.LiveViewTest.HooksLive.exits_with(lv, ArgumentError, fn ->
+    assert Phoenix.LiveViewTest.Support.HooksLive.exits_with(lv, ArgumentError, fn ->
              render_click(lv, "consume-stream-invalid", %{})
            end) =~ ~r/streams can only be consumed directly by a for comprehension/
   end
@@ -534,7 +535,7 @@ defmodule Phoenix.LiveView.StreamTest do
   test "stream raises when nodes without id are in container", %{conn: conn} do
     {:ok, lv, _html} = live(conn, "/stream")
 
-    assert Phoenix.LiveViewTest.HooksLive.exits_with(lv, ArgumentError, fn ->
+    assert Phoenix.LiveViewTest.Support.HooksLive.exits_with(lv, ArgumentError, fn ->
              render_click(lv, "stream-no-id", %{})
            end) =~
              ~r/setting phx-update to "stream" requires setting an ID on each child/

--- a/test/phoenix_live_view/integrations/telemetry_test.exs
+++ b/test/phoenix_live_view/integrations/telemetry_test.exs
@@ -9,7 +9,7 @@ defmodule Phoenix.LiveView.TelemetryTest do
   import Phoenix.LiveView.TelemetryTestHelpers
 
   alias Phoenix.LiveView.Socket
-  alias Phoenix.LiveViewTest.Endpoint
+  alias Phoenix.LiveViewTest.Support.Endpoint
 
   @endpoint Endpoint
   @moduletag session: %{names: ["chris", "jose"], from: nil}
@@ -44,10 +44,10 @@ defmodule Phoenix.LiveView.TelemetryTest do
           assert metadata.uri == "http://www.example.com/thermo?foo=bar"
         end)
 
-      refute log =~ "MOUNT Phoenix.LiveViewTest.ThermostatLive"
+      refute log =~ "MOUNT Phoenix.LiveViewTest.Support.ThermostatLive"
       refute log =~ "Replied in "
 
-      refute log =~ "HANDLE PARAMS in Phoenix.LiveViewTest.ThermostatLive"
+      refute log =~ "HANDLE PARAMS in Phoenix.LiveViewTest.Support.ThermostatLive"
       refute log =~ "Replied in "
     end
 
@@ -103,12 +103,12 @@ defmodule Phoenix.LiveView.TelemetryTest do
           assert metadata.uri == "http://www.example.com/thermo?foo=bar"
         end)
 
-      assert log =~ "MOUNT Phoenix.LiveViewTest.ThermostatLive"
+      assert log =~ "MOUNT Phoenix.LiveViewTest.Support.ThermostatLive"
       assert log =~ "  Parameters: %{\"foo\" => \"bar\"}"
       assert log =~ "  Session: %{\"current_user_id\" => \"1\"}"
       assert log =~ "Replied in"
 
-      assert log =~ "HANDLE PARAMS in Phoenix.LiveViewTest.ThermostatLive"
+      assert log =~ "HANDLE PARAMS in Phoenix.LiveViewTest.Support.ThermostatLive"
       assert log =~ "  Parameters: %{\"foo\" => \"bar\"}"
       assert log =~ "Replied in"
     end
@@ -163,7 +163,7 @@ defmodule Phoenix.LiveView.TelemetryTest do
           assert metadata.params == %{"temp" => "20"}
         end)
 
-      assert log =~ "HANDLE EVENT \"save\" in Phoenix.LiveViewTest.ThermostatLive"
+      assert log =~ "HANDLE EVENT \"save\" in Phoenix.LiveViewTest.Support.ThermostatLive"
       assert log =~ "  Parameters: %{\"temp\" => \"20\"}"
       assert log =~ "Replied in"
     end
@@ -231,7 +231,7 @@ defmodule Phoenix.LiveView.TelemetryTest do
 
           assert metadata.socket.transport_pid
           assert metadata.event == "transform"
-          assert metadata.component == Phoenix.LiveViewTest.StatefulComponent
+          assert metadata.component == Phoenix.LiveViewTest.Support.StatefulComponent
           assert metadata.params == %{"op" => "upcase"}
 
           assert_receive {:event, [:phoenix, :live_component, :handle_event, :stop],
@@ -239,12 +239,12 @@ defmodule Phoenix.LiveView.TelemetryTest do
 
           assert metadata.socket.transport_pid
           assert metadata.event == "transform"
-          assert metadata.component == Phoenix.LiveViewTest.StatefulComponent
+          assert metadata.component == Phoenix.LiveViewTest.Support.StatefulComponent
           assert metadata.params == %{"op" => "upcase"}
         end)
 
-      assert log =~ "HANDLE EVENT \"transform\" in Phoenix.LiveViewTest.WithComponentLive"
-      assert log =~ "  Component: Phoenix.LiveViewTest.StatefulComponent"
+      assert log =~ "HANDLE EVENT \"transform\" in Phoenix.LiveViewTest.Support.WithComponentLive"
+      assert log =~ "  Component: Phoenix.LiveViewTest.Support.StatefulComponent"
       assert log =~ "  Parameters: %{\"op\" => \"upcase\"}"
       assert log =~ "Replied in"
     end
@@ -262,7 +262,7 @@ defmodule Phoenix.LiveView.TelemetryTest do
 
       assert metadata.socket.transport_pid
       assert metadata.event == "transform"
-      assert metadata.component == Phoenix.LiveViewTest.StatefulComponent
+      assert metadata.component == Phoenix.LiveViewTest.Support.StatefulComponent
       assert metadata.params == %{"op" => "boom"}
 
       assert_receive {:event, [:phoenix, :live_component, :handle_event, :exception],
@@ -272,7 +272,7 @@ defmodule Phoenix.LiveView.TelemetryTest do
       assert metadata.reason == {:case_clause, "boom"}
       assert metadata.socket.transport_pid
       assert metadata.event == "transform"
-      assert metadata.component == Phoenix.LiveViewTest.StatefulComponent
+      assert metadata.component == Phoenix.LiveViewTest.Support.StatefulComponent
       assert metadata.params == %{"op" => "boom"}
     end
 
@@ -285,7 +285,7 @@ defmodule Phoenix.LiveView.TelemetryTest do
                       metadata}
 
       assert metadata.socket
-      assert metadata.component == Phoenix.LiveViewTest.StatefulComponent
+      assert metadata.component == Phoenix.LiveViewTest.Support.StatefulComponent
 
       assert [
                {
@@ -299,7 +299,7 @@ defmodule Phoenix.LiveView.TelemetryTest do
                       metadata}
 
       assert metadata.socket
-      assert metadata.component == Phoenix.LiveViewTest.StatefulComponent
+      assert metadata.component == Phoenix.LiveViewTest.Support.StatefulComponent
       assert [updated_component_socket, _] = metadata.sockets
 
       assert updated_component_socket != component_socket
@@ -320,7 +320,7 @@ defmodule Phoenix.LiveView.TelemetryTest do
           {:ok, _view, _html} = live(conn, "/log-override")
         end)
 
-      assert log =~ "MOUNT Phoenix.LiveViewTest.WithLogOverride"
+      assert log =~ "MOUNT Phoenix.LiveViewTest.Support.WithLogOverride"
       assert log =~ "Replied in "
     end
 
@@ -331,7 +331,7 @@ defmodule Phoenix.LiveView.TelemetryTest do
           {:ok, _view, _html} = live(conn, "/log-disabled")
         end)
 
-      refute log =~ "MOUNT Phoenix.LiveViewTest.WithLogDisabled"
+      refute log =~ "MOUNT Phoenix.LiveViewTest.Support.WithLogDisabled"
       refute log =~ "Replied in "
     end
   end

--- a/test/phoenix_live_view/integrations/update_test.exs
+++ b/test/phoenix_live_view/integrations/update_test.exs
@@ -3,7 +3,8 @@ defmodule Phoenix.LiveView.UpdateTest do
   import Phoenix.ConnTest
 
   import Phoenix.LiveViewTest
-  alias Phoenix.LiveViewTest.{Endpoint, DOM}
+  alias Phoenix.LiveViewTest.DOM
+  alias Phoenix.LiveViewTest.Support.Endpoint
 
   @endpoint Endpoint
 

--- a/test/phoenix_live_view/plug_test.exs
+++ b/test/phoenix_live_view/plug_test.exs
@@ -4,10 +4,10 @@ defmodule Phoenix.LiveView.PlugTest do
   import Phoenix.ConnTest
 
   alias Phoenix.LiveView.Plug, as: LiveViewPlug
-  alias Phoenix.LiveViewTest.{ThermostatLive, DashboardLive, Endpoint}
+  alias Phoenix.LiveViewTest.Support.{ThermostatLive, DashboardLive, Endpoint}
 
   defp call(conn, view, opts \\ []) do
-    opts = Keyword.merge([router: Phoenix.LiveViewTest.Router, layout: false], opts)
+    opts = Keyword.merge([router: Phoenix.LiveViewTest.Support.Router, layout: false], opts)
 
     conn
     |> Plug.Test.init_test_session(%{})
@@ -53,6 +53,6 @@ defmodule Phoenix.LiveView.PlugTest do
     conn = call(conn, DashboardLive, container: {:span, style: "phx-flex"})
 
     assert conn.resp_body =~
-             ~r/<span[^>]*class="Phoenix.LiveViewTest.DashboardLive"[^>]*style="phx-flex">/
+             ~r/<span[^>]*class="Phoenix.LiveViewTest.Support.DashboardLive"[^>]*style="phx-flex">/
   end
 end

--- a/test/phoenix_live_view/router_test.exs
+++ b/test/phoenix_live_view/router_test.exs
@@ -4,8 +4,9 @@ defmodule Phoenix.LiveView.RouterTest do
   import Phoenix.LiveViewTest
 
   alias Phoenix.LiveView.{Route, Session}
-  alias Phoenix.LiveViewTest.{Endpoint, DashboardLive, DOM}
-  alias Phoenix.LiveViewTest.Router.Helpers, as: Routes
+  alias Phoenix.LiveViewTest.DOM
+  alias Phoenix.LiveViewTest.Support.{Endpoint, DashboardLive}
+  alias Phoenix.LiveViewTest.Support.Router.Helpers, as: Routes
 
   @endpoint Endpoint
 
@@ -48,7 +49,7 @@ defmodule Phoenix.LiveView.RouterTest do
     conn = get(conn, "/router/thermo_container/123")
 
     assert conn.resp_body =~
-             ~r/<span[^>]*class="Phoenix.LiveViewTest.DashboardLive"[^>]*style="flex-grow">/
+             ~r/<span[^>]*class="Phoenix.LiveViewTest.Support.DashboardLive"[^>]*style="flex-grow">/
   end
 
   test "live non-action helpers", %{conn: conn} do
@@ -68,7 +69,7 @@ defmodule Phoenix.LiveView.RouterTest do
   end
 
   test "user-defined metadata is available inside of metadata key" do
-    assert Phoenix.LiveViewTest.Router
+    assert Phoenix.LiveViewTest.Support.Router
            |> Phoenix.Router.route_info("GET", "/thermo-with-metadata", nil)
            |> Map.get(:route_name) == "opts"
   end
@@ -78,7 +79,7 @@ defmodule Phoenix.LiveView.RouterTest do
       path = "/thermo-live-session"
 
       assert {:internal, route} =
-               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
+               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Support.Router, path)
 
       assert route.live_session.name == :test
       assert route.live_session.vsn
@@ -90,7 +91,7 @@ defmodule Phoenix.LiveView.RouterTest do
       path = "/thermo-live-session-admin"
 
       assert {:internal, route} =
-               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
+               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Support.Router, path)
 
       assert route.live_session.name == :admin
       assert route.live_session.vsn
@@ -103,7 +104,7 @@ defmodule Phoenix.LiveView.RouterTest do
       path = "/thermo-live-session-mfa"
 
       assert {:internal, route} =
-               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
+               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Support.Router, path)
 
       assert route.live_session.name == :mfa
       assert route.live_session.vsn
@@ -116,21 +117,25 @@ defmodule Phoenix.LiveView.RouterTest do
       path = "/lifecycle/halt-connected-mount"
 
       assert {:internal, route} =
-               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
+               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Support.Router, path)
 
       assert route.live_session.extra == %{
                on_mount: [
                  %{
-                   id: {Phoenix.LiveViewTest.HaltConnectedMount, :default},
+                   id: {Phoenix.LiveViewTest.Support.HaltConnectedMount, :default},
                    stage: :mount,
                    function:
-                     Function.capture(Phoenix.LiveViewTest.HaltConnectedMount, :on_mount, 4)
+                     Function.capture(
+                       Phoenix.LiveViewTest.Support.HaltConnectedMount,
+                       :on_mount,
+                       4
+                     )
                  }
                ]
              }
 
       assert conn |> get(path) |> html_response(200) =~
-               "last_on_mount:Phoenix.LiveViewTest.HaltConnectedMount"
+               "last_on_mount:Phoenix.LiveViewTest.Support.HaltConnectedMount"
 
       assert {:error, {:live_redirect, %{to: "/lifecycle"}}} = live(conn, path)
     end
@@ -139,14 +144,15 @@ defmodule Phoenix.LiveView.RouterTest do
       path = "/lifecycle/mount-mod-arg"
 
       assert {:internal, route} =
-               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
+               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Support.Router, path)
 
       assert route.live_session.extra == %{
                on_mount: [
                  %{
-                   id: {Phoenix.LiveViewTest.MountArgs, :inlined},
+                   id: {Phoenix.LiveViewTest.Support.MountArgs, :inlined},
                    stage: :mount,
-                   function: Function.capture(Phoenix.LiveViewTest.MountArgs, :on_mount, 4)
+                   function:
+                     Function.capture(Phoenix.LiveViewTest.Support.MountArgs, :on_mount, 4)
                  }
                ]
              }
@@ -159,19 +165,20 @@ defmodule Phoenix.LiveView.RouterTest do
       path = "/lifecycle/mount-mods"
 
       assert {:internal, route} =
-               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
+               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Support.Router, path)
 
       assert route.live_session.extra == %{
                on_mount: [
                  %{
-                   id: {Phoenix.LiveViewTest.OnMount, :default},
+                   id: {Phoenix.LiveViewTest.Support.OnMount, :default},
                    stage: :mount,
-                   function: Function.capture(Phoenix.LiveViewTest.OnMount, :on_mount, 4)
+                   function: Function.capture(Phoenix.LiveViewTest.Support.OnMount, :on_mount, 4)
                  },
                  %{
-                   id: {Phoenix.LiveViewTest.OtherOnMount, :default},
+                   id: {Phoenix.LiveViewTest.Support.OtherOnMount, :default},
                    stage: :mount,
-                   function: Function.capture(Phoenix.LiveViewTest.OtherOnMount, :on_mount, 4)
+                   function:
+                     Function.capture(Phoenix.LiveViewTest.Support.OtherOnMount, :on_mount, 4)
                  }
                ]
              }
@@ -183,19 +190,20 @@ defmodule Phoenix.LiveView.RouterTest do
       path = "/lifecycle/mount-mods-args"
 
       assert {:internal, route} =
-               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
+               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Support.Router, path)
 
       assert route.live_session.extra == %{
                on_mount: [
                  %{
-                   id: {Phoenix.LiveViewTest.OnMount, :other},
+                   id: {Phoenix.LiveViewTest.Support.OnMount, :other},
                    stage: :mount,
-                   function: Function.capture(Phoenix.LiveViewTest.OnMount, :on_mount, 4)
+                   function: Function.capture(Phoenix.LiveViewTest.Support.OnMount, :on_mount, 4)
                  },
                  %{
-                   id: {Phoenix.LiveViewTest.OtherOnMount, :other},
+                   id: {Phoenix.LiveViewTest.Support.OtherOnMount, :other},
                    stage: :mount,
-                   function: Function.capture(Phoenix.LiveViewTest.OtherOnMount, :on_mount, 4)
+                   function:
+                     Function.capture(Phoenix.LiveViewTest.Support.OtherOnMount, :on_mount, 4)
                  }
                ]
              }
@@ -245,10 +253,10 @@ defmodule Phoenix.LiveView.RouterTest do
       path = "/dashboard-live-session-layout"
 
       assert {:internal, route} =
-               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
+               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Support.Router, path)
 
       assert route.live_session.extra == %{
-               layout: {Phoenix.LiveViewTest.LayoutView, :live_override}
+               layout: {Phoenix.LiveViewTest.Support.LayoutView, :live_override}
              }
 
       {:ok, view, html} = live(conn, path)
@@ -264,10 +272,10 @@ defmodule Phoenix.LiveView.RouterTest do
       path = "/dashboard-live-session-layout"
 
       assert {:internal, route} =
-               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Router, path)
+               Route.live_link_info(@endpoint, Phoenix.LiveViewTest.Support.Router, path)
 
       assert route.live_session.extra == %{
-               layout: {Phoenix.LiveViewTest.LayoutView, :live_override}
+               layout: {Phoenix.LiveViewTest.Support.LayoutView, :live_override}
              }
 
       conn = get(conn, path)

--- a/test/phoenix_live_view/upload/channel_test.exs
+++ b/test/phoenix_live_view/upload/channel_test.exs
@@ -5,9 +5,10 @@ defmodule Phoenix.LiveView.UploadChannelTest do
   import Phoenix.LiveViewTest
 
   alias Phoenix.{Component, LiveView}
-  alias Phoenix.LiveViewTest.{UploadClient, UploadLive, UploadLiveWithComponent}
+  alias Phoenix.LiveViewTest.UploadClient
+  alias Phoenix.LiveViewTest.Support.{UploadLive, UploadLiveWithComponent}
 
-  @endpoint Phoenix.LiveViewTest.Endpoint
+  @endpoint Phoenix.LiveViewTest.Support.Endpoint
 
   defmodule TestWriter do
     @behaviour Phoenix.LiveView.UploadWriter
@@ -856,7 +857,7 @@ defmodule Phoenix.LiveView.UploadChannelTest do
              {:reply, :ok, new_socket}
            end
 
-           LiveView.send_update(Phoenix.LiveViewTest.UploadComponent,
+           LiveView.send_update(Phoenix.LiveViewTest.Support.UploadComponent,
              id: "upload1",
              run: {run, nil}
            )
@@ -951,7 +952,7 @@ defmodule Phoenix.LiveView.UploadChannelTest do
              {:reply, :ok, new_socket}
            end
 
-           LiveView.send_update(Phoenix.LiveViewTest.UploadComponent,
+           LiveView.send_update(Phoenix.LiveViewTest.Support.UploadComponent,
              id: "upload1",
              run: {run, nil}
            )

--- a/test/phoenix_live_view/upload/external_test.exs
+++ b/test/phoenix_live_view/upload/external_test.exs
@@ -1,12 +1,12 @@
 defmodule Phoenix.LiveView.UploadExternalTest do
   use ExUnit.Case, async: true
 
-  @endpoint Phoenix.LiveViewTest.Endpoint
+  @endpoint Phoenix.LiveViewTest.Support.Endpoint
 
   import Phoenix.LiveViewTest
 
   alias Phoenix.LiveView
-  alias Phoenix.LiveViewTest.UploadLive
+  alias Phoenix.LiveViewTest.Support.UploadLive
 
   def inspect_html_safe(term) do
     term

--- a/test/phoenix_live_view/utils_test.exs
+++ b/test/phoenix_live_view/utils_test.exs
@@ -2,7 +2,7 @@ defmodule Phoenix.LiveView.UtilsTest do
   use ExUnit.Case, async: true
 
   alias Phoenix.LiveView.Utils
-  alias Phoenix.LiveViewTest.Endpoint
+  alias Phoenix.LiveViewTest.Support.Endpoint
 
   test "sign" do
     assert is_binary(Utils.sign_flash(Endpoint, %{"info" => "hi"}))

--- a/test/phoenix_live_view_test.exs
+++ b/test/phoenix_live_view_test.exs
@@ -4,18 +4,18 @@ defmodule Phoenix.LiveViewUnitTest do
   import Phoenix.LiveView
 
   alias Phoenix.LiveView.{Utils, Socket}
-  alias Phoenix.LiveViewTest.Endpoint
+  alias Phoenix.LiveViewTest.Support.Endpoint
 
   @socket Utils.configure_socket(
             %Socket{
               endpoint: Endpoint,
-              router: Phoenix.LiveViewTest.Router,
-              view: Phoenix.LiveViewTest.ParamCounterLive
+              router: Phoenix.LiveViewTest.Support.Router,
+              view: Phoenix.LiveViewTest.Support.ParamCounterLive
             },
             %{
               connect_params: %{},
               connect_info: %{},
-              root_view: Phoenix.LiveViewTest.ParamCounterLive,
+              root_view: Phoenix.LiveViewTest.Support.ParamCounterLive,
               live_temp: %{}
             },
             nil,
@@ -282,7 +282,7 @@ defmodule Phoenix.LiveViewUnitTest do
         push_patch(@socket, to: "//foo.com")
       end
 
-      socket = %{@socket | view: Phoenix.LiveViewTest.ParamCounterLive}
+      socket = %{@socket | view: Phoenix.LiveViewTest.Support.ParamCounterLive}
 
       assert push_patch(socket, to: "/counter/123").redirected ==
                {:live, :patch, %{kind: :push, to: "/counter/123"}}

--- a/test/support/controller.ex
+++ b/test/support/controller.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.Controller do
+defmodule Phoenix.LiveViewTest.Support.Controller do
   use Phoenix.Controller
   import Phoenix.LiveView.Controller
 
@@ -6,34 +6,38 @@ defmodule Phoenix.LiveViewTest.Controller do
 
   def widget(conn, _) do
     conn
-    |> put_view(Phoenix.LiveViewTest.LayoutView)
+    |> put_view(Phoenix.LiveViewTest.Support.LayoutView)
     |> render("widget.html")
   end
 
   def incoming(conn, %{"type" => "live-render-2"}) do
-    live_render(conn, Phoenix.LiveViewTest.DashboardLive)
+    live_render(conn, Phoenix.LiveViewTest.Support.DashboardLive)
   end
 
   def incoming(conn, %{"type" => "live-render-3"}) do
-    live_render(conn, Phoenix.LiveViewTest.DashboardLive, session: %{"custom" => :session})
+    live_render(conn, Phoenix.LiveViewTest.Support.DashboardLive,
+      session: %{"custom" => :session}
+    )
   end
 
   def incoming(conn, %{"type" => "live-render-4"}) do
     conn
-    |> put_layout({Phoenix.LiveViewTest.AssignsLayoutView, :app})
-    |> live_render(Phoenix.LiveViewTest.DashboardLive)
+    |> put_layout({Phoenix.LiveViewTest.Support.AssignsLayoutView, :app})
+    |> live_render(Phoenix.LiveViewTest.Support.DashboardLive)
   end
 
   def incoming(conn, %{"type" => "render-with-function-component"}) do
     conn
-    |> put_view(Phoenix.LiveViewTest.LayoutView)
+    |> put_view(Phoenix.LiveViewTest.Support.LayoutView)
     |> render("with-function-component.html")
   end
 
   def incoming(conn, %{"type" => "render-layout-with-function-component"}) do
     conn
-    |> put_view(Phoenix.LiveViewTest.LayoutView)
-    |> put_root_layout({Phoenix.LiveViewTest.LayoutView, "layout-with-function-component.html"})
+    |> put_view(Phoenix.LiveViewTest.Support.LayoutView)
+    |> put_root_layout(
+      {Phoenix.LiveViewTest.Support.LayoutView, "layout-with-function-component.html"}
+    )
     |> render("hello.html")
   end
 

--- a/test/support/endpoint.ex
+++ b/test/support/endpoint.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.EndpointOverridable do
+defmodule Phoenix.LiveViewTest.Support.EndpointOverridable do
   defmacro __before_compile__(_env) do
     quote do
       @parsers Plug.Parsers.init(
@@ -13,16 +13,16 @@ defmodule Phoenix.LiveViewTest.EndpointOverridable do
         %{conn | secret_key_base: config(:secret_key_base)}
         |> Plug.Parsers.call(@parsers)
         |> Plug.Conn.put_private(:phoenix_endpoint, __MODULE__)
-        |> Phoenix.LiveViewTest.Router.call([])
+        |> Phoenix.LiveViewTest.Support.Router.call([])
       end
     end
   end
 end
 
-defmodule Phoenix.LiveViewTest.Endpoint do
+defmodule Phoenix.LiveViewTest.Support.Endpoint do
   use Phoenix.Endpoint, otp_app: :phoenix_live_view
 
-  @before_compile Phoenix.LiveViewTest.EndpointOverridable
+  @before_compile Phoenix.LiveViewTest.Support.EndpointOverridable
 
   socket "/live", Phoenix.LiveView.Socket
 

--- a/test/support/layout_view.ex
+++ b/test/support/layout_view.ex
@@ -1,10 +1,10 @@
-defmodule Phoenix.LiveViewTest.LayoutView do
+defmodule Phoenix.LiveViewTest.Support.LayoutView do
   use Phoenix.View, root: ""
   use Phoenix.Component
 
   use Phoenix.VerifiedRoutes,
-    router: Phoenix.LiveViewTest.Router,
-    endpoint: Phoenix.LiveViewTest.Endpoint,
+    router: Phoenix.LiveViewTest.Support.Router,
+    endpoint: Phoenix.LiveViewTest.Support.Endpoint,
     statics: ~w(css)
 
   def render("app.html", assigns) do
@@ -29,19 +29,19 @@ defmodule Phoenix.LiveViewTest.LayoutView do
 
   def render("widget.html", assigns) do
     ~H"""
-    WIDGET:<%= live_render(@conn, Phoenix.LiveViewTest.ClockLive) %>
+    WIDGET:<%= live_render(@conn, Phoenix.LiveViewTest.Support.ClockLive) %>
     """
   end
 
   def render("with-function-component.html", assigns) do
     ~H"""
-    RENDER:<Phoenix.LiveViewTest.FunctionComponent.render value="from component" />
+    RENDER:<Phoenix.LiveViewTest.Support.FunctionComponent.render value="from component" />
     """
   end
 
   def render("layout-with-function-component.html", assigns) do
     ~H"""
-    LAYOUT:<Phoenix.LiveViewTest.FunctionComponent.render value="from layout" />
+    LAYOUT:<Phoenix.LiveViewTest.Support.FunctionComponent.render value="from layout" />
     <%= @inner_content %>
     """
   end
@@ -84,7 +84,7 @@ defmodule Phoenix.LiveViewTest.LayoutView do
   end
 end
 
-defmodule Phoenix.LiveViewTest.AssignsLayoutView do
+defmodule Phoenix.LiveViewTest.Support.AssignsLayoutView do
   use Phoenix.View, root: ""
 
   def render("app.html", assigns) do

--- a/test/support/live_views/cids_destroyed.ex
+++ b/test/support/live_views/cids_destroyed.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.CidsDestroyedLive do
+defmodule Phoenix.LiveViewTest.Support.CidsDestroyedLive do
   use Phoenix.LiveView
 
   defmodule Button do

--- a/test/support/live_views/collocated.ex
+++ b/test/support/live_views/collocated.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.CollocatedLive do
+defmodule Phoenix.LiveViewTest.Support.CollocatedLive do
   use Phoenix.LiveView
 
   def mount(_params, _session, socket) do
@@ -6,6 +6,6 @@ defmodule Phoenix.LiveViewTest.CollocatedLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.CollocatedComponent do
+defmodule Phoenix.LiveViewTest.Support.CollocatedComponent do
   use Phoenix.LiveComponent
 end

--- a/test/support/live_views/component_and_nested_in_live.ex
+++ b/test/support/live_views/component_and_nested_in_live.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.ComponentAndNestedInLive do
+defmodule Phoenix.LiveViewTest.Support.ComponentAndNestedInLive do
   use Phoenix.LiveView
 
   defmodule NestedLive do

--- a/test/support/live_views/component_in_live.ex
+++ b/test/support/live_views/component_in_live.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.ComponentInLive.Root do
+defmodule Phoenix.LiveViewTest.Support.ComponentInLive.Root do
   use Phoenix.LiveView
 
   def mount(_params, _session, socket) do
@@ -6,7 +6,8 @@ defmodule Phoenix.LiveViewTest.ComponentInLive.Root do
   end
 
   def render(assigns) do
-    ~H"<%= @enabled && live_render(@socket, Phoenix.LiveViewTest.ComponentInLive.Live, id: :nested_live) %>"
+    ~H"<%= @enabled &&
+  live_render(@socket, Phoenix.LiveViewTest.Support.ComponentInLive.Live, id: :nested_live) %>"
   end
 
   def handle_info(:disable, socket) do
@@ -14,7 +15,7 @@ defmodule Phoenix.LiveViewTest.ComponentInLive.Root do
   end
 end
 
-defmodule Phoenix.LiveViewTest.ComponentInLive.Live do
+defmodule Phoenix.LiveViewTest.Support.ComponentInLive.Live do
   use Phoenix.LiveView
 
   def mount(_params, _session, socket) do
@@ -22,7 +23,10 @@ defmodule Phoenix.LiveViewTest.ComponentInLive.Live do
   end
 
   def render(assigns) do
-    ~H"<.live_component module={Phoenix.LiveViewTest.ComponentInLive.Component} id={:nested_component} />"
+    ~H"<.live_component
+  module={Phoenix.LiveViewTest.Support.ComponentInLive.Component}
+  id={:nested_component}
+/>"
   end
 
   def handle_event("disable", _params, socket) do
@@ -31,7 +35,7 @@ defmodule Phoenix.LiveViewTest.ComponentInLive.Live do
   end
 end
 
-defmodule Phoenix.LiveViewTest.ComponentInLive.Component do
+defmodule Phoenix.LiveViewTest.Support.ComponentInLive.Component do
   use Phoenix.LiveComponent
 
   # Make sure mount is calling by setting assigns in them.

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.FunctionComponent do
+defmodule Phoenix.LiveViewTest.Support.FunctionComponent do
   use Phoenix.Component
 
   def render(assigns) do
@@ -14,7 +14,7 @@ defmodule Phoenix.LiveViewTest.FunctionComponent do
   end
 end
 
-defmodule Phoenix.LiveViewTest.FunctionComponentWithAttrs do
+defmodule Phoenix.LiveViewTest.Support.FunctionComponentWithAttrs do
   use Phoenix.Component
 
   defmodule Struct do
@@ -183,7 +183,7 @@ defmodule Phoenix.LiveViewTest.FunctionComponentWithAttrs do
   def fun_attr_values_examples(assigns), do: ~H[]
 end
 
-defmodule Phoenix.LiveViewTest.StatefulComponent do
+defmodule Phoenix.LiveViewTest.Support.StatefulComponent do
   use Phoenix.LiveComponent
 
   def mount(socket) do
@@ -245,7 +245,7 @@ defmodule Phoenix.LiveViewTest.StatefulComponent do
   end
 end
 
-defmodule Phoenix.LiveViewTest.WithComponentLive do
+defmodule Phoenix.LiveViewTest.Support.WithComponentLive do
   use Phoenix.LiveView
 
   def render(%{disabled: :all} = assigns) do
@@ -259,7 +259,7 @@ defmodule Phoenix.LiveViewTest.WithComponentLive do
     Redirect: <%= @redirect %>
     <%= for name <- @names do %>
       <.live_component
-        module={Phoenix.LiveViewTest.StatefulComponent}
+        module={Phoenix.LiveViewTest.Support.StatefulComponent}
         id={name}
         name={name}
         from={@from}
@@ -298,7 +298,7 @@ defmodule Phoenix.LiveViewTest.WithComponentLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.WithMultipleTargets do
+defmodule Phoenix.LiveViewTest.Support.WithMultipleTargets do
   use Phoenix.LiveView
 
   def mount(_params, %{"names" => names, "from" => from} = session, socket) do
@@ -320,7 +320,7 @@ defmodule Phoenix.LiveViewTest.WithMultipleTargets do
       <%= @message %>
       <%= for name <- @names do %>
         <.live_component
-          module={Phoenix.LiveViewTest.StatefulComponent}
+          module={Phoenix.LiveViewTest.Support.StatefulComponent}
           id={name}
           name={name}
           from={@from}
@@ -341,7 +341,7 @@ defmodule Phoenix.LiveViewTest.WithMultipleTargets do
   end
 end
 
-defmodule Phoenix.LiveViewTest.WithLogOverride do
+defmodule Phoenix.LiveViewTest.Support.WithLogOverride do
   use Phoenix.LiveView, log: :warning
 
   def mount(_params, _session, socket) do
@@ -351,7 +351,7 @@ defmodule Phoenix.LiveViewTest.WithLogOverride do
   def render(assigns), do: ~H[]
 end
 
-defmodule Phoenix.LiveViewTest.WithLogDisabled do
+defmodule Phoenix.LiveViewTest.Support.WithLogDisabled do
   use Phoenix.LiveView, log: false
 
   def mount(_params, _session, socket) do

--- a/test/support/live_views/connect.ex
+++ b/test/support/live_views/connect.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.ConnectLive do
+defmodule Phoenix.LiveViewTest.Support.ConnectLive do
   use Phoenix.LiveView
 
   def render(assigns) do

--- a/test/support/live_views/debug_anno.exs
+++ b/test/support/live_views/debug_anno.exs
@@ -1,6 +1,6 @@
 # Note this file is intentionally a .exs file because it is loaded
 # in the test helper with debug_heex_annotations turned on.
-defmodule Phoenix.LiveViewTest.DebugAnno do
+defmodule Phoenix.LiveViewTest.Support.DebugAnno do
   use Phoenix.Component
 
   def remote(assigns) do

--- a/test/support/live_views/elements.ex
+++ b/test/support/live_views/elements.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.ElementsLive do
+defmodule Phoenix.LiveViewTest.Support.ElementsLive do
   use Phoenix.LiveView
 
   alias Phoenix.LiveView.JS
@@ -10,7 +10,7 @@ defmodule Phoenix.LiveViewTest.ElementsLive do
     <div id="scoped-render"><span>This</span> is a div</div>
     <div>This</div>
     <div id="child-component">
-      <.live_component module={Phoenix.LiveViewTest.ElementsComponent} id={1} />
+      <.live_component module={Phoenix.LiveViewTest.Support.ElementsComponent} id={1} />
     </div>
 
     <% # basic render_* %>
@@ -284,7 +284,7 @@ defmodule Phoenix.LiveViewTest.ElementsLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.ElementsComponent do
+defmodule Phoenix.LiveViewTest.Support.ElementsComponent do
   use Phoenix.LiveComponent
 
   alias Phoenix.LiveView.JS

--- a/test/support/live_views/events.ex
+++ b/test/support/live_views/events.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.EventsLive do
+defmodule Phoenix.LiveViewTest.Support.EventsLive do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
 
   def render(assigns) do
@@ -24,7 +24,7 @@ defmodule Phoenix.LiveViewTest.EventsLive do
   def handle_info({:run, func}, socket), do: func.(socket)
 end
 
-defmodule Phoenix.LiveViewTest.EventsMultiJSLive do
+defmodule Phoenix.LiveViewTest.Support.EventsMultiJSLive do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
   alias Phoenix.LiveView.JS
 
@@ -71,7 +71,7 @@ defmodule Phoenix.LiveViewTest.EventsMultiJSLive do
   def handle_info({:run, func}, socket), do: func.(socket)
 end
 
-defmodule Phoenix.LiveViewTest.EventsInComponentMultiJSLive do
+defmodule Phoenix.LiveViewTest.Support.EventsInComponentMultiJSLive do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
   alias Phoenix.LiveView.JS
 
@@ -132,7 +132,7 @@ defmodule Phoenix.LiveViewTest.EventsInComponentMultiJSLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.EventsInMountLive do
+defmodule Phoenix.LiveViewTest.Support.EventsInMountLive do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
 
   defmodule Child do
@@ -166,7 +166,7 @@ defmodule Phoenix.LiveViewTest.EventsInMountLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.EventsInComponentLive do
+defmodule Phoenix.LiveViewTest.Support.EventsInComponentLive do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
 
   defmodule Child do

--- a/test/support/live_views/expensive_runtime_checks.ex
+++ b/test/support/live_views/expensive_runtime_checks.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.ExpensiveRuntimeChecksLive do
+defmodule Phoenix.LiveViewTest.Support.ExpensiveRuntimeChecksLive do
   use Phoenix.LiveView
 
   @impl Phoenix.LiveView

--- a/test/support/live_views/flash.ex
+++ b/test/support/live_views/flash.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.FlashLive do
+defmodule Phoenix.LiveViewTest.Support.FlashLive do
   use Phoenix.LiveView
 
   def render(assigns) do
@@ -6,8 +6,8 @@ defmodule Phoenix.LiveViewTest.FlashLive do
     uri[<%= @uri %>]
     root[<%= Phoenix.Flash.get(@flash, :info) %>]:info
     root[<%= Phoenix.Flash.get(@flash, :error) %>]:error
-    <.live_component module={Phoenix.LiveViewTest.FlashComponent} id="flash-component" />
-    child[<%= live_render(@socket, Phoenix.LiveViewTest.FlashChildLive, id: "flash-child") %>]
+    <.live_component module={Phoenix.LiveViewTest.Support.FlashComponent} id="flash-component" />
+    child[<%= live_render(@socket, Phoenix.LiveViewTest.Support.FlashChildLive, id: "flash-child") %>]
     """
   end
 
@@ -42,7 +42,7 @@ defmodule Phoenix.LiveViewTest.FlashLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.FlashComponent do
+defmodule Phoenix.LiveViewTest.Support.FlashComponent do
   use Phoenix.LiveComponent
 
   def render(assigns) do
@@ -80,7 +80,7 @@ defmodule Phoenix.LiveViewTest.FlashComponent do
   end
 end
 
-defmodule Phoenix.LiveViewTest.FlashChildLive do
+defmodule Phoenix.LiveViewTest.Support.FlashChildLive do
   use Phoenix.LiveView
 
   def render(assigns) do

--- a/test/support/live_views/general.ex
+++ b/test/support/live_views/general.ex
@@ -1,6 +1,6 @@
-alias Phoenix.LiveViewTest.{ClockLive, ClockControlsLive}
+alias Phoenix.LiveViewTest.Support.{ClockLive, ClockControlsLive}
 
-defmodule Phoenix.LiveViewTest.ThermostatLive do
+defmodule Phoenix.LiveViewTest.Support.ThermostatLive do
   use Phoenix.LiveView, container: {:article, class: "thermo"}, namespace: Phoenix.LiveViewTest
 
   defmodule Error do
@@ -86,7 +86,7 @@ defmodule Phoenix.LiveViewTest.ThermostatLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.ClockLive do
+defmodule Phoenix.LiveViewTest.Support.ClockLive do
   use Phoenix.LiveView, container: {:section, class: "clock"}
 
   def render(assigns) do
@@ -121,7 +121,7 @@ defmodule Phoenix.LiveViewTest.ClockLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.ClockControlsLive do
+defmodule Phoenix.LiveViewTest.Support.ClockControlsLive do
   use Phoenix.LiveView
 
   def render(assigns), do: ~H|<button phx-click="snooze">+</button>|
@@ -134,7 +134,7 @@ defmodule Phoenix.LiveViewTest.ClockControlsLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.DashboardLive do
+defmodule Phoenix.LiveViewTest.Support.DashboardLive do
   use Phoenix.LiveView, container: {:div, class: inspect(__MODULE__)}
 
   def render(assigns) do
@@ -148,7 +148,7 @@ defmodule Phoenix.LiveViewTest.DashboardLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.SameChildLive do
+defmodule Phoenix.LiveViewTest.Support.SameChildLive do
   use Phoenix.LiveView
 
   def render(%{dup: true} = assigns) do
@@ -176,9 +176,9 @@ defmodule Phoenix.LiveViewTest.SameChildLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.RootLive do
+defmodule Phoenix.LiveViewTest.Support.RootLive do
   use Phoenix.LiveView
-  alias Phoenix.LiveViewTest.ChildLive
+  alias Phoenix.LiveViewTest.Support.ChildLive
 
   def render(assigns) do
     ~H"""
@@ -204,7 +204,7 @@ defmodule Phoenix.LiveViewTest.RootLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.ChildLive do
+defmodule Phoenix.LiveViewTest.Support.ChildLive do
   use Phoenix.LiveView
 
   def render(assigns) do
@@ -224,7 +224,7 @@ defmodule Phoenix.LiveViewTest.ChildLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.OptsLive do
+defmodule Phoenix.LiveViewTest.Support.OptsLive do
   use Phoenix.LiveView
 
   def render(assigns), do: ~H|<%= @description %>. <%= @canary %>|
@@ -238,7 +238,7 @@ defmodule Phoenix.LiveViewTest.OptsLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.RedirLive do
+defmodule Phoenix.LiveViewTest.Support.RedirLive do
   use Phoenix.LiveView
 
   def render(assigns) do
@@ -299,7 +299,7 @@ defmodule Phoenix.LiveViewTest.RedirLive do
   defp do_redirect(socket, "push_patch", opts), do: push_patch(socket, opts)
 end
 
-defmodule Phoenix.LiveViewTest.AssignsNotInSocketLive do
+defmodule Phoenix.LiveViewTest.Support.AssignsNotInSocketLive do
   use Phoenix.LiveView
 
   def render(assigns), do: ~H|<%= boom(@socket) %>|
@@ -307,7 +307,7 @@ defmodule Phoenix.LiveViewTest.AssignsNotInSocketLive do
   defp boom(socket), do: socket.assigns.boom
 end
 
-defmodule Phoenix.LiveViewTest.ErrorsLive do
+defmodule Phoenix.LiveViewTest.Support.ErrorsLive do
   use Phoenix.LiveView
 
   alias Phoenix.LiveView.Socket
@@ -334,13 +334,13 @@ defmodule Phoenix.LiveViewTest.ErrorsLive do
   def handle_event("crash", _params, _socket), do: raise("boom handle_event")
 end
 
-defmodule Phoenix.LiveViewTest.ClassListLive do
+defmodule Phoenix.LiveViewTest.Support.ClassListLive do
   use Phoenix.LiveView, container: {:span, class: ~w(foo bar)}
 
   def render(assigns), do: ~H|Some content|
 end
 
-defmodule Phoenix.LiveViewTest.AssignAsyncLive do
+defmodule Phoenix.LiveViewTest.Support.AssignAsyncLive do
   use Phoenix.LiveView
 
   on_mount({__MODULE__, :defaults})
@@ -351,7 +351,12 @@ defmodule Phoenix.LiveViewTest.AssignAsyncLive do
 
   def render(assigns) do
     ~H"""
-    <.live_component :if={@lc} module={Phoenix.LiveViewTest.AssignAsyncLive.LC} test={@lc} id="lc" />
+    <.live_component
+      :if={@lc}
+      module={Phoenix.LiveViewTest.Support.AssignAsyncLive.LC}
+      test={@lc}
+      id="lc"
+    />
 
     <div :if={@data.loading}>data loading...</div>
     <div :if={@data.ok? && @data.result == nil}>no data found</div>
@@ -460,7 +465,7 @@ defmodule Phoenix.LiveViewTest.AssignAsyncLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.AssignAsyncLive.LC do
+defmodule Phoenix.LiveViewTest.Support.AssignAsyncLive.LC do
   use Phoenix.LiveComponent
 
   def render(assigns) do
@@ -544,7 +549,7 @@ defmodule Phoenix.LiveViewTest.AssignAsyncLive.LC do
   end
 end
 
-defmodule Phoenix.LiveViewTest.StartAsyncLive do
+defmodule Phoenix.LiveViewTest.Support.StartAsyncLive do
   use Phoenix.LiveView
 
   on_mount({__MODULE__, :defaults})
@@ -555,8 +560,12 @@ defmodule Phoenix.LiveViewTest.StartAsyncLive do
 
   def render(assigns) do
     ~H"""
-    <.live_component :if={@lc} module={Phoenix.LiveViewTest.StartAsyncLive.LC} test={@lc} id="lc" />
-    result: <%= inspect(@result) %>
+    <.live_component
+      :if={@lc}
+      module={Phoenix.LiveViewTest.Support.StartAsyncLive.LC}
+      test={@lc}
+      id="lc"
+    /> result: <%= inspect(@result) %>
     <%= if flash = @flash["info"] do %>
       flash: <%= flash %>
     <% end %>
@@ -730,7 +739,7 @@ defmodule Phoenix.LiveViewTest.StartAsyncLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.StartAsyncLive.LC do
+defmodule Phoenix.LiveViewTest.Support.StartAsyncLive.LC do
   use Phoenix.LiveComponent
 
   def render(assigns) do

--- a/test/support/live_views/host.ex
+++ b/test/support/live_views/host.ex
@@ -1,6 +1,6 @@
-defmodule Phoenix.LiveViewTest.HostLive do
+defmodule Phoenix.LiveViewTest.Support.HostLive do
   use Phoenix.LiveView
-  alias Phoenix.LiveViewTest.Router.Helpers, as: Routes
+  alias Phoenix.LiveViewTest.Support.Router.Helpers, as: Routes
 
   def handle_params(_params, uri, socket) do
     {:noreply, assign(socket, :uri, uri)}

--- a/test/support/live_views/layout.ex
+++ b/test/support/live_views/layout.ex
@@ -1,9 +1,9 @@
-defmodule Phoenix.LiveViewTest.ParentLayoutLive do
+defmodule Phoenix.LiveViewTest.Support.ParentLayoutLive do
   use Phoenix.LiveView
 
   def render(assigns) do
     ~H"""
-    <%= live_render(@socket, Phoenix.LiveViewTest.LayoutLive, session: @session, id: "layout") %>
+    <%= live_render(@socket, Phoenix.LiveViewTest.Support.LayoutLive, session: @session, id: "layout") %>
     """
   end
 
@@ -12,8 +12,8 @@ defmodule Phoenix.LiveViewTest.ParentLayoutLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.LayoutLive do
-  use Phoenix.LiveView, layout: {Phoenix.LiveViewTest.LayoutView, :live}
+defmodule Phoenix.LiveViewTest.Support.LayoutLive do
+  use Phoenix.LiveView, layout: {Phoenix.LiveViewTest.Support.LayoutView, :live}
 
   def render(assigns), do: ~H|The value is: <%= @val %>|
 

--- a/test/support/live_views/lifecycle.ex
+++ b/test/support/live_views/lifecycle.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.InitAssigns do
+defmodule Phoenix.LiveViewTest.Support.InitAssigns do
   alias Phoenix.Component
 
   def on_mount(:default, _params, _session, socket) do
@@ -16,7 +16,7 @@ defmodule Phoenix.LiveViewTest.InitAssigns do
   end
 end
 
-defmodule Phoenix.LiveViewTest.MountArgs do
+defmodule Phoenix.LiveViewTest.Support.MountArgs do
   import Phoenix.LiveView
 
   def on_mount(:inlined, _params, _session, socket) do
@@ -25,7 +25,7 @@ defmodule Phoenix.LiveViewTest.MountArgs do
   end
 end
 
-defmodule Phoenix.LiveViewTest.OnMount do
+defmodule Phoenix.LiveViewTest.Support.OnMount do
   def on_mount(:default, _params, _session, socket) do
     {:cont, socket}
   end
@@ -35,7 +35,7 @@ defmodule Phoenix.LiveViewTest.OnMount do
   end
 end
 
-defmodule Phoenix.LiveViewTest.OtherOnMount do
+defmodule Phoenix.LiveViewTest.Support.OtherOnMount do
   def on_mount(:default, _params, _session, socket) do
     {:cont, socket}
   end
@@ -45,9 +45,9 @@ defmodule Phoenix.LiveViewTest.OtherOnMount do
   end
 end
 
-defmodule Phoenix.LiveViewTest.HooksLive do
+defmodule Phoenix.LiveViewTest.Support.HooksLive do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
-  alias Phoenix.LiveViewTest.InitAssigns
+  alias Phoenix.LiveViewTest.Support.InitAssigns
 
   on_mount InitAssigns
   on_mount {InitAssigns, :other}
@@ -143,7 +143,7 @@ defmodule Phoenix.LiveViewTest.HooksLive do
   def proxy_pid(%{proxy: {_ref, _topic, pid}}), do: pid
 end
 
-defmodule Phoenix.LiveViewTest.HooksLive.BadMount do
+defmodule Phoenix.LiveViewTest.Support.HooksLive.BadMount do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
 
   on_mount __MODULE__
@@ -157,7 +157,7 @@ defmodule Phoenix.LiveViewTest.HooksLive.BadMount do
   def render(assigns), do: ~H"<div></div>"
 end
 
-defmodule Phoenix.LiveViewTest.HooksLive.HaltMount do
+defmodule Phoenix.LiveViewTest.Support.HooksLive.HaltMount do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
 
   on_mount {__MODULE__, :hook}
@@ -166,7 +166,7 @@ defmodule Phoenix.LiveViewTest.HooksLive.HaltMount do
   def render(assigns), do: ~H"<div></div>"
 end
 
-defmodule Phoenix.LiveViewTest.HooksLive.RedirectMount do
+defmodule Phoenix.LiveViewTest.Support.HooksLive.RedirectMount do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
 
   def mount(_, _, socket) do
@@ -185,7 +185,7 @@ defmodule Phoenix.LiveViewTest.HooksLive.RedirectMount do
   def render(assigns), do: ~H"<div></div>"
 end
 
-defmodule Phoenix.LiveViewTest.HooksLive.Noop do
+defmodule Phoenix.LiveViewTest.Support.HooksLive.Noop do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
 
   def render(assigns) do
@@ -196,7 +196,7 @@ defmodule Phoenix.LiveViewTest.HooksLive.Noop do
   end
 end
 
-defmodule Phoenix.LiveViewTest.HaltConnectedMount do
+defmodule Phoenix.LiveViewTest.Support.HaltConnectedMount do
   alias Phoenix.{Component, LiveView}
 
   def on_mount(_arg, _params, _session, socket) do
@@ -208,7 +208,7 @@ defmodule Phoenix.LiveViewTest.HaltConnectedMount do
   end
 end
 
-defmodule Phoenix.LiveViewTest.HooksAttachInfoComponent do
+defmodule Phoenix.LiveViewTest.Support.HooksAttachInfoComponent do
   use Phoenix.LiveComponent
   alias Phoenix.LiveView
 
@@ -223,7 +223,7 @@ defmodule Phoenix.LiveViewTest.HooksAttachInfoComponent do
   def render(assigns), do: ~H"<div></div>"
 end
 
-defmodule Phoenix.LiveViewTest.HooksDetachInfoComponent do
+defmodule Phoenix.LiveViewTest.Support.HooksDetachInfoComponent do
   use Phoenix.LiveComponent
   alias Phoenix.LiveView
 
@@ -234,7 +234,7 @@ defmodule Phoenix.LiveViewTest.HooksDetachInfoComponent do
   def render(assigns), do: ~H"<div></div>"
 end
 
-defmodule Phoenix.LiveViewTest.HooksEventComponent do
+defmodule Phoenix.LiveViewTest.Support.HooksEventComponent do
   use Phoenix.LiveComponent
   alias Phoenix.LiveView
 
@@ -258,10 +258,10 @@ defmodule Phoenix.LiveViewTest.HooksEventComponent do
   end
 end
 
-defmodule Phoenix.LiveViewTest.HooksLive.WithComponent do
+defmodule Phoenix.LiveViewTest.Support.HooksLive.WithComponent do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
-  alias Phoenix.LiveViewTest.{HooksAttachInfoComponent, HooksDetachInfoComponent}
-  alias Phoenix.LiveViewTest.HooksEventComponent
+  alias Phoenix.LiveViewTest.Support.{HooksAttachInfoComponent, HooksDetachInfoComponent}
+  alias Phoenix.LiveViewTest.Support.HooksEventComponent
 
   def mount(params, _session, socket) do
     type = String.to_existing_atom(params["type"])
@@ -297,7 +297,7 @@ defmodule Phoenix.LiveViewTest.HooksLive.WithComponent do
   end
 end
 
-defmodule Phoenix.LiveViewTest.HooksLive.HandleParamsNotDefined do
+defmodule Phoenix.LiveViewTest.Support.HooksLive.HandleParamsNotDefined do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
 
   def mount(_, _, socket) do
@@ -310,7 +310,7 @@ defmodule Phoenix.LiveViewTest.HooksLive.HandleParamsNotDefined do
   def render(assigns), do: ~H"url=<%= assigns[:url] %>"
 end
 
-defmodule Phoenix.LiveViewTest.HooksLive.HandleInfoNotDefined do
+defmodule Phoenix.LiveViewTest.Support.HooksLive.HandleInfoNotDefined do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
 
   def mount(_, _, socket) do
@@ -326,7 +326,7 @@ defmodule Phoenix.LiveViewTest.HooksLive.HandleInfoNotDefined do
   def render(assigns), do: ~H"data=<%= assigns[:data] %>"
 end
 
-defmodule Phoenix.LiveViewTest.HooksLive.OnMountOptions do
+defmodule Phoenix.LiveViewTest.Support.HooksLive.OnMountOptions do
   use Phoenix.LiveView, namespace: Phoenix.LiveViewTest
 
   on_mount {__MODULE__, :temporary_assigns}
@@ -337,7 +337,7 @@ defmodule Phoenix.LiveViewTest.HooksLive.OnMountOptions do
   end
 
   def on_mount(:layout, _params, _session, socket) do
-    {:cont, socket, layout: {Phoenix.LiveViewTest.LayoutView, :on_mount_layout}}
+    {:cont, socket, layout: {Phoenix.LiveViewTest.Support.LayoutView, :on_mount_layout}}
   end
 
   def render(assigns), do: ~H"data-<%= @data %>"

--- a/test/support/live_views/live_in_component.ex
+++ b/test/support/live_views/live_in_component.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.LiveInComponent.Root do
+defmodule Phoenix.LiveViewTest.Support.LiveInComponent.Root do
   use Phoenix.LiveView
 
   def mount(_params, _session, socket) do
@@ -6,23 +6,26 @@ defmodule Phoenix.LiveViewTest.LiveInComponent.Root do
   end
 
   def render(assigns) do
-    ~H"<.live_component module={Phoenix.LiveViewTest.LiveInComponent.Component} id={:nested_component} />"
+    ~H"<.live_component
+  module={Phoenix.LiveViewTest.Support.LiveInComponent.Component}
+  id={:nested_component}
+/>"
   end
 end
 
-defmodule Phoenix.LiveViewTest.LiveInComponent.Component do
+defmodule Phoenix.LiveViewTest.Support.LiveInComponent.Component do
   use Phoenix.LiveComponent
 
   def render(assigns) do
     ~H"""
     <div>
-      <%= live_render(@socket, Phoenix.LiveViewTest.LiveInComponent.Live, id: :nested_live) %>"
+      <%= live_render(@socket, Phoenix.LiveViewTest.Support.LiveInComponent.Live, id: :nested_live) %>"
     </div>
     """
   end
 end
 
-defmodule Phoenix.LiveViewTest.LiveInComponent.Live do
+defmodule Phoenix.LiveViewTest.Support.LiveInComponent.Live do
   use Phoenix.LiveView
 
   def mount(_params, _session, socket) do

--- a/test/support/live_views/params.ex
+++ b/test/support/live_views/params.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.ParamCounterLive do
+defmodule Phoenix.LiveViewTest.Support.ParamCounterLive do
   use Phoenix.LiveView
 
   def render(assigns) do
@@ -68,7 +68,7 @@ defmodule Phoenix.LiveViewTest.ParamCounterLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.ActionLive do
+defmodule Phoenix.LiveViewTest.Support.ActionLive do
   use Phoenix.LiveView
 
   def render(assigns) do
@@ -92,7 +92,7 @@ defmodule Phoenix.LiveViewTest.ActionLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.ErrorInHandleParamsLive do
+defmodule Phoenix.LiveViewTest.Support.ErrorInHandleParamsLive do
   use Phoenix.LiveView
 
   def render(assigns), do: ~H|<div>I crash in handle_params</div>|

--- a/test/support/live_views/reload_live.ex
+++ b/test/support/live_views/reload_live.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.ReloadLive do
+defmodule Phoenix.LiveViewTest.Support.ReloadLive do
   use Phoenix.LiveView
 
   def mount(_params, _session, socket) do

--- a/test/support/live_views/render_with.ex
+++ b/test/support/live_views/render_with.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.RenderWithLive do
+defmodule Phoenix.LiveViewTest.Support.RenderWithLive do
   use Phoenix.LiveView
 
   def mount(_params, _session, socket) do

--- a/test/support/live_views/streams.ex
+++ b/test/support/live_views/streams.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.StreamLive do
+defmodule Phoenix.LiveViewTest.Support.StreamLive do
   use Phoenix.LiveView
 
   def run(lv, func) do
@@ -71,7 +71,7 @@ defmodule Phoenix.LiveViewTest.StreamLive do
         <button phx-click="admin-move-to-last" phx-value-id={id}>make last</button>
       </div>
     </div>
-    <.live_component id="stream-component" module={Phoenix.LiveViewTest.StreamComponent} />
+    <.live_component id="stream-component" module={Phoenix.LiveViewTest.Support.StreamComponent} />
 
     <button phx-click="reset-users">Reset users</button>
     <button phx-click="reset-users-reorder">Reorder users</button>
@@ -195,7 +195,7 @@ defmodule Phoenix.LiveViewTest.StreamLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.StreamComponent do
+defmodule Phoenix.LiveViewTest.Support.StreamComponent do
   use Phoenix.LiveComponent
 
   def run(lv, func) do
@@ -263,7 +263,7 @@ defmodule Phoenix.LiveViewTest.StreamComponent do
   end
 end
 
-defmodule Phoenix.LiveViewTest.HealthyLive do
+defmodule Phoenix.LiveViewTest.Support.HealthyLive do
   use Phoenix.LiveView
 
   @healthy_stuff %{
@@ -319,7 +319,7 @@ defmodule Phoenix.LiveViewTest.HealthyLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.StreamResetLive do
+defmodule Phoenix.LiveViewTest.Support.StreamResetLive do
   use Phoenix.LiveView
 
   # see https://github.com/phoenixframework/phoenix_live_view/issues/2994
@@ -492,7 +492,7 @@ defmodule Phoenix.LiveViewTest.StreamResetLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.StreamResetLCLive do
+defmodule Phoenix.LiveViewTest.Support.StreamResetLCLive do
   use Phoenix.LiveView
 
   # see https://github.com/phoenixframework/phoenix_live_view/issues/2982
@@ -553,7 +553,7 @@ defmodule Phoenix.LiveViewTest.StreamResetLCLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.StreamLimitLive do
+defmodule Phoenix.LiveViewTest.Support.StreamLimitLive do
   use Phoenix.LiveView
 
   # see https://github.com/phoenixframework/phoenix_live_view/issues/2686
@@ -640,7 +640,7 @@ defmodule Phoenix.LiveViewTest.StreamLimitLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.StreamNestedLive do
+defmodule Phoenix.LiveViewTest.Support.StreamNestedLive do
   use Phoenix.LiveView
 
   def mount(_params, _session, socket) do
@@ -657,13 +657,13 @@ defmodule Phoenix.LiveViewTest.StreamNestedLive do
     ~H"""
     <div id="nested-container">
       <%= @foo %>
-      <%= live_render(@socket, Phoenix.LiveViewTest.StreamResetLive, id: "nested") %>
+      <%= live_render(@socket, Phoenix.LiveViewTest.Support.StreamResetLive, id: "nested") %>
     </div>
     """
   end
 end
 
-defmodule Phoenix.LiveViewTest.StreamInsideForLive do
+defmodule Phoenix.LiveViewTest.Support.StreamInsideForLive do
   # https://github.com/phoenixframework/phoenix_live_view/issues/3129
   use Phoenix.LiveView
 
@@ -699,7 +699,7 @@ defmodule Phoenix.LiveViewTest.StreamInsideForLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.StreamNestedComponentResetLive do
+defmodule Phoenix.LiveViewTest.Support.StreamNestedComponentResetLive do
   use Phoenix.LiveView
 
   defmodule InnerComponent do
@@ -801,7 +801,7 @@ defmodule Phoenix.LiveViewTest.StreamNestedComponentResetLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.HighFrequencyStreamAndNoStreamUpdatesLive do
+defmodule Phoenix.LiveViewTest.Support.HighFrequencyStreamAndNoStreamUpdatesLive do
   use Phoenix.LiveView
 
   def mount(_params, _session, socket) do

--- a/test/support/live_views/update.ex
+++ b/test/support/live_views/update.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.TZLive do
+defmodule Phoenix.LiveViewTest.Support.TZLive do
   use Phoenix.LiveView
 
   def render(assigns) do
@@ -12,14 +12,14 @@ defmodule Phoenix.LiveViewTest.TZLive do
   end
 end
 
-defmodule Phoenix.LiveViewTest.ShuffleLive do
+defmodule Phoenix.LiveViewTest.Support.ShuffleLive do
   use Phoenix.LiveView
 
   def render(assigns) do
     ~H"""
     <%= for zone <- @time_zones do %>
       <div id={"score-" <> zone["id"]}>
-        <%= live_render(@socket, Phoenix.LiveViewTest.TZLive,
+        <%= live_render(@socket, Phoenix.LiveViewTest.Support.TZLive,
           id: "tz-#{zone["id"]}",
           session: %{"name" => zone["name"]}
         ) %>

--- a/test/support/live_views/upload_live.ex
+++ b/test/support/live_views/upload_live.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.UploadLive do
+defmodule Phoenix.LiveViewTest.Support.UploadLive do
   use Phoenix.LiveView
 
   def render(%{uploads: _} = assigns) do
@@ -77,7 +77,7 @@ defmodule Phoenix.LiveViewTest.UploadLive do
   def proxy_pid(%{proxy: {_ref, _topic, pid}}), do: pid
 end
 
-defmodule Phoenix.LiveViewTest.UploadComponent do
+defmodule Phoenix.LiveViewTest.Support.UploadComponent do
   use Phoenix.LiveComponent
 
   def render(%{uploads: _} = assigns) do
@@ -142,7 +142,7 @@ defmodule Phoenix.LiveViewTest.UploadComponent do
   end
 end
 
-defmodule Phoenix.LiveViewTest.UploadLiveWithComponent do
+defmodule Phoenix.LiveViewTest.Support.UploadLiveWithComponent do
   use Phoenix.LiveView
 
   def render(assigns) do
@@ -150,7 +150,7 @@ defmodule Phoenix.LiveViewTest.UploadLiveWithComponent do
     <div>
       <%= if @uploads_count > 0 do %>
         <%= for i <- 0..@uploads_count do %>
-          <.live_component module={Phoenix.LiveViewTest.UploadComponent} id={"upload#{i}"} />
+          <.live_component module={Phoenix.LiveViewTest.Support.UploadComponent} id={"upload#{i}"} />
         <% end %>
       <% end %>
     </div>
@@ -170,7 +170,7 @@ defmodule Phoenix.LiveViewTest.UploadLiveWithComponent do
   end
 
   def handle_call({:run, func}, from, socket) do
-    send_update(Phoenix.LiveViewTest.UploadComponent, id: "upload0", run: {func, from})
+    send_update(Phoenix.LiveViewTest.Support.UploadComponent, id: "upload0", run: {func, from})
     {:noreply, socket}
   end
 end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveViewTest.Router do
+defmodule Phoenix.LiveViewTest.Support.Router do
   use Phoenix.Router
   import Phoenix.LiveView.Router
 
@@ -21,7 +21,7 @@ defmodule Phoenix.LiveViewTest.Router do
     plug :put_root_layout, {UnknownView, :unknown_template}
   end
 
-  scope "/", Phoenix.LiveViewTest do
+  scope "/", Phoenix.LiveViewTest.Support do
     pipe_through [:browser]
 
     live "/thermo", ThermostatLive
@@ -67,15 +67,15 @@ defmodule Phoenix.LiveViewTest.Router do
     live "/router/foobarbaz/nested/index", FooBarLive.Nested.Index, :index
     live "/router/foobarbaz/nested/show", FooBarLive.Nested.Index, :show
     live "/router/foobarbaz/custom", FooBarLive, :index, as: :custom_foo_bar
-    live "/router/foobarbaz/with_live", Phoenix.LiveViewTest.Live.Nested.Module, :action
+    live "/router/foobarbaz/with_live", Phoenix.LiveViewTest.Support.Live.Nested.Module, :action
     live "/router/foobarbaz/nosuffix", NoSuffix, :index, as: :custom_route
 
     # integration layout
-    live_session :styled_layout, root_layout: {Phoenix.LiveViewTest.LayoutView, :styled} do
+    live_session :styled_layout, root_layout: {Phoenix.LiveViewTest.Support.LayoutView, :styled} do
       live "/styled-elements", ElementsLive
     end
 
-    live_session :app_layout, root_layout: {Phoenix.LiveViewTest.LayoutView, :app} do
+    live_session :app_layout, root_layout: {Phoenix.LiveViewTest.Support.LayoutView, :app} do
       live "/layout", LayoutLive
     end
 
@@ -170,33 +170,33 @@ defmodule Phoenix.LiveViewTest.Router do
       live "/thermo-live-session-merged", ThermostatLive
     end
 
-    live_session :lifecycle, on_mount: Phoenix.LiveViewTest.HaltConnectedMount do
+    live_session :lifecycle, on_mount: Phoenix.LiveViewTest.Support.HaltConnectedMount do
       live "/lifecycle/halt-connected-mount", HooksLive.Noop
     end
 
-    live_session :mount_mod_arg, on_mount: {Phoenix.LiveViewTest.MountArgs, :inlined} do
+    live_session :mount_mod_arg, on_mount: {Phoenix.LiveViewTest.Support.MountArgs, :inlined} do
       live "/lifecycle/mount-mod-arg", HooksLive.Noop
     end
 
     live_session :mount_mods,
-      on_mount: [Phoenix.LiveViewTest.OnMount, Phoenix.LiveViewTest.OtherOnMount] do
+      on_mount: [Phoenix.LiveViewTest.Support.OnMount, Phoenix.LiveViewTest.Support.OtherOnMount] do
       live "/lifecycle/mount-mods", HooksLive.Noop
     end
 
     live_session :mount_mod_args,
       on_mount: [
-        {Phoenix.LiveViewTest.OnMount, :other},
-        {Phoenix.LiveViewTest.OtherOnMount, :other}
+        {Phoenix.LiveViewTest.Support.OnMount, :other},
+        {Phoenix.LiveViewTest.Support.OtherOnMount, :other}
       ] do
       live "/lifecycle/mount-mods-args", HooksLive.Noop
     end
 
-    live_session :layout, layout: {Phoenix.LiveViewTest.LayoutView, :live_override} do
+    live_session :layout, layout: {Phoenix.LiveViewTest.Support.LayoutView, :live_override} do
       live "/dashboard-live-session-layout", LayoutLive
     end
   end
 
-  scope "/", as: :user_defined_metadata, alias: Phoenix.LiveViewTest do
+  scope "/", as: :user_defined_metadata, alias: Phoenix.LiveViewTest.Support do
     live "/sessionless-thermo", ThermostatLive
     live "/thermo-with-metadata", ThermostatLive, metadata: %{route_name: "opts"}
   end

--- a/test/support/templates/heex/dead_with_function_component.html.heex
+++ b/test/support/templates/heex/dead_with_function_component.html.heex
@@ -1,3 +1,3 @@
 pre: <%= @pre %>
-<Phoenix.LiveViewTest.FunctionComponent.render value="the value"/>
+<Phoenix.LiveViewTest.Support.FunctionComponent.render value="the value"/>
 post: <%= @post %>

--- a/test/support/templates/heex/dead_with_function_component_with_inner_content.html.heex
+++ b/test/support/templates/heex/dead_with_function_component_with_inner_content.html.heex
@@ -1,5 +1,5 @@
 pre: <%= @pre %>
-<Phoenix.LiveViewTest.FunctionComponent.render_with_inner_content value="the value">
+<Phoenix.LiveViewTest.Support.FunctionComponent.render_with_inner_content value="the value">
   The inner content
-</Phoenix.LiveViewTest.FunctionComponent.render_with_inner_content>
+</Phoenix.LiveViewTest.Support.FunctionComponent.render_with_inner_content>
 post: <%= @post %>

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,5 +5,5 @@ Application.put_env(:phoenix_live_view, :debug_heex_annotations, true)
 Code.require_file("test/support/live_views/debug_anno.exs")
 Application.put_env(:phoenix_live_view, :debug_heex_annotations, false)
 
-{:ok, _} = Phoenix.LiveViewTest.Endpoint.start_link()
+{:ok, _} = Phoenix.LiveViewTest.Support.Endpoint.start_link()
 ExUnit.start(exclude: after_verify_exclude)


### PR DESCRIPTION
To properly separate the support files from the actual Phoenix.LiveViewTest modules, this commit moves the support modules to Phoenix.LiveViewTest.Support.*