### PR TITLE
Tweak file upload docs

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -3213,8 +3213,16 @@ defmodule Phoenix.Component do
 
   [INSERT LVATTRDOCS]
 
-  Note the `id` attribute cannot be overwritten, but you can create a label with a `for` attribute
-  pointing to the UploadConfig `ref`.
+  ## Customizing the Label
+
+  The `id` attribute cannot be overwritten, but you can create a label with a `for` attribute
+  pointing to the UploadConfig `ref`:
+
+  ```heex
+  <label for={@uploads.avatar.ref}>
+    <.live_file_input upload={@uploads.avatar} />
+  </label>
+  ```
 
   ## Drag and Drop
 
@@ -3223,10 +3231,9 @@ defmodule Phoenix.Component do
   for drag and drop support:
 
   ```heex
-  <div class="container" phx-drop-target={@uploads.avatar.ref}>
-    <!-- ... -->
+  <label for={@uploads.avatar.ref} phx-drop-target={@uploads.avatar.ref}>
     <.live_file_input upload={@uploads.avatar} />
-  </div>
+  </label>
   ```
 
   ## Examples


### PR DESCRIPTION
I think the docs for `live_file_upload`, when demonstrating the usage of the drag and drop feature, should really do so using a `label` rather than a `div`. This makes the most semantic/a11y sense. To make it flow best, we should also introduce the concept of using the label in that manner in a little more detail in the paragraph above.

I also removed the class and placeholder comment from the second example. I think it adds more noise then it does really inform--anyone reading this should know they can add a class on there or add other markup inside the label.