### PR TITLE
Fix infinite loading streams in zoomed viewports

### DIFF
--- a/assets/js/phoenix_live_view/hooks.js
+++ b/assets/js/phoenix_live_view/hooks.js
@@ -95,17 +95,17 @@ let top = (scrollContainer) => {
 
 let isAtViewportTop = (el, scrollContainer) => {
   let rect = el.getBoundingClientRect()
-  return rect.top >= top(scrollContainer) && rect.left >= 0 && rect.top <= bottom(scrollContainer)
+  return Math.ceil(rect.top) >= top(scrollContainer) && Math.ceil(rect.left) >= 0 && Math.floor(rect.top) <= bottom(scrollContainer)
 }
 
 let isAtViewportBottom = (el, scrollContainer) => {
   let rect = el.getBoundingClientRect()
-  return rect.right >= top(scrollContainer) && rect.left >= 0 && rect.bottom <= bottom(scrollContainer)
+  return Math.ceil(rect.bottom) >= top(scrollContainer) && Math.ceil(rect.left) >= 0 && Math.floor(rect.bottom) <= bottom(scrollContainer)
 }
 
 let isWithinViewport = (el, scrollContainer) => {
   let rect = el.getBoundingClientRect()
-  return rect.top >= top(scrollContainer) && rect.left >= 0 && rect.top <= bottom(scrollContainer)
+  return Math.ceil(rect.top) >= top(scrollContainer) && Math.ceil(rect.left) >= 0 && Math.floor(rect.top) <= bottom(scrollContainer)
 }
 
 Hooks.InfiniteScroll = {


### PR DESCRIPTION
In zoomed viewports (from doing `⌘` or `Ctrl` + `+`), `phx-viewport-*` events do not fire when scrolled to bottom/top under certain screen/viewport/row height combinations.

That is because `Element.getBoundingClientRect()` may return coordinates with decimal places when the viewport is zoomed. When compared to viewport coordinates which are always whole numbers, the bounds check may fail.

I inserted logs into `isAtViewportBottom` and this is the lowest `rect.bottom` can get after scrolling to the bottom.

![infinite-loading-float-bug](https://github.com/user-attachments/assets/bc0e9e89-7ef3-4367-8eea-ac812d7086e7)

This pull request rounds them with `Math.floor` and `Math.ceil` to increase the odds of falling within bounds, which in my tests, totally fixes the issue.

**To Reproduce**
1. Create an infinite loading `<table>`.
2. Zoom in twice or more in the browser.
3. Scrolling to the end does not load new rows.

Sample code is not provided because reproduction is entirely environment-specific. However, I easily reproduced this on different machines by playing with different zoom and row heights, especially with Chrome and Firefox. Safari seems to be less of an issue because overscrolling fires `scroll` events with coordinates well within the bounds check.

**Workarounds**
Adding some padding to the stream container helps but in my case, I have a `<tbody>` as my container (which ignores padding) and tables are semantically the best fit.