### PR TITLE
Phoenix.LiveView.Debug

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -408,6 +408,25 @@ defmodule Phoenix.LiveView.Channel do
     {:noreply, register_entry_upload(state, from, info)}
   end
 
+  # Phoenix.LiveView.Debug.socket/1
+  def handle_call({@prefix, :debug_get_socket}, _from, state) do
+    {:reply, {:ok, state.socket}, state}
+  end
+
+  # Phoenix.LiveView.Debug.live_components/1
+  def handle_call(
+        {@prefix, :debug_live_components},
+        _from,
+        %{components: {components, _, _}} = state
+      ) do
+    component_info =
+      Enum.map(components, fn {cid, {mod, id, assigns, private, _prints}} ->
+        %{id: id, cid: cid, module: mod, assigns: assigns, children_cids: private.children_cids}
+      end)
+
+    {:reply, {:ok, component_info}, state}
+  end
+
   def handle_call(msg, from, %{socket: socket} = state) do
     case socket.view.handle_call(msg, from, socket) do
       {:reply, reply, %Socket{} = new_socket} ->

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -1110,6 +1110,7 @@ defmodule Phoenix.LiveView.Channel do
                  {:ok, config} <- load_live_view(view) do
               # TODO: replace with Process.put_label/2 when we require Elixir 1.17
               Process.put(:"$process_label", {Phoenix.LiveView, view, phx_socket.topic})
