### PR TITLE
Catch promise rejections from pushWithReply

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -1133,9 +1133,7 @@ export default class View {
       event: event,
       value: payload,
       cid: this.closestComponentID(targetCtx)
-    })
-      .then(({resp: _resp, reply: hookReply}) => onReply(hookReply, ref))
-      .catch((error) => logError("Failed to push hook event", error))
+    }).then(({resp: _resp, reply: hookReply}) => onReply(hookReply, ref))
 
     return ref
   }

--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -1133,7 +1133,9 @@ export default class View {
       event: event,
       value: payload,
       cid: this.closestComponentID(targetCtx)
-    }).then(({resp: _resp, reply: hookReply}) => onReply(hookReply, ref))
+    })
+      .then(({resp: _resp, reply: hookReply}) => onReply(hookReply, ref))
+      .catch((error) => logError("Failed to push hook event", error))
 
     return ref
   }
@@ -1166,7 +1168,9 @@ export default class View {
       event: phxEvent,
       value: this.extractMeta(el, meta, opts.value),
       cid: this.targetComponentID(el, targetCtx, opts)
-    }).then(({reply}) => onReply && onReply(reply))
+    })
+      .then(({reply}) => onReply && onReply(reply))
+      .catch((error) => logError("Failed to push event", error))
   }
 
   pushFileProgress(fileEl, entryRef, progress, onReply = function (){ }){
@@ -1177,7 +1181,9 @@ export default class View {
         entry_ref: entryRef,
         progress: progress,
         cid: view.targetComponentID(fileEl.form, targetCtx)
-      }).then(({resp}) => onReply(resp))
+      })
+        .then(({resp}) => onReply(resp))
+        .catch((error) => logError("Failed to push file progress", error))
     })
   }
 
@@ -1242,7 +1248,7 @@ export default class View {
       } else {
         callback && callback(resp)
       }
-    })
+    }).catch((error) => logError("Failed to push input event", error))
   }
 
   triggerAwaitingSubmit(formEl, phxEvent){
@@ -1341,7 +1347,9 @@ export default class View {
           value: formData,
           meta: meta,
           cid: cid
-        }).then(({resp}) => onReply(resp))
+        })
+          .then(({resp}) => onReply(resp))
+          .catch((error) => logError("Failed to push form submit", error))
       })
     } else if(!(formEl.hasAttribute(PHX_REF_SRC) && formEl.classList.contains("phx-submit-loading"))){
       let meta = this.extractMeta(formEl, {}, opts.value)
@@ -1352,7 +1360,9 @@ export default class View {
         value: formData,
         meta: meta,
         cid: cid
-      }).then(({resp}) => onReply(resp))
+      })
+        .then(({resp}) => onReply(resp))
+        .catch((error) => logError("Failed to push form submit", error))
     }
   }
 
@@ -1408,7 +1418,7 @@ export default class View {
           }
           uploader.initAdapterUpload(resp, onError, this.liveSocket)
         }
-      })
+      }).catch((error) => logError("Failed to push upload", error))
     })
   }
 
@@ -1544,10 +1554,10 @@ export default class View {
           if(completelyDestroyCIDs.length > 0){
             this.pushWithReply(null, "cids_destroyed", {cids: completelyDestroyCIDs}).then(({resp}) => {
               this.rendered.pruneCIDs(resp.cids)
-            })
+            }).catch((error) => logError("Failed to push components destroyed", error))
           }
         })
-      })
+      }).catch((error) => logError("Failed to push components destroyed", error))
     }
   }
 


### PR DESCRIPTION
https://github.com/phoenixframework/phoenix_live_view/pull/3443 changed the pushWithReply function to use promises instead. Previously, if we did not handle the timeout, it was just ignored, but now we reject the promise, which will cause unhandled promise rejections.

This PR adds catch clauses to all cases where we previously did not handle the timeout. At the moment, these log an error, but we can also silently drop if we want. cc @chrismccord

Supersedes https://github.com/phoenixframework/phoenix_live_view/pull/3760.