### PR TITLE
mark follow_redirect AST as generated

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1706,7 +1706,7 @@ defmodule Phoenix.LiveViewTest do
 
   """
   defmacro follow_redirect(reason, conn, to \\ nil) do
-    quote bind_quoted: binding() do
+    quote bind_quoted: binding(), generated: true do
       case reason do
         {:error, {:live_redirect, opts}} ->
           {conn, to} = Phoenix.LiveViewTest.__follow_redirect__(conn, @endpoint, to, opts)


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix_live_view/pull/3581.

@josevalim I didn't try it, but if I understand the generated stuff correctly, this should prevent type warnings when the case clause cannot match, right?