### PR TITLE
Fix documentation of JS.transition/1

### DIFF
--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -649,7 +649,7 @@ defmodule Phoenix.LiveView.JS do
   @doc """
   Transitions elements.
 
-    * `transition` - A string of classes to apply before removing classes or
+    * `transition` - A string of classes to apply during the transition or
       a 3-tuple containing the transition class, the class to apply
       to start the transition, and the ending transition class, such as:
       `{"ease-out duration-300", "opacity-0", "opacity-100"}`


### PR DESCRIPTION
Was probably an accidental copy-paste from `JS.remove_class/1` that went unnoticed for a long time (even as I updated the docs 8 months ago).