### PR TITLE
invoking push form recovery callback if no input was found

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -1918,6 +1918,7 @@ export default class View {
       (el) => DOM.isFormInput(el) && el.name && !el.hasAttribute(phxChange),
     );
     if (inputs.length === 0) {
+      callback(); 
       return;
     }
 


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix_live_view/issues/3818

I believe I've tracked down the reason why this issue is happening. In `maybeRecoverForms`, LiveView loops over all of the forms that enable recovery until it completes recovery for each of them, and then let's the LiveView continue with the connection. However, in `pushFormRecovery`, if the length of inputs identified on the form is 0, then the function returns early, without ever running the callback that is passed in by `maybeRecoverForms` to clear the form from the associate list.

This PR simply adds the call to that callback to ensure that it is run when no inputs are found to avoid crashing the LiveView on reconnection.