### PR TITLE
Update form-bindings guide with up-to-date `inputmode` browser support

### DIFF
--- a/guides/client/form-bindings.md
+++ b/guides/client/form-bindings.md
@@ -146,7 +146,7 @@ decrease the number.
 
 One alternative is the `inputmode` attribute, which may serve your application's needs
 and users much better. According to [Can I Use?](https://caniuse.com/#search=inputmode),
-the following is supported by 86% of the global market (as of Sep 2021):
+the following is supported by 94% of the global market (as of Nov 2024):
 
 ```heex
 <input type="text" inputmode="numeric" pattern="[0-9]*">


### PR DESCRIPTION
Was perusing the number input portion of the form-bindings.md guide, and I followed the CanIUse link to find that browser support for `inputmode` is in a far better place than it was back in 2021