### PR TITLE
JS: add `set_property/3`

### DIFF
--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -162,6 +162,10 @@ let JS = {
     this.setOrRemoveAttrs(el, [[attr, val]], [])
   },
 
+  exec_set_prop(e, eventType, phxEvent, view, sourceEl, el, {attr: [prop, val]}){
+    el[prop] = val
+  },
+
   exec_remove_attr(e, eventType, phxEvent, view, sourceEl, el, {attr}){
     this.setOrRemoveAttrs(el, [], [attr])
   },

--- a/assets/test/js_test.js
+++ b/assets/test/js_test.js
@@ -1002,6 +1002,20 @@ describe("JS", () => {
     })
   })
 
+  describe("set_prop", () => {
+    test("sets a property", () => {
+      let view = setupView(`
+      <input type="text" id="name" value="Name" />
+      <button phx-click={JS.set_property({"value", ""}, to: "#name")}>Clear</button>
+      `)
+      let button = document.querySelector("button")
+
+      expect(view.el.querySelector("#name").value).toEqual("Name")
+      JS.exec(event, "click", button.getAttribute("phx-click"), view, button)
+      expect(view.el.querySelector("#name").value).toEqual("")
+    })
+  })
+
   describe("exec", () => {
     test("executes command", done => {
       let view = setupView(`

--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -741,6 +741,40 @@ defmodule Phoenix.LiveView.JS do
   end
 
   @doc """
+  Sets a property on elements.
+
+  Accepts a tuple `{property, value}` to set a DOM property.
+
+  ## Options
+
+    * `:to` - An optional DOM selector to add attributes to.
+      Defaults to the interacted element. See the `DOM selectors`
+      section for details.
+
+  ## Examples
+
+  ```heex
+  <input type="text" id="name" />
+  <button phx-click={JS.set_property({"value", ""}, to: "#name")}>
+    Clear
+  </button>
+  ```
+  """
+  def set_property({prop, val}), do: set_property(%JS{}, {prop, val}, [])
+
+  @doc "See `set_property/1`."
+  def set_property({prop, val}, opts) when is_list(opts),
+    do: set_property(%JS{}, {prop, val}, opts)
+
+  def set_property(%JS{} = js, {prop, val}), do: set_property(js, {prop, val}, [])
+
+  @doc "See `set_property/1`."
+  def set_property(%JS{} = js, {prop, val}, opts) when is_list(opts) do
+    opts = validate_keys(opts, :set_property, [:to])
+    put_op(js, "set_prop", to: opts[:to], prop: [prop, val])
+  end
+
+  @doc """
   Removes an attribute from elements.
 
     * `attr` - The string attribute name to remove.


### PR DESCRIPTION
The `set_property/3` function allows developers to programmatically set DOM properties as opposed to attributes on target elements.

While `set_attribute/3` is useful for static HTML attributes, some UI interactions require manipulating properties, such as value, checked, or disabled.