### PR TITLE
introduce `:key`-ed `:for` comprehensions

### DIFF
--- a/guides/server/assigns-eex.md
+++ b/guides/server/assigns-eex.md
@@ -267,8 +267,15 @@ in `@posts` changes, all posts are sent again.
 
 There are two common solutions to this problem.
 
-The first one is to use `Phoenix.LiveComponent` for each item in the
-comprehension:
+The first one is to also provide a `:key` expression:
+
+```heex
+<section :for={@post <- @posts} :key={@post.id}>
+  <h1>{expand_title(@post.title)}</h1>
+</section>
+```
+
+This is functionally equivalent to doing:
 
 ```heex
 <section :for={post <- @posts}>
@@ -280,8 +287,9 @@ Since LiveComponents have their own assigns, LiveComponents would allow
 you to perform change tracking for each item. If the `@posts` variable
 changes, the client will simply send a list of component IDs (which are
 integers) and only the data for the posts that actually changed.
+You can read more about `:key` in the [documentation for sigil_H/2](Phoenix.Component.html#sigil_H/2-special-attributes).
 
-Another solution is to use `Phoenix.LiveView.stream/4`, which gives you
+The second solution is to use `Phoenix.LiveView.stream/4`, which gives you
 precise control over how elements are added, removed, and updated. Streams
 are particularly useful when you don't need to keep the collection in memory,
 allowing you to reduce the data sent over the wire and the server memory

--- a/guides/server/assigns-eex.md
+++ b/guides/server/assigns-eex.md
@@ -287,7 +287,7 @@ Since LiveComponents have their own assigns, LiveComponents would allow
 you to perform change tracking for each item. If the `@posts` variable
 changes, the client will simply send a list of component IDs (which are
 integers) and only the data for the posts that actually changed.
-You can read more about `:key` in the [documentation for sigil_H/2](Phoenix.Component.html#sigil_H/2-special-attributes).
+You can read more about `:key` in the [documentation for `sigil_H/2`](Phoenix.Component.html#sigil_H/2-special-attributes).
 
 The second solution is to use `Phoenix.LiveView.stream/4`, which gives you
 precise control over how elements are added, removed, and updated. Streams

--- a/guides/server/assigns-eex.md
+++ b/guides/server/assigns-eex.md
@@ -270,8 +270,8 @@ There are two common solutions to this problem.
 The first one is to also provide a `:key` expression:
 
 ```heex
-<section :for={@post <- @posts} :key={@post.id}>
-  <h1>{expand_title(@post.title)}</h1>
+<section :for={post <- @posts} :key={post.id}>
+  <h1>{expand_title(post.title)}</h1>
 </section>
 ```
 

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -838,16 +838,12 @@ defmodule Phoenix.Component do
 
   ```heex
   <ul>
-    <li :for={%{id: @id, name: @name} <- @items} :key={@id}>
+    <li :for={%{id: id, name: name} <- @items} :key={id}>
       Count: <span>{@count}</span>,
-      item: {@name}
+      item: {name}
     </li>
   </ul>
   ```
-
-  Note that the `:for` expression is special for comprehensions with `:key` in that you
-  must define the generator expression using the `@` assigns syntax. This allows LiveView
-  to track the change-tracked assigns introduced by the comprehension.
 
   Internally, this works by turning the tag where the comprehension is defined on
   into the template of a `Phoenix.LiveComponent`. Because of this, the following limitations

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -831,6 +831,39 @@ defmodule Phoenix.Component do
   Note that unlike Elixir's regular `for`, HEEx' `:for` does not support multiple
   generators in one expression. In such cases, you must use `EEx`'s blocks.
 
+  #### `:key`ed comprehensions
+
+  When using `:for`, you can optionally provide a `:key` expression to also perform
+  change-tracking inside the comprehension:
+
+  ```heex
+  <ul>
+    <li :for={%{id: @id, name: @name} <- @items} :key={@id}>
+      Count: <span>{@count}</span>,
+      item: {@name}
+    </li>
+  </ul>
+  ```
+
+  Note that the `:for` expression is special for comprehensions with `:key` in that you
+  must define the generator expression using the `@` assigns syntax. This allows LiveView
+  to track the change-tracked assigns introduced by the comprehension.
+
+  Internally, this works by turning the tag where the comprehension is defined on
+  into the template of a `Phoenix.LiveComponent`. Because of this, the following limitations
+  apply to comprehensions defined with `:key`:
+
+    1. A `:key` can only be defined on regular HTML tags, not on components or slots.
+    2. The diff over the wire is optimized to only send changes for each item,
+       but it will always include a list of component IDs (integers) specifying
+       the overall order of items.
+    3. Removing an entry involves separate round-trips with the client to confirm
+       the component removal.
+
+  We recommend to use `:key`ed comprehensions only if you already determined that you need
+  to optimize the diff over the write and [streams](`Phoenix.LiveView.stream/4`)
+  are not an option.
+
   ### Function components
 
   Function components are stateless components implemented as pure functions

--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -1059,7 +1059,7 @@ defmodule Phoenix.LiveView.Engine do
       Map.get(map, name) == :change_track ->
         {expr, {type, map}, Map.put(assigns, {:vars_changed, [name]}, true)}
 
-      :change_track in meta ->
+      Keyword.get(meta, :change_track) ->
         # this is a variable inside the left-hand side of a keyed for expression;
         # we mark it as change_track in the vars map so that we treat it as change-tracked
         # when we see it used again later (see the previous analyze clause above)

--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -360,13 +360,9 @@ defmodule Phoenix.LiveView.Engine do
       |> handle_end(opts)
       |> to_rendered_struct({:untainted, %{}}, %{}, state.caller, opts)
 
-    if opts[:skip_require] do
-      rendered
-    else
-      quote do
-        require Phoenix.LiveView.Engine
-        unquote(rendered)
-      end
+    quote do
+      require Phoenix.LiveView.Engine
+      unquote(rendered)
     end
   end
 

--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -626,16 +626,7 @@ defmodule Phoenix.LiveView.Engine do
   defp changed_assigns(assigns) do
     checks =
       for {{changed_var, key}, _} <- assigns, not nested_and_parent_is_checked?(key, assigns) do
-        changed =
-          case changed_var do
-            :changed ->
-              quote do
-                changed
-              end
-
-            :vars_changed ->
-              Macro.var(:vars_changed, __MODULE__)
-          end
+        changed = Macro.var(changed_var, __MODULE__)
 
         case key do
           [assign] ->

--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -423,6 +423,8 @@ defmodule Phoenix.LiveView.Engine do
           end
         end
 
+      root = Keyword.get(opts, :root, meta[:root])
+
       {:ok,
        quote do
          dynamic = fn track_changes? ->
@@ -435,7 +437,7 @@ defmodule Phoenix.LiveView.Engine do
            static: unquote(static),
            dynamic: dynamic,
            fingerprint: unquote(fingerprint),
-           root: unquote(opts[:root])
+           root: unquote(root)
          }
        end}
     else

--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -1051,7 +1051,8 @@ defmodule Phoenix.LiveView.Engine do
     {expr, vars, assigns}
   end
 
-  # Vars always taint unless we are in restricted mode.
+  # Vars always taint unless we are in restricted mode
+  # or the variable is marked as `:change_track` for vars_changed.
   defp analyze({name, meta, nil} = expr, {:restricted, map} = vars, assigns, caller)
        when is_atom(name) do
     case map do

--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -118,6 +118,21 @@ defmodule Phoenix.LiveView.Comprehension do
   end
 end
 
+defmodule Phoenix.LiveView.KeyedComprehension do
+  @moduledoc false
+
+  def update(%{assigns: assigns, render: render}, socket) do
+    socket =
+      Enum.reduce(assigns, socket, fn {key, value}, socket ->
+        Phoenix.LiveView.Utils.assign(socket, key, value)
+      end)
+
+    {:ok, Phoenix.LiveView.render_with(socket, render)}
+  end
+
+  def __live__, do: %{kind: :component, layout: false}
+end
+
 defmodule Phoenix.LiveView.Rendered do
   @moduledoc """
   The struct returned by .heex templates.
@@ -359,9 +374,13 @@ defmodule Phoenix.LiveView.Engine do
       |> handle_end(opts)
       |> to_rendered_struct({:untainted, %{}}, %{}, state.caller, opts)
 
-    quote do
-      require Phoenix.LiveView.Engine
-      unquote(rendered)
+    if opts[:skip_require] do
+      rendered
+    else
+      quote do
+        require Phoenix.LiveView.Engine
+        unquote(rendered)
+      end
     end
   end
 

--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -118,21 +118,6 @@ defmodule Phoenix.LiveView.Comprehension do
   end
 end
 
-defmodule Phoenix.LiveView.KeyedComprehension do
-  @moduledoc false
-
-  def update(%{assigns: assigns, render: render}, socket) do
-    socket =
-      Enum.reduce(assigns, socket, fn {key, value}, socket ->
-        Phoenix.LiveView.Utils.assign(socket, key, value)
-      end)
-
-    {:ok, Phoenix.LiveView.render_with(socket, render)}
-  end
-
-  def __live__, do: %{kind: :component, layout: false}
-end
-
 defmodule Phoenix.LiveView.Rendered do
   @moduledoc """
   The struct returned by .heex templates.
@@ -370,10 +355,12 @@ defmodule Phoenix.LiveView.Engine do
 
   @impl true
   def handle_body(state, opts \\ []) do
+    vars = {:untainted, Map.new(opts[:vars_changed] || [], fn key -> {key, :change_track} end)}
+
     {:ok, rendered} =
       state
       |> handle_end(opts)
-      |> to_rendered_struct({:untainted, %{}}, %{}, state.caller, opts)
+      |> to_rendered_struct(vars, %{}, state.caller, opts)
 
     if opts[:skip_require] do
       rendered
@@ -638,11 +625,22 @@ defmodule Phoenix.LiveView.Engine do
 
   defp changed_assigns(assigns) do
     checks =
-      for {key, _} <- assigns, not nested_and_parent_is_checked?(key, assigns) do
+      for {{changed_var, key}, _} <- assigns, not nested_and_parent_is_checked?(key, assigns) do
+        changed =
+          case changed_var do
+            :changed ->
+              quote do
+                changed
+              end
+
+            :vars_changed ->
+              Macro.var(:vars_changed, __MODULE__)
+          end
+
         case key do
           [assign] ->
             quote do
-              unquote(__MODULE__).changed_assign?(changed, unquote(assign))
+              unquote(__MODULE__).changed_assign?(unquote(changed), unquote(assign))
             end
 
           [assign | tail] ->
@@ -651,7 +649,7 @@ defmodule Phoenix.LiveView.Engine do
                 unquote(tail),
                 unquote(assign),
                 unquote(@assigns_var),
-                changed
+                unquote(changed)
               )
             end
         end
@@ -720,8 +718,25 @@ defmodule Phoenix.LiveView.Engine do
               keys != %{},
               do: {key, to_component_keys(keys)}
 
+        has_vars_changed? =
+          Enum.any?(keys, fn {_name, entries} ->
+            is_list(entries) and Enum.any?(entries, &match?({:vars_changed, _}, &1))
+          end)
+
+        vars_changed =
+          if has_vars_changed? do
+            Macro.var(:vars_changed, __MODULE__)
+          else
+            []
+          end
+
         quote do
-          unquote(__MODULE__).to_component_static(unquote(keys), unquote(@assigns_var), changed)
+          unquote(__MODULE__).to_component_static(
+            unquote(keys),
+            unquote(@assigns_var),
+            changed,
+            unquote(vars_changed)
+          )
         end
       else
         Macro.escape(%{})
@@ -753,6 +768,15 @@ defmodule Phoenix.LiveView.Engine do
       true ->
         {_, keys, _} = analyze_and_return_tainted_keys(dynamic, vars, %{}, caller)
 
+        has_vars_changed? = keys != :all and Enum.any?(keys, &match?({:vars_changed, _}, &1))
+
+        vars_changed =
+          if has_vars_changed? do
+            Macro.var(:vars_changed, __MODULE__)
+          else
+            []
+          end
+
         quote do
           unquote(__MODULE__).to_component_dynamic(
             %{unquote_splicing(static)},
@@ -760,7 +784,8 @@ defmodule Phoenix.LiveView.Engine do
             unquote(static_changed),
             unquote(to_component_keys(keys)),
             unquote(@assigns_var),
-            changed
+            changed,
+            unquote(vars_changed)
           )
         end
     end
@@ -770,25 +795,25 @@ defmodule Phoenix.LiveView.Engine do
   defp to_component_keys(map), do: Map.keys(map)
 
   @doc false
-  def to_component_static(_keys, _assigns, nil) do
+  def to_component_static(_keys, _assigns, nil, []) do
     nil
   end
 
-  def to_component_static(keys, assigns, changed) do
+  def to_component_static(keys, assigns, changed, vars_changed) do
     for {assign, entries} <- keys,
-        changed = component_changed(entries, assigns, changed),
+        changed = component_changed(entries, assigns, changed, vars_changed),
         into: %{},
         do: {assign, changed}
   end
 
   @doc false
-  def to_component_dynamic(static, dynamic, _static_changed, _keys, _assigns, nil) do
+  def to_component_dynamic(static, dynamic, _static_changed, _keys, _assigns, nil, []) do
     merge_dynamic_static_changed(dynamic, static, nil)
   end
 
-  def to_component_dynamic(static, dynamic, static_changed, keys, assigns, changed) do
+  def to_component_dynamic(static, dynamic, static_changed, keys, assigns, changed, vars_changed) do
     component_changed =
-      if component_changed(keys, assigns, changed) do
+      if component_changed(keys, assigns, changed, vars_changed) do
         Enum.reduce(dynamic, static_changed, fn {k, _}, acc -> Map.put(acc, k, true) end)
       else
         static_changed
@@ -801,19 +826,23 @@ defmodule Phoenix.LiveView.Engine do
     dynamic |> Map.merge(static) |> Map.put(:__changed__, changed)
   end
 
-  defp component_changed(:all, _assigns, _changed), do: true
+  defp component_changed(:all, _assigns, _changed, _vars_changed), do: true
 
-  defp component_changed([path], assigns, changed) do
+  defp component_changed([path], assigns, changed, vars_changed) do
     case path do
-      [key] -> changed_assign(changed, key)
-      [key | tail] -> nested_changed_assign(tail, key, assigns, changed)
+      {:changed, [key]} -> changed_assign(changed, key)
+      {:changed, [key | tail]} -> nested_changed_assign(tail, key, assigns, changed)
+      {:vars_changed, [key]} -> changed_assign(vars_changed, key)
+      {:vars_changed, [key | tail]} -> nested_changed_assign(tail, key, assigns, vars_changed)
     end
   end
 
-  defp component_changed(entries, assigns, changed) do
+  defp component_changed(entries, assigns, changed, vars_changed) do
     Enum.any?(entries, fn
-      [key] -> changed_assign?(changed, key)
-      [key | tail] -> nested_changed_assign?(tail, key, assigns, changed)
+      {:changed, [key]} -> changed_assign?(changed, key)
+      {:changed, [key | tail]} -> nested_changed_assign?(tail, key, assigns, changed)
+      {:vars_changed, [key]} -> changed_assign?(vars_changed, key)
+      {:vars_changed, [key | tail]} -> nested_changed_assign?(tail, key, assigns, vars_changed)
     end)
   end
 
@@ -907,11 +936,29 @@ defmodule Phoenix.LiveView.Engine do
     {ast, keys, vars}
   end
 
+  # if we find a variable (or something more complex handled by the other clauses)
+  # like foo[:bar][:baz] and foo is marked as :change_track in vars, we consider it
+  # as an assign, but look into vars_changed instead of changed
+  defp analyze_assign(
+         {name, _, context} = expr,
+         {type, map} = vars,
+         assigns,
+         _caller,
+         nest
+       )
+       when is_atom(name) and is_atom(context) and is_map_key(map, name) and type != :tainted do
+    if map[name] == :change_track do
+      {expr, vars, Map.put(assigns, {:vars_changed, [name | nest]}, true)}
+    else
+      {expr, vars, assigns}
+    end
+  end
+
   # @name
   defp analyze_assign({:@, meta, [{name, _, context}]}, vars, assigns, _caller, nest)
        when is_atom(name) and is_atom(context) do
     expr = {{:., meta, [@assigns_var, name]}, [no_parens: true] ++ meta, []}
-    {expr, vars, Map.put(assigns, [name | nest], true)}
+    {expr, vars, Map.put(assigns, {:changed, [name | nest]}, true)}
   end
 
   # assigns.name
@@ -923,7 +970,7 @@ defmodule Phoenix.LiveView.Engine do
          nest
        )
        when is_atom(name) and args in [[], nil] do
-    {expr, vars, Map.put(assigns, [name | nest], true)}
+    {expr, vars, Map.put(assigns, {:changed, [name | nest]}, true)}
   end
 
   # assigns[:name]
@@ -935,7 +982,7 @@ defmodule Phoenix.LiveView.Engine do
          nest
        )
        when is_atom(name) and is_access(access) do
-    {expr, vars, Map.put(assigns, [name | nest], true)}
+    {expr, vars, Map.put(assigns, {:changed, [name | nest]}, true)}
   end
 
   # Maybe: assigns.foo[:bar]
@@ -1005,19 +1052,29 @@ defmodule Phoenix.LiveView.Engine do
   end
 
   # Vars always taint unless we are in restricted mode.
-  defp analyze({name, meta, nil} = expr, {:restricted, map}, assigns, caller)
+  defp analyze({name, meta, nil} = expr, {:restricted, map} = vars, assigns, caller)
        when is_atom(name) do
-    if Map.has_key?(map, name) do
-      maybe_warn_taint(name, meta, caller)
-      {expr, {:tainted, map}, assigns}
-    else
-      {expr, {:restricted, map}, assigns}
+    case map do
+      %{^name => :tainted} ->
+        maybe_warn_taint(name, meta, caller)
+        {expr, {:tainted, map}, assigns}
+
+      %{^name => :change_track} ->
+        {expr, vars, Map.put(assigns, {:vars_changed, [name]}, true)}
+
+      _ ->
+        {expr, {:restricted, map}, assigns}
     end
   end
 
-  defp analyze({name, meta, nil} = expr, {_, map}, assigns, caller) when is_atom(name) do
-    maybe_warn_taint(name, meta, caller)
-    {expr, {:tainted, Map.put(map, name, true)}, assigns}
+  defp analyze({name, meta, nil} = expr, {type, map}, assigns, caller)
+       when is_atom(name) do
+    if Map.get(map, name) == :change_track do
+      {expr, {type, map}, Map.put(assigns, {:vars_changed, [name]}, true)}
+    else
+      maybe_warn_taint(name, meta, caller)
+      {expr, {:tainted, Map.put(map, name, :tainted)}, assigns}
+    end
   end
 
   # Quoted vars are ignored as they come from engine code.

--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -631,11 +631,23 @@ defmodule Phoenix.LiveView.Engine do
             end
 
           [assign | tail] ->
+            assigns_var =
+              case changed_var do
+                :changed ->
+                  @assigns_var
+
+                :vars_changed ->
+                  # we pass a map %{var: var} for nested change tracking
+                  quote do
+                    %{unquote(assign) => unquote(Macro.var(assign, nil))}
+                  end
+              end
+
             quote do
               unquote(__MODULE__).nested_changed_assign?(
                 unquote(tail),
                 unquote(assign),
-                unquote(@assigns_var),
+                unquote(assigns_var),
                 unquote(changed)
               )
             end

--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -312,7 +312,8 @@ defmodule Phoenix.LiveView.Engine do
   mind the collection itself is not "diffed" across renders.
   If one entry in the comprehension changes, the whole collection
   is sent again. Consider using `Phoenix.LiveComponent` and
-  `Phoenix.LiveView.stream/4` to optimize those cases.
+  `Phoenix.LiveView.stream/4` to optimize those cases, or see the
+  [`:key` attribute when using :for`](Phoenix.Component.html#sigil_H/2-special-attributes).
 
   The list of dynamics is always a list of iodatas or components,
   as we don't perform change tracking inside the comprehensions

--- a/lib/phoenix_live_view/keyed_comprehension.ex
+++ b/lib/phoenix_live_view/keyed_comprehension.ex
@@ -1,0 +1,25 @@
+defmodule Phoenix.LiveView.KeyedComprehension do
+  @moduledoc false
+
+  use Phoenix.LiveComponent
+
+  def update(assigns, socket) do
+    # we assign all entries from vars_changed to change-track them inside
+    # the LiveComponent
+    socket =
+      Enum.reduce(assigns.vars_changed, socket, fn {key, value}, socket ->
+        assign(socket, key, value)
+      end)
+
+    socket =
+      socket
+      |> assign(:render, assigns.render)
+      |> assign(:keys, Map.keys(assigns.vars_changed))
+
+    {:ok,
+     render_with(socket, fn assigns ->
+       vars_changed = Map.take(assigns.__changed__, assigns.keys)
+       assigns.render.(vars_changed)
+     end)}
+  end
+end

--- a/lib/phoenix_live_view/keyed_comprehension.ex
+++ b/lib/phoenix_live_view/keyed_comprehension.ex
@@ -3,6 +3,7 @@ defmodule Phoenix.LiveView.KeyedComprehension do
 
   use Phoenix.LiveComponent
 
+  @impl true
   def update(assigns, socket) do
     # we assign all entries from vars_changed to change-track them inside
     # the LiveComponent
@@ -11,17 +12,17 @@ defmodule Phoenix.LiveView.KeyedComprehension do
         assign(socket, key, value)
       end)
 
