### PR TITLE
actually warn, don't raise on duplicate ids in LiveViewTest

### DIFF
--- a/lib/phoenix_live_view/test/dom.ex
+++ b/lib/phoenix_live_view/test/dom.ex
@@ -44,16 +44,18 @@ defmodule Phoenix.LiveViewTest.DOM do
     case Floki.attribute(node, "id") do
       [id] ->
         if MapSet.member?(ids, id) do
-          raise """
-          Duplicate id found: #{id}
+          IO.warn("""
+          Duplicate id found while testing LiveView: #{id}
+
+          #{inspect_html(node)}
 
           LiveView requires that all elements have unique ids, duplicate IDs will cause
           undefined behavior at runtime, as DOM patching will not be able to target the correct
           elements.
-          """
-        else
-          detect_duplicate_ids(children, MapSet.put(ids, id))
+          """)
         end
+
+        detect_duplicate_ids(children, MapSet.put(ids, id))
 
       _ ->
         detect_duplicate_ids(children, ids)

--- a/test/phoenix_live_view/integrations/nested_test.exs
+++ b/test/phoenix_live_view/integrations/nested_test.exs
@@ -147,7 +147,7 @@ defmodule Phoenix.LiveView.NestedTest do
     :ok = GenServer.call(view.pid, {:dynamic_child, :static})
 
     assert Exception.format(:exit, catch_exit(render(view))) =~
-             "Duplicate id found: static"
+             "expected selector \"#static\" to return a single element, but got 2"
   end
 
   describe "navigation helpers" do

--- a/test/phoenix_live_view/test/dom_test.exs
+++ b/test/phoenix_live_view/test/dom_test.exs
@@ -292,24 +292,4 @@ defmodule Phoenix.LiveViewTest.DOMTest do
                %{s: "bar", streams: []}
     end
   end
-
-  describe "parse" do
-    test "detects duplicate ids" do
-      assert_raise RuntimeError, fn ->
-        DOM.parse("""
-        <div id="foo">
-          <div id="foo"></div>
-        </div>
-        """)
-      end
-    end
-
-    test "handles declarations (issue #3594)" do
-      assert DOM.parse("""
-             <div id="foo">
-               <?xml version="1.0" standalone="yes"?>
-             </div>
-             """)
-    end
-  end
 end

--- a/test/phoenix_live_view/test/dom_warn_test.exs
+++ b/test/phoenix_live_view/test/dom_warn_test.exs
@@ -1,0 +1,27 @@
+defmodule Phoenix.LiveViewTest.DOMWarnTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias Phoenix.LiveViewTest.DOM
+
+  describe "parse" do
+    test "detects duplicate ids" do
+      assert capture_io(:stderr, fn ->
+               DOM.parse("""
+               <div id="foo">
+                 <div id="foo"></div>
+               </div>
+               """)
+             end) =~ "Duplicate id found while testing LiveView"
+    end
+
+    test "handles declarations (issue #3594)" do
+      assert DOM.parse("""
+             <div id="foo">
+               <?xml version="1.0" standalone="yes"?>
+             </div>
+             """)
+    end
+  end
+end


### PR DESCRIPTION
Relates to #3588.
Relates to: https://github.com/phoenixframework/phoenix_live_view/pull/3560.

cc @josevalim 