### PR TITLE
Element text selector: Normalize whitespace

### DIFF
--- a/lib/phoenix_live_view/test/dom.ex
+++ b/lib/phoenix_live_view/test/dom.ex
@@ -147,7 +147,12 @@ defmodule Phoenix.LiveViewTest.DOM do
 
   def to_html(html_tree), do: Floki.raw_html(html_tree)
 
-  def to_text(html_tree), do: Floki.text(html_tree)
+  def to_text(html_tree) do
+    html_tree
+    |> Floki.text()
+    |> String.replace(~r/[\s]+/, " ")
+    |> String.trim()
+  end
 
   # TODO: rewrite to use Floki.get_by_id/2
   # currently it does not raise when multiple elements are found

--- a/test/phoenix_live_view/integrations/elements_test.exs
+++ b/test/phoenix_live_view/integrations/elements_test.exs
@@ -27,6 +27,7 @@ defmodule Phoenix.LiveView.ElementsTest do
       assert view |> element("#scoped-render") |> has_element?()
       assert view |> element("div", "This is a div") |> has_element?()
       assert view |> element("#scoped-render", ~r/^This is a div$/) |> has_element?()
+      assert view |> element("span", "Normalize whitespace") |> has_element?()
 
       refute view |> element("#unknown") |> has_element?()
       refute view |> element("div", "no matching text") |> has_element?()

--- a/test/support/live_views/elements.ex
+++ b/test/support/live_views/elements.ex
@@ -12,6 +12,10 @@ defmodule Phoenix.LiveViewTest.Support.ElementsLive do
     <div id="child-component">
       <.live_component module={Phoenix.LiveViewTest.Support.ElementsComponent} id={1} />
     </div>
+    <span phx-no-format>
+      Normalize
+      <span> whitespace</span>
+    </span>
 
     {# basic render_*}
     <span id="span-no-attr">This is a span</span>


### PR DESCRIPTION
Goal: Make it easier to find an element by text (`element/3`, `has_element?/3`) if there is nested markup.

Example input:
```
<span>
  Text
  <span>with whitespace</span>
</span>
```

Status quo:
- `element(view, "span", "Text\n  with whitespace")`
- `element(view, "span", ~r/Text\n.*with whitespace/)`

With this PR:
- `element(view, "span", "Text with whitespace")`

Solution: Normalize whitespace (convert different whitespace characters to regular space, collapse consecutive whitespace).

Breaking change: This PR changes the default behaviour. Maybe this should be opt-in instead?

## Pointers
To feature test libraries, which of course can't be compared 1:1.

Wallaby
>  Matches any element by its inner text.
`~s{.//*[contains(normalize-space(text()), "#{selector}")]}`
[xpath.ex](https://github.com/elixir-wallaby/wallaby/blob/c144c92e8bc1812c1f712cc1f1c652c4d2c7ce4b/lib/wallaby/query/xpath.ex#L80)
https://developer.mozilla.org/en-US/docs/Web/XPath/Functions/normalize-space

Playwright
> Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into one, turns line breaks into spaces and ignores leading and trailing whitespace.
https://playwright.dev/docs/locators#get-by-text