### PR TITLE
Document `start_async` ignores previous with same `name`

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -2035,6 +2035,9 @@ defmodule Phoenix.LiveView do
   The result of the task is sent to the `c:handle_async/3` callback
   of the caller LiveView or LiveComponent.
 
+  If there is an in-flight task with the same `name`, the later `start_async` wins and the previous task’s result is ignored.
+  You are not restricted to just atoms for `name`, it can be any term such as a tuple.
+
   The task is only started when the socket is connected.
 
   ## Options

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -2036,6 +2036,7 @@ defmodule Phoenix.LiveView do
   of the caller LiveView or LiveComponent.
 
   If there is an in-flight task with the same `name`, the later `start_async` wins and the previous task’s result is ignored.
+  If you wish to replace an existing task, you can use `cancel_async/3` before `start_async/3`.
   You are not restricted to just atoms for `name`, it can be any term such as a tuple.
 
   The task is only started when the socket is connected.


### PR DESCRIPTION
While fixing a bug in the day job I realised that:

- `start_async` manages concurrent tasks for you. If you reuse a `name` for `start_async`, then the last one wins and the previous one(s)’ results are ignored. It doesn’t terminate them it just safely ignores the results.
- The `name` is not restricted to being an atom, it can be any term AFAIK, say a tuple.

This PR documents these things. I’m sure it can be worded better so open to some editing!

BTW at the day job we use a `name` of a tuple with an atom and a list of Dates: `{:load_times, dates}` so the richness in being able to use terms was really appreciated.