### PR TITLE
allow testing phx-viewport bindings with render_hook

### DIFF
--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -473,3 +473,11 @@ end
 ```
 
 This code simply calls the `paginate_posts` function we defined as our first step, using the current or next page to drive the results. Notice that we match on a special `"_overran" => true` parameter in our `"prev-page"` event. The viewport events send this parameter when the user has "overran" the viewport top or bottom. Imagine the case where the user is scrolling back up through many pages of results, but grabs the scrollbar and returns immediately to the top of the page. This means our `<ul id="posts">` container was overrun by the top of the viewport, and we need to reset the the UI to page the first page.
+
+When testing, you can use `Phoenix.LiveViewTest.render_hook/3` to test the viewport events:
+
+```elixir
+view
+|> element("#posts")
+|> render_hook("next-page")
+```

--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -1103,16 +1103,21 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
   defp maybe_event(:hook, node, %Element{event: event} = element) do
     true = is_binary(event)
 
-    if TreeDOM.attribute(node, "phx-hook") do
-      if TreeDOM.attribute(node, "id") do
+    cond do
+      TreeDOM.attribute(node, "phx-hook") ->
+        if TreeDOM.attribute(node, "id") do
+          {:ok, event, []}
+        else
+          {:error, :invalid,
+           "element selected by #{inspect(element.selector)} for phx-hook does not have an ID"}
+        end
+
+      TreeDOM.attribute(node, "phx-viewport-top") || TreeDOM.attribute(node, "phx-viewport-bottom") ->
         {:ok, event, []}
-      else
+
+      true ->
         {:error, :invalid,
-         "element selected by #{inspect(element.selector)} for phx-hook does not have an ID"}
-      end
-    else
-      {:error, :invalid,
-       "element selected by #{inspect(element.selector)} does not have phx-hook attribute"}
+         "element selected by #{inspect(element.selector)} does not have phx-hook attribute"}
     end
   end
 

--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -1112,7 +1112,8 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
            "element selected by #{inspect(element.selector)} for phx-hook does not have an ID"}
         end
 
-      TreeDOM.attribute(node, "phx-viewport-top") || TreeDOM.attribute(node, "phx-viewport-bottom") ->
+      TreeDOM.attribute(node, "phx-viewport-top") ||
+          TreeDOM.attribute(node, "phx-viewport-bottom") ->
         {:ok, event, []}
 
       true ->

--- a/test/phoenix_live_view/integrations/elements_test.exs
+++ b/test/phoenix_live_view/integrations/elements_test.exs
@@ -229,6 +229,13 @@ defmodule Phoenix.LiveView.ElementsTest do
                    "element selected by \"span#span-no-attr\" does not have phx-hook attribute",
                    fn -> view |> element("span#span-no-attr") |> render_hook("custom-event") end
     end
+
+    test "works with phx-viewport bindings", %{live: view} do
+      assert view |> element("#posts") |> render_hook("prev-page") |> is_binary()
+      assert last_event(view) =~ ~s|prev-page: %{}|
+      assert view |> element("#posts") |> render_hook("next-page") |> is_binary()
+      assert last_event(view) =~ ~s|next-page: %{}|
+    end
   end
 
   describe "render_blur" do

--- a/test/support/live_views/elements.ex
+++ b/test/support/live_views/elements.ex
@@ -129,6 +129,13 @@ defmodule Phoenix.LiveViewTest.Support.ElementsLive do
     <section phx-hook="Example" id="hook-section" phx-value-foo="ignore">Section</section>
     <section phx-hook="Example" id="hook-section-2" class="idless-hook">Section</section>
 
+    <ul
+      id="posts"
+      phx-update="stream"
+      phx-viewport-top="prev-page"
+      phx-viewport-bottom="next-page"
+    />
+
     <%!-- forms --%>
     <a id="a-no-form" phx-change="hello" phx-submit="world">Change</a>
     <form id="empty-form" phx-change="form-change" phx-submit="form-submit"></form>

--- a/test/support/live_views/elements.ex
+++ b/test/support/live_views/elements.ex
@@ -129,12 +129,7 @@ defmodule Phoenix.LiveViewTest.Support.ElementsLive do
     <section phx-hook="Example" id="hook-section" phx-value-foo="ignore">Section</section>
     <section phx-hook="Example" id="hook-section-2" class="idless-hook">Section</section>
 
-    <ul
-      id="posts"
-      phx-update="stream"
-      phx-viewport-top="prev-page"
-      phx-viewport-bottom="next-page"
-    />
+    <ul id="posts" phx-update="stream" phx-viewport-top="prev-page" phx-viewport-bottom="next-page" />
 
     <%!-- forms --%>
     <a id="a-no-form" phx-change="hello" phx-submit="world">Change</a>

--- a/test/support/live_views/general.ex
+++ b/test/support/live_views/general.ex
@@ -323,7 +323,7 @@ defmodule Phoenix.LiveViewTest.Support.ErrorsLive do
   def mount(_params, _session, socket), do: {:ok, socket}
 
   def handle_params(%{"crash_on" => "disconnected_handle_params"}, _, %Socket{transport_pid: nil}),
-    do: raise("boom disconnected handle_params")
+      do: raise("boom disconnected handle_params")
 
   def handle_params(%{"crash_on" => "connected_handle_params"}, _, %Socket{transport_pid: pid})
       when is_pid(pid),

--- a/test/support/live_views/general.ex
+++ b/test/support/live_views/general.ex
@@ -323,7 +323,7 @@ defmodule Phoenix.LiveViewTest.Support.ErrorsLive do
   def mount(_params, _session, socket), do: {:ok, socket}
 
   def handle_params(%{"crash_on" => "disconnected_handle_params"}, _, %Socket{transport_pid: nil}),
-      do: raise("boom disconnected handle_params")
+    do: raise("boom disconnected handle_params")
 
   def handle_params(%{"crash_on" => "connected_handle_params"}, _, %Socket{transport_pid: pid})
       when is_pid(pid),

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -73,7 +73,8 @@ defmodule Phoenix.LiveViewTest.Support.Router do
     live "/router/foobarbaz/nosuffix", NoSuffix, :index, as: :custom_route
 
     # integration layout
-    live_session :styled_layout, root_layout: {Phoenix.LiveViewTest.Support.LayoutView, :styled} do
+    live_session :styled_layout,
+      root_layout: {Phoenix.LiveViewTest.Support.LayoutView, :styled} do
       live "/styled-elements", ElementsLive
     end
 


### PR DESCRIPTION
At the moment, `phx-viewport-top` and `phx-viewport-bottom` can't really be tested in LiveViewTest when targeting a specific element. One can use `render_hook` targeting a view, because it skips the `phx-hook` validation, but when the events should target a LiveComponent, this doesn't work, as the specific element must be passed to render_hook.

As the phx-viewport bindings are implemented as a private hook on the client, it might make sense to specifically allow `render_hook` to work in that case as well. Another option would be to have a generalized `render_event` function that skips any validation, but @chrismccord didn't like that.

See also: https://elixirforum.com/t/testing-phx-viewport-bindings-in-liveview/68237