### PR TITLE
support pushEvent returning a promise

### DIFF
--- a/assets/js/phoenix_live_view/view_hook.js
+++ b/assets/js/phoenix_live_view/view_hook.js
@@ -249,11 +249,37 @@ export default class ViewHook {
     }
   }
 
-  pushEvent(event, payload = {}, onReply = function (){ }){
+  pushEvent(event, payload = {}, onReply){
+    if (onReply === undefined) {
+      return new Promise((resolve, reject) => {
+        try {
+          const ref = this.__view().pushHookEvent(this.el, null, event, payload, (reply, _ref) => resolve(reply));
+          if (ref === false) {
+            reject(new Error("unable to push hook event. LiveView not connected"))
+          }
+        } catch (error) {
+          reject(error)
+        }
+      });
+    }
     return this.__view().pushHookEvent(this.el, null, event, payload, onReply)
   }
 
-  pushEventTo(phxTarget, event, payload = {}, onReply = function (){ }){
+  pushEventTo(phxTarget, event, payload = {}, onReply){
+    if (onReply === undefined) {
+      return new Promise((resolve, reject) => {
+        try {
+          this.__view().withinTargets(phxTarget, (view, targetCtx) => {
+            const ref = view.pushHookEvent(this.el, targetCtx, event, payload, (reply, _ref) => resolve(reply))
+            if (ref === false) {
+              reject(new Error("unable to push hook event. LiveView not connected"))
+            }
+          })
+        } catch (error) {
+          reject(error)
+        }
+      });
+    }
     return this.__view().withinTargets(phxTarget, (view, targetCtx) => {
       return view.pushHookEvent(this.el, targetCtx, event, payload, onReply)
     })

--- a/assets/test/js_test.js
+++ b/assets/test/js_test.js
@@ -26,7 +26,7 @@ describe("JS", () => {
   describe("hook.js()", () => {
     let js, view, modal
     beforeEach(() => {
-      view = setupView(`<div id="modal">modal</div>`)
+      view = setupView("<div id=\"modal\">modal</div>")
       modal = view.el.querySelector("#modal")
       let hook = new ViewHook(view, view.el, {})
       js = hook.js()
@@ -35,7 +35,7 @@ describe("JS", () => {
     test("exec", done => {
       simulateVisibility(modal)
       expect(modal.style.display).toBe("")
-      js.exec(`[["toggle", {"to": "#modal"}]]`)
+      js.exec("[[\"toggle\", {\"to\": \"#modal\"}]]")
       jest.advanceTimersByTime(100)
       expect(modal.style.display).toBe("none")
       done()

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -860,7 +860,7 @@ describe("View Hooks", function(){
     })
     let customEl = document.createElement("custom-el")
     el.appendChild(customEl)
-    let view = simulateJoinedView(el, liveSocket)
+    simulateJoinedView(el, liveSocket)
   })
 
   test("view destroyed", async () => {


### PR DESCRIPTION
This is a breaking change. Until now, pushEvent always returned the ref, but with this change it returns a promise by default, if no onReply function is given.

Relates to: #1937

I don't really like the code as is, but if we want to support this, now would be the time I'd say, pre 1.0.

@chrismccord 