### PR TITLE
Doc change to make atom keys explicit for dynamic attributes

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -707,6 +707,7 @@ defmodule Phoenix.Component do
 
   In this case, the expression inside `{...}` must be either a keyword list or
   a map containing the key-value pairs representing the dynamic attributes.
+  If using a map, ensure your keys are atoms.
 
   ### Interpolating blocks
 


### PR DESCRIPTION
Dynamic attributes need to have atom keys. String keys can work but fail in certain cases, like `<.form ... {attrs_with_string_keys()}>` because the form component checks for atom keys in `assigns.rest`
This update makes the requirement explicit.