### PR TITLE
Revert "Fix unnecessary remount when navigating back"

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -317,9 +317,6 @@ export default class View {
     if(this.root === this){
       this.formsForRecovery = this.getFormsForRecovery()
     }
-    if(this.isMain()){
-      this.liveSocket.replaceRootHistory()
-    }
 
     if(liveview_version !== this.liveSocket.version()){
       console.error(`LiveView asset version mismatch. JavaScript version ${this.liveSocket.version()} vs. server ${liveview_version}. To avoid issues, please ensure that your assets use the same version as the server.`)

--- a/test/e2e/tests/navigation.spec.js
+++ b/test/e2e/tests/navigation.spec.js
@@ -225,18 +225,3 @@ test("scrolls hash el into view after live navigation (issue #3452)", async ({ p
   await expect(scrollTop).toBeGreaterThanOrEqual(offset - 500);
   await expect(scrollTop).toBeLessThanOrEqual(offset + 500);
 });
-
-test("navigating all the way back works without remounting (only patching)", async ({ page }) => {
-  await page.goto("/navigation/a");
-  await syncLV(page);
-  networkEvents = [];
-  await page.getByRole("link", { name: "Patch this LiveView" }).click();
-  await syncLV(page);
-  await page.goBack();
-  await syncLV(page);
-  await expect(networkEvents).toEqual([]);
-  // we only expect patch navigation
-  await expect(webSocketEvents.filter(e => e.payload.indexOf("phx_leave") !== -1)).toHaveLength(0);
-  // we patched 2 times
-  await expect(webSocketEvents.filter(e => e.payload.indexOf("live_patch") !== -1)).toHaveLength(2);
-});


### PR DESCRIPTION
Reverts phoenixframework/phoenix_live_view#3335
Fixes https://github.com/phoenixframework/phoenix_live_view/issues/3508.

The history API is the worst...

replaceRootHistory sets the initial type to "patch". Now assuming the following events:

1. initial navigation to /page1

History:

```
==> /page1, type patch
```

2. Navigating to /page2 (navigate, no patch)

```
    /page1, type patch
==> /page2, type redirect
```

Then we'd call replaceRootHistory after the new join:

```
    /page1, type patch
==> /page2, type patch
```

If we now use the back button, the browser would send us a popstate event including the previous state (type=patch). Instead of a navigate, we'd do a patch.

We could change replaceRootHistory to not assume type=patch, but then the initial PR would be useless as well, as there would still be a remount when navigating back.

To properly fix this, we'd need a way to get the state from before the popstate event to determine what navigation type was used, but that's not possible. Another option would be to always update the current state before pushing a new one to include a `backType` that would be used when navigating in the other direction. But this would require us to be able to distinguish a back from a forward navigation, as we'd only want to use the `backType` when navigating back. There are ways to do this (https://stackoverflow.com/questions/8980255/how-do-i-retrieve-if-the-popstate-event-comes-from-back-or-forward-actions-with), but it's definitely not pretty and doesn't seem worth it imho.

We might revisit this in the future, when the Navigation API is more widely available.