### PR TITLE
Adding documention for implications assign_async might have in testing

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -2027,6 +2027,16 @@ defmodule Phoenix.LiveView do
         # ...
         send_update(parent, Component, data)
       end)
+
+  ## Testing
+
+  You might want to include render_async/1 in any tests for LiveViews that make use
+  of assign_async, to ensure the test waits until the async assigns are done before performing
+  any assertions, for example:
+
+      {:ok, view, _html} = live(conn, "/my_live_view")
+      html = render_async(view)
+      assert html =~ "My assertion"
   """
   defmacro assign_async(socket, key_or_keys, func, opts \\ []) do
     Async.assign_async(socket, key_or_keys, func, opts, __CALLER__)

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -2030,7 +2030,7 @@ defmodule Phoenix.LiveView do
 
   ## Testing
 
-  You might want to include render_async/1 in any tests for LiveViews that make use
+  You might want to include render_async/2 in any tests for LiveViews that make use
   of assign_async, to ensure the test waits until the async assigns are done before performing
   any assertions, for example:
 


### PR DESCRIPTION
Recently ran into a Mox problem due to using assign_async and forgetting to use `render_async/2` in my tests. The documentation for assign_async did not mention anything, so i thought of adding it.