-    socket =
-      socket
-      |> assign(:render, assigns.render)
-      |> assign(:keys, Map.keys(assigns.vars_changed))
+    socket
+    |> assign(:render, assigns.render)
+    |> assign(:keys, Map.keys(assigns.vars_changed))
+    |> then(&{:ok, &1})
+  end
 
-    {:ok,
-     render_with(socket, fn assigns ->
-       vars_changed = Map.take(assigns.__changed__, assigns.keys)
-       rendered = assigns.render.(vars_changed)
-       # the engine ensures that this is valid
-       %{rendered | root: true}
-     end)}
+  @impl true
+  def render(assigns) do
+    vars_changed = Map.take(assigns.__changed__, assigns.keys)
+    rendered = assigns.render.(vars_changed)
+    # the engine ensures that this is valid
+    %{rendered | root: true}
   end
 end

--- a/lib/phoenix_live_view/keyed_comprehension.ex
+++ b/lib/phoenix_live_view/keyed_comprehension.ex
@@ -21,8 +21,6 @@ defmodule Phoenix.LiveView.KeyedComprehension do
   @impl true
   def render(assigns) do
     vars_changed = Map.take(assigns.__changed__, assigns.keys)
-    rendered = assigns.render.(vars_changed)
-    # the engine ensures that this is valid
-    %{rendered | root: true}
+    assigns.render.(vars_changed)
   end
 end

