### PR TITLE
fix doc: Slot Attributes example table/1 code

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -428,8 +428,8 @@ defmodule Phoenix.Component do
       def table(assigns) do
         ~H"""
         <table>
-          <tr :for={col <- @column}>
-            <th>{col.label}</th>
+          <tr>
+            <th :for={col <- @column}>{col.label}</th>
           </tr>
           <tr :for={row <- @rows}>
             <td :for={col <- @column}>{render_slot(col, row)}</td>


### PR DESCRIPTION
Generate a `th`, instead of a `tr`, for each `col`.