### PR TITLE
add telemetry event after destroying a live component

### DIFF
--- a/guides/server/telemetry.md
+++ b/guides/server/telemetry.md
@@ -191,6 +191,16 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
             changed?: boolean
           }
 
+  * `[:phoenix, :live_view, :component_destroyed]` - Dispatched by a `Phoenix.LiveView`
+     after a LiveComponent is destroyed. No measurement.
+
+     * Metadata:
+
+          %{
+            socket: Phoenix.LiveView.Socket.t,
+            cid: integer()
+          }
+
   * `[:phoenix, :live_component, :update, :start]` - Dispatched by a `Phoenix.LiveComponent`
     immediately before [`update/2`](`c:Phoenix.LiveComponent.update/2`) or a
     [`update_many/1`](`c:Phoenix.LiveComponent.update_many/1`) is invoked.

--- a/guides/server/telemetry.md
+++ b/guides/server/telemetry.md
@@ -191,16 +191,6 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
             changed?: boolean
           }
 
-  * `[:phoenix, :live_view, :component_destroyed]` - Dispatched by a `Phoenix.LiveView`
-     after a LiveComponent is destroyed. No measurement.
-
-     * Metadata:
-
-          %{
-            socket: Phoenix.LiveView.Socket.t,
-            cid: integer()
-          }
-
   * `[:phoenix, :live_component, :update, :start]` - Dispatched by a `Phoenix.LiveComponent`
     immediately before [`update/2`](`c:Phoenix.LiveComponent.update/2`) or a
     [`update_many/1`](`c:Phoenix.LiveComponent.update_many/1`) is invoked.
@@ -310,3 +300,15 @@ LiveView currently exposes the following [`telemetry`](https://hexdocs.pm/teleme
             event: String.t(),
             params: unsigned_params
           }
+
+  * `[:phoenix, :live_component, :destroyed]` - Dispatched by a `Phoenix.LiveComponent`
+    after it is destroyed. No measurement.
+
+    * Metadata:
+
+        %{
+          socket: Phoenix.LiveView.Socket.t,
+          component: atom,
+          cid: integer(),
+          live_view_socket: Phoenix.LiveView.Socket.t
+        }

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -1527,6 +1527,11 @@ defmodule Phoenix.LiveView.Channel do
     Enum.flat_map_reduce(cids, state, fn cid, acc ->
       {deleted_cids, new_components} = Diff.delete_component(cid, acc.components)
 
+      :telemetry.execute([:phoenix, :live_view, :component_destroyed], %{}, %{
+        socket: state.socket,
+        cid: cid
+      })
+
       canceled_confs =
         deleted_cids
         |> Enum.filter(fn deleted_cid -> deleted_cid in upload_cids end)

--- a/test/phoenix_live_view/integrations/live_components_test.exs
+++ b/test/phoenix_live_view/integrations/live_components_test.exs
@@ -72,7 +72,7 @@ defmodule Phoenix.LiveView.LiveComponentsTest do
 
   test "tracks removals", %{conn: conn} do
     ref =
-      :telemetry_test.attach_event_handlers(self(), [[:phoenix, :live_view, :component_destroyed]])
+      :telemetry_test.attach_event_handlers(self(), [[:phoenix, :live_component, :destroyed]])
 
     {:ok, view, html} = live(conn, "/components")
 
@@ -105,7 +105,13 @@ defmodule Phoenix.LiveView.LiveComponentsTest do
 
     refute view |> element("#chris") |> has_element?()
 
-    assert_received {[:phoenix, :live_view, :component_destroyed], ^ref, _, %{socket: _, cid: 1}}
+    assert_received {[:phoenix, :live_component, :destroyed], ^ref, _,
+                     %{
+                       component: StatefulComponent,
+                       cid: 1,
+                       socket: %{assigns: %{name: "chris"}},
+                       live_view_socket: %{assigns: %{names: ["jose"]}}
+                     }}
   end
 
   test "tracks removals when whole root changes", %{conn: conn} do

--- a/test/phoenix_live_view/integrations/live_components_test.exs
+++ b/test/phoenix_live_view/integrations/live_components_test.exs
@@ -71,6 +71,9 @@ defmodule Phoenix.LiveView.LiveComponentsTest do
   end
 
   test "tracks removals", %{conn: conn} do
+    ref =
+      :telemetry_test.attach_event_handlers(self(), [[:phoenix, :live_view, :component_destroyed]])
+
     {:ok, view, html} = live(conn, "/components")
 
     assert [
@@ -101,6 +104,8 @@ defmodule Phoenix.LiveView.LiveComponentsTest do
              |> TreeDOM.normalize_to_tree(sort_attributes: true)
 
     refute view |> element("#chris") |> has_element?()
+
+    assert_received {[:phoenix, :live_view, :component_destroyed], ^ref, _, %{socket: _, cid: 1}}
   end
 
   test "tracks removals when whole root changes", %{conn: conn} do


### PR DESCRIPTION
The people from [LiveDebugger](https://github.com/software-mansion/live-debugger) mentioned that they struggle to react to live components that are removed from a page. A new telemetry event should help.