--- a/lib/phoenix_live_view/keyed_comprehension.ex
+++ b/lib/phoenix_live_view/keyed_comprehension.ex
@@ -19,7 +19,9 @@ defmodule Phoenix.LiveView.KeyedComprehension do
     {:ok,
      render_with(socket, fn assigns ->
        vars_changed = Map.take(assigns.__changed__, assigns.keys)
-       assigns.render.(vars_changed)
+       rendered = assigns.render.(vars_changed)
+       # the engine ensures that this is valid
+       %{rendered | root: true}
      end)}
   end
 end

--- a/lib/phoenix_live_view/tag_engine.ex
+++ b/lib/phoenix_live_view/tag_engine.ex
@@ -1227,7 +1227,8 @@ defmodule Phoenix.LiveView.TagEngine do
     {for_expr, invoke_subengine(state, :handle_end, [])}
   end
 
-  defp mark_variables_as_change_tracked(ast) do
+  @doc false
+  def mark_variables_as_change_tracked(ast) do
     # we traverse the AST and mark elements that should not considered
     # to be variables as "skip";
     # we need to handle both the pre and post phases to properly unmark

--- a/lib/phoenix_live_view/tag_engine.ex
+++ b/lib/phoenix_live_view/tag_engine.ex
@@ -1202,16 +1202,14 @@ defmodule Phoenix.LiveView.TagEngine do
 
     new_ast =
       quote do
