### PR TITLE
Expose `HTMLFormatter.tokenize/1` as a public function

### DIFF
--- a/lib/phoenix_live_view/html_formatter.ex
+++ b/lib/phoenix_live_view/html_formatter.ex
@@ -248,6 +248,7 @@ defmodule Phoenix.LiveView.HTMLFormatter do
     end
   end
 
+  @doc false
   # Tokenize contents using EEx.tokenize and Phoenix.Live.Tokenizer respectively.
   #
   # The following content:
@@ -276,7 +277,7 @@ defmodule Phoenix.LiveView.HTMLFormatter do
   #
   @eex_expr [:start_expr, :expr, :end_expr, :middle_expr]
 
-  defp tokenize(source) do
+  def tokenize(source) do
     {:ok, eex_nodes} = EEx.tokenize(source)
     {tokens, cont} = Enum.reduce(eex_nodes, {[], {:text, :enabled}}, &do_tokenize(&1, &2, source))
     Tokenizer.finalize(tokens, "nofile", cont, source)


### PR DESCRIPTION
Currently, [TailwindFormatter vendors HTMLFormatter, Tokenizer and HTMLEngine](https://github.com/100phlecs/tailwind_formatter/pull/35).

It would be convenient for TailwindFormatter to use `HTMLFormatter.tokenize/1` directly and stay in sync with PhoenixLiveView.