### PR TITLE
properly scope findExistingParentCIDs

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -148,7 +148,7 @@ let DOM = {
     cids.forEach(cid => {
       this.filterWithinSameLiveView(this.all(node, `[${PHX_COMPONENT}="${cid}"]`), node).forEach(parent => {
         parentCids.add(cid)
-        this.all(parent, `[${PHX_COMPONENT}]`)
+        this.filterWithinSameLiveView(this.all(parent, `[${PHX_COMPONENT}]`), parent)
           .map(el => parseInt(el.getAttribute(PHX_COMPONENT)))
           .forEach(childCID => childrenCids.add(childCID))
       })

--- a/assets/test/dom_test.js
+++ b/assets/test/dom_test.js
@@ -157,6 +157,26 @@ describe("DOM", () => {
       `))
       expect(DOM.findExistingParentCIDs(view, [1, 2, 3])).toEqual(new Set([1]))
     })
+
+    test("ignores elements in child LiveViews #3626", () => {
+      let view = tag("div", {}, `
+        <div data-phx-main="true"
+            data-phx-session="123"
+            data-phx-static="456"
+            id="phx-123"
+            class="phx-connected"
+            data-phx-root-id="phx-FgFpFf-J8Gg-jEnh">
+        </div>
+      `)
+      document.body.appendChild(view)
+
+      view.appendChild(tag("div", {"data-phx-component": 1}, `
+        <div data-phx-session="123" data-phx-static="456" data-phx-parent="phx-123" id="phx-child-view">
+          <div data-phx-component="1"></div>
+        </div>
+      `))
+      expect(DOM.findExistingParentCIDs(view, [1])).toEqual(new Set([1]))
+    })
   })
 
   describe("findComponentNodeList", () => {


### PR DESCRIPTION
findExistingParentCIDs did not ignore CIDs in child LiveViews, causing updates to be ignored in certain cases.

Fixes #3626.