### PR TITLE
Document `:fun` and `{:fun, arity}` type supported by `attr/3`

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1886,6 +1886,8 @@ defmodule Phoenix.Component do
   | `:float`        | any float                                                            |
   | `:list`         | any list of any arbitrary types                                      |
   | `:map`          | any map of any arbitrary types                                       |
+  | `:fun`          | any function                                                         |
+  | `{:fun, arity}` | any function of arity                                                |
   | `:global`       | any common HTML attributes, plus those defined by `:global_prefixes` |
   | A struct module | any module that defines a struct with `defstruct/1`                  |
 


### PR DESCRIPTION
Document functionality introduced by https://github.com/phoenixframework/phoenix_live_view/pull/3419

eg.

```elixir
attr :on_complete, {:fun, 2}
```
