### PR TITLE
Send JS command values on phx-submit

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -67,8 +67,8 @@ export let prependFormDataKey = (key, prefix) => {
   return baseKey
 }
 
-let serializeForm = (form, metadata, onlyNames = []) => {
-  const {submitter, ...meta} = metadata
+let serializeForm = (form, opts, onlyNames = []) => {
+  const {submitter} = opts
 
   // We must inject the submitter in the order that it exists in the DOM
   // relative to other inputs. For example, for checkbox groups, the order must be maintained.
@@ -118,8 +118,6 @@ let serializeForm = (form, metadata, onlyNames = []) => {
   if(submitter && injectedElement){
     submitter.parentElement.removeChild(injectedElement)
   }
-
-  for(let metaKey in meta){ params.append(metaKey, meta[metaKey]) }
 
   return params.toString()
 }
@@ -1171,12 +1169,13 @@ export default class View {
       ], phxEvent, "change", opts)
     }
     let formData
-    let meta  = this.extractMeta(inputEl.form)
-    if(inputEl instanceof HTMLButtonElement){ meta.submitter = inputEl }
+    let meta = this.extractMeta(inputEl.form, {}, opts.value)
+    let serializeOpts = {}
+    if(inputEl instanceof HTMLButtonElement){ serializeOpts.submitter = inputEl }
     if(inputEl.getAttribute(this.binding("change"))){
-      formData = serializeForm(inputEl.form, {_target: opts._target, ...meta}, [inputEl.name])
+      formData = serializeForm(inputEl.form, serializeOpts, [inputEl.name])
     } else {
-      formData = serializeForm(inputEl.form, {_target: opts._target, ...meta})
+      formData = serializeForm(inputEl.form, serializeOpts)
     }
     if(DOM.isUploadInput(inputEl) && inputEl.files && inputEl.files.length > 0){
       LiveUploader.trackFiles(inputEl, Array.from(inputEl.files))
@@ -1187,6 +1186,7 @@ export default class View {
       type: "form",
       event: phxEvent,
       value: formData,
+      meta: {_target: opts._target, ...meta},
       uploads: uploads,
       cid: cid
     }
@@ -1300,22 +1300,24 @@ export default class View {
         if(LiveUploader.inputsAwaitingPreflight(formEl).length > 0){
           return this.undoRefs(ref, phxEvent)
         }
-        let meta = this.extractMeta(formEl)
-        let formData = serializeForm(formEl, {submitter, ...meta})
+        let meta = this.extractMeta(formEl, {}, opts.value)
+        let formData = serializeForm(formEl, {submitter})
         this.pushWithReply(proxyRefGen, "event", {
           type: "form",
           event: phxEvent,
           value: formData,
+          meta: meta,
           cid: cid
         }).then(({resp}) => onReply(resp))
       })
     } else if(!(formEl.hasAttribute(PHX_REF_SRC) && formEl.classList.contains("phx-submit-loading"))){
-      let meta = this.extractMeta(formEl)
-      let formData = serializeForm(formEl, {submitter, ...meta})
+      let meta = this.extractMeta(formEl, {}, opts.value)
+      let formData = serializeForm(formEl, {submitter})
       this.pushWithReply(refGenerator, "event", {
         type: "form",
         event: phxEvent,
         value: formData,
+        meta: meta,
         cid: cid
       }).then(({resp}) => onReply(resp))
     }

--- a/assets/test/js_test.js
+++ b/assets/test/js_test.js
@@ -529,6 +529,41 @@ describe("JS", () => {
       JS.exec(event, "change", form.getAttribute("phx-change"), view, input, args)
     })
 
