### PR TITLE
change nav type to redirect when doing live navigation

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -787,6 +787,10 @@ export default class LiveSocket {
     this.withPageLoading({to: href, kind: "redirect"}, done => {
       this.replaceMain(href, flash, (linkRef) => {
         if(linkRef === this.linkRef){
+          // we must change the type of the current history state as well
+          // to ensure we also do a redirect type navigation when we navigate back;
+          // otherwise we run into https://github.com/phoenixframework/phoenix_live_view/issues/3536
+          if(history.state?.type === "patch"){ Browser.updateCurrentState((state) => ({...state, type: "redirect"})) }
           Browser.pushState(linkState, {type: "redirect", id: this.main.id, scroll: scroll}, href)
           DOM.dispatchEvent(window, "phx:navigate", {detail: {href, patch: false, pop: false}})
           this.registerNewLocation(window.location)


### PR DESCRIPTION
Fixes #3536.

Browser history API strikes back (again). Because live navigation shares the id of the view between live navigations, the following scenario could happen:

1. User visits page 1 (initial nav)
2. User patches the page
3. User visits page 2 (live nav)
4. User patches the page
5. User uses browser back button (state from 3 -> live nav)
6. User uses browser back button (state from 2 -> PATCH)

In step 6, the user is still on page 2, but LiveView would try to patch the page instead of performing a live navigation. This is only a problem if the two pages use the same underlying LiveView module, otherwise the patch request would fallback to a navigation.

This commit "fixes" this by modifying the current history entry at step 2 to `redirect` before pushing the new state. This way, LiveView does a live navigation when popping the state in step 6.

The underlying problem is that we cannot differentiate a forward from a backward navigation when handling a popstate. If we could, we'd be able to separately store the backwards and forwards navigation type. The current approach will also do a live navigation when navigating forward again, therefore if a user went back in history to step 1 and pressed forward, we now do a live navigation instead of a patch, therefore potentially losing state.

See also https://github.com/phoenixframework/phoenix_live_view/pull/3513#issue-2666178852.