### PR TITLE
clarify that `phx-disable-with` can be blank in the docs

### DIFF
--- a/guides/client/form-bindings.md
+++ b/guides/client/form-bindings.md
@@ -336,6 +336,16 @@ the "Save" button to "Saving...", and restore it to "Save" on acknowledgment:
 <button type="submit" phx-disable-with="Saving...">Save</button>
 ```
 
+If you don't want to change the button's text but want it to be disabled, simply
+add the attribute but leave it blank:
+
+```heex
+<button type="submit" phx-disable-with>Save</button>
+```
+
+This couples well with CSS loading states to indicate the button's disabled state
+through other means than its text.
+
 You may also take advantage of LiveView's CSS loading state classes to
 swap out your form content while the form is submitting. For example,
 with the following rules in your `app.css`:

--- a/guides/client/syncing-changes.md
+++ b/guides/client/syncing-changes.md
@@ -84,6 +84,8 @@ Events that happen inside a form have their state applied to both the element an
 
 ```heex
 <button phx-disable-with="Submitting...">Submit</button>
+<!-- Or, to disable without changing the text: -->
+<button phx-disable-with>Submit</button>
 ```
 
 ### Tailwind integration


### PR DESCRIPTION
I was tearing my hair out over this and trying to implement it manually using hooks yesterday until I realized that this actually worked the way that I wanted it to. It couples well with Tailwind's built-in `disabled` variant, too. If this pull request is accepted, should I add a quick mention of that?