### PR TITLE
Add `popover` to global attributes list

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -107,6 +107,7 @@ defmodule Phoenix.Component.Declarative do
     onwaiting
     part
     placeholder
+    popover
     rel
     role
     slot


### PR DESCRIPTION
Popover API is now "Newly available" so it's supported in the latest browsers

https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover