### PR TITLE
fix accumulation of empty text nodes in streams

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -20,6 +20,7 @@ import {
   PHX_STICKY,
   PHX_EVENT_CLASSES,
   THROTTLED,
+  PHX_STREAM,
 } from "./constants";
 
 import { logError } from "./utils";
@@ -629,7 +630,9 @@ const DOM = {
   },
 
   cleanChildNodes(container, phxUpdate) {
-    if (DOM.isPhxUpdate(container, phxUpdate, ["append", "prepend"])) {
+    if (
+      DOM.isPhxUpdate(container, phxUpdate, ["append", "prepend", PHX_STREAM])
+    ) {
       const toRemove = [];
       container.childNodes.forEach((childNode) => {
         if (!childNode.id) {

--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -333,6 +333,9 @@ export default class LiveSocket {
   }
 
   getHookDefinition(name) {
+    if (!name) {
+      return;
+    }
     return (
       this.maybeInternalHook(name) ||
       this.hooks[name] ||

--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -890,6 +890,11 @@ export default class View {
       const hookName =
         el.getAttribute(`data-phx-${PHX_HOOK}`) ||
         el.getAttribute(this.binding(PHX_HOOK));
+
+      if (!hookName) {
+        return;
+      }
+
       const hookDefinition = this.liveSocket.getHookDefinition(hookName);
 
       if (hookDefinition) {


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix_live_view/issues/3784.

Because stream nodes are not indexed by morphdom,
new nodes that do not have an ID are just appended to the stream container. This leads to linear growth of text nodes.

There's a critical problem though as soon as locked trees are involved. When unlocking, the number of text nodes would double, leading to exponential growth of (in most cases empty) text nodes.

We already handled this problem for phx-update "append" / "prepend", but apparently forgot that this also happens in streams.