### PR TITLE
fix race conditions when upload progress redirects

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1071,9 +1071,10 @@ defmodule Phoenix.LiveViewTest do
              |> render() == "Snooze"
   """
   def render(view_or_element) do
-    view_or_element
-    |> render_tree()
-    |> DOM.to_html()
+    case render_tree(view_or_element) do
+      {:error, reason} -> {:error, reason}
+      html -> DOM.to_html(html)
+    end
   end
 
   @doc """
@@ -2017,12 +2018,29 @@ defmodule Phoenix.LiveViewTest do
   end
 
   defp render_chunk(upload, entry_name, percent) do
-    %{proxy: {_ref, _topic, pid}} = upload.view
+    pid = proxy_pid(upload.view)
     monitor_ref = Process.monitor(pid)
+    trap = Process.flag(:trap_exit, true)
 
     try do
       case UploadClient.chunk(upload, entry_name, percent, proxy_pid(upload.view)) do
         {:ok, _} ->
+          # The chunk function returns as soon as the upload is consumed, therefore
+          # the following could happen:
+          #
+          #   1. the upload is consumed, and the channel is closed
+          #     --> we receive :ok here
+          #     --> the progress callback redirected, the channel sends a message to itself
+          #   2. we try to render and send a message to the ClientProxy, which pings the channel
+          #   3. the channel receives the ping before it is scheduled to send the redirect message to
+          #      itself, therefore the ping succeeds
+          #   4. we receive the HTML, but we expected a redirect shutdown
+          #
+          # If we synchronize here, we ensure that the channel successfully sent the redirect message
+          # before we try to render. This way, either the first sync already fails, or the second sync
+          # inside the render fails because at that time, the redirect message must have been processed
+          # by the channel.
+          sync_with_root!(upload.view)
           render(upload.view)
 
         {:error, reason} ->
@@ -2039,6 +2057,14 @@ defmodule Phoenix.LiveViewTest do
         after
           0 -> exit(reason)
         end
+    after
+      Process.flag(:trap_exit, trap)
     end
+  end
+
+  defp sync_with_root!(%View{} = view) do
+    pid = proxy_pid(view)
+    proxy_topic = proxy_topic(view)
+    GenServer.call(pid, {:sync_with_root, proxy_topic})
   end
 end


### PR DESCRIPTION
When someone does a push_navigate in the progress callback of an upload, the render_upload function of LiveViewTest sometimes did not properly return the live_redirect error tuple. This happened because the UploadChannel closes as soon as an upload is consumed. When this happens in the progress callback, the test code and the channel code raced:
The channel sends a redirect message to itself (or the root view) which shuts down once it receives it. The test code triggers a new render through the ClientProxy. Now it could happen that:

1. the test process can successfully call the ClientProxy, but the ClientProxy then crashed while pinging the channel
2. or the ClientProxy succeeds in pinging and actually returns the new HTML while the test expects the redirect error tuple
3. or the channel and client proxy shut down in time for the test process to fail rendering and return the error tuple as expected

We fix this race by ensuring that we ping the view (and root view) as soon as the upload is finished. This ensures that the channel has time to send the redirect message before the render call can ping it again. Thus, we always get the expected shutdown at the latest when the render call pings the channel.

Fixes https://github.com/phoenixframework/phoenix_live_view/issues/3662.
Relates to: https://github.com/phoenixframework/phoenix_live_view/issues/2047
Relates to: https://github.com/phoenixframework/phoenix_live_view/issues/1620