### PR TITLE
Add assert_* functions to locals_without_parens config

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,13 @@
 [
   import_deps: [:phoenix],
   plugins: [Phoenix.LiveView.HTMLFormatter],
-  inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"],
+  locals_without_parens: [
+    assert_patch: :*,
+    assert_patched: :*,
+    assert_push_event: :*,
+    assert_redirect: :*,
+    assert_redirected: :*,
+    assert_reply: :*
+  }
 ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -9,5 +9,5 @@
     assert_redirect: :*,
     assert_redirected: :*,
     assert_reply: :*
-  }
+  ]
 ]


### PR DESCRIPTION
So one can simply add `:phoenix_live_view` to their `:plugins` option in `.formatter.exs` and it will not automatically include parens to those functions when `mix format`ing