### PR TITLE
Update docs mentioning a unique id for an empty state in a stream

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1793,8 +1793,8 @@ defmodule Phoenix.LiveView do
 
   When rendering a list of items, it is common to show a message for the empty case.
   But when using streams, we cannot rely on `Enum.empty?/1` or similar approaches to
-  check if the list is empty. Instead we can use the CSS `:only-child` selector
-  and show the message client side:
+  check if the list is empty. Instead we can add a unique id and use the CSS 
+  `:only-child` selector and show the message client side:
 
   ```heex
   <table>


### PR DESCRIPTION
Currently the docs do not mention that you need an id when adding an empty state inside the stream DOM element. It is added in the code example.

This PR updates the wording above the example.

## Reasoning
When the stream is updated the empty state will be added multiple times if it does not have an id. Therefore the `:only` selector will not work. Makes perfect sense, but it would be good to call it out in the docs.

## Example
if you forget to add the ID here it will not work

```diff
<tbody id="songs" phx-update="stream">
-  <tr class="only:block hidden">
 + <tr id="songs-empty" class="only:block hidden">
      <td colspan="2">No songs found</td>
  </tr>
</tbody>
```