### PR TITLE
ensure LazyHTML is actually optional

### DIFF
--- a/lib/phoenix_live_view/test/dom.ex
+++ b/lib/phoenix_live_view/test/dom.ex
@@ -141,7 +141,7 @@ defmodule Phoenix.LiveViewTest.DOM do
   @doc """
   Turns a lazy into a tree.
   """
-  def to_tree(%LazyHTML{} = lazy, opts \\ []), do: LazyHTML.to_tree(lazy, opts)
+  def to_tree(lazy, opts \\ []) when is_struct(lazy, LazyHTML), do: LazyHTML.to_tree(lazy, opts)
 
   @doc """
   Turns a tree into a lazy.

--- a/lib/phoenix_live_view/test/tree_dom.ex
+++ b/lib/phoenix_live_view/test/tree_dom.ex
@@ -565,8 +565,8 @@ defmodule Phoenix.LiveViewTest.TreeDOM do
 
     tree =
       case html do
-        {%LazyHTML{}, tree} -> tree
-        %LazyHTML{} -> DOM.to_tree(html)
+        {%{} = struct, tree} when is_struct(struct, LazyHTML) -> tree
+        html when is_struct(html, LazyHTML) -> DOM.to_tree(html)
         _ -> html
       end
 

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Phoenix.LiveView.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       test_options: [docs: true],
       test_coverage: [summary: [threshold: 85], ignore_modules: coverage_ignore_modules()],
-      xref: [exclude: [LazyHTML]],
+      xref: [exclude: [LazyHTML, LazyHTML.Tree]],
       package: package(),
       deps: deps(),
       aliases: aliases(),


### PR DESCRIPTION
we cannot directly reference the LazyHTML struct, as it might not be available.