+    test("form change event with phx-value and JS command value", done => {
+      let view = setupView(`
+      <div id="modal" class="modal">modal</div>
+      <form id="my-form"
+            phx-change='[["push", {"event": "validate", "_target": "username", "value": {"command_value": "command","nested":{"array":[1,2]}}}]]'
+            phx-submit="submit"
+            phx-value-attribute_value="attribute"
+      >
+        <input type="text" name="username" id="username" phx-click=''></div>
+      </form>
+      `)
+      let form = document.querySelector("#my-form")
+      let input = document.querySelector("#username")
+      view.pushWithReply = (refGen, event, payload) => {
+        expect(payload).toEqual({
+          "cid": null,
+          "event": "validate",
+          "type": "form",
+          "value": "_unused_username=&username=",
+          "meta": {
+            "_target": "username",
+            "command_value": "command",
+            "nested": {
+              "array": [1, 2]
+            },
+            "attribute_value": "attribute"
+          },
+          "uploads": {}
+        })
+        return Promise.resolve({resp: done()})
+      }
+      let args = ["push", {_target: input.name, dispatcher: input}]
+      JS.exec(event, "change", form.getAttribute("phx-change"), view, input, args)
+    })
+
     test("form change event with string event", done => {
       let view = setupView(`
       <div id="modal" class="modal">modal</div>
@@ -553,7 +588,8 @@ describe("JS", () => {
           event: "validate",
           type: "form",
           uploads: {},
-          value: "_unused_username=&username=&_unused_other=&other=&_target=username"
+          value: "_unused_username=&username=&_unused_other=&other=",
+          meta: {"_target": "username"}
         })
         return Promise.resolve({resp: done()})
       }
@@ -584,7 +620,8 @@ describe("JS", () => {
           event: "username_changed",
           type: "form",
           uploads: {},
-          value: "_unused_username=&username=&_target=username"
+          value: "_unused_username=&username=",
+          meta: {"_target": "username"}
         })
         return Promise.resolve({resp: done()})
       }
@@ -615,7 +652,8 @@ describe("JS", () => {
           event: "username_changed",
           type: "form",
           uploads: {},
-          value: "_unused_username=&username=&_target=username"
+          value: "_unused_username=&username=",
+          meta: {"_target": "username"}
         })
         return Promise.resolve({resp: done()})
       }
@@ -634,7 +672,46 @@ describe("JS", () => {
       let form = document.querySelector("#my-form")
 
       view.pushWithReply = (refGen, event, payload) => {
-        expect(payload).toEqual({"cid": null, "event": "save", "type": "form", "value": "username=&desc="})
+        expect(payload).toEqual({
+          "cid": null,
+          "event": "save",
+          "type": "form",
+          "value": "username=&desc=",
+          "meta": {}
+        })
+        return Promise.resolve({resp: done()})
+      }
+      JS.exec(event, "submit", form.getAttribute("phx-submit"), view, form, ["push", {}])
+    })
+
+    test("submit event with phx-value and JS command value", done => {
+      let view = setupView(`
+      <div id="modal" class="modal">modal</div>
+      <form id="my-form"
+            phx-change="validate"
+            phx-submit='[["push", {"event": "save", "value": {"command_value": "command","nested":{"array":[1,2]}}}]]'
+            phx-value-attribute_value="attribute"
+      >
+        <input type="text" name="username" id="username" />
+        <input type="text" name="desc" id="desc" phx-change="desc_changed" />
+      </form>
+      `)
+      let form = document.querySelector("#my-form")
+
+      view.pushWithReply = (refGen, event, payload) => {
+        expect(payload).toEqual({
+          "cid": null,
+          "event": "save",
+          "type": "form",
+          "value": "username=&desc=",
+          "meta": {
+            "command_value": "command",
+            "nested": {
+              "array": [1, 2]
+            },
+            "attribute_value": "attribute"
+          }
+        })
         return Promise.resolve({resp: done()})
       }
       JS.exec(event, "submit", form.getAttribute("phx-submit"), view, form, ["push", {}])

--- a/assets/test/js_test.js
+++ b/assets/test/js_test.js
@@ -533,9 +533,9 @@ describe("JS", () => {
       let view = setupView(`
       <div id="modal" class="modal">modal</div>
       <form id="my-form"
-            phx-change='[["push", {"event": "validate", "_target": "username", "value": {"command_value": "command","nested":{"array":[1,2]}}}]]'
-            phx-submit="submit"
-            phx-value-attribute_value="attribute"
+        phx-change='[["push", {"event": "validate", "_target": "username", "value": {"command_value": "command","nested":{"array":[1,2]}}}]]'
+        phx-submit="submit"
+        phx-value-attribute_value="attribute"
       >
         <input type="text" name="username" id="username" phx-click=''></div>
       </form>
@@ -555,6 +555,58 @@ describe("JS", () => {
               "array": [1, 2]
             },
             "attribute_value": "attribute"
+          },
+          "uploads": {}
+        })
+        return Promise.resolve({resp: done()})
+      }
+      let args = ["push", {_target: input.name, dispatcher: input}]
+      JS.exec(event, "change", form.getAttribute("phx-change"), view, input, args)
+    })
+
+    test("form change event prefers JS.push value over phx-value-* over input value", (done) => {
+      let view = setupView(`
+        <form id="my-form" phx-value-name="value from phx-value param" phx-change="[[&quot;push&quot;,{&quot;value&quot;:{&quot;name&quot;:&quot;value from push opts&quot;},&quot;event&quot;:&quot;change&quot;}]]">
+          <input id="textField" name="name" value="input value" />
+        </form>
+      `)
+      let form = document.querySelector("#my-form")
+      let input = document.querySelector("#textField")
+      view.pushWithReply = (refGen, event, payload) => {
+        expect(payload).toEqual({
+          "cid": null,
+          "event": "change",
+          "type": "form",
+          "value": "_unused_name=&name=input+value",
+          "meta": {
+            "_target": "name",
+            "name": "value from push opts"
+          },
+          "uploads": {}
+        })
+        return Promise.resolve({resp: done()})
+      }
+      let args = ["push", {_target: input.name, dispatcher: input}]
+      JS.exec(event, "change", form.getAttribute("phx-change"), view, input, args)
+    })
+  
+    test("form change event prefers phx-value-* over input value", (done) => {
+      let view = setupView(`
+        <form id="my-form" phx-value-name="value from phx-value param" phx-change="change">
+          <input id="textField" name="name" value="input value" />
+        </form>
+      `)
+      let form = document.querySelector("#my-form")
+      let input = document.querySelector("#textField")
+      view.pushWithReply = (refGen, event, payload) => {
+        expect(payload).toEqual({
+          "cid": null,
+          "event": "change",
+          "type": "form",
+          "value": "_unused_name=&name=input+value",
+          "meta": {
+            "_target": "name",
+            "name": "value from phx-value param"
           },
           "uploads": {}
         })

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -245,7 +245,7 @@ defmodule Phoenix.LiveView.Channel do
 
   def handle_info(%Message{topic: topic, event: "event"} = msg, %{topic: topic} = state) do
     %{"value" => raw_val, "event" => event, "type" => type} = payload = msg.payload
-    val = decode_event_type(type, raw_val)
+    val = decode_event_type(type, raw_val, msg.payload)
 
     if cid = msg.payload["cid"] do
       component_handle(state, cid, msg.ref, fn component_socket, component ->
@@ -777,13 +777,14 @@ defmodule Phoenix.LiveView.Channel do
     )
   end
 
-  defp decode_event_type("form", url_encoded) do
+  defp decode_event_type("form", url_encoded, raw_payload) do
     url_encoded
     |> Plug.Conn.Query.decode()
     |> decode_merge_target()
+    |> maybe_merge_meta(raw_payload)
   end
 
-  defp decode_event_type(_, value), do: value
+  defp decode_event_type(_, value, _raw_payload), do: value
 
   defp decode_merge_target(%{"_target" => target} = params) when is_list(target), do: params
 
@@ -793,6 +794,12 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   defp decode_merge_target(%{} = params), do: params
+
+  defp maybe_merge_meta(value, %{"meta" => meta}) when is_map(value) do
+    Map.merge(value, meta)
+  end
+
+  defp maybe_merge_meta(value, _raw_payload), do: value
 
   defp gather_keys(%{} = map, acc) do
     case Enum.at(map, 0) do

--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -203,7 +203,9 @@ defmodule Phoenix.LiveView.JS do
       phx:page-loading-stop events for this push. Defaults to `false`.
     * `:value` - A map of values to send to the server. These values will be
       merged over any `phx-value-*` attributes that are present on the element.
-      All keys will be treated as strings when merging.
+      All keys will be treated as strings when merging. When used on a form event
+      like `phx-change` or `phx-submit`, the precedence is
+      `JS.push value > phx-value-* > input value`.
 
   ## Examples
 


### PR DESCRIPTION
Alternative implementation for #3674.

Closes #3674.