### PR TITLE
Update live_title examples for consistent spacing

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2068,13 +2068,13 @@ defmodule Phoenix.Component do
   ## Examples
 
   ```heex
-  <.live_title default="Welcome" prefix="MyApp – ">
+  <.live_title default="Welcome" prefix="MyApp · ">
     {assigns[:page_title]}
   </.live_title>
   ```
 
   ```heex
-  <.live_title default="Welcome" suffix="- MyApp">
+  <.live_title default="Welcome" suffix=" · MyApp">
     {assigns[:page_title]}
   </.live_title>
   ```


### PR DESCRIPTION
The suffix should contain a space before the separator to render as expected.

The example separators were different characters; update to be the same as used in the phx.new root template.