### PR TITLE
Return updated state instead of updated socket

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -472,7 +472,8 @@ defmodule Phoenix.LiveView.Channel do
     %{view: view} = socket
 
     if exported?(view, :code_change, 3) do
-      view.code_change(old, socket, extra)
+      {:ok, socket} = view.code_change(old, socket, extra)
+      {:ok, %{state | socket: socket}}
     else
       {:ok, state}
     end


### PR DESCRIPTION
If a LiveView implements `code_change/3`, it returns an updated socket. The channel should return an updated state with the updated socket instead of the updated socket itself.