### PR TITLE
doc: Form bindings > Error Feedback: Remove legacy error example

### DIFF
--- a/guides/client/form-bindings.md
+++ b/guides/client/form-bindings.md
@@ -122,7 +122,6 @@ def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
 
   assigns
   |> assign(field: nil, id: assigns.id || field.id)
-  |> assign(:errors, Enum.map(field.errors, &translate_error(&1)))
   |> assign(:errors, Enum.map(errors, &translate_error(&1)))
 ```
 


### PR DESCRIPTION
Removes deprecated error handling code that was left over from before the `phx-feedback-for` migration.
