### PR TITLE
only:block break table structure, table-row is a valid table context.

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1820,7 +1820,7 @@ defmodule Phoenix.LiveView do
   ```heex
   <table>
     <tbody id="songs" phx-update="stream">
-      <tr id="songs-empty" class="only:block hidden">
+      <tr id="songs-empty" class="only:table-row hidden">
         <td colspan="2">No songs found</td>
       </tr>
       <tr


### PR DESCRIPTION
Fix documentation example using `:only-child` selector, with `block` that break table structure, using `table-row` instead, fixing the issue.

with block you won't have the cell that span over the whole row, even with `colspan="2"`.