-        Phoenix.LiveView.TagEngine.component(
-          &Phoenix.Component.live_component/1,
-          %{
-            id: {unquote(state.caller.module), unquote(tag_meta.line), unquote(key_expr)},
-            module: Phoenix.LiveView.KeyedComprehension,
+        %Phoenix.LiveView.Component{
+          id: {unquote(state.caller.module), unquote(tag_meta.line), unquote(key_expr)},
+          component: Phoenix.LiveView.KeyedComprehension,
+          assigns: %{
             vars_changed: %{unquote_splicing(for_assigns)},
             render: fn unquote(vars_changed) -> unquote(ast) end
-          },
-          {__MODULE__, __ENV__.function, __ENV__.file, unquote(tag_meta.line)}
-        )
+          }
+        }
       end
 
     state = pop_substate_from_stack(state)

--- a/lib/phoenix_live_view/tag_engine.ex
+++ b/lib/phoenix_live_view/tag_engine.ex
@@ -1227,8 +1227,6 @@ defmodule Phoenix.LiveView.TagEngine do
     {for_expr, invoke_subengine(state, :handle_end, [])}
   end
 
-  # we already validated that the for expression has the correct shape in
-  # validate_quoted_special_attr
   defp mark_variables_as_change_tracked(ast) do
     {ast, {_, vars}} =
       Macro.prewalk(ast, {true, []}, fn

--- a/lib/phoenix_live_view/tag_engine.ex
+++ b/lib/phoenix_live_view/tag_engine.ex
@@ -1250,7 +1250,7 @@ defmodule Phoenix.LiveView.TagEngine do
 
         {name, meta, context}, {true, vars}
         when is_atom(name) and is_list(meta) and is_atom(context) ->
-          var = {name, [:change_track | meta], context}
+          var = {name, Keyword.put(meta, :change_track, true), context}
           {var, {true, [{name, var} | vars]}}
 
         other, acc ->

--- a/lib/phoenix_live_view/tag_engine.ex
+++ b/lib/phoenix_live_view/tag_engine.ex
@@ -1207,7 +1207,7 @@ defmodule Phoenix.LiveView.TagEngine do
           {unquote(state.caller.module), unquote(tag_meta.line), unquote(tag_meta.column),
            unquote(key_expr)},
           %{unquote_splicing(variables)},
-          do: unquote(invoke_subengine(state, :handle_end, []))
+          do: unquote(invoke_subengine(state, :handle_end, [[meta: [root: true]]]))
         )
       end
 

