### PR TITLE
Ensure `_target` is sent as `"undefined"` when it doesn't exist

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -1212,7 +1212,14 @@ export default class View {
       type: "form",
       event: phxEvent,
       value: formData,
-      meta: {_target: opts._target, ...meta},
+      meta: {
+        // no target was implicitly sent as "undefined" in LV <= 1.0.5, therefore
+        // we have to keep it. In 1.0.6 we switched from passing meta as URL encoded data
+        // to passing it directly in the event, but the JSON encode would drop keys with
+        // undefined values.
+        _target: opts._target || "undefined",
+        ...meta
+      },
       uploads: uploads,
       cid: cid
     }

--- a/assets/test/view_test.js
+++ b/assets/test/view_test.js
@@ -276,6 +276,31 @@ describe("View + DOM", function(){
     view.pushInput(input, el, null, "validate", {_target: input.name, value: optValue})
   })
 
+  test("pushInput with nameless input", function(){
+    expect.assertions(4)
+
+    let liveSocket = new LiveSocket("/live", Socket)
+    let el = liveViewDOM()
+    let input = el.querySelector("input")
+    input.removeAttribute("name")
+    simulateUsedInput(input)
+    let view = simulateJoinedView(el, liveSocket)
+    let channelStub = {
+      push(_evt, payload, _timeout){
+        expect(payload.type).toBe("form")
+        expect(payload.event).toBeDefined()
+        expect(payload.value).toBe("_unused_note=&note=2")
+        expect(payload.meta).toEqual({"_target": "undefined"})
+        return {
+          receive(){ return this }
+        }
+      }
+    }
+    view.channel = channelStub
+
+    view.pushInput(input, el, null, "validate", {_target: input.name})
+  })
+
   test("getFormsForRecovery", function(){
     let view, html, liveSocket = new LiveSocket("/live", Socket)
 


### PR DESCRIPTION
Fixes #3727.

In LV <= 1.0.5 we sent the `_target` as part of the url encoded form values, but in 1.0.6 we switched to sending the meta values directly in the form event to support `JS.push`'s value parameter for nested values. Since the event itself is JSON encoded, this meant that any keys with undefined value would be dropped by JS. To be backwards compatible, we now ensure that the `_target` is always sent and restore the old behavior of it being the string `"undefined"`, although that seems a bit ugly. It is what it is now...