### PR TITLE
pass fromEl and toEl to hook beforeUpdate

### DIFF
--- a/assets/js/phoenix_live_view/view.ts
+++ b/assets/js/phoenix_live_view/view.ts
@@ -654,7 +654,7 @@ export default class View {
       !fromEl.isEqualNode(toEl) &&
       !(isIgnored && isEqualObj(fromEl.dataset, toEl.dataset))
     ) {
-      hook.__beforeUpdate();
+      hook.__beforeUpdate(fromEl, toEl);
       return hook;
     }
   }

--- a/assets/js/phoenix_live_view/view.ts
+++ b/assets/js/phoenix_live_view/view.ts
@@ -654,7 +654,7 @@ export default class View {
       !fromEl.isEqualNode(toEl) &&
       !(isIgnored && isEqualObj(fromEl.dataset, toEl.dataset))
     ) {
-      hook.__beforeUpdate(fromEl, toEl);
+      hook.__beforeUpdate(toEl);
       return hook;
     }
   }

--- a/assets/js/phoenix_live_view/view_hook.ts
+++ b/assets/js/phoenix_live_view/view_hook.ts
@@ -41,7 +41,7 @@ export interface HookInterface<E extends HTMLElement = HTMLElement> {
    * Called when the element is about to be updated in the DOM.
    * Note: any call here must be synchronous as the operation cannot be deferred or cancelled.
    */
-  beforeUpdate?: () => void;
+  beforeUpdate?: (fromEl: E, toEl: E) => void;
 
   /**
    * The updated callback.
@@ -222,7 +222,7 @@ export interface Hook<T = object, E extends HTMLElement = HTMLElement> {
    * Called when the element is about to be updated in the DOM.
    * Note: any call here must be synchronous as the operation cannot be deferred or cancelled.
    */
-  beforeUpdate?: (this: T & HookInterface<E>) => void;
+  beforeUpdate?: (this: T & HookInterface<E>, fromEl: E, toEl: E) => void;
 
   /**
    * The updated callback.
@@ -408,7 +408,7 @@ export class ViewHook<
 
   // Default lifecycle methods
   mounted(): void {}
-  beforeUpdate(): void {}
+  beforeUpdate(_fromEl: E, _toEl: E): void {}
   updated(): void {}
   destroyed(): void {}
   disconnected(): void {}
@@ -425,8 +425,8 @@ export class ViewHook<
     this.updated();
   }
   /** @internal */
-  __beforeUpdate() {
-    this.beforeUpdate();
+  __beforeUpdate(fromEl, toEl) {
+    this.beforeUpdate(fromEl, toEl);
   }
   /** @internal */
   __destroyed() {

--- a/assets/js/phoenix_live_view/view_hook.ts
+++ b/assets/js/phoenix_live_view/view_hook.ts
@@ -39,9 +39,14 @@ export interface HookInterface<E extends HTMLElement = HTMLElement> {
    * The beforeUpdate callback.
    *
    * Called when the element is about to be updated in the DOM.
+   *
+   * `toEl` is a detached element carrying the update that is about to be applied;
+   * `el` is still the unmodified element as it currently exists in the DOM. `toEl` is
+   * discarded once the patch has been applied and must not be kept past the callback.
+   *
    * Note: any call here must be synchronous as the operation cannot be deferred or cancelled.
    */
-  beforeUpdate?: (fromEl: E, toEl: E) => void;
+  beforeUpdate?: (toEl: E) => void;
 
   /**
    * The updated callback.
@@ -220,9 +225,14 @@ export interface Hook<T = object, E extends HTMLElement = HTMLElement> {
    * The beforeUpdate callback.
    *
    * Called when the element is about to be updated in the DOM.
+   *
+   * `toEl` is a detached element carrying the update that is about to be applied;
+   * `el` is still the unmodified element as it currently exists in the DOM. `toEl` is
+   * discarded once the patch has been applied and must not be kept past the callback.
+   *
    * Note: any call here must be synchronous as the operation cannot be deferred or cancelled.
    */
-  beforeUpdate?: (this: T & HookInterface<E>, fromEl: E, toEl: E) => void;
+  beforeUpdate?: (this: T & HookInterface<E>, toEl: E) => void;
 
   /**
    * The updated callback.
@@ -408,7 +418,7 @@ export class ViewHook<
 
   // Default lifecycle methods
   mounted(): void {}
-  beforeUpdate(_fromEl: E, _toEl: E): void {}
+  beforeUpdate(_toEl: E): void {}
   updated(): void {}
   destroyed(): void {}
   disconnected(): void {}
@@ -425,8 +435,8 @@ export class ViewHook<
     this.updated();
   }
   /** @internal */
-  __beforeUpdate(fromEl, toEl) {
-    this.beforeUpdate(fromEl, toEl);
+  __beforeUpdate(toEl: E) {
+    this.beforeUpdate(toEl);
   }
   /** @internal */
   __destroyed() {

--- a/assets/test/view_test.ts
+++ b/assets/test/view_test.ts
@@ -1928,6 +1928,134 @@ describe("View Hooks", function () {
     expect((view.el.firstChild! as HTMLElement).innerHTML).toBe("updated");
   });
 
+  test("beforeUpdate receives toEl", async () => {
+    let args: object | null = null;
+    const Hooks = <HooksOptions>{
+      MyHook: {
+        beforeUpdate(toEl) {
+          args = {
+            // el is still the unmodified element in the DOM
+            elHTML: this.el.outerHTML,
+            toHTML: toEl.outerHTML,
+            toIsConnected: document.contains(toEl),
+          };
+        },
+      },
+    };
+    liveSocket = new LiveSocket("/live", Socket, { hooks: Hooks });
+    const el = liveViewDOM();
+    const view = simulateJoinedView(el, liveSocket);
+
+    view.onJoin({
+      rendered: {
+        s: ['<div id="hook" phx-hook="MyHook">initial</div>'],
+        fingerprint: 123,
+      },
+      liveview_version,
+    });
+    expect(args).toBe(null);
+
+    view.update(
+      {
+        s: ['<div id="hook" phx-hook="MyHook" class="x">updated</div>'],
+        fingerprint: 123,
+      },
+      [],
+    );
+
+    expect(args).toEqual({
+      elHTML: '<div id="hook" phx-hook="MyHook">initial</div>',
+      // toEl carries the update that is about to be applied
+      toHTML: '<div id="hook" phx-hook="MyHook" class="x">updated</div>',
+      // and it is detached; it is discarded once the patch is applied
+      toIsConnected: false,
+    });
+  });
+
+  test("beforeUpdate receives new attributes for phx-update=ignore", async () => {
+    let elV: string | undefined;
+    let toV: string | undefined;
+    const Hooks = <HooksOptions>{
+      MyHook: {
+        beforeUpdate(toEl) {
+          elV = this.el.dataset.v;
+          toV = toEl.dataset.v;
+        },
+      },
+    };
+    liveSocket = new LiveSocket("/live", Socket, { hooks: Hooks });
+    const el = liveViewDOM();
+    const view = simulateJoinedView(el, liveSocket);
+
+    view.onJoin({
+      rendered: {
+        s: [
+          '<div id="hook" phx-hook="MyHook" phx-update="ignore" data-v="1">initial</div>',
+        ],
+        fingerprint: 123,
+      },
+      liveview_version,
+    });
+
+    view.update(
+      {
+        s: [
+          '<div id="hook" phx-hook="MyHook" phx-update="ignore" data-v="2">updated</div>',
+        ],
+        fingerprint: 123,
+      },
+      [],
+    );
+
+    // the hook sees the new data attributes before they are merged into el
+    expect(elV).toBe("1");
+    expect(toV).toBe("2");
+    // the content is ignored, but the data attributes are merged
+    expect(el.querySelector("#hook")!.outerHTML).toBe(
+      '<div id="hook" phx-hook="MyHook" phx-update="ignore" data-v="2">initial</div>',
+    );
+  });
+
+  test("beforeUpdate observes toEl changes from dom.onBeforeElUpdated", async () => {
+    let seen: string | null = null;
+    const Hooks = <HooksOptions>{
+      MyHook: {
+        beforeUpdate(toEl) {
+          seen = toEl.getAttribute("data-js-flag");
+        },
+      },
+    };
+    liveSocket = new LiveSocket("/live", Socket, {
+      hooks: Hooks,
+      dom: {
+        onBeforeElUpdated(_from, to) {
+          to.setAttribute("data-js-flag", "set-by-dom-callback");
+        },
+      },
+    });
+    const el = liveViewDOM();
+    const view = simulateJoinedView(el, liveSocket);
+
+    view.onJoin({
+      rendered: {
+        s: ['<div id="hook" phx-hook="MyHook">initial</div>'],
+        fingerprint: 123,
+      },
+      liveview_version,
+    });
+
+    view.update(
+      {
+        s: ['<div id="hook" phx-hook="MyHook">updated</div>'],
+        fingerprint: 123,
+      },
+      [],
+    );
+
+    // onBeforeElUpdated runs before the hook's beforeUpdate
+    expect(seen).toBe("set-by-dom-callback");
+  });
+
   test("can overwrite property", async () => {
     let customHandleEventCalled = false;
     const Hooks = <HooksOptions>{

--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -148,7 +148,11 @@ or removed by the server, a hook object may be provided via `phx-hook`.
 
   * `mounted` - the element has been added to the DOM and its server
     LiveView has finished mounting
-  * `beforeUpdate` - the element is about to be updated in the DOM.
+  * `beforeUpdate(toEl)` - the element is about to be updated in the DOM.
+    `toEl` is a detached element carrying the update that is about to be applied,
+    while `this.el` is still the unmodified element as it currently exists in the DOM.
+    This is the per-element counterpart to the `dom` option's `onBeforeElUpdated`
+    callback described below.
     *Note*: any call here must be synchronous as the operation cannot
     be deferred or cancelled.
   * `updated` - the element has been updated in the DOM by the server.
@@ -249,6 +253,16 @@ let liveSocket = new LiveSocket("/live", Socket, {
 ```
 
 In the example above, all attributes starting with `data-js-` won't be replaced when the DOM is patched by LiveView.
+
+`onBeforeElUpdated` is called for every element LiveView is about to patch. A hook's
+`beforeUpdate(toEl)` callback receives the same `toEl` node, but only for the hooked
+element itself, and only when that element actually changed. For an element with
+`phx-update="ignore"`, it is additionally only called when the element's `data-*`
+attributes changed.
+
+In both callbacks, `toEl` is a detached node that is discarded once the patch has been
+applied. Read what you need from it synchronously; keeping a reference to it past the
+callback retains a detached element that will never reflect the live DOM.
 
 A hook can also be defined as a subclass of `ViewHook`:
 


### PR DESCRIPTION
Relates to https://github.com/phoenixframework/phoenix_live_view/issues/3516.
Relates to #3615.

Allowing beforeUpdate to cancel an update by returning false is **not** implemented, as this would require more complex internal changes.