### PR TITLE
Allow default uploader when using external uploaders in LiveView

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1352,7 +1352,7 @@ defmodule Phoenix.LiveViewTest do
         start_upload_client(builder, view, selector, name, entries, cid)
 
       {:ok, %{external: func}} when is_function(func) ->
-        start_external_upload_client(view, selector, name, entries, cid)
+        start_upload_client(builder, view, selector, name, entries, cid)
 
       :error ->
         raise "no uploads allowed for #{name}"
@@ -1375,12 +1375,6 @@ defmodule Phoenix.LiveViewTest do
   defp start_upload_client(builder, view, form_selector, name, entries, cid) do
     {:ok, socket} = builder.()
     spec = {UploadClient, socket: socket, cid: cid}
-    {:ok, pid} = Supervisor.start_child(fetch_test_supervisor!(), spec)
-    Upload.new(pid, view, form_selector, name, entries, cid)
-  end
-
-  defp start_external_upload_client(view, form_selector, name, entries, cid) do
-    spec = {UploadClient, cid: cid}
     {:ok, pid} = Supervisor.start_child(fetch_test_supervisor!(), spec)
     Upload.new(pid, view, form_selector, name, entries, cid)
   end

--- a/lib/phoenix_live_view/test/upload_client.ex
+++ b/lib/phoenix_live_view/test/upload_client.ex
@@ -108,7 +108,7 @@ defmodule Phoenix.LiveViewTest.UploadClient do
     end
   end
 
-  defp build_and_join_entry(%{socket: nil} = _state, client_entry, token) do
+  defp build_and_join_entry(_state, client_entry, token) when is_map(token) do
     %{
       "name" => name,
       "content" => content,
@@ -124,6 +124,8 @@ defmodule Phoenix.LiveViewTest.UploadClient do
       type: type,
       ref: ref,
       token: token,
+      # external uploads have a meta map as token
+      external: true,
       chunk_percent: 0
     }
     |> with_chunk_boundaries()
@@ -152,6 +154,7 @@ defmodule Phoenix.LiveViewTest.UploadClient do
           socket: entry_socket,
           ref: ref,
           token: token,
+          external: false,
           chunk_percent: 0
         }
         |> with_chunk_boundaries()
@@ -221,7 +224,7 @@ defmodule Phoenix.LiveViewTest.UploadClient do
     end
   end
 
-  defp do_chunk(%{socket: nil, cid: cid} = state, from, entry, proxy_pid, element, percent) do
+  defp do_chunk(%{cid: cid} = state, from, %{external: true} = entry, proxy_pid, element, percent) do
     stats = progress_stats(entry, percent)
 
     :ok =
@@ -322,7 +325,7 @@ defmodule Phoenix.LiveViewTest.UploadClient do
       {name, _entry} ->
         new_state = %{state | entries: Map.delete(state.entries, name)}
 
-        if has_channel_entries?(new_state.entries) do
+        if has_upload_entries?(new_state.entries) do
           {:noreply, new_state}
         else
           {:stop, reason, new_state}
@@ -341,9 +344,10 @@ defmodule Phoenix.LiveViewTest.UploadClient do
     end)
   end
 
-  defp has_channel_entries?(entries) do
+  defp has_upload_entries?(entries) do
     Enum.any?(entries, fn
       {_name, %{socket: %{channel_pid: _pid}}} -> true
+      {_name, %{socket: nil}} -> true
       {_name, _entry} -> false
     end)
   end

--- a/lib/phoenix_live_view/test/upload_client.ex
+++ b/lib/phoenix_live_view/test/upload_client.ex
@@ -126,6 +126,7 @@ defmodule Phoenix.LiveViewTest.UploadClient do
       token: token,
       # external uploads have a meta map as token
       external: true,
+      socket: nil,
       chunk_percent: 0
     }
     |> with_chunk_boundaries()

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -410,7 +410,7 @@ defmodule Phoenix.LiveView.Upload do
         channel_preflight(new_socket, new_conf, new_entries, cid, client_meta)
 
       func when is_function(func) ->
