### PR TITLE
Warn on duplicate IDs and fail test, but don't prevent debugging

### DIFF
--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -82,12 +82,13 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
       router: router,
       session: session,
       url: url,
-      test_supervisor: test_supervisor
+      test_supervisor: test_supervisor,
+      duplicate_id_target: duplicate_id_target
     } = opts
 
     # We can assume there is at least one LiveView
     # because the live_module assign was set.
-    root_html = DOM.parse(response_html)
+    root_html = DOM.parse(response_html, duplicate_id_target)
 
     {id, session_token, static_token, redirect_url} =
       case Map.fetch(opts, :live_redirect) do

--- a/test/phoenix_live_view/integrations/nested_test.exs
+++ b/test/phoenix_live_view/integrations/nested_test.exs
@@ -147,7 +147,7 @@ defmodule Phoenix.LiveView.NestedTest do
     :ok = GenServer.call(view.pid, {:dynamic_child, :static})
 
     assert Exception.format(:exit, catch_exit(render(view))) =~
-             "Duplicate id found: static"
+             "expected selector \"#static\" to return a single element, but got 2"
   end
 
   describe "navigation helpers" do


### PR DESCRIPTION
Relates to: https://github.com/phoenixframework/phoenix_live_view/pull/3560

I don't think that the code is particularly pretty, but it shows the idea.

Sample output:

```
Running ExUnit with seed: 389897, max_cases: 20

.........................................................................................................................................................................................warning: Duplicate id found while testing LiveView: push-to-self

    <button id="push-to-self" phx-click="[[&quot;push&quot;,{&quot;value&quot;:{&quot;inc&quot;:1},&quot;target&quot;:&quot;#child_1&quot;,&quot;event&quot;:&quot;inc&quot;}],[&quot;push&quot;,{&quot;value&quot;:{&quot;inc&quot;:10},&quot;target&quot;:&quot;#child_1&quot;,&quot;event&quot;:&quot;inc&quot;}]]">
       Both to self
     </button>


LiveView requires that all elements have unique ids, duplicate IDs will cause
undefined behavior at runtime, as DOM patching will not be able to target the correct
elements.

  (phoenix_live_view 1.0.1) lib/phoenix_live_view/test/live_view_test.ex:430: Phoenix.LiveViewTest.warn_duplicate_ids_loop/3

warning: Duplicate id found while testing LiveView: push-to-other-targets

    <button id="push-to-other-targets" phx-click="[[&quot;push&quot;,{&quot;value&quot;:{&quot;inc&quot;:2},&quot;target&quot;:&quot;#child_2&quot;,&quot;event&quot;:&quot;inc&quot;}],[&quot;push&quot;,{&quot;value&quot;:{&quot;inc&quot;:1},&quot;target&quot;:&quot;#child_1&quot;,&quot;event&quot;:&quot;inc&quot;}],[&quot;push&quot;,{&quot;value&quot;:{&quot;inc&quot;:-1},&quot;event&quot;:&quot;inc&quot;}]]">
       One to everyone
     </button>


LiveView requires that all elements have unique ids, duplicate IDs will cause
undefined behavior at runtime, as DOM patching will not be able to target the correct
elements.

  (phoenix_live_view 1.0.1) lib/phoenix_live_view/test/live_view_test.ex:430: Phoenix.LiveViewTest.warn_duplicate_ids_loop/3

warning: Duplicate id found while testing LiveView: push-to-self

    <button id="push-to-self" phx-click="[[&quot;push&quot;,{&quot;value&quot;:{&quot;inc&quot;:1},&quot;target&quot;:&quot;#child_1&quot;,&quot;event&quot;:&quot;inc&quot;}],[&quot;push&quot;,{&quot;value&quot;:{&quot;inc&quot;:10},&quot;target&quot;:&quot;#child_1&quot;,&quot;event&quot;:&quot;inc&quot;}]]">
       Both to self
     </button>


LiveView requires that all elements have unique ids, duplicate IDs will cause
undefined behavior at runtime, as DOM patching will not be able to target the correct
elements.

  (phoenix_live_view 1.0.1) lib/phoenix_live_view/test/live_view_test.ex:430: Phoenix.LiveViewTest.warn_duplicate_ids_loop/3

warning: Duplicate id found while testing LiveView: push-to-other-targets

    <button id="push-to-other-targets" phx-click="[[&quot;push&quot;,{&quot;value&quot;:{&quot;inc&quot;:2},&quot;target&quot;:&quot;#child_2&quot;,&quot;event&quot;:&quot;inc&quot;}],[&quot;push&quot;,{&quot;value&quot;:{&quot;inc&quot;:1},&quot;target&quot;:&quot;#child_1&quot;,&quot;event&quot;:&quot;inc&quot;}],[&quot;push&quot;,{&quot;value&quot;:{&quot;inc&quot;:-1},&quot;event&quot;:&quot;inc&quot;}]]">
       One to everyone
     </button>


LiveView requires that all elements have unique ids, duplicate IDs will cause
undefined behavior at runtime, as DOM patching will not be able to target the correct
elements.

  (phoenix_live_view 1.0.1) lib/phoenix_live_view/test/live_view_test.ex:430: Phoenix.LiveViewTest.warn_duplicate_ids_loop/3



  1) test LiveViewTest supports multiple JS.push events from a component to other targets (Phoenix.LiveView.EventTest)
     test/phoenix_live_view/integrations/event_test.exs:194
     ** (RuntimeError) Detected duplicate IDs! Check the warnings logged for details.
     stacktrace:
       (phoenix_live_view 1.0.1) lib/phoenix_live_view/test/live_view_test.ex:420: anonymous fn/2 in Phoenix.LiveViewTest.start_duplicate_id_check/1
       (ex_unit 1.19.0-dev) lib/ex_unit/on_exit_handler.ex:136: ExUnit.OnExitHandler.exec_callback/1
       (ex_unit 1.19.0-dev) lib/ex_unit/on_exit_handler.ex:122: ExUnit.OnExitHandler.on_exit_runner_loop/0

.

  2) test LiveViewTest supports multiple JS.push events from a component to itself (Phoenix.LiveView.EventTest)
     test/phoenix_live_view/integrations/event_test.exs:183
     ** (RuntimeError) Detected duplicate IDs! Check the warnings logged for details.
     stacktrace:
       (phoenix_live_view 1.0.1) lib/phoenix_live_view/test/live_view_test.ex:420: anonymous fn/2 in Phoenix.LiveViewTest.start_duplicate_id_check/1
       (ex_unit 1.19.0-dev) lib/ex_unit/on_exit_handler.ex:136: ExUnit.OnExitHandler.exec_callback/1
       (ex_unit 1.19.0-dev) lib/ex_unit/on_exit_handler.ex:122: ExUnit.OnExitHandler.on_exit_runner_loop/0

.............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
Finished in 4.5 seconds (1.8s async, 2.6s sync)
6 doctests, 1219 tests, 2 failures
```