### PR TITLE
abort form recovery when there are no inputs

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -1918,7 +1918,7 @@ export default class View {
       (el) => DOM.isFormInput(el) && el.name && !el.hasAttribute(phxChange),
     );
     if (inputs.length === 0) {
-      callback(); 
+      callback();
       return;
     }
 

--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -1918,6 +1918,7 @@ export default class View {
       (el) => DOM.isFormInput(el) && el.name && !el.hasAttribute(phxChange),
     );
     if (inputs.length === 0) {
+      callback(); 
       return;
     }
 

--- a/test/e2e/support/issues/issue_3819.ex
+++ b/test/e2e/support/issues/issue_3819.ex
@@ -1,0 +1,29 @@
+defmodule Phoenix.LiveViewTest.E2E.Issue3819Live do
+  use Phoenix.LiveView
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :reconnected, false)}
+  end
+
+  def handle_event("validate", _params, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event("save", _params, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event("reconnected", _params, socket) do
+    {:noreply, assign(socket, :reconnected, true)}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <.form id="recover" phx-change="validate" phx-submit="save">
+      <button>Submit</button>
+    </.form>
+
+    <p :if={@reconnected} id="reconnected">Reconnected!</p>
+    """
+  end
+end

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -180,6 +180,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/3709/:id", Issue3709Live
       live "/3719", Issue3719Live
       live "/3814", Issue3814Live
+      live "/3819", Issue3819Live
     end
   end
 

--- a/test/e2e/tests/issues/3819.spec.js
+++ b/test/e2e/tests/issues/3819.spec.js
@@ -1,0 +1,22 @@
+import { test, expect } from "../../test-fixtures";
+import { syncLV } from "../../utils";
+
+// https://github.com/phoenixframework/phoenix_live_view/issues/3819
+test("form recovery aborts early when form is empty", async ({ page }) => {
+  await page.goto("/issues/3819");
+  await syncLV(page);
+
+  await page.evaluate(
+    () => new Promise((resolve) => window.liveSocket.disconnect(resolve)),
+  );
+  await expect(page.locator(".phx-loading")).toHaveCount(1);
+  await page.evaluate(() => {
+    window.addEventListener("phx:page-loading-stop", () => {
+      window.liveSocket.js().push(window.liveSocket.main.el, "reconnected");
+    });
+    window.liveSocket.connect();
+  });
+
+  await expect(page.locator(".phx-loading")).toHaveCount(0);
+  await expect(page.locator("#reconnected")).toBeVisible();
+});


### PR DESCRIPTION
Supersedes https://github.com/phoenixframework/phoenix_live_view/issues/3819.

Closes https://github.com/phoenixframework/phoenix_live_view/issues/3818.
Closes https://github.com/phoenixframework/phoenix_live_view/issues/3819.