### PR TITLE
Update external-uploads.md - fix typo `uploaded_files` to `uploads`

### DIFF
--- a/guides/client/external-uploads.md
+++ b/guides/client/external-uploads.md
@@ -41,7 +41,7 @@ Configure your uploader on `c:Phoenix.LiveView.mount/3`:
     def mount(_params, _session, socket) do
       {:ok,
        socket
-       |> assign(:uploaded_files, [])
+       |> assign(:uploads, [])
        |> allow_upload(:avatar, accept: :any, max_entries: 3, external: &presign_upload/2)}
     end
 
@@ -144,7 +144,7 @@ We will first implement the LiveView portion:
 def mount(_params, _session, socket) do
   {:ok,
     socket
-    |> assign(:uploaded_files, [])
+    |> assign(:uploads, [])
     |> allow_upload(:avatar, accept: :any, max_entries: 3, external: &presign_upload/2)}
 end
 


### PR DESCRIPTION
It looks like `uploaded_files` should be `uploads`. It's assigned `uploaded_files` in the on_mount but later it's pulled from the socket.assigns as `uploads`