### PR TITLE
Allow `handle_event` to return socket directly

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -282,7 +282,7 @@ defmodule Phoenix.LiveView do
   and sent as a reply to the client.
   """
   @callback handle_event(event :: binary, unsigned_params(), socket :: Socket.t()) ::
-              {:noreply, Socket.t()} | {:reply, map, Socket.t()}
+              Socket.t() | {:noreply, Socket.t()} | {:reply, map, Socket.t()}
 
   @doc """
   Invoked to handle calls from other Elixir processes.

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -532,6 +532,9 @@ defmodule Phoenix.LiveView.Channel do
               {:reply, reply, %Socket{} = socket} ->
                 {{:reply, reply, socket}, %{socket: socket, event: event, params: val}}
 
+              %Socket{} = socket ->
+                {{:noreply, socket}, %{socket: socket, event: event, params: val}}
+
               other ->
                 raise_bad_callback_response!(other, socket.view, :handle_event, 3)
             end

--- a/test/e2e/support/form_feedback.ex
+++ b/test/e2e/support/form_feedback.ex
@@ -92,7 +92,7 @@ defmodule Phoenix.LiveViewTest.E2E.FormFeedbackLive do
   end
 
   def handle_event("inc", _params, socket) do
-    {:noreply, assign(socket, :count, socket.assigns.count + 1)}
+    assign(socket, :count, socket.assigns.count + 1)
   end
 
   def handle_event("dec", _params, socket) do


### PR DESCRIPTION
In my experience 99% of all `handle_event` callbacks are `:noreply`.

This leads to code like:

```elixir
  def handle_event("inc", _params, socket) do
    {:noreply, assign(socket, :count, socket.assigns.count + 1)}
  end
```

Or I see a lot when piping, the pattern of rebinding the `socket` variable:

```elixir
  def handle_event("inc", _params, socket) do
    socket = socket
    |> assign(:count, socket.assigns.count + 1)
    |> assign(:used?, true)

    {:noreply, socket}
  end
```

This PR removes the need to wrap in tuple `{:noreply, socket}`. It still accepts the previous tuples, so it‘s a non-breaking change.

This means the above examples can become:

```elixir
  def handle_event("inc", _params, socket) do
    assign(socket, :count, socket.assigns.count + 1)
  end
```

Piping:

```elixir
  def handle_event("inc", _params, socket) do
    socket
    |> assign(:count, socket.assigns.count + 1)
    |> assign(:used?, true)
  end
```

With LiveView hitting stable 1.0, I’m curious to see how its developer experience (DX) can be improved.