### PR TITLE
Downcase form method in <.form>

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2362,8 +2362,13 @@ defmodule Phoenix.Component do
   end
 
   defp form_method(nil), do: {"post", nil}
-  defp form_method(method) when method in ~w(get post), do: {method, nil}
-  defp form_method(method) when is_binary(method), do: {"post", method}
+
+  defp form_method(method) when is_binary(method) do
+    case String.downcase(method) do
+      method when method in ~w(get post) -> {method, nil}
+      _ -> {"post", method}
+    end
+  end
 
   @doc """
   Renders nested form inputs for associations or embeds.

--- a/test/phoenix_component/components_test.exs
+++ b/test/phoenix_component/components_test.exs
@@ -445,6 +445,39 @@ defmodule Phoenix.LiveView.ComponentsTest do
                </form>
                """
     end
+
+    test "method is case insensitive when using get or post with action" do
+      assigns = %{}
+
+      template = ~H"""
+      <.form for={%{}} method="GET" action="/"></.form>
+      """
+
+      assert t2h(template) ==
+               ~x{<form method="get" action="/"></form>}
+
+      template = ~H"""
+      <.form for={%{}} method="PoST" action="/"></.form>
+      """
+
+      csrf = Plug.CSRFProtection.get_csrf_token_for("/")
+
+      assert t2h(template) ==
+               ~x{<form method="post" action="/"><input name="_csrf_token" type="hidden" hidden="hidden" value="#{csrf}"></form>}
+
+      # for anything != get or post we use post and set the hidden _method field
+      template = ~H"""
+      <.form for={%{}} method="PuT" action="/"></.form>
+      """
+
+      assert t2h(template) ==
+               ~x"""
+               <form action="/" method="post">
+                 <input name="_method" type="hidden" hidden="hidden" value="PuT">
+                 <input name="_csrf_token" type="hidden" hidden="hidden" value="#{csrf}">
+               </form>
+               """
+    end
   end
 
   describe "inputs_for" do


### PR DESCRIPTION
The HTML form method attribute is case insensitive, so if we get a get / post we always use the downcased version.

Fixes #3422.