### PR TITLE
Improve doc links betweens `async result/1` and `assign_async/4`

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -3387,15 +3387,26 @@ defmodule Phoenix.Component do
   end
 
   @doc """
-  Renders an async assign with slots for the different loading states.
+  Renders a `Phoenix.LiveView.AsyncResult` struct (e.g. from `Phoenix.LiveView.assign_async/4`) 
+  with slots for the different loading states.
   The result state takes precedence over subsequent loading and failed
   states.
 
-  *Note*: The inner block receives the result of the async assign as a :let.
-  The let is only accessible to the inner block and is not in scope to the
-  other slots.
+  > #### Note {: .info}
+  >
+  > The inner block receives the result of the async assign as a `:let`.
+  > The let is only accessible to the inner block and is not in scope to the
+  > other slots.
 
   ## Examples
+
+  ```elixir
+  def mount(%{"slug" => slug}, _, socket) do
+    {:ok,
+      socket
+      |> assign_async(:org, fn -> {:ok, %{org: fetch_org!(slug)}} end)}
+  end
+  ```
 
   ```heex
   <.async_result :let={org} assign={@org}>
@@ -3408,6 +3419,8 @@ defmodule Phoenix.Component do
     <% end %>
   </.async_result>
   ```
+
+  See [Async Operations](`m:Phoenix.LiveView#module-async-operations`) for more information.
 
   To display loading and failed states again on subsequent `assign_async` calls,
   reset the assign to a result-free `%AsyncResult{}`:

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -2138,7 +2138,7 @@ defmodule Phoenix.LiveView do
 
   Wraps your function in a task linked to the caller, errors are wrapped.
   Each key passed to `assign_async/3` will be assigned to
-  an `%AsyncResult{}` struct holding the status of the operation
+  an `Phoenix.LiveView.AsyncResult` struct holding the status of the operation
   and the result when the function completes.
 
   The task is only started when the socket is connected.
@@ -2159,7 +2159,7 @@ defmodule Phoenix.LiveView do
          |> assign_async([:profile, :rank], fn -> {:ok, %{profile: ..., rank: ...}} end)}
       end
 
-  See the moduledoc for more information.
+  See [Async Operations](#module-async-operations) for more information.
 
   ## `assign_async/3` and `send_update/3`
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -2151,13 +2151,15 @@ defmodule Phoenix.LiveView do
 
   ## Examples
 
-      def mount(%{"slug" => slug}, _, socket) do
-        {:ok,
-         socket
-         |> assign(:foo, "bar")
-         |> assign_async(:org, fn -> {:ok, %{org: fetch_org!(slug)}} end)
-         |> assign_async([:profile, :rank], fn -> {:ok, %{profile: ..., rank: ...}} end)}
-      end
+  ```elixir
+  def mount(%{"slug" => slug}, _, socket) do
+    {:ok,
+      socket
+      |> assign(:foo, "bar")
+      |> assign_async(:org, fn -> {:ok, %{org: fetch_org!(slug)}} end)
+      |> assign_async([:profile, :rank], fn -> {:ok, %{profile: ..., rank: ...}} end)}
+  end
+  ```
 
   See [Async Operations](#module-async-operations) for more information.
 
@@ -2168,11 +2170,13 @@ defmodule Phoenix.LiveView do
   since `send_update/2` assumes it is running inside the LiveView process.
   The solution is to explicitly send the update to the LiveView:
 
-      parent = self()
-      assign_async(socket, :org, fn ->
-        # ...
-        send_update(parent, Component, data)
-      end)
+  ```elixir
+  parent = self()
+  assign_async(socket, :org, fn ->
+    # ...
+    send_update(parent, Component, data)
+  end)
+  ```
 
   ## Testing async operations
 
@@ -2180,14 +2184,19 @@ defmodule Phoenix.LiveView do
   `Phoenix.LiveViewTest.render_async/2` to ensure the test waits until the async operations
   are complete before proceeding with assertions or before ending the test. For example:
 
-      {:ok, view, _html} = live(conn, "/my_live_view")
-      html = render_async(view)
-      assert html =~ "My assertion"
+  ```elixir
+  {:ok, view, _html} = live(conn, "/my_live_view")
+  html = render_async(view)
+  assert html =~ "My assertion"
+  ```
 
   Not calling `render_async/2` to ensure all async assigns have finished might result in errors in
   cases where your process has side effects:
 
-      [error] MyXQL.Connection (#PID<0.308.0>) disconnected: ** (DBConnection.ConnectionError) client #PID<0.794.0>
+  ```
+  [error] MyXQL.Connection (#PID<0.308.0>) disconnected: ** (DBConnection.ConnectionError) client #PID<0.794.0>
+  ```
+
   """
   defmacro assign_async(socket, key_or_keys, func, opts \\ []) do
     Async.assign_async(socket, key_or_keys, func, opts, __CALLER__)


### PR DESCRIPTION
I've stumbled across the docs for `async_result` and was missing an example where an `AsyncResult` was coming from and added a simplified `mount` function from the `assign_async/4` docs and added some links between the two.
Also converted the reference to the moduledoc with an actual link you can click on.

The last commit i'm not sure of. All the other code examples in this module use code with indentation. When i change them to fenced code blocks (which the formatter can now use BTW), i get better syntax highlighting in my editor. Should i keep this change or propose that in another PR?