### PR TITLE
Fix used_input? after form recovery

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -280,6 +280,13 @@ const DOM = {
     }
   },
 
+  deepCopyPrivates(target, source) {
+    this.copyPrivates(target, source);
+    for (let key of Object.keys(target.children)) {
+      this.deepCopyPrivates(target.children[key], source.children[key]);
+    }
+  },
+
   putTitle(str) {
     const titleEl = document.querySelector("title");
     if (titleEl) {

--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -398,6 +398,13 @@ export default class View {
     this.flash = null;
     if (this.root === this) {
       this.formsForRecovery = this.getFormsForRecovery();
+      const keys = Object.keys(this.formsForRecovery);
+      keys.map((id) => {
+        const oldForm = this.el.querySelector(`form#${id}`);
+        if (oldForm) {
+          DOM.deepCopyPrivates(this.formsForRecovery[id], oldForm);
+        }
+      }, this);
     }
     if (this.isMain() && window.history.state === null) {
       // set initial history entry if this is the first page load (no history)

--- a/test/e2e/tests/forms.spec.js
+++ b/test/e2e/tests/forms.spec.js
@@ -139,9 +139,7 @@ for (const path of ["/form/nested", "/form"]) {
             { type: "received", payload: expect.stringContaining("phx_reply") },
             {
               type: "sent",
-              payload: expect.stringMatching(
-                /event.*_unused_a=&a=foo&_unused_b=&b=test/,
-              ),
+              payload: expect.stringMatching(/event.*_unused_a=&a=foo&b=test/),
             },
           ]),
         );
@@ -258,9 +256,7 @@ for (const path of ["/form/nested", "/form"]) {
             { type: "received", payload: expect.stringContaining("phx_reply") },
             {
               type: "sent",
-              payload: expect.stringMatching(
-                /event.*_unused_a=&a=foo&_unused_b=&b=test/,
-              ),
+              payload: expect.stringMatching(/event.*_unused_a=&a=foo&b=test/),
             },
           ]),
         );


### PR DESCRIPTION
Hi devs! I've found an inconsistency (see commit message below), and tried to fix it with this patch. This is my first dive into the codebase, I hope I didn't miss anything :) Looking forward for your comments!

#### Commit message:
There's an inconsistency with using `Phoenix.Component.used_input?` after form recovery following a socket reconnect.

Suppose we have a field named `"a"` that has been used (i.e. there is no `"_unused_a"` parameter sent to the server and `used_input?` returns `true`). What happens is that, immediately after a reconnect, the used field is initially treated as unused, with an `"_unused_a"` parameter sent to the server and with `used_input?` incorrectly returning `false`. However, on the first user interaction with any field in the form, the correct state is considered and now the filed is again treated as used (therefore no `"_unused_a"` parameter is sent to the server). Now, `used_input?` returns `true` as it did before the recovery.

This inconsistent behavior results for example in displayed error messages suddenly disappearing on socket reconnect, only to reappear on the first user interaction with the form. This breaks the user experience and the paradigm which is also mentioned in the documentation for `used_input?`: "Used inputs are only those inputs that have been focused, interacted with, or submitted by the client. In most cases, a user shouldn't receive error feedback for forms they haven't yet interacted with, until they submit the form. Filtering the errors based on used input fields can be done with `used_input?/1`."

This patch fixes this issue by immediately copying the DOM privates (which track, among other things, whether the field has been used) so that `"_unused_"` params are not sent to the server on socket reconnect for fields that were considered as used before the disconnect.