### PR TITLE
Fix: Update calls in `follow_redirect/3` error case example to not cause type warning.

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1684,7 +1684,8 @@ defmodule Phoenix.LiveViewTest do
 
   Or in the case of an error tuple:
 
-      assert {:error, {:redirect, %{to: "/somewhere"}}} = result = live(conn, "my-path")
+      result = live(conn, "/route?tab=option1&source=option2")
+      assert {:error, {:live_redirect, %{to: "/route?tab=option1}}} = result
       {:ok, view, html} = follow_redirect(result, conn)
 
   `follow_redirect/3` expects a connection as second argument.


### PR DESCRIPTION
This came up while we were upgrading to Elixir `1.18.0-rc0`.

We had the following code snippet, built from the example above before this change:

```elixir
      # ...
      assert result =
               {:error, {:live_redirect, %{to: "/sales/amazon/diagnostics/?tab=availability"}}} =
               live(
                 conn,
                 "/sales/amazon/diagnostics?tab=availability&source=galileo.email.buy_box"
               )

      {:ok, view, _html} = follow_redirect(result, conn)
      # ...
```

Which resulted in this type warning:

```
     warning: the following clause will never match:

         {:error, {:redirect, opts}}

     because it attempts to match on the result of:

         reason

     which has type:

         dynamic({:error, {:live_redirect, %{..., to: binary()}}})

     typing violation found at:
     │
 678 │       {:ok, view, _html} = follow_redirect(result, conn)
     │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Now, our fix was to make it look like this, which I believe is functionally equivalent but does not raise the type error:

```elixir
  result = live(conn, "/route?tab=option1&source=option2")
  assert {:error, {:live_redirect, %{to: "/route?tab=option1}}} = result
  {:ok, view, _html} = follow_redirect(result, conn)
```

I believe this will just hopefully reduce confusion for anyone referencing these docs as everyone moves to 1.18, and should be harmless for existing users.

Thoughts? Didn't mean to just make a drive by docs PR, but wanted to understand what/if there actually was an issue here. 😄 