### PR TITLE
keep original form action when none is provided to to_form

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1500,7 +1500,7 @@ defmodule Phoenix.Component do
 
     {_as, options} = Keyword.pop(options, :as)
     {errors, options} = Keyword.pop(options, :errors, data.errors)
-    {action, options} = Keyword.pop(options, :action)
+    {action, options} = Keyword.pop(options, :action, data.action)
     options = Keyword.merge(data.options, options)
 
     %Phoenix.HTML.Form{

--- a/test/phoenix_component_test.exs
+++ b/test/phoenix_component_test.exs
@@ -304,6 +304,9 @@ defmodule Phoenix.ComponentUnitTest do
 
       form = to_form(base, action: :validate)
       assert form.action == :validate
+
+      form = to_form(%{base | action: :validate})
+      assert form.action == :validate
     end
   end
 


### PR DESCRIPTION
Fixes #3493.

When using `<.form for={@form} :let={f}>`, the `f` form would have no action set, even if the original `@form` has one. This led to errors not being displayed on nested forms.