### PR TITLE
always merge defaultArgs in JS.exec

### DIFF
--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -12,8 +12,9 @@ let JS = {
       JSON.parse(phxEvent) : [[defaultKind, defaultArgs]]
 
     commands.forEach(([kind, args]) => {
-      if(kind === defaultKind && defaultArgs.data){
-        args.data = Object.assign(args.data || {}, defaultArgs.data)
+      if(kind === defaultKind){
+        // always prefer the args, but keep existing keys from the defaultArgs
+        args = {...defaultArgs, ...args}
         args.callback = args.callback || defaultArgs.callback
       }
       this.filterToEls(view.liveSocket, sourceEl, args).forEach(el => {


### PR DESCRIPTION
Fixes #3494.

I don't know why, but when passing "defaults" to JS.exec, we only merged the defaults if there is a "data" property. If someone used

    <form phx-submit={JS.push("save")}>
      <button name="foo" value="baz">Submit</button>
    </form>

the submitter would be passed as defaults, but the command itself would be `["push", {"event": "save"}]`, therefore the defaults would not be merged. This commit changes the merging to always happen, but the phxEvent args always override the defaults.