### PR TITLE
Add doc section on accessing a nested field's value

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2502,22 +2502,25 @@ defmodule Phoenix.Component do
   You can optionally add a similar button before the `<.inputs_for>`, in the case you want
   to prepend entries.
 
-  > #### A note on accessing a field's `value` {: .warning}
+  > ### A note on accessing a field's `value` {: .warning}
   >
-  > Directly accessing the `.value` of a nested field can lead to unexpected behavior,
-  > because you might encounter:
-  > - `%Ecto.Changeset{}` structs
-  > - the underlying data struct
-  > - raw parameters sent by the client
+  > You may be tempted to access `form[:field].value` or attempt to manipulate
+  > the form metadata in your templates. However, bear in mind that `form[:field]`
+  > value reflects the most recent changes. For example, a `:integer` field may
+  > either contain integer values, but it may also hold a string, if the form has
+  > been submitted.
   >
-  > The last case can occur when using the `drop_param` option and the overall data
-  > remains unchanged after Ecto drops an entry. Generally, a field's value reflects
-  > the most recent changes, including requests to drop an entry.
+  > This is particularly noticeable when using `inputs_for`. Accessing the `.value`
+  > of a nested field may either return a struct, a changeset, or raw parameters
+  > sent by the client (when using `drop_param`). This makes the `form[:field].value`
+  > inpractical for deriving or computing other properties.
   >
-  > It is preferable to do any processing on the underlying data, for example
-  > by working with the changeset in your event handlers instead.
+  > The correct way to approach this problem is by computing any property either in
+  > your LiveViews, by traversing the relevant changesets and data structures, or by
+  > moving the logic to the `Ecto.Changeset` itself.
   >
   > As an example, imagine you are building an time tracking application where:
+  >
   > - users enter the total work time for a day
   > - individual activities are tracked as embeds
   > - the sum of all activities should match the total time

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2505,7 +2505,7 @@ defmodule Phoenix.Component do
   > ### A note on accessing a field's `value` {: .warning}
   >
   > You may be tempted to access `form[:field].value` or attempt to manipulate
-  > the form metadata in your templates. However, bear in mind that `form[:field]`
+  > the form metadata in your templates. However, bear in mind that the `form[:field]`
   > value reflects the most recent changes. For example, an `:integer` field may
   > either contain integer values, but it may also hold a string, if the form has
   > been submitted.
@@ -2513,7 +2513,7 @@ defmodule Phoenix.Component do
   > This is particularly noticeable when using `inputs_for`. Accessing the `.value`
   > of a nested field may either return a struct, a changeset, or raw parameters
   > sent by the client (when using `drop_param`). This makes the `form[:field].value`
-  > inpractical for deriving or computing other properties.
+  > impractical for deriving or computing other properties.
   >
   > The correct way to approach this problem is by computing any property either in
   > your LiveViews, by traversing the relevant changesets and data structures, or by

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2506,7 +2506,7 @@ defmodule Phoenix.Component do
   >
   > You may be tempted to access `form[:field].value` or attempt to manipulate
   > the form metadata in your templates. However, bear in mind that `form[:field]`
-  > value reflects the most recent changes. For example, a `:integer` field may
+  > value reflects the most recent changes. For example, an `:integer` field may
   > either contain integer values, but it may also hold a string, if the form has
   > been submitted.
   >
@@ -2519,7 +2519,7 @@ defmodule Phoenix.Component do
   > your LiveViews, by traversing the relevant changesets and data structures, or by
   > moving the logic to the `Ecto.Changeset` itself.
   >
-  > As an example, imagine you are building an time tracking application where:
+  > As an example, imagine you are building a time tracking application where:
   >
   > - users enter the total work time for a day
   > - individual activities are tracked as embeds


### PR DESCRIPTION
When using `<.inputs_for>`, accessing the raw value of the nested field and doing calculations on it has some pitfalls, because the value can be changesets, data or even raw parameters, depending on what is currently happening in the form. This leads to complex code that can be avoided by doing such calculations on the changeset instead. This commit adds a warning adomonition block mentioning this together with a small example.

Closes #3461.

@josevalim not 100% sure about this. It's a little longer than I anticipated, but I couldn't come up with a shorter explanation that I was satisfied with. Feel free to modify as you see fit.

I didn't add anything to the `Phoenix.Component.form/1` docs, as it is generally only a problem with complex fields, such as those used with `inputs_for`.