### PR TITLE
Make JS.put_op/3 public

### DIFF
--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -960,7 +960,8 @@ defmodule Phoenix.LiveView.JS do
   """
   def concat(%JS{ops: first}, %JS{ops: second}), do: %JS{ops: first ++ second}
 
-  defp put_op(%JS{ops: ops} = js, kind, args) do
+  @doc false
+  def put_op(%JS{ops: ops} = js, kind, args) do
     args = drop_nil_values(args)
     struct!(js, ops: ops ++ [[kind, args]])
   end


### PR DESCRIPTION
I think this PR will require a lot more than this but wanted to start the conversation. I think JS.commands should be extensible where other libraries can write their own set of JS commands that can be called. For example, motion.dev was just released and this libray could easily be called from LiveView. However, the JS module should do most of the work to make it easier for others to build their own extensions.

I suspect in addition to this adding an extensible API in `js.js` would be nice as well so extensions could dispatch commands to the libraries they want.

If you'd like I can add documentation and a unit test.