### PR TITLE
Add a note to the JS hide/1 and show/1 functions for clarifying targeted elements

### DIFF
--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -329,6 +329,8 @@ defmodule Phoenix.LiveView.JS do
   @doc """
   Shows elements.
 
+  *Note*: Only targets elements that are visible, meaning they have a height and/or width greater than zero.
+
   ## Options
 
     * `:to` - An optional DOM selector to show.
@@ -380,6 +382,8 @@ defmodule Phoenix.LiveView.JS do
 
   @doc """
   Hides elements.
+
+  *Note*: Only targets elements that are visible, meaning they have a height and/or width greater than zero.
 
   ## Options
 

--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -329,7 +329,7 @@ defmodule Phoenix.LiveView.JS do
   @doc """
   Shows elements.
 
-  *Note*: Only targets elements that are visible, meaning they have a height and/or width greater than zero.
+  *Note*: Only targets elements that are hidden, meaning they have a height and/or width equal to zero.
 
   ## Options
 


### PR DESCRIPTION
When using [hide](https://github.com/phoenixframework/phoenix_live_view/blob/main/lib/phoenix_live_view/js.ex#L413) and [show](https://github.com/phoenixframework/phoenix_live_view/blob/bb991f5a188bd1486b8de2ca4768c05f9f4aa7e4/lib/phoenix_live_view/js.ex#L362) functions, I noticed that elements that weren't visible to the users weren't being hidden by adding the `display: none` style. 

After looking at the JS code, I saw that the corresponding js functions check if the [element is visible](https://github.com/phoenixframework/phoenix_live_view/blob/bb991f5a188bd1486b8de2ca4768c05f9f4aa7e4/assets/js/phoenix_live_view/js.js#L160) or not before applying the style. IMO this is not trivial and should be added to the documentation.