### PR TITLE
fix: allow refute_redirect to refute any redirections

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1462,11 +1462,17 @@ defmodule Phoenix.LiveViewTest do
 
   It returns :ok if the specified redirect isn't already in the mailbox.
 
+  If no path is specified, refutes any redirection on the given view.
+
   ## Examples
 
       render_click(view, :event_that_triggers_redirect_to_path)
       :ok = refute_redirected view, "/wrong_path"
   """
+  def refute_redirected(view) do
+    refute_navigation(view, :redirect, nil)
+  end
+
   def refute_redirected(view, to) when is_binary(to) do
     refute_navigation(view, :redirect, to)
   end
@@ -1481,7 +1487,7 @@ defmodule Phoenix.LiveViewTest do
             "expected #{inspect(view.module)} not to #{kind}, "
           end
 
-        raise ArgumentError, message <> "but got a #{kind} to #{inspect(to)}"
+        raise ArgumentError, message <> "but got a #{kind} to #{inspect(new_to)}"
     after
       0 -> :ok
     end

--- a/test/phoenix_live_view/integrations/nested_test.exs
+++ b/test/phoenix_live_view/integrations/nested_test.exs
@@ -200,6 +200,22 @@ defmodule Phoenix.LiveView.NestedTest do
           assert %ArgumentError{message: message} = e
           assert message =~ "not to redirect to"
       end
+
+      send(
+        clock_view.pid,
+        {:run,
+         fn socket ->
+           {:noreply, LiveView.push_navigate(socket, to: "/any_url")}
+         end}
+      )
+
+      try do
+        refute_redirected(thermo_view)
+      rescue
+        e ->
+          assert %ArgumentError{message: message} = e
+          assert message =~ "not to redirect, but got a redirect to /any_url"
+      end
     end
 
     @tag session: %{nest: []}


### PR DESCRIPTION
I'd like to be able to assert that a redirection happened no matter the path.
So if my paths change I don't have to change them on the tests too.
Usually if I don't want one redirection to happen I don't want any.

Looking at the code I saw that the private function refute_navigation supports `to` being `nil` and does exactly what I want, so the change should be this easy :)