### PR TITLE
Update JSDoc for hook examples

### DIFF
--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -183,7 +183,7 @@ Then a hook callback object could be defined and passed to the socket:
 
 ```javascript
 /**
- * @type {Object.<string, import("phoenix_live_view").ViewHook>}
+ * @type {import("phoenix_live_view").HooksOptions}
  */
 let Hooks = {}
 Hooks.PhoneNumber = {
@@ -251,7 +251,7 @@ And then in the client:
 
 ```javascript
 /**
- * @type {import("phoenix_live_view").ViewHook}
+ * @type {import("phoenix_live_view").Hook}
  */
 Hooks.InfiniteScroll = {
   page() { return this.el.dataset.page },
@@ -278,7 +278,7 @@ And then on the client:
 
 ```javascript
 /**
- * @type {import("phoenix_live_view").ViewHook}
+ * @type {import("phoenix_live_view").Hook}
  */
 Hooks.Chart = {
   mounted(){

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1608,7 +1608,7 @@ defmodule Phoenix.LiveView do
 
   ```javascript
   /**
-   * @type {Object.<string, import("phoenix_live_view").ViewHook>}
+   * @type {import("phoenix_live_view").HooksOption}
    */
   let Hooks = {}
   Hooks.ClientHook = {


### PR DESCRIPTION
After recent updates to [@types/phoenix_live_view](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/phoenix_live_view), the existing JSDoc examples became outdated and no longer worked as intended. This PR updates those examples to align with the latest type definitions.

Note: Due to changes in the typings, autocomplete may be less helpful in some areas—for example, it works for lifecycle methods (like mounted, updated, etc.) but not for hook properties such as el, liveSocket, and others.