### PR TITLE
document `attr` values/examples even when there is a default

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -982,12 +982,19 @@ defmodule Phoenix.Component.Declarative do
     end
   end
 
-  defp build_attr_values_or_examples(%{opts: [values: values]}) do
-    ["Must be one of ", build_literals_list(values, "or"), ?.]
-  end
+  defp build_attr_values_or_examples(%{opts: opts} = attr) do
+    space_before = if attr[:doc] || opts[:default], do: ?\s, else: []
 
-  defp build_attr_values_or_examples(%{opts: [examples: examples]}) do
-    ["Examples include ", build_literals_list(examples, "and"), ?.]
+    cond do
+      Keyword.get(opts, :values) ->
+        [space_before, "Must be one of ", build_literals_list(opts[:values], "or"), ?.]
+
+      Keyword.get(opts, :examples) ->
+        [space_before, "Examples include ", build_literals_list(opts[:examples], "and"), ?.]
+
+      true ->
+        []
+    end
   end
 
   defp build_attr_values_or_examples(_attr) do

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -1060,6 +1060,9 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       * `attr2` (`:atom`) - Examples include `:foo`, `:bar`, and `:baz`.
       * `attr3` (`:list`) - Must be one of `[60, 40]`.
       * `attr4` (`:list`) - Examples include `[60, 40]`.
+      * `attr5` (`:atom`) - Defaults to `:foo`. Must be one of `:foo`, `:bar`, or `:baz`.
+      * `attr6` (`:atom`) - Attr 6 doc. Must be one of `:foo`, `:bar`, or `:baz`.
+      * `attr7` (`:atom`) - Attr 7 doc. Defaults to `:foo`. Must be one of `:foo`, `:bar`, or `:baz`.
       """
     }
 

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -179,7 +179,9 @@ defmodule Phoenix.LiveViewTest.Support.FunctionComponentWithAttrs do
   attr :attr2, :atom, examples: [:foo, :bar, :baz]
   attr :attr3, :list, values: [[60, 40]]
   attr :attr4, :list, examples: [[60, 40]]
-
+  attr :attr5, :atom, default: :foo, values: [:foo, :bar, :baz]
+  attr :attr6, :atom, doc: "Attr 6 doc", values: [:foo, :bar, :baz]
+  attr :attr7, :atom, doc: "Attr 7 doc", default: :foo, values: [:foo, :bar, :baz]
   def fun_attr_values_examples(assigns), do: ~H[]
 end
 


### PR DESCRIPTION
Hello! I was struggling to effectively document a function component attribute's list of values or examples, and realized that the pattern-matching used in these lines doesn't quite work if there are any other keys present in `opt` (in my case, a `:default`).

https://github.com/phoenixframework/phoenix_live_view/blob/84c9aff10d7c25672c7b5143742bb9ede66c9507/lib/phoenix_component/declarative.ex#L985-L991

This PR adds support for documenting those component attributes which have both a default and a list of values or examples, along with a few test cases for verification.