### PR TITLE
Phoenix.LiveViewTest.refute_push_event/4

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1613,6 +1613,44 @@ defmodule Phoenix.LiveViewTest do
     end
   end
 
+
+  @doc """
+  Refutes an event will be pushed within timeout
+  The default `timeout` is [ExUnit](https://hexdocs.pm/ex_unit/ExUnit.html#configure/1)'s
+  `assert_receive_timeout` (100 ms).
+
+  ## Examples
+
+      refute_push_event view, "scores", %{points: _, user: "josé"}
+  """
+  defmacro refute_push_event(
+             view,
+             event,
+             payload,
+             timeout \\ Application.fetch_env!(:ex_unit, :refute_receive_timeout)
+           ) do
+    pattern = Macro.to_string(payload)
+
+    quote do
+      %{proxy: {ref, _topic, _}} = unquote(view)
+
+      receive do
+        {^ref, {:push_event, unquote(event), unquote(payload) = data}} ->
+          flunk("""
+          Unexpectedly received event "#{unquote(event)}"
+
+          Payload:
+          #{inspect(data)}
+
+          (which matched #{unquote(pattern)})
+          """)
+
+        unquote(timeout) ->
+          false
+      end
+    end
+  end
+
   @doc """
   Asserts a hook reply was returned from a `handle_event` callback.
 


### PR DESCRIPTION
Adds the `refute_receive` equivalent to `assert_push_event`. If we are ok with adding this feature, I'll add some tests

Errors look like:

```elixir
  1) test it can refute events
     test/example_test.exs
     Unexpectedly received event "scores"

     Payload:
     %{points: 100, user: "Dave"}

     (which matched %{points: _, user: "josé"})

     code: refute_push_event(live, "scores", %{points: _, user: "josé"})
     stacktrace:
       test/example_test.exs:273: (test)
```