### PR TITLE
restore scroll position on initial navigation

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -362,7 +362,11 @@ export default class LiveSocket {
       view.setHref(this.getHref())
       view.joinDead()
       if(!this.main){ this.main = view }
-      window.requestAnimationFrame(() => view.execNewMounted())
+      window.requestAnimationFrame(() => {
+        view.execNewMounted()
+        // restore scroll position when navigating from an external / non-live page
+        this.maybeScroll(history.state?.scroll)
+      })
     }
   }
 

--- a/test/e2e/support/navigation.ex
+++ b/test/e2e/support/navigation.ex
@@ -43,6 +43,10 @@ defmodule Phoenix.LiveViewTest.E2E.Navigation.Layout do
         <.link navigate="/stream" style="background-color: #f1f5f9; padding: 0.5rem;">
           LiveView (other session)
         </.link>
+
+        <.link navigate="/navigation/dead" style="background-color: #f1f5f9; padding: 0.5rem;">
+          Dead View
+        </.link>
       </div>
 
       <div style="margin-left: 22rem; flex: 1; padding: 2rem;">
@@ -162,6 +166,31 @@ defmodule Phoenix.LiveViewTest.E2E.Navigation.BLive do
     <div :if={@live_action == :show}>
       <p>Item {@id}</p>
     </div>
+    """
+  end
+end
+
+defmodule Phoenix.LiveViewTest.E2E.Navigation.Dead do
+  use Phoenix.Controller,
+    formats: [:html],
+    layouts: [html: {Phoenix.LiveViewTest.E2E.Navigation.Layout, :live}]
+
+  import Phoenix.Component, only: [sigil_H: 2]
+
+  def index(conn, _params) do
+    assigns = %{}
+
+    conn
+    |> render(:index)
+  end
+end
+
+defmodule Phoenix.LiveViewTest.E2E.Navigation.DeadHTML do
+  use Phoenix.Component
+
+  def index(assigns) do
+    ~H"""
+    <h1>Dead view</h1>
     """
   end
 end

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -161,6 +161,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/a", Phoenix.LiveViewTest.E2E.Navigation.ALive
       live "/b", Phoenix.LiveViewTest.E2E.Navigation.BLive, :index
       live "/b/:id", Phoenix.LiveViewTest.E2E.Navigation.BLive, :show
+      get "/dead", Phoenix.LiveViewTest.E2E.Navigation.Dead, :index
     end
   end
 


### PR DESCRIPTION
In the past, when navigating back from an external or dead page to a live page, the scroll position would not be restored.