### PR TITLE
Add JS.concat/2

### DIFF
--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -911,6 +911,11 @@ defmodule Phoenix.LiveView.JS do
     put_op(js, "exec", attr: attr, to: opts[:to])
   end
 
+  @doc """
+  Combines two JS commands, appending the second to the first.
+  """
+  def concat(%JS{ops: first}, %JS{ops: second}), do: %JS{ops: first ++ second}
+
   defp put_op(%JS{ops: ops} = js, kind, args) do
     args = drop_nil_values(args)
     struct!(js, ops: ops ++ [[kind, args]])

--- a/test/phoenix_live_view/js_test.exs
+++ b/test/phoenix_live_view/js_test.exs
@@ -1111,6 +1111,22 @@ defmodule Phoenix.LiveView.JSTest do
     end
   end
 
+  describe "concat" do
+    test "combines multiple JS structs" do
+      js1 = JS.push("inc", value: %{one: 1, two: 2})
+      js2 = JS.add_class("show", to: "#modal", time: 100)
+      js3 = JS.remove_class("show")
+
+      assert JS.concat(js1, js2) |> JS.concat(js3) == %JS{
+               ops: [
+                 ["push", %{event: "inc", value: %{one: 1, two: 2}}],
+                 ["add_class", %{names: ["show"], time: 100, to: "#modal"}],
+                 ["remove_class", %{names: ["show"]}]
+               ]
+             }
+    end
+  end
+
   defp js_to_string(%JS{} = js) do
     js
     |> Map.update!(:ops, &order_ops_map_keys/1)


### PR DESCRIPTION
This commit introduces a new function `JS.concat/2` to concatenate two JS commands together. Previously, you could only append new commands at the back, now you can also prepend commands by doing something like `JS.concat(JS.dispatch("my_event"), existing_js)`.

Closes #3233.