### PR TITLE
write empty manifest when no colocated js is used

### DIFF
--- a/lib/phoenix_live_view/colocated_js.ex
+++ b/lib/phoenix_live_view/colocated_js.ex
@@ -102,7 +102,7 @@ defmodule Phoenix.LiveView.ColocatedJS do
   > #### Warning! {: .warning}
   >
   > LiveView assumes full ownership over the configured `:target_directory`. When
-  > compiling, it will **delete** any files and folders inside the `:target_directory`, 
+  > compiling, it will **delete** any files and folders inside the `:target_directory`,
   > that it does not associate with a colocated JavaScript module or manifest.
 
   ### Imports in colocated JS
@@ -275,13 +275,20 @@ defmodule Phoenix.LiveView.ColocatedJS do
   end
 
   defp write_new_manifests!(files) do
-    files
-    |> Enum.group_by(fn {_file, config} ->
-      config[:manifest] || "index.js"
-    end)
-    |> Enum.each(fn {manifest, entries} ->
-      write_manifest(manifest, entries)
-    end)
+    if files == [] do
+      File.write!(
+        Path.join(target_dir(), "index.js"),
+        "export const hooks = {};\nexport default {};"
+      )
+    else
+      files
+      |> Enum.group_by(fn {_file, config} ->
+        config[:manifest] || "index.js"
+      end)
+      |> Enum.each(fn {manifest, entries} ->
+        write_manifest(manifest, entries)
+      end)
+    end
   end
 
   defp write_manifest(manifest, entries) do

--- a/test/phoenix_live_view/colocated_hook_test.exs
+++ b/test/phoenix_live_view/colocated_hook_test.exs
@@ -57,6 +57,9 @@ defmodule Phoenix.LiveView.ColocatedHookTest do
                script,
                Path.join(Mix.Project.build_path(), "phoenix-colocated/phoenix_live_view/")
              )
+  after
+    :code.delete(__MODULE__.TestComponent)
+    :code.purge(__MODULE__.TestComponent)
   end
 
   test "raises for invalid name" do

--- a/test/phoenix_live_view/colocated_js_test.exs
+++ b/test/phoenix_live_view/colocated_js_test.exs
@@ -59,6 +59,9 @@ defmodule Phoenix.LiveView.ColocatedJSTest do
                script,
                Path.join(Mix.Project.build_path(), "phoenix-colocated/phoenix_live_view/")
              )
+  after
+    :code.delete(__MODULE__.TestComponent)
+    :code.purge(__MODULE__.TestComponent)
   end
 
   test "keyed script is available under default named export" do
@@ -124,6 +127,9 @@ defmodule Phoenix.LiveView.ColocatedJSTest do
 
     assert [_match, export_name] = Regex.run(~r/export \{ (imp_.*) as components \}/, manifest)
     assert manifest =~ "#{export_name}[\"my-script\"] = #{js_name};"
+  after
+    :code.delete(__MODULE__.TestComponentKey)
+    :code.purge(__MODULE__.TestComponentKey)
   end
 
   test "raises for invalid name" do
@@ -143,5 +149,12 @@ defmodule Phoenix.LiveView.ColocatedJSTest do
                      end
                    end
                  end
+  end
+
+  test "writes empty index.js when no colocated scripts exist" do
+    manifest = Path.join(Mix.Project.build_path(), "phoenix-colocated/phoenix_live_view/index.js")
+    Phoenix.LiveView.ColocatedJS.compile()
+    assert File.exists?(manifest)
+    assert File.read!(manifest) == "export const hooks = {};\nexport default {};"
   end
 end


### PR DESCRIPTION
This allows a freshly generated app to have an import statement in `app.js` even when no colocated JS / Hooks are there.