+              Process.put(:"$phx_transport_pid", phx_socket.transport_pid)
 
               verified_mount(
                 new_verified,

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -1089,6 +1089,9 @@ defmodule Phoenix.LiveView.Channel do
             with {:ok, %Session{view: view} = new_verified, route, url} <-
                    authorize_session(verified, endpoint, params),
                  {:ok, config} <- load_live_view(view) do
+              # TODO: replace with Process.put_label/2 when we require Elixir 1.17
+              Process.put(:"$process_label", {Phoenix.LiveView, view, phx_socket.topic})
+
               verified_mount(
                 new_verified,
                 config,

--- a/lib/phoenix_live_view/debug.ex
+++ b/lib/phoenix_live_view/debug.ex
@@ -1,0 +1,108 @@
+defmodule Phoenix.LiveView.Debug do
+  @moduledoc """
+  Functions for runtime introspection and debugging of LiveViews.
+
+  TODO
+  """
+
+  @doc """
+  Returns a list of all currently connected LiveView processes (on the curret node).
+
+  ## Examples
+
+      iex> list_liveview_processes()
+      [#PID<0.123.0>]
+
+  """
+  def list_liveview_processes do
+    for pid <- Process.list(), liveview_process?(pid) do
+      pid
+    end
+  end
+
+  @doc """
+  Returns true if the given pid is a LiveView process.
+
+  ## Examples
+
+      iex> list_liveview_processes() |> Enum.at(0) |> liveview_process?()
+      true
+
+      iex> liveview_process?(pid(0,456,0))
+      false
+
+  """
+  def liveview_process?(pid) do
+    # LiveViews set the "$process_label" to {Phoenix.LiveView, view, topic}
+    with info when is_list(info) <- Process.info(pid, [:dictionary]),
+         {:dictionary, dictionary} <- List.keyfind(info, :dictionary, 0),
+         {:"$process_label", label} <- List.keyfind(dictionary, :"$process_label", 0),
+         true <-
+           match?({Phoenix.LiveView, view, topic} when is_atom(view) and is_binary(topic), label) do
+      true
+    else
+      _ -> false
+    end
+  end
+
+  @doc """
+  Returns the socket of the LiveView process.
+
+  ## Examples
+
+      iex> list_liveview_processes() |> Enum.at(0) |> socket()
+      {:ok, %Phoenix.LiveView.Socket{...}}
+
+      iex> socket(pid(0,123,0))
+      {:error, :not_a_liveview}
+
+  """
+  def socket(liveview_pid) do
+    case :sys.get_state(liveview_pid, 5000) do
+      %{socket: %Phoenix.LiveView.Socket{} = socket} -> {:ok, socket}
+      _ -> {:error, :not_a_liveview}
+    end
+  end
+
+  @doc """
+  Returns a list with information about all LiveComponents rendered in the LiveView.
+
+  ## Examples
+
+      iex> live_components(pid)
+      {:ok,
+       [
+         %{
+           id: "component-1",
+           module: MyAppWeb.PostLive.Index.Component1,
+           cid: 1,
+           assigns: %{
+             id: "component-1",
+             __changed__: %{},
+             flash: %{},
+             myself: %Phoenix.LiveComponent.CID{cid: 1},
+             ...
+           }
+         }
+       ]}
+
+  """
+  def live_components(liveview_pid) do
+    case :sys.get_state(liveview_pid, 5000) do
+      %{socket: %Phoenix.LiveView.Socket{}, components: components} ->
+        {:ok, extract_components(components)}
+
+      _ ->
+        {:error, :not_a_liveview}
+    end
+  end
+
+  defp extract_components({components, _, _}) when components == %{}, do: []
+
+  defp extract_components({components, _, _}) do
+    # components is a map of cid => {module, id, assigns, private, fingerprints}
+    Enum.map(components, fn {cid, {mod, id, assigns, _private, _prints}} ->
+      %{id: id, cid: cid, module: mod, assigns: assigns}
+    end)
+  end
+end

--- a/test/phoenix_live_view/debug_test.exs
+++ b/test/phoenix_live_view/debug_test.exs
@@ -1,0 +1,93 @@
+defmodule Phoenix.LiveView.DebugTest do
+  use ExUnit.Case, async: true
+
+  alias Phoenix.LiveView.Debug
+  import Phoenix.LiveViewTest
+
+  @endpoint Phoenix.LiveViewTest.Support.Endpoint
+
+  defmodule TestLV do
+    use Phoenix.LiveView
+
+    defmodule Component do
+      use Phoenix.LiveComponent
+
+      def render(assigns) do
+        ~H"""
+        <p>Hello</p>
+        """
+      end
+    end
+
+    def mount(_params, _session, socket) do
+      {:ok, assign(socket, :hello, :world)}
+    end
+
+    def render(assigns) do
+      ~H"""
+      <div>
+        <p>Hello</p>
+        <.live_component id="component-1" module={Component} />
+      </div>
+      """
+    end
+  end
+
+  describe "list_liveviews/0" do
+    test "returns a list of all currently connected LiveView processes" do
+      conn = Plug.Test.conn(:get, "/")
+      {:ok, view, _} = live_isolated(conn, TestLV)
+      live_views = Debug.list_liveviews()
+
+      assert is_list(live_views)
+      assert lv = Enum.find(live_views, fn lv -> lv.pid == view.pid end)
+      assert lv.view == TestLV
+      assert lv.transport_pid
+      assert lv.topic
+    end
+  end
+
+  describe "liveview_process?/1" do
+    test "returns true if the given pid is a LiveView process" do
+      conn = Plug.Test.conn(:get, "/")
+      {:ok, view, _} = live_isolated(conn, TestLV)
+      assert Debug.liveview_process?(view.pid)
+    end
+  end
+
+  describe "socket/1" do
+    test "returns the socket of the given LiveView process" do
+      conn = Plug.Test.conn(:get, "/")
+      {:ok, view, _} = live_isolated(conn, TestLV)
+      assert {:ok, socket} = Debug.socket(view.pid)
+      assert socket.assigns.hello == :world
+    end
+
+    test "returns an error if the given pid is not a LiveView process" do
+      defmodule NotALiveView do
+        use GenServer
+
+        def start_link(opts) do
+          GenServer.start_link(__MODULE__, opts)
+        end
+
+        def init(opts) do
+          {:ok, opts}
+        end
+      end
+
+      pid = start_supervised!(NotALiveView)
+      assert {:error, :not_alive_or_not_a_liveview} = Debug.socket(pid)
+    end
+  end
+
+  describe "live_components/1" do
+    test "returns a list of all LiveComponents rendered in the given LiveView" do
+      conn = Plug.Test.conn(:get, "/")
+      {:ok, view, _} = live_isolated(conn, TestLV)
+
+      assert {:ok, [%{id: "component-1", module: TestLV.Component}]} =
+               Debug.live_components(view.pid)
+    end
+  end
+end


### PR DESCRIPTION
The BEAM provides us with all the tools we need for introspecting out runtime. Tools like [LiveDebugger](https://github.com/software-mansion/live-debugger) use this information for providing a rich UI to look into the inner workings of LiveView pages. At the moment, this requires knowledge about the internals of LiveView, using private APIs, some of which could break at any moment.

The idea behind `Phoenix.LiveView.Debug` is to provide a public API with functions for introspecting LiveViews (and LiveComponents, etc.) that can help tools like LiveDebugger, but also regular developers, for example when debugging inside a remote IEx console.

This is a first draft with limited functionality to get some feedback on what functionality would be useful.