### PR TITLE
Fix _target not being correctly decoded

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -781,8 +781,8 @@ defmodule Phoenix.LiveView.Channel do
   defp decode_event_type("form", url_encoded, raw_payload) do
     url_encoded
     |> Plug.Conn.Query.decode()
-    |> decode_merge_target()
     |> maybe_merge_meta(raw_payload)
+    |> decode_merge_target()
   end
 
   defp decode_event_type(_, value, _raw_payload), do: value

--- a/test/e2e/support/issues/issue_3719.ex
+++ b/test/e2e/support/issues/issue_3719.ex
@@ -1,0 +1,22 @@
+defmodule Phoenix.LiveViewTest.E2E.Issue3719Live do
+  # https://github.com/phoenixframework/phoenix_live_view/issues/3719
+  use Phoenix.LiveView
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :target, nil)}
+  end
+
+  def handle_event("inc", %{"_target" => target}, socket) do
+    {:noreply, assign(socket, :target, target)}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <form phx-change="inc">
+      <input id="a" type="text" name="foo" />
+      <input id="b" type="text" name="foo[bar]" />
+    </form>
+    <span id="target">{inspect(@target)}</span>
+    """
+  end
+end

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -165,6 +165,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/3684", Issue3684Live
       live "/3709", Issue3709Live
       live "/3709/:id", Issue3709Live
+      live "/3719", Issue3719Live
     end
   end
 

--- a/test/e2e/tests/issues/3719.spec.js
+++ b/test/e2e/tests/issues/3719.spec.js
@@ -1,0 +1,20 @@
+const {test, expect} = require("../../test-fixtures")
+const {syncLV} = require("../../utils")
+
+// https://github.com/phoenixframework/phoenix_live_view/issues/3719
+test("target is properly decoded", async ({page}) => {
+  const logs = []
+  page.on("console", (e) => logs.push(e.text()))
+
+  await page.goto("/issues/3719")
+  await syncLV(page)
+  await page.locator("#a").fill("foo")
+  await syncLV(page)
+  await expect(page.locator("#target")).toHaveText("[\"foo\"]")
+
+  await page.locator("#b").fill("foo")
+  await syncLV(page)
+  await expect(page.locator("#target")).toHaveText("[\"foo\", \"bar\"]")
+
+  expect(logs).not.toEqual(expect.arrayContaining([expect.stringMatching("view crashed")]))
+})


### PR DESCRIPTION
After #3688, the _target parameter was decoded too early, as it is now sent in the extra values that are merged into the form values.

Fixes #3719.