### PR TITLE
fix misleading docs for enableLatencySim

### DIFF
--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -55,7 +55,7 @@ so LiveView includes a latency simulator with the JavaScript client to ensure yo
 application provides a pleasant experience. Like the `enableDebug()` function above,
 the `LiveSocket` instance includes `enableLatencySim(milliseconds)` and `disableLatencySim()`
 functions which apply throughout the current browser session. The `enableLatencySim` function
-accepts an integer in milliseconds for the round-trip-time to the server. For example:
+accepts an integer in milliseconds for the one-way latency to and from the server. For example:
 
 ```javascript
 // app.js


### PR DESCRIPTION
[The docs](https://hexdocs.pm/phoenix_live_view/1.0.0-rc.6/js-interop.html#simulating-latency) for `liveSocket.enableLatencySim` seem misleading if not outright wrong:

> The `enableLatencySim` function accepts an integer in milliseconds for the **round-trip-time** to the server.

"Round-trip time" means the total time taken for the signal to go from client to server then back again. I.e. if I set the latency sim to `5000` ms, I would expect that when I e.g. when I change something in an `<input>` it would take 5 seconds to see the result (e.g. error messages appearing on the form.)

But experimenting with this feature, it seems that the argument I submit to `enableLatencySim` is actually the one-way time, not the round-trip time. I.e. if I set it to `5000` ms then it takes 10 seconds to see the results of my actions, not 5.

I'm not sure what the actual intended behaviour is (I can't figure it out from a brief look at the JS source code) but the docs don't appear to match what actually happens. Submitting this minor doc change to make it consistent.