### PR TITLE
add `requestAnimationFrame` back for `toggle` js function

### DIFF
--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -216,14 +216,18 @@ let JS = {
       }
     } else {
       if(this.isVisible(el)){
-        el.dispatchEvent(new Event("phx:hide-start"))
-        DOM.putSticky(el, "toggle", currentEl => currentEl.style.display = "none")
-        el.dispatchEvent(new Event("phx:hide-end"))
+        window.requestAnimationFrame(() => {
+          el.dispatchEvent(new Event("phx:hide-start"))
+          DOM.putSticky(el, "toggle", currentEl => currentEl.style.display = "none")
+          el.dispatchEvent(new Event("phx:hide-end"))
+        })
       } else {
-        el.dispatchEvent(new Event("phx:show-start"))
-        let stickyDisplay = display || this.defaultDisplay(el)
-        DOM.putSticky(el, "toggle", currentEl => currentEl.style.display = stickyDisplay)
-        el.dispatchEvent(new Event("phx:show-end"))
+        window.requestAnimationFrame(() => {
+          el.dispatchEvent(new Event("phx:show-start"))
+          let stickyDisplay = display || this.defaultDisplay(el)
+          DOM.putSticky(el, "toggle", currentEl => currentEl.style.display = stickyDisplay)
+          el.dispatchEvent(new Event("phx:show-end"))
+        })
       }
     }
   },


### PR DESCRIPTION
This commit  https://github.com/phoenixframework/phoenix_live_view/commit/485c3496a06d9163a4d457efa34369d4f7571f36 removed some occasions of `window.requestAnimationFrame`, where one of them are necessary(as i understand it) for the toggle function. The commit is part of version 1.0.3 -> 1.0.4 release. 

The example in issue #3675 is used to test that the reversion works. 

I dont know if a simple undo of the code is the way to go, and if not, i will gladly go in a different direction, with a little guidance :) 