### PR TITLE
Change line in layout docs about root/app difference

### DIFF
--- a/guides/server/live-layouts.md
+++ b/guides/server/live-layouts.md
@@ -2,8 +2,7 @@
 
 Your LiveView applications can be made of two layouts:
 
-  * the root layout - this is a layout used by both LiveView and
-    regular controller views. This layout typically contains the `<html>`
+  * the root layout - this layout typically contains the `<html>`
     definition alongside the head and body tags. Any content defined
     in the root layout will remain the same, even as you live navigate
     across LiveViews. The root layout is typically declared on the


### PR DESCRIPTION
Hi all,

I realize this is in flux now with 1.8 RC, however, assuming the thrust of how root/app works isn't changing I'd like to propose the removal of the line documenting that root is used 'for both live views and controller rendered pages'.

I think this kind of *implies* that app layout can't be used in dead views, which is not the case. So I think this line does more harm then good.