### PR TITLE
Add the ability to strip data-test- attributes from HEEX output

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -542,6 +542,19 @@ defmodule Phoenix.Component do
 
   Changing this configuration will require `mix clean` and a full recompile.
 
+  ## Strip data-test- attributes
+
+  When testing a LiveView application, you use CSS selectors to target elements in your HTML.
+  Changes to layout or styling can break your tests even when functionality remains unchanged.
+  By using attributes beginning with `data-test-` you can target specific elements in your tests without having to rely
+  on the specifics of the layout.
+
+  These test attributes can be stripped from the HTML output in production by adding the following configuration to your `config/prod.exs` file:
+
+      config :phoenix_live_view, strip_test_attributes: true
+
+  Changing this configuration will require `mix clean` and a full recompile.
+
   ## Dynamic Component Rendering
 
   Sometimes you might need to decide at runtime which component to render.

--- a/lib/phoenix_live_view/tag_engine.ex
+++ b/lib/phoenix_live_view/tag_engine.ex
@@ -854,6 +854,16 @@ defmodule Phoenix.LiveView.TagEngine do
   end
 
   defp handle_tag_attrs(state, meta, attrs) do
+    attrs =
+      if Application.get_env(:phoenix_live_view, :strip_test_attributes, false) do
+        Enum.filter(attrs, fn
+          {<<"data-test-", _::binary>>, _, _} -> false
+          _ -> true
+        end)
+      else
+        attrs
+      end
+
     Enum.reduce(attrs, state, fn
       {:root, {:expr, _, _} = expr, _attr_meta}, state ->
         ast = parse_expr!(expr, state.file)

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -393,6 +393,28 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
     assert render("<div attr='1'/>") == "<div attr='1'></div>"
   end
 
+  describe "test attributes" do
+    import Phoenix.LiveViewTest.Support.TestAttributes
+
+    test "with value" do
+      assigns = %{test_id: "foo"}
+      assert compile("<.with_value test_id='foo'/>") == "<div></div>"
+      assert compile("<div data-test-id={@test_id}/>") == "<div data-test-id=\"foo\"></div>"
+    end
+
+    test "with static value" do
+      assigns = %{}
+      assert compile("<.with_static_value/>") == "<div></div>"
+      assert compile("<div data-test-name=\"foo\"/>") == "<div data-test-name=\"foo\"></div>"
+    end
+
+    test "without value" do
+      assigns = %{}
+      assert compile("<.without_value/>") == "<div></div>"
+      assert compile("<div data-test-attr/>") == "<div data-test-attr></div>"
+    end
+  end
+
   describe "debug annotations" do
     alias Phoenix.LiveViewTest.Support.DebugAnno
     import Phoenix.LiveViewTest.Support.DebugAnno

--- a/test/support/live_views/test_attributes.exs
+++ b/test/support/live_views/test_attributes.exs
@@ -1,0 +1,19 @@
+# Note this file is intentionally a .exs file because it is loaded
+# in the test helper with strip_test_attributes turned on.
+defmodule Phoenix.LiveViewTest.Support.TestAttributes do
+  use Phoenix.Component
+
+  def with_value(assigns) do
+    ~H"<div data-test-id={@test_id}></div>"
+  end
+
+  def with_static_value(assigns) do
+    ~H"""
+    <div data-test-name="foo"></div>
+    """
+  end
+
+  def without_value(assigns) do
+    ~H"<div data-test-attr></div>"
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,5 +2,9 @@ Application.put_env(:phoenix_live_view, :debug_heex_annotations, true)
 Code.require_file("test/support/live_views/debug_anno.exs")
 Application.put_env(:phoenix_live_view, :debug_heex_annotations, false)
 
+Application.put_env(:phoenix_live_view, :strip_test_attributes, true)
+Code.require_file("test/support/live_views/test_attributes.exs")
+Application.put_env(:phoenix_live_view, :strip_test_attributes, false)
+
 {:ok, _} = Phoenix.LiveViewTest.Support.Endpoint.start_link()
 ExUnit.start()


### PR DESCRIPTION
This suggested change is inspired by [ember-test-selectors](https://github.com/mainmatter/ember-test-selectors)
To make tests more robust, you can use test specific attributes like `data-test-user-id={@user.id}` for easier element lookup and identification without a reliance on the specifics of the HTML markup, but this is test specific code that doesn’t belong in production.
This change adds a compilation flag to strip all test attributes which can be placed in the `config/prod.exs` file