--- a/test/phoenix_live_view/diff_test.exs
+++ b/test/phoenix_live_view/diff_test.exs
@@ -1727,7 +1727,7 @@ defmodule Phoenix.LiveView.DiffTest do
 
       assert {%{
                 1 =>
-                  {Phoenix.LiveView.KeyedComprehension, {Phoenix.LiveView.DiffTest, _, 1},
+                  {Phoenix.LiveView.KeyedComprehension, {Phoenix.LiveView.DiffTest, _, _, 1},
                    %{
                      id: 1,
                      name: "First",
@@ -1736,7 +1736,7 @@ defmodule Phoenix.LiveView.DiffTest do
                      myself: %Phoenix.LiveComponent.CID{cid: 1}
                    }, %{}, _},
                 2 =>
-                  {Phoenix.LiveView.KeyedComprehension, {Phoenix.LiveView.DiffTest, _, 2},
+                  {Phoenix.LiveView.KeyedComprehension, {Phoenix.LiveView.DiffTest, _, _, 2},
                    %{
                      id: 2,
                      name: "Second",

--- a/test/phoenix_live_view/diff_test.exs
+++ b/test/phoenix_live_view/diff_test.exs
@@ -1691,11 +1691,23 @@ defmodule Phoenix.LiveView.DiffTest do
   end
 
   describe "keyed comprehensions" do
-    def keyed_comprehension_with_pattern(assigns) do
+    defp keyed_comprehension_with_pattern(assigns) do
       ~H"""
       <ul>
         <li :for={%{id: id, name: name} <- @items} :key={id}>
           Outside assign: {@count} Inside assign: {name}
+        </li>
+      </ul>
+      """
+    end
+
+    defp keyed_comprehension_with_nested_access(assigns) do
+      ~H"""
+      <ul>
+        <li :for={{id, entry} <- @items} :key={id}>
+          <span>Count: {@count}</span>
+          <span>Dot: {entry.foo.bar}</span>
+          <span>Access: {entry[:foo][:bar]}</span>
         </li>
       </ul>
       """
@@ -1783,6 +1795,76 @@ defmodule Phoenix.LiveView.DiffTest do
       assert fourth_render == %{
                0 => %{d: [[1], [3]]},
                :c => %{3 => %{0 => "1", 1 => "Third", :s => -1}}
+             }
+    end
+
+    test "change-tracking for complex access" do
+      items = [
+        {1, %{foo: %{bar: "First", baz: "1"}, other: "hey"}},
+        {2, %{foo: %{bar: "Second", baz: "1"}, other: "hey"}}
+      ]
+
+      assigns = %{socket: %Socket{}, items: items, count: 0, __changed__: %{}}
+
+      {full_render, fingerprints, components} =
+        render(keyed_comprehension_with_nested_access(assigns))
+
+      assert full_render == %{
+               0 => %{d: [[1], [2]], s: ["", ""]},
+               :c => %{
+                 1 => %{
+                   0 => "0",
+                   1 => "First",
+                   :r => 1,
+                   :s => [
+                     "<li>\n    <span>Count: ",
+                     "</span>\n    <span>Dot: ",
+                     "</span>\n    <span>Access: ",
+                     "</span>\n  </li>"
+                   ],
+                   2 => "First"
+                 },
+                 2 => %{0 => "0", 1 => "Second", :s => 1, 2 => "Second"}
+               },
+               :r => 1,
+               :s => ["<ul>\n  ", "\n</ul>"]
+             }
+
+      # change entries, but no part that is rendered
+      assigns =
+        Phoenix.Component.assign(
+          assigns,
+          :items,
+          [
+            {1, %{foo: %{bar: "First", baz: "2"}, other: "heyo"}},
+            {2, %{foo: %{bar: "Second", baz: "2"}, other: "heyo"}}
+          ]
+        )
+
+      {second_render, fingerprints, components} =
+        render(keyed_comprehension_with_nested_access(assigns), fingerprints, components)
+
+      # no diff, because nothing relevant changed
+      assert second_render == %{0 => %{d: [[1], [2]]}}
+
+      # now change bar for first entry
+      assigns =
+        Phoenix.Component.assign(
+          assigns,
+          :items,
+          [
+            {1, %{foo: %{bar: "Updated", baz: "2"}, other: "heyo"}},
+            {2, %{foo: %{bar: "Second", baz: "2"}, other: "heyo"}}
+          ]
+        )
+
+      {third_render, _fingerprints, _components} =
+        render(keyed_comprehension_with_nested_access(assigns), fingerprints, components)
+
+      # no diff, because nothing relevant changed
+      assert third_render == %{
+               0 => %{d: [[1], [2]]},
+               :c => %{1 => %{1 => "Updated", 2 => "Updated"}}
              }
     end
   end

--- a/test/phoenix_live_view/tag_engine_test.exs
+++ b/test/phoenix_live_view/tag_engine_test.exs
@@ -1,0 +1,83 @@
+defmodule Phoenix.LiveView.TagEngineTest do
+  use ExUnit.Case, async: true
+
+  defp to_ast(source) do
+    options = [
+      engine: Phoenix.LiveView.TagEngine,
+      file: __ENV__.file,
+      line: __ENV__.line,
+      caller: __ENV__,
+      indentation: 0,
+      source: source,
+      tag_handler: Phoenix.LiveView.HTMLEngine
+    ]
+
+    EEx.compile_string(source, options)
+  end
+
+  defmacrop keyed_comprehension(id, vars_changed) do
+    quote do
+      {{:., [], [{_, _, [:Phoenix, :LiveView, :TagEngine]}, :keyed_comprehension]}, [],
+       [unquote(id), unquote(vars_changed), _]}
+    end
+  end
+
+  defp keyed_comprehensions(ast) do
+    {_, kc} =
+      Macro.prewalk(ast, [], fn
+        keyed_comprehension(id, vars_changed) = ast, acc ->
+          {ast, [{id, vars_changed} | acc]}
+
+        other, acc ->
+          {other, acc}
+      end)
+
+    kc
+  end
+
+  describe "keyed comprehensions" do
+    test "has vars_changed" do
+      ast =
+        to_ast("""
+        <ul>
+          <li :for={%{id: id, name: name} <- @items} :key={@id}>
+            Count: <span>{@count}</span>,
+            item: {name}
+          </li>
+        </ul>
+        """)
+
+      assert [{id, vars_changed}] = keyed_comprehensions(ast)
+      assert {:{}, _, [__MODULE__, _line, _col, {{:., _, [{:assigns, _, _}, :id]}, _, []}]} = id
+      assert {:%{}, [], keys_and_vars} = vars_changed
+
+      assert [
+               id: {:id, [{:change_track, true} | _], _},
+               name: {:name, [{:change_track, true} | _], _}
+             ] = Enum.sort_by(keys_and_vars, fn {key, _} -> key end)
+    end
+
+    test "vars_changed ignores pin and binary type" do
+      ast =
+        to_ast("""
+        <ul>
+          <li :for={{id, name, ^bar, <<other::binary>>, stuff} <- @items} :key={@id}>
+            Count: <span>{@count}</span>,
+            item: {name}
+          </li>
+        </ul>
+        """)
+
+      assert [{id, vars_changed}] = keyed_comprehensions(ast)
+      assert {:{}, _, [__MODULE__, _line, _col, {{:., _, [{:assigns, _, _}, :id]}, _, []}]} = id
+      assert {:%{}, [], keys_and_vars} = vars_changed
+
+      assert [
+               id: {:id, [{:change_track, true} | _], _},
+               name: {:name, [{:change_track, true} | _], _},
+               other: {:other, [{:change_track, true} | _], _},
+               stuff: {:stuff, [{:change_track, true} | _], _}
+             ] = Enum.sort_by(keys_and_vars, fn {key, _} -> key end)
+    end
+  end
+end

--- a/test/phoenix_live_view/tag_engine_test.exs
+++ b/test/phoenix_live_view/tag_engine_test.exs
@@ -1,83 +1,24 @@
 defmodule Phoenix.LiveView.TagEngineTest do
   use ExUnit.Case, async: true
 
-  defp to_ast(source) do
-    options = [
-      engine: Phoenix.LiveView.TagEngine,
-      file: __ENV__.file,
-      line: __ENV__.line,
-      caller: __ENV__,
-      indentation: 0,
-      source: source,
-      tag_handler: Phoenix.LiveView.HTMLEngine
-    ]
+  alias Phoenix.LiveView.TagEngine
 
-    EEx.compile_string(source, options)
-  end
-
-  defmacrop keyed_comprehension(id, vars_changed) do
-    quote do
-      {{:., [], [{_, _, [:Phoenix, :LiveView, :TagEngine]}, :keyed_comprehension]}, [],
-       [unquote(id), unquote(vars_changed), _]}
-    end
-  end
-
-  defp keyed_comprehensions(ast) do
-    {_, kc} =
-      Macro.prewalk(ast, [], fn
-        keyed_comprehension(id, vars_changed) = ast, acc ->
-          {ast, [{id, vars_changed} | acc]}
-
-        other, acc ->
-          {other, acc}
-      end)
-
-    kc
-  end
-
-  describe "keyed comprehensions" do
-    test "has vars_changed" do
+  describe "mark_variables_ast_change_tracked/1" do
+    test "ignores pinned variables and binary modifiers" do
       ast =
-        to_ast("""
-        <ul>
-          <li :for={%{id: id, name: name} <- @items} :key={@id}>
-            Count: <span>{@count}</span>,
-            item: {name}
-          </li>
-        </ul>
-        """)
+        quote do
+          %{foo: foo, bar: ^bar, bin: <<thebin::binary>>, other: other}
+        end
 
-      assert [{id, vars_changed}] = keyed_comprehensions(ast)
-      assert {:{}, _, [__MODULE__, _line, _col, {{:., _, [{:assigns, _, _}, :id]}, _, []}]} = id
-      assert {:%{}, [], keys_and_vars} = vars_changed
+      assert {new_ast, variables} = TagEngine.mark_variables_as_change_tracked(ast)
 
       assert [
-               id: {:id, [{:change_track, true} | _], _},
-               name: {:name, [{:change_track, true} | _], _}
-             ] = Enum.sort_by(keys_and_vars, fn {key, _} -> key end)
-    end
+               {:foo, {:foo, [change_track: true], _}},
+               {:other, {:other, [change_track: true], _}},
+               {:thebin, {:thebin, [change_track: true], _}}
+             ] = Enum.sort_by(variables, &elem(&1, 0))
 
-    test "vars_changed ignores pin and binary type" do
-      ast =
-        to_ast("""
-        <ul>
-          <li :for={{id, name, ^bar, <<other::binary>>, stuff} <- @items} :key={@id}>
-            Count: <span>{@count}</span>,
-            item: {name}
-          </li>
-        </ul>
-        """)
-
-      assert [{id, vars_changed}] = keyed_comprehensions(ast)
-      assert {:{}, _, [__MODULE__, _line, _col, {{:., _, [{:assigns, _, _}, :id]}, _, []}]} = id
-      assert {:%{}, [], keys_and_vars} = vars_changed
-
-      assert [
-               id: {:id, [{:change_track, true} | _], _},
-               name: {:name, [{:change_track, true} | _], _},
-               other: {:other, [{:change_track, true} | _], _},
-               stuff: {:stuff, [{:change_track, true} | _], _}
-             ] = Enum.sort_by(keys_and_vars, fn {key, _} -> key end)
+      assert new_ast != ast
     end
   end
 end


### PR DESCRIPTION
A keyed for comprehension works by transforming the comprehension's content into a LiveComponent, which will perform change-tracking and optimizes the payload over the wire:

```heex
<ul>
  <li :for={%{id: id, name: name} <- @items} :key={id}>
    Count: <span>{@count}</span>,
    item: {name}
  </li>
</ul>
```

Because they use live components under the hood, keyed comprehensions come with the limitation of only being supported on HTML tags, so while you can use a regular `:for` comprehension on `<.function_components>`, and `<:slots>`, this is not supported keyed comprehensions and will raise an exception at compile time.