### PR TITLE
Remove logic error in viewport checks

### DIFF
--- a/assets/js/phoenix_live_view/hooks.js
+++ b/assets/js/phoenix_live_view/hooks.js
@@ -95,17 +95,17 @@ let top = (scrollContainer) => {
 
 let isAtViewportTop = (el, scrollContainer) => {
   let rect = el.getBoundingClientRect()
-  return Math.ceil(rect.top) >= top(scrollContainer) && Math.ceil(rect.left) >= 0 && Math.floor(rect.top) <= bottom(scrollContainer)
+  return Math.ceil(rect.top) >= top(scrollContainer) && Math.floor(rect.top) <= bottom(scrollContainer)
 }
 
 let isAtViewportBottom = (el, scrollContainer) => {
   let rect = el.getBoundingClientRect()
-  return Math.ceil(rect.bottom) >= top(scrollContainer) && Math.ceil(rect.left) >= 0 && Math.floor(rect.bottom) <= bottom(scrollContainer)
+  return Math.ceil(rect.bottom) >= top(scrollContainer) && Math.floor(rect.bottom) <= bottom(scrollContainer)
 }
 
 let isWithinViewport = (el, scrollContainer) => {
   let rect = el.getBoundingClientRect()
-  return Math.ceil(rect.top) >= top(scrollContainer) && Math.ceil(rect.left) >= 0 && Math.floor(rect.top) <= bottom(scrollContainer)
+  return Math.ceil(rect.top) >= top(scrollContainer) && Math.floor(rect.top) <= bottom(scrollContainer)
 }
 
 Hooks.InfiniteScroll = {


### PR DESCRIPTION
The logic in phx-viewport-* checks whether elements in a scrollable list are left of the viewport, that doesn't really make sense. You can test this by putting a negative margin on your elements and see that the load action never fires. I have just removed that condition entirely; if we do want some kind of check there in place of what is there currently let me know. 