### PR TITLE
Clarifications about nested live views and their appropriate use

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1011,6 +1011,11 @@ defmodule Phoenix.Component do
   Beware if you set this to `:body`, as any content injected inside the body
   (such as `Phoenix.LiveReload` features) will be discarded once the LiveView
   connects
+
+  ## Testing
+
+  Note that `render_click/1` will send events to the root LiveView, and you will want to
+  `find_live_child/2` to interact with nested LiveViews in your live tests.
   """
   def live_render(conn_or_socket, view, opts \\ [])
 

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -946,7 +946,10 @@ defmodule Phoenix.Component do
 
   * When rendering a LiveView inside a regular (non-live) controller/view.
 
-  ## Options
+  Most other cases for shared functionality, including state management and user interactions, can be
+  [achieved with LiveComponents](welcome.html#compartmentalize-state-markup-and-events-in-liveview)
+
+    ## Options
 
   * `:session` - a map of binary keys with extra session data to be serialized and sent
   to the client. All session data currently in the connection is automatically available

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -949,7 +949,7 @@ defmodule Phoenix.Component do
   Most other cases for shared functionality, including state management and user interactions, can be
   [achieved with function components or LiveComponents](welcome.html#compartmentalize-state-markup-and-events-in-liveview)
 
-    ## Options
+  ## Options
 
   * `:session` - a map of binary keys with extra session data to be serialized and sent
   to the client. All session data currently in the connection is automatically available

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -947,7 +947,7 @@ defmodule Phoenix.Component do
   * When rendering a LiveView inside a regular (non-live) controller/view.
 
   Most other cases for shared functionality, including state management and user interactions, can be
-  [achieved with LiveComponents](welcome.html#compartmentalize-state-markup-and-events-in-liveview)
+  [achieved with function components or LiveComponents](welcome.html#compartmentalize-state-markup-and-events-in-liveview)
 
     ## Options
 
@@ -1017,7 +1017,7 @@ defmodule Phoenix.Component do
 
   ## Testing
 
-  Note that `render_click/1` will send events to the root LiveView, and you will want to
+  Note that `render_click/1` and other testing functions will send events to the root LiveView, and you will want to
   `find_live_child/2` to interact with nested LiveViews in your live tests.
   """
   def live_render(conn_or_socket, view, opts \\ [])


### PR DESCRIPTION
I had a problem with nested live view testing where the test helpers did not understand where to send the click events.

This was discussed in issue #3393 and a subsequent read of the code makes it clear to me that there is no obvious way to have the test infrastructure walk up the DOM or process tree looking for the correct child to send clicks to (if someone knows a way to fix that I would love to encourage you to look into it).

So barring that, and informed by a separate conversation in the forums, here are some bits of advice gleaned from those two conversations. I think if the core Phoenix crew believes that Nested LiveViews are something you should use very sparingly, then the docs should warn new users that they are flying into the proverbial terrain.

There are some old SO threads and ancient forum threads that the participants didn't know about attach_hook. I don't know if that's lack of experience or later additions to the API. I'm hoping some more links in the docs will help with those.
