### PR TITLE
Allow form associated inputs to be recognized by isFormInput

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -602,6 +602,19 @@ const DOM = {
   },
 
   isFormInput(el) {
+    if (el.localName && customElements.get(el.localName)) {
+      // Custom Elements may be form associated. This allows them
+      // to participate within a form's lifecycle, including form
+      // validity and form submissions.
+      // The spec for Form Associated custom elements requires the
+      // custom element's class to contain a static boolean value of `formAssociated`
+      // which identifies this class as allowed to associate to a form.
+      // See https://html.spec.whatwg.org/dev/custom-elements.html#custom-elements-face-example
+      // for details.
+      return customElements.get(el.localName)[`formAssociated`]
+    }
+
+
     return (
       /^(?:input|select|textarea)$/i.test(el.tagName) && el.type !== "button"
     );


### PR DESCRIPTION
A follow up to #3819 and #3821. This identifies form associated custom elements as form inputs in `isFormInput` to allow users to use custom form associated elements in LiveView.