### PR TITLE
Formatter - Keep intentional newlines when formatting comments

### DIFF
--- a/lib/phoenix_live_view/html_formatter.ex
+++ b/lib/phoenix_live_view/html_formatter.ex
@@ -446,7 +446,12 @@ defmodule Phoenix.LiveView.HTMLFormatter do
          stack,
          source
        ) do
-    to_tree(tokens, [{:html_comment, [{:text, String.trim(text), %{}}]} | buffer], stack, source)
+    meta = %{
+      newlines_before_text: count_newlines_until_text(text, 0),
+      newlines_after_text: text |> String.reverse() |> count_newlines_until_text(0)
+    }
+
+    to_tree(tokens, [{:html_comment, [{:text, String.trim(text), meta}]} | buffer], stack, source)
   end
 
   defp to_tree([{:text, text, _meta} | tokens], buffer, stack, source) do

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -2100,6 +2100,42 @@ defmodule Phoenix.LiveView.HTMLFormatterTest do
     """)
   end
 
+  test "keep intentional lines breaks from HTML comments" do
+    assert_formatter_doesnt_change("""
+    <h1>Title</h1>
+
+    <!-- comment -->
+    <p>Text</p>
+    """)
+
+    assert_formatter_doesnt_change("""
+    <h1>Title</h1>
+
+    <!-- comment -->
+
+    <p>Text</p>
+    """)
+
+    assert_formatter_output(
+      """
+      <h1>Title</h1>
+
+
+      <!-- comment -->
+
+
+      <p>Text</p>
+      """,
+      """
+      <h1>Title</h1>
+
+      <!-- comment -->
+
+      <p>Text</p>
+      """
+    )
+  end
+
   # TODO: Remove this `if` when we require Elixir 1.14+
   if function_exported?(EEx, :tokenize, 2) do
     test "handle EEx comments" do

--- a/test/phoenix_live_view/integrations/html_formatter_test.exs
+++ b/test/phoenix_live_view/integrations/html_formatter_test.exs
@@ -95,6 +95,7 @@ defmodule Phoenix.LiveView.Integrations.HTMLFormatterTest do
         </td>
       <% end %>
     </section>
+
     <!-- comment -->
     <div>
       <p>Hello</p>


### PR DESCRIPTION
This PR improves the HTML formatter so that it keeps at least one line (which usually are lines we want to keep intentionally) when formatting comments.