### PR TITLE
Added a catch block to the pushWithReply expression to handle uncaught promise timeout error

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -1242,6 +1242,8 @@ export default class View {
       } else {
         callback && callback(resp)
       }
+    }).catch(err => {
+      console.error(err)
     })
   }
 


### PR DESCRIPTION
Added a catch block to the `this.pushWithReply` function inside `pushInput` to handle an `Uncaught (in promise) {timeout: true}` error.

The motivation is to handle the uncaught promise error thrown inside `view.js` usually thrown in idle tabs. In a production app we're seeing a lot of `Uncaught (in promise) {timeout: true}` errors thrown in the console with Sentry reporting a `UnhandledRejection: Object captured as promise rejection with keys: timeout`. We've typically noticed this error when a user's tab goes idle , either through inactivity or on mobile through switching apps or closing their device for an extended period of time.

### Browser Error
![plv-viewjs-console-error-uncaught-timeout](https://github.com/user-attachments/assets/c0bfaf44-9a08-43fc-9185-8630f0567c0c)

### Browser view.js Trace
![plv-viewjs-error-highlight](https://github.com/user-attachments/assets/13ea06d4-dd6f-4fed-bd25-fd2e20f75b46)
