### PR TITLE
Send JS command values on phx-submit

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -1186,7 +1186,7 @@ export default class View {
       ], phxEvent, "change", opts)
     }
     let formData
-    let meta  = this.extractMeta(inputEl.form)
+    let meta = this.extractMeta(inputEl.form, {}, opts.value)
     if(inputEl instanceof HTMLButtonElement){ meta.submitter = inputEl }
     if(inputEl.getAttribute(this.binding("change"))){
       formData = serializeForm(inputEl.form, {_target: opts._target, ...meta}, [inputEl.name])

--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -1300,7 +1300,7 @@ export default class View {
         if(LiveUploader.inputsAwaitingPreflight(formEl).length > 0){
           return this.undoRefs(ref, phxEvent)
         }
-        let meta = this.extractMeta(formEl)
+        let meta = this.extractMeta(formEl, {}, opts.value)
         let formData = serializeForm(formEl, {submitter, ...meta})
         this.pushWithReply(proxyRefGen, "event", {
           type: "form",
@@ -1310,7 +1310,7 @@ export default class View {
         }).then(({resp}) => onReply(resp))
       })
     } else if(!(formEl.hasAttribute(PHX_REF_SRC) && formEl.classList.contains("phx-submit-loading"))){
-      let meta = this.extractMeta(formEl)
+      let meta = this.extractMeta(formEl, {}, opts.value)
       let formData = serializeForm(formEl, {submitter, ...meta})
       this.pushWithReply(refGenerator, "event", {
         type: "form",

--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -119,9 +119,24 @@ let serializeForm = (form, metadata, onlyNames = []) => {
     submitter.parentElement.removeChild(injectedElement)
   }
 
-  for(let metaKey in meta){ params.append(metaKey, meta[metaKey]) }
+  for(let metaKey in meta){
+    appendToUrlParams(params, metaKey, meta[metaKey])
+  }
 
   return params.toString()
+}
+
+let appendToUrlParams = (params, name, value) => {
+  if(Array.isArray(value)){
+    value.forEach((v) => appendToUrlParams(params, `${name}[]`, v))
+  } else if(value instanceof Object){
+    Object.entries(value).forEach(([key, v]) => {
+      appendToUrlParams(params, `${name}[${key}]`, v)
+    })
+  } else {
+    params.append(name, value)
+  }
+  return params
 }
 
 export default class View {

--- a/assets/test/js_test.js
+++ b/assets/test/js_test.js
@@ -645,7 +645,7 @@ describe("JS", () => {
       <div id="modal" class="modal">modal</div>
       <form id="my-form"
             phx-change="validate"
-            phx-submit='[["push", {"event": "save", "value": {"command_value": "command"}}]]'
+            phx-submit='[["push", {"event": "save", "value": {"command_value": "command","nested":{"array":[1,2]}}}]]'
             phx-value-attribute_value="attribute"
       >
         <input type="text" name="username" id="username" />
@@ -655,7 +655,7 @@ describe("JS", () => {
       let form = document.querySelector("#my-form")
 
       view.pushWithReply = (refGen, event, payload) => {
-        let expectedValue = "username=&desc=&attribute_value=attribute&command_value=command"
+        let expectedValue = "username=&desc=&attribute_value=attribute&command_value=command&nested%5Barray%5D%5B%5D=1&nested%5Barray%5D%5B%5D=2"
         expect(payload).toEqual({"cid": null, "event": "save", "type": "form", "value": expectedValue})
         return Promise.resolve({resp: done()})
       }

--- a/assets/test/js_test.js
+++ b/assets/test/js_test.js
@@ -529,6 +529,28 @@ describe("JS", () => {
       JS.exec(event, "change", form.getAttribute("phx-change"), view, input, args)
     })
 
+    test("form change event with phx-value and JS command value", done => {
+      let view = setupView(`
+      <div id="modal" class="modal">modal</div>
+      <form id="my-form"
+            phx-change='[["push", {"event": "validate", "_target": "username", "value": {"command_value": "command","nested":{"array":[1,2]}}}]]'
+            phx-submit="submit"
+            phx-value-attribute_value="attribute"
+      >
+        <input type="text" name="username" id="username" phx-click=''></div>
+      </form>
+      `)
+      let form = document.querySelector("#my-form")
+      let input = document.querySelector("#username")
+      view.pushWithReply = (refGen, event, payload) => {
+        let expectedValue = "_unused_username=&username=&_target=username&attribute_value=attribute&command_value=command&nested%5Barray%5D%5B%5D=1&nested%5Barray%5D%5B%5D=2"
+        expect(payload).toEqual({"cid": null, "event": "validate", "type": "form", "value": expectedValue, "uploads": {}})
+        return Promise.resolve({resp: done()})
+      }
+      let args = ["push", {_target: input.name, dispatcher: input}]
+      JS.exec(event, "change", form.getAttribute("phx-change"), view, input, args)
+    })
+
     test("form change event with string event", done => {
       let view = setupView(`
       <div id="modal" class="modal">modal</div>

--- a/assets/test/js_test.js
+++ b/assets/test/js_test.js
@@ -640,6 +640,28 @@ describe("JS", () => {
       JS.exec(event, "submit", form.getAttribute("phx-submit"), view, form, ["push", {}])
     })
 
+    test("submit event with phx-value and JS command value", done => {
+      let view = setupView(`
+      <div id="modal" class="modal">modal</div>
+      <form id="my-form"
+            phx-change="validate"
+            phx-submit='[["push", {"event": "save", "value": {"command_value": "command"}}]]'
+            phx-value-attribute_value="attribute"
+      >
+        <input type="text" name="username" id="username" />
+        <input type="text" name="desc" id="desc" phx-change="desc_changed" />
+      </form>
+      `)
+      let form = document.querySelector("#my-form")
+
+      view.pushWithReply = (refGen, event, payload) => {
+        let expectedValue = "username=&desc=&attribute_value=attribute&command_value=command"
+        expect(payload).toEqual({"cid": null, "event": "save", "type": "form", "value": expectedValue})
+        return Promise.resolve({resp: done()})
+      }
+      JS.exec(event, "submit", form.getAttribute("phx-submit"), view, form, ["push", {}])
+    })
+
     test("page_loading", done => {
       let view = setupView(`
       <div id="modal" class="modal">modal</div>

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -236,6 +236,37 @@ describe("View + DOM", function(){
     view.pushInput(input, el, null, "validate", {_target: input.name})
   })
 
+  test("pushInput with with phx-value and JS command value", function(){
+    expect.assertions(3)
+
+    let liveSocket = new LiveSocket("/live", Socket)
+    let el = liveViewDOM(`
+      <form id="my-form" phx-value-attribute_value="attribute">
+        <label for="plus">Plus</label>
+        <input id="plus" value="1" name="increment" />
+        <textarea id="note" name="note">2</textarea>
+        <input type="checkbox" phx-click="toggle_me" />
+        <button phx-click="inc_temperature">Inc Temperature</button>
+      </form>
+    `)
+    let input = el.querySelector("input")
+    simulateUsedInput(input)
+    let view = simulateJoinedView(el, liveSocket)
+    let channelStub = {
+      push(_evt, payload, _timeout){
+        expect(payload.type).toBe("form")
+        expect(payload.event).toBeDefined()
+        expect(payload.value).toBe("increment=1&_unused_note=&note=2&_target=increment&attribute_value=attribute&nested%5Bcommand_value%5D=command&nested%5Barray%5D%5B%5D=1&nested%5Barray%5D%5B%5D=2")
+        return {
+          receive(){ return this }
+        }
+      }
+    }
+    view.channel = channelStub
+    let optValue = {nested: {command_value: "command", array: [1, 2]}}
+    view.pushInput(input, el, null, "validate", {_target: input.name, value: optValue})
+  })
+
   test("getFormsForRecovery", function(){
     let view, html, liveSocket = new LiveSocket("/live", Socket)
 

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -316,14 +316,15 @@ describe("View + DOM", function(){
         push(_evt, payload, _timeout){
           expect(payload.type).toBe("form")
           expect(payload.event).toBeDefined()
-          expect(payload.value).toBe("increment=1&note=2&attribute_value=attribute&command_value=command")
+          expect(payload.value).toBe("increment=1&note=2&attribute_value=attribute&nested%5Bcommand_value%5D=command&nested%5Barray%5D%5B%5D=1&nested%5Barray%5D%5B%5D=2")
           return {
             receive(){ return this }
           }
         }
       }
       view.channel = channelStub
-      view.submitForm(form, form, {target: form}, undefined, {value: {command_value: "command"}})
+      let opts = {value: {nested: {command_value: "command", array: [1, 2]}}}
+      view.submitForm(form, form, {target: form}, undefined, opts)
     })
 
     test("payload includes submitter when name is provided", function(){


### PR DESCRIPTION
Currently, when setting the `phx-submit` with a `JS.push/3` with the `:value` attribute set, it does not send this value to the server (only the `phx-value-*` are sent)

Example:

```heex
<form id="userForm" phx-submit={JS.push("submit", value: %{command_value: "some value"})}>
   ...
</form>
```

The `%{command_value: "some value"}` will not be present in the `handle_event/3` params.
