### PR TITLE
Add doc examples using attach_hook for code organization instead of LiveComponents

### DIFF
--- a/guides/introduction/welcome.md
+++ b/guides/introduction/welcome.md
@@ -250,12 +250,12 @@ and to reuse markup in your LiveViews.
 Sometimes you need to share more than just markup across LiveViews. When you also
 want to move events to a separate module, or use the same event handler in multiple
 places, function components can be paired with
-[`Phoenix.LiveView.attach_hook/4`](`Phoenix.LiveView.attach_hook/4#sharing-event-handling-logic`)
+[`Phoenix.LiveView.attach_hook/4`](`Phoenix.LiveView.attach_hook/4#sharing-event-handling-logic`).
 
 ### Live components to encapsulate additional state
 
 A component will occasionally need control over not only its own events,
-but also its own seperate state. For these cases, LiveView
+but also its own separate state. For these cases, LiveView
 provides `Phoenix.LiveComponent`, which are rendered using
 [`live_component/1`](`Phoenix.Component.live_component/1`):
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1511,7 +1511,7 @@ defmodule Phoenix.LiveView do
   ## Sharing event handling logic
 
   Lifecycle hooks are an excellent way to extract related events out of the parent LiveView and
-  into seperate modules without resorting unnecessarily to LiveComponents for organization.
+  into separate modules without resorting unnecessarily to LiveComponents for organization.
 
       defmodule DemoLive do
         use Phoenix.LiveView


### PR DESCRIPTION
Update Welcome doc to use the guidance in "Functional components or live components?"
(near the top of `Phoenix.LiveComponent`) to avoid using LiveComponents
only for organization

Add hierarchy headers to the "Compartmentalize state, markup, and events" section

Provide some example code with a few different alternatives of *what* to use for
organizing handle_events *other* than LiveComponents

Example code adapted from @Gazler's incredibly helpful explanation in the below Issue

Resolves #3679 