### PR TITLE
Reserve `{` outside of attributes

### DIFF
--- a/lib/phoenix_live_view/tokenizer.ex
+++ b/lib/phoenix_live_view/tokenizer.ex
@@ -155,6 +155,18 @@ defmodule Phoenix.LiveView.Tokenizer do
     handle_tag_open(rest, line, column + 1, text_to_acc, %{state | context: []})
   end
 
+  defp handle_text("{" <> rest, line, column, [?\\ | buffer], acc, state) do
+    handle_text(rest, line, column + 1, [?{ | buffer], acc, state)
+  end
+
+  defp handle_text("{" <> _rest, line, column, _buffer, _acc, state) do
+    raise_syntax_error!(
+      "`{` outside of attributes is reserved, use `\\\\{` to escape",
+      %{line: line, column: column},
+      state
+    )
+  end
+
   defp handle_text(<<c::utf8, rest::binary>>, line, column, buffer, acc, state) do
     handle_text(rest, line, column + 1, [char_or_bin(c) | buffer], acc, state)
   end

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -257,6 +257,38 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
     end
   end
 
+  test "interpolation outside of attributes is reserved" do
+    assert_raise Phoenix.LiveView.Tokenizer.ParseError,
+                 ~r/outside of attributes is reserved/,
+                 fn ->
+                   render("{x}", %{})
+                 end
+
+    assert_raise Phoenix.LiveView.Tokenizer.ParseError,
+                 ~r/outside of attributes is reserved/,
+                 fn ->
+                   render(" {x}", %{})
+                 end
+
+    assert_raise Phoenix.LiveView.Tokenizer.ParseError,
+                 ~r/outside of attributes is reserved/,
+                 fn ->
+                   render("<p>{x}</p>", %{})
+                 end
+
+    assert_raise Phoenix.LiveView.Tokenizer.ParseError,
+                 ~r/outside of attributes is reserved/,
+                 fn ->
+                   render("<p id={x}>{x}</p>", %{})
+                 end
+  end
+
+  test "escaped interpolation" do
+    assert render("\\{x}", %{}) == "{x}"
+    assert render(" \\{x}", %{}) == " {x}"
+    assert render("<div id={:foo}>\\{x}</div>", %{}) == "<div id=\"foo\">{x}</div>"
+  end
+
   def do_block(do: block), do: block
 
   test "handles do blocks with expressions" do

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -257,7 +257,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
     end
   end
 
-  test "interpolation outside of attributes is reserved" do
+  test "{} outside of attributes is reserved" do
     assert_raise Phoenix.LiveView.Tokenizer.ParseError,
                  ~r/outside of attributes is reserved/,
                  fn ->
@@ -283,7 +283,25 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
                  end
   end
 
-  test "escaped interpolation" do
+  test "{} inside <script> and <style>" do
+    html = """
+    <script>
+    if (true) { console.log("true") }
+    </script>\
+    """
+
+    assert render(html, %{}) == html
+
+    html = """
+    <style>
+    p { color: red; }
+    </style>\
+    """
+
+    assert render(html, %{}) == html
+  end
+
+  test "{} escaping" do
     assert render("\\{x}", %{}) == "{x}"
     assert render(" \\{x}", %{}) == " {x}"
     assert render("<div id={:foo}>\\{x}</div>", %{}) == "<div id=\"foo\">{x}</div>"

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -1052,7 +1052,7 @@ defmodule Phoenix.LiveView.HTMLFormatterTest do
   test "format <pre> tag with EEx" do
     assert_formatter_doesnt_change("""
     <pre>
-      :root {
+      :root \\{
         <%= 2 + 2 %>
         <%= 2 + 2 %>
       }


### PR DESCRIPTION
Before this patch, this was valid:

    <div id={id}>{content}</div>

and the text `{content}` is rendered _as is_, without interpolation. I'd like to reserve this syntax for later and for now raise an error:

    iex> import Phoenix.Component, only: [sigil_H: 2]
    iex> assigns = %{}; ~H"<div id={id}>{content}</div>"
    ** (Phoenix.LiveView.Tokenizer.ParseError) iex:3:14: `{` outside of attributes is reserved, use `\\{` to escape
      |
    1 | <div id={id}>{content}</div>
        (phoenix_live_view 1.0.0-rc.7) lib/phoenix_live_view/tokenizer.ex:732: Phoenix.LiveView.Tokenizer.raise_syntax_error!/3
        (phoenix_live_view 1.0.0-rc.7) lib/phoenix_live_view/tag_engine.ex:295: Phoenix.LiveView.TagEngine.handle_text/3
        (eex 1.18.0-dev) lib/eex/compiler.ex:331: EEx.Compiler.generate_buffer/4
        (phoenix_live_view 1.0.0-rc.7) expanding macro: Phoenix.Component.sigil_H/2
        iex:2: (file)

If someone needs to use `{`, there's a way to escape it using `\\{`:

    iex> assigns = %{}; ~H"<div id={:foo}>\\{content}</div>".static
    ["<div", ">\\{content}</div>"]

The idea is to eventually use the same interpolation syntax across the board. And when that happens, deprecate `<%= %>` in favour of `{ }`. Supporting new syntax as well as deprecating old syntax is a massive change because of existing Phoenix projects, syntax highlighters, etc. I think we should be able to automate moving from `<% %>` to `{ }` using tools like https://github.com/adobe/elixir-styler.
