### PR TITLE
add browser pipeline to example router so the root layout and JS get loaded

### DIFF
--- a/guides/introduction/welcome.md
+++ b/guides/introduction/welcome.md
@@ -106,6 +106,7 @@ defmodule MyAppWeb.Router do
   import Phoenix.LiveView.Router
 
   scope "/", MyAppWeb do
+    pipe_through :browser
     live "/thermostat", ThermostatLive
   end
 end

--- a/guides/introduction/welcome.md
+++ b/guides/introduction/welcome.md
@@ -43,8 +43,8 @@ file below to `lib/my_app_web/live/thermostat_live.ex`:
 
 ```elixir
 defmodule MyAppWeb.ThermostatLive do
-  # In Phoenix v1.6+ apps, the line is typically: use MyAppWeb, :live_view
-  use Phoenix.LiveView
+  # In versions of Phoenix older than 1.6, the line is typically: use Phoenix.LiveView
+  use MyAppWeb, :live_view
 
   def render(assigns) do
     ~H"""


### PR DESCRIPTION
I was following the example in the welcome, and it wasn't working because the root layout wasn't getting loaded, which means the `<head>` section that loads `app.js` was missing. The example is incomplete without the browser pipeline being used.

Also, Phoenix 1.5 is no longer supported, so updating the `use` line in the example to only show the new way.