-        external_preflight(new_socket, new_conf, new_entries, client_meta)
+        external_preflight(new_socket, new_conf, new_entries, cid, client_meta)
     end
   end
 
@@ -457,7 +457,13 @@ defmodule Phoenix.LiveView.Upload do
     for {ref, err} <- conf.errors, ref == entry.ref, do: err
   end
 
-  defp external_preflight(%Socket{} = socket, %UploadConfig{} = conf, entries, client_config_meta) do
+  defp external_preflight(
+         %Socket{} = socket,
+         %UploadConfig{} = conf,
+         entries,
+         cid,
+         client_config_meta
+       ) do
     reply_entries =
       Enum.reduce_while(entries, {:ok, %{}, %{}, socket}, fn entry, {:ok, metas, errors, acc} ->
         if conf.auto_upload? and not entry.valid? do
@@ -469,6 +475,16 @@ defmodule Phoenix.LiveView.Upload do
             {:ok, %{} = meta, new_socket} ->
               new_socket = update_upload_entry_meta(new_socket, conf.name, entry, meta)
               {:cont, {:ok, Map.put(metas, entry.ref, meta), errors, new_socket}}
+
+            {:ok, :default, new_socket} ->
+              token =
+                Phoenix.LiveView.Static.sign_token(socket.endpoint, %{
+                  pid: self(),
+                  ref: {conf.ref, entry.ref},
+                  cid: cid
+                })
+
+              {:cont, {:ok, Map.put(metas, entry.ref, token), errors, new_socket}}
 
             {:error, %{} = meta, new_socket} ->
               if conf.auto_upload? do

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -325,55 +325,61 @@ defmodule Phoenix.LiveView.Upload do
 
   defp consume_entries(%UploadConfig{} = conf, entries, func)
        when is_list(entries) and is_function(func) do
-    if conf.external do
-      results =
-        entries
-        |> Enum.map(fn entry ->
-          meta = Map.fetch!(conf.entry_refs_to_metas, entry.ref)
+    {results, consumed_refs} =
+      Enum.reduce(entries, {[], []}, fn entry, {results, consumed_refs} ->
+        case UploadConfig.entry_pid(conf, entry) do
+          pid when is_pid(pid) ->
+            result = Phoenix.LiveView.UploadChannel.consume(pid, entry, func)
+            {[result | results], consumed_refs}
 
-          result =
-            cond do
-              is_function(func, 1) -> func.(meta)
-              is_function(func, 2) -> func.(meta, entry)
+          nil ->
+            case Map.fetch!(conf.entry_refs_to_metas, entry.ref) do
+              %{uploader: _} ->
+                {result, consumed?} = consume_external_entry(conf, entry, func)
+                consumed_refs = if consumed?, do: [entry.ref | consumed_refs], else: consumed_refs
+                {[result | results], consumed_refs}
+
+              %{} ->
+                {results, consumed_refs}
             end
+        end
+      end)
 
-          case result do
-            {:ok, return} ->
-              {entry.ref, return}
-
-            {:postpone, return} ->
-              {:postpone, return}
-
-            return ->
-              IO.warn("""
-              consuming uploads requires a return signature matching:
-
-                  {:ok, value} | {:postpone, value}
-
-              got:
-
-                  #{inspect(return)}
-              """)
-
-              {entry.ref, return}
-          end
-        end)
-
-      consumed_refs =
-        Enum.flat_map(results, fn
-          {:postpone, _result} -> []
-          {ref, _result} -> [ref]
-        end)
-
+    if consumed_refs != [] do
       Phoenix.LiveView.Channel.drop_consumed_upload_entries(conf, consumed_refs)
+    end
 
-      Enum.map(results, fn {_ref, result} -> result end)
-    else
-      for entry <- entries,
-          pid = UploadConfig.entry_pid(conf, entry),
-          is_pid(pid) do
-        Phoenix.LiveView.UploadChannel.consume(pid, entry, func)
+    Enum.reverse(results)
+  end
+
+  defp consume_external_entry(%UploadConfig{} = conf, entry, func) do
+    meta = Map.fetch!(conf.entry_refs_to_metas, entry.ref)
+
+    result =
+      cond do
+        is_function(func, 1) -> func.(meta)
+        is_function(func, 2) -> func.(meta, entry)
       end
+
+    case result do
+      {:ok, return} ->
+        {return, true}
+
+      {:postpone, return} ->
+        {return, false}
+
+      return ->
+        IO.warn("""
+        consuming uploads requires a return signature matching:
+
+            {:ok, value} | {:postpone, value}
+
+        got:
+
+            #{inspect(return)}
+        """)
+
+        {return, true}
     end
   end
 
@@ -478,11 +484,15 @@ defmodule Phoenix.LiveView.Upload do
 
             {:ok, :default, new_socket} ->
               token =
-                Phoenix.LiveView.Static.sign_token(socket.endpoint, %{
-                  pid: self(),
-                  ref: {conf.ref, entry.ref},
-                  cid: cid
-                })
+                Phoenix.LiveView.Static.sign_token(
+                  socket.endpoint,
+                  %{
+                    pid: self(),
+                    ref: {conf.ref, entry.ref},
+                    cid: cid
+                  },
+                  @upload_token_opts
+                )
 
               {:cont, {:ok, Map.put(metas, entry.ref, token), errors, new_socket}}
 

--- a/test/e2e/support/upload_live.ex
+++ b/test/e2e/support/upload_live.ex
@@ -19,6 +19,16 @@ defmodule Phoenix.LiveViewTest.E2E.UploadLive do
     |> then(&{:noreply, &1})
   end
 
+  def handle_params(%{"mixed_upload" => _}, _uri, socket) do
+    socket
+    |> allow_upload(:avatar,
+      accept: ~w(.txt .md),
+      max_entries: 2,
+      external: &mixed_preflight/2
+    )
+    |> then(&{:noreply, &1})
+  end
+
   def handle_params(_params, _uri, socket) do
     {:noreply, socket}
   end
@@ -36,15 +46,41 @@ defmodule Phoenix.LiveViewTest.E2E.UploadLive do
   @impl Phoenix.LiveView
   def handle_event("save", _params, socket) do
     uploaded_files =
-      consume_uploaded_entries(socket, :avatar, fn %{path: path}, _entry ->
-        dir = Path.join([System.tmp_dir!(), "lvupload"])
-        _ = File.mkdir_p(dir)
-        dest = Path.join([dir, Path.basename(path)])
-        File.cp!(path, dest)
-        {:ok, "/tmp/lvupload/#{Path.basename(dest)}"}
+      consume_uploaded_entries(socket, :avatar, fn
+        %{uploader: "TestExternal", path: path}, entry ->
+          {:ok, %{href: path, name: entry.client_name, uploader: "external"}}
+
+        %{path: path}, entry ->
+          dir = Path.join([System.tmp_dir!(), "lvupload"])
+          _ = File.mkdir_p(dir)
+          dest = Path.join([dir, Path.basename(path)])
+          File.cp!(path, dest)
+
+          {:ok,
+           %{
+             href: "/tmp/lvupload/#{Path.basename(dest)}",
+             name: entry.client_name,
+             uploader: "default"
+           }}
       end)
 
     {:noreply, update(socket, :uploaded_files, &(&1 ++ uploaded_files))}
+  end
+
+  defp mixed_preflight(%{client_type: "text/plain"}, socket) do
+    {:ok, :default, socket}
+  end
+
+  defp mixed_preflight(%{client_type: "text/markdown"} = entry, socket) do
+    key = "#{System.unique_integer([:positive, :monotonic])}-#{Path.basename(entry.client_name)}"
+
+    {:ok,
+     %{
+       uploader: "TestExternal",
+       url: "/upload/external",
+       key: key,
+       path: "/tmp/lvupload/#{key}"
+     }, socket}
   end
 
   @impl Phoenix.LiveView
@@ -79,7 +115,9 @@ defmodule Phoenix.LiveViewTest.E2E.UploadLive do
       </section>
 
       <ul>
-        <li :for={file <- @uploaded_files}><a href={file}>{Path.basename(file)}</a></li>
+        <li :for={file <- @uploaded_files} data-uploader={file.uploader}>
+          <a href={file.href}>{file.name}</a>
+        </li>
       </ul>
     </form>
     """

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -57,12 +57,35 @@ defmodule Phoenix.LiveViewTest.E2E.Layout do
           this.pushEvent("ping", {}, () => (this.el.innerText += "pong"));
         },
       };
+      let Uploaders = {};
+      Uploaders.TestExternal = function (entries, onViewError) {
+        entries.forEach((entry) => {
+          let formData = new FormData();
+          formData.append("key", entry.meta.key);
+          formData.append("file", entry.file);
+
+          let xhr = new XMLHttpRequest();
+          onViewError(() => xhr.abort());
+          xhr.onload = () =>
+            xhr.status === 204 ? entry.progress(100) : entry.error();
+          xhr.onerror = () => entry.error();
+          xhr.upload.addEventListener("progress", (event) => {
+            if (event.lengthComputable) {
+              let percent = Math.round((event.loaded / event.total) * 100);
+              if (percent < 100) entry.progress(percent);
+            }
+          });
+          xhr.open("POST", entry.meta.url, true);
+          xhr.send(formData);
+        });
+      };
       let csrfToken = document
         .querySelector("meta[name='csrf-token']")
         .getAttribute("content");
       let liveSocket = new LiveSocket("/live", window.Phoenix.Socket, {
         params: { _csrf_token: csrfToken },
         hooks: { ...Hooks, ...window.hooks, ...colocatedHooks },
+        uploaders: Uploaders,
       });
       liveSocket.connect();
       window.liveSocket = liveSocket;
@@ -119,6 +142,17 @@ defmodule Phoenix.LiveViewTest.E2E.SubmitController do
 
   def submit(conn, params) do
     send_resp(conn, 200, Phoenix.json_library().encode!(params))
+  end
+end
+
+defmodule Phoenix.LiveViewTest.E2E.UploadController do
+  use Phoenix.Controller, formats: []
+
+  def upload(conn, %{"file" => %Plug.Upload{path: path}, "key" => key}) do
+    dir = Path.join(System.tmp_dir!(), "lvupload")
+    File.mkdir_p!(dir)
+    File.cp!(path, Path.join(dir, Path.basename(key)))
+    send_resp(conn, 204, "")
   end
 end
 
@@ -278,6 +312,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
   end
 
   post "/eval", Phoenix.LiveViewTest.E2E.EvalController, :eval
+  post "/upload/external", Phoenix.LiveViewTest.E2E.UploadController, :upload
 end
 
 defmodule Phoenix.LiveViewTest.E2E.Endpoint do

--- a/test/e2e/tests/uploads.spec.js
+++ b/test/e2e/tests/uploads.spec.js
@@ -124,6 +124,53 @@ test("can upload multiple files", async ({ page }) => {
   await expect(page.locator("ul li")).toHaveCount(2);
 });
 
+// https://github.com/phoenixframework/phoenix_live_view/pull/3801
+test("can mix default and external uploaders", async ({ page, request }) => {
+  await page.goto("/upload?mixed_upload=1");
+  await syncLV(page);
+
+  const externalUpload = page.waitForResponse(
+    (response) =>
+      new URL(response.url()).pathname === "/upload/external" &&
+      response.request().method() === "POST",
+  );
+
+  await page.locator("#upload-form input").setInputFiles([
+    {
+      name: "default.txt",
+      mimeType: "text/plain",
+      buffer: Buffer.from("uploaded through the LiveView channel"),
+    },
+    {
+      name: "external.md",
+      mimeType: "text/markdown",
+      buffer: Buffer.from("uploaded through the external endpoint"),
+    },
+  ]);
+  await syncLV(page);
+  await page.getByRole("button", { name: "Upload" }).click();
+
+  const externalUploadResponse = await externalUpload;
+  expect(externalUploadResponse.status()).toBe(204);
+
+  const defaultUpload = page.locator('ul li[data-uploader="default"]');
+  const externalUploadResult = page.locator('ul li[data-uploader="external"]');
+
+  await expect(defaultUpload).toHaveText("default.txt");
+  await expect(externalUploadResult).toHaveText("external.md");
+
+  for (const [upload, contents] of [
+    [defaultUpload, "uploaded through the LiveView channel"],
+    [externalUploadResult, "uploaded through the external endpoint"],
+  ]) {
+    const response = await request.get(
+      await upload.getByRole("link").getAttribute("href"),
+    );
+    expect(response.ok()).toBe(true);
+    expect((await response.body()).toString()).toEqual(contents);
+  }
+});
+
 test("shows error when there are too many files", async ({ page }) => {
   await page.goto("/upload");
   await syncLV(page);

--- a/test/phoenix_live_view/upload/external_test.exs
+++ b/test/phoenix_live_view/upload/external_test.exs
@@ -8,6 +8,11 @@ defmodule Phoenix.LiveView.UploadExternalTest do
   alias Phoenix.LiveView
   alias Phoenix.LiveViewTest.Support.UploadLive
 
+  setup_all do
+    start_supervised!(Phoenix.PubSub.child_spec(name: Phoenix.LiveView.PubSub))
+    :ok
+  end
+
   def inspect_html_safe(term) do
     term
     |> inspect()
@@ -65,6 +70,10 @@ defmodule Phoenix.LiveView.UploadExternalTest do
     {:ok, %{uploader: "S3"}, new_socket}
   end
 
+  def default_preflight(%LiveView.UploadEntry{}, socket) do
+    {:ok, :default, socket}
+  end
+
   def consume(%LiveView.UploadEntry{} = entry, socket) do
     if entry.done? do
       Phoenix.LiveView.consume_uploaded_entry(socket, entry, fn _ -> {:ok, :ok} end)
@@ -108,6 +117,29 @@ defmodule Phoenix.LiveView.UploadExternalTest do
     assert render_upload(avatar, "foo1.jpeg", 1) =~ "foo1.jpeg:1%"
     assert render(lv) =~ "preflight:#{UploadLive.inspect_html_safe("foo1.jpeg")}"
     assert render(lv) =~ "preflight:#{UploadLive.inspect_html_safe("foo2.jpeg")}"
+  end
+
+  @tag allow: [max_entries: 1, chunk_size: 20, accept: :any, external: :default_preflight]
+  test "external upload can use the default uploader", %{lv: lv} do
+    content = String.duplicate("ok", 100)
+
+    avatar =
+      file_input(lv, "form", :avatar, [
+        %{name: "foo.jpeg", content: content}
+      ])
+
+    assert render_upload(avatar, "foo.jpeg") =~ "foo.jpeg:100%"
+
+    assert run(lv, fn socket ->
+             {[entry], []} = Phoenix.LiveView.uploaded_entries(socket, :avatar)
+
+             result =
+               Phoenix.LiveView.consume_uploaded_entry(socket, entry, fn %{path: path} ->
+                 {:ok, File.read!(path)}
+               end)
+
+             {:reply, result, socket}
+           end) == content
   end
 
   @tag allow: [max_entries: 1, chunk_size: 20, accept: :any, external: :preflight]


### PR DESCRIPTION
In the current implementation of Phoenix.LiveView.Upload, when you configure external: &function/2, it becomes mandatory to specify an uploader.

This makes sense in most cases, but there’s an important limitation: Once you introduce even a single external uploader, you lose the ability to fall back to the default built-in uploader.

This can be problematic when you want to mix different uploader strategies depending on the file — for instance, using a custom external uploader for images, but sticking to the built-in uploader for PDFs or other files.

I’ve patched LiveView locally to support falling back to the default uploader even when external: &function/2 is set — and it works well in my testing.

```elixir
defmodule MyApp.SampleLive do
  ...
  def mount(_, _, socket) do
    socket =
      socket
      |> allow_upload(:files, external: &presign_upload/2)

    {:ok, socket}
  end

  defp presign_upload(entry, socket) do
    meta =
      case entry.client_type do
        "image/" <> _ -> %{uploader: "S3", presigned_url: "..."}
        _ -> %{uploader: :default}
      end

    {:ok, meta, socket}
  end
end
```

If simply returning `:default` for the uploader in meta seems inappropriate.

https://elixirforum.com/t/allow-default-uploader-when-using-external-uploaders-in-liveview/70501