### PR TITLE
allow any selector as portal target

### DIFF
--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -713,10 +713,12 @@ export default class DOMPatch {
   }
 
   teleport(el, morph) {
-    const targetId = el.getAttribute(PHX_PORTAL);
-    const portalContainer = document.getElementById(targetId);
+    const targetSelector = el.getAttribute(PHX_PORTAL);
+    const portalContainer = document.querySelector(targetSelector);
     if (!portalContainer) {
-      throw new Error("portal target with id " + targetId + " not found");
+      throw new Error(
+        "portal target with selector " + targetSelector + " not found",
+      );
     }
     // phx-portal templates must have a single root element, so we assume this to be
     // the case here

--- a/assets/test/integration/portal_test.ts
+++ b/assets/test/integration/portal_test.ts
@@ -26,7 +26,7 @@ function createViewWithPortal(rootId = "root") {
 
 function createHtmlWithPortal(id, targetId, content) {
   const portalHtml = `
-    <template id="${id}" ${PHX_PORTAL}="${targetId}">
+    <template id="${id}" ${PHX_PORTAL}="#${targetId}">
       <div id="portal-content-${id}">
         ${content}
       </div>
@@ -149,7 +149,7 @@ describe("Portal handling", () => {
     // Expect error when teleporting
     expect(() => {
       performPatch(view, content, html);
-    }).toThrow("portal target with id non-existent-target not found");
+    }).toThrow("portal target with selector #non-existent-target not found");
   });
 
   test("portal template without id throws error", () => {
@@ -159,7 +159,7 @@ describe("Portal handling", () => {
     // Create template with content that has no ID
     const html = `
       <div>
-        <template id="invalid-portal" ${PHX_PORTAL}="portal-target">
+        <template id="invalid-portal" ${PHX_PORTAL}="#portal-target">
           <div>Content without ID</div>
         </template>
       </div>
@@ -259,7 +259,7 @@ describe("Portal handling", () => {
     // Create template with skipped content
     const html = `
       <div>
-        <template id="skipped-portal" ${PHX_PORTAL}="portal-target">
+        <template id="skipped-portal" ${PHX_PORTAL}="#portal-target">
           <div id="portal-content-skipped">Hello World!</div>
         </template>
       </div>
@@ -275,7 +275,7 @@ describe("Portal handling", () => {
 
     const html2 = `
       <div>
-        <template id="skipped-portal" ${PHX_PORTAL}="portal-target">
+        <template id="skipped-portal" ${PHX_PORTAL}="#portal-target">
           <div id="portal-content-skipped" ${PHX_SKIP}></div>
         </template>
       </div>

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -3488,16 +3488,19 @@ defmodule Phoenix.Component do
   ## Examples
 
   ```heex
-  <.portal id="modal" target="target-id">
+  <.portal id="modal" target="body">
     ...
   </.portal>
-  <!-- The content of the portal will be rendered in the div below -->
-  <div id="target-id"></div>
   ```
   """
 
   attr.(:id, :string, required: true)
-  attr.(:target, :string, required: true)
+
+  attr.(:target, :string,
+    required: true,
+    doc: "A CSS selector that identifies the target. The target must be unique."
+  )
+
   attr.(:class, :string, default: nil, doc: "The class to apply to the portal wrapper.")
   attr.(:container, :string, default: "div", doc: "The HTML tag to use as the portal wrapper.")
   slot.(:inner_block, required: true)

--- a/test/e2e/support/portal.ex
+++ b/test/e2e/support/portal.ex
@@ -12,6 +12,9 @@ defmodule Phoenix.LiveViewTest.E2E.PortalLive do
       </script>
       <script src="/assets/phoenix/phoenix.min.js">
       </script>
+      <style>
+        [data-phx-session], [data-phx-portal-wrapper] { display: contents }
+      </style>
       <script type="module">
         import { LiveSocket } from "/assets/phoenix_live_view/phoenix_live_view.esm.js";
         import { computePosition, autoUpdate, offset } from 'https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.7.0/+esm';
@@ -66,7 +69,6 @@ defmodule Phoenix.LiveViewTest.E2E.PortalLive do
     </head>
 
     <body>
-      <div id="tooltips"></div>
       <main style="flex: 1; padding: 2rem;">
         {@inner_content}
       </main>
@@ -79,7 +81,7 @@ defmodule Phoenix.LiveViewTest.E2E.PortalLive do
     ~H"""
     {@inner_content}
 
-    <div id="portal-target"></div>
+    <div id="app-portal"></div>
     """
   end
 
@@ -137,7 +139,7 @@ defmodule Phoenix.LiveViewTest.E2E.PortalLive do
 
     <.button phx-click={JS.navigate("/form")}>Live navigate</.button>
 
-    <.portal :if={@render_modal} id="portal-source" target="root-portal">
+    <.portal :if={@render_modal} id="portal-source" target="#root-portal">
       <.modal id="my-modal">
         This is a modal.
         <p>DOM patching works as expected: {@count}</p>
@@ -145,13 +147,13 @@ defmodule Phoenix.LiveViewTest.E2E.PortalLive do
       </.modal>
     </.portal>
 
-    <.portal id="portal-source-2" target="portal-target">
+    <.portal id="portal-source-2" target="#app-portal">
       <.modal id="my-modal-2">
         This is a second modal.
       </.modal>
     </.portal>
 
-    <.portal id="portal-with-live-component" target="root-portal">
+    <.portal id="portal-with-live-component" target="#root-portal">
       <.live_component module={Phoenix.LiveViewTest.E2E.PortalLive.LC} id="lc" />
     </.portal>
 
@@ -312,19 +314,15 @@ defmodule Phoenix.LiveViewTest.E2E.PortalLive.NestedLive do
 
       <button phx-click="event">Toggle event in nested LV</button>
 
-      <template id="nested-tpl" phx-portal="portal-target">
-        <div id="button-from-nested-lv">
-          <button phx-click="event">Toggle event in nested LV (from teleported button)</button>
-        </div>
-      </template>
+      <.portal id="nested-lv-button" target="body">
+        <button phx-click="event">Toggle event in nested LV (from teleported button)</button>
+      </.portal>
 
-      <template id="teleported-nested-lv" phx-portal="portal-target">
-        <div id="nested-lv-container">
-          {live_render(@socket, Phoenix.LiveViewTest.E2E.PortalLive.NestedTeleportedLive,
-            id: "nested-teleported"
-          )}
-        </div>
-      </template>
+      <.portal id="nested-lv" target="body">
+        {live_render(@socket, Phoenix.LiveViewTest.E2E.PortalLive.NestedTeleportedLive,
+          id: "nested-teleported"
+        )}
+      </.portal>
     </div>
     """
   end
@@ -351,7 +349,7 @@ end
 defmodule Phoenix.LiveViewTest.E2E.PortalLive.LC do
   use Phoenix.LiveComponent
 
-  def update(assigns, socket) do
+  def update(_assigns, socket) do
     {:ok, stream(socket, :items, [%{id: 1, name: "Item 1"}, %{id: 2, name: "Item 2"}])}
   end
 
@@ -403,7 +401,7 @@ defmodule Phoenix.LiveViewTest.E2E.PortalTooltip do
       <div id={"#{@id}-activator"} aria-describedby={@id} data-activator>
         {render_slot(@activator)}
       </div>
-      <.portal :if={@portal} id={"#{@id}-portal"} target="tooltips">
+      <.portal :if={@portal} id={"#{@id}-portal"} target="body">
         <div
           id={@id}
           phx-mounted={JS.ignore_attributes(["style"])}

--- a/test/e2e/support/portal.ex
+++ b/test/e2e/support/portal.ex
@@ -302,9 +302,13 @@ end
 defmodule Phoenix.LiveViewTest.E2E.PortalLive.NestedLive do
   use Phoenix.LiveView
 
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :count, 0)}
+  end
+
   def handle_event("event", _params, socket) do
     IO.puts("Nested LV got event!")
-    {:noreply, socket}
+    {:noreply, assign(socket, :count, socket.assigns.count + 1)}
   end
 
   def render(assigns) do
@@ -312,10 +316,12 @@ defmodule Phoenix.LiveViewTest.E2E.PortalLive.NestedLive do
     <div class="border border-orange-200">
       <h1>Nested LiveView</h1>
 
-      <button phx-click="event">Toggle event in nested LV</button>
+      <p id="nested-event-count">{@count}</p>
+
+      <button phx-click="event">Trigger event in nested LV</button>
 
       <.portal id="nested-lv-button" target="body">
-        <button phx-click="event">Toggle event in nested LV (from teleported button)</button>
+        <button phx-click="event">Trigger event in nested LV (from teleported button)</button>
       </.portal>
 
       <.portal id="nested-lv" target="body">

--- a/test/e2e/tests/portal.spec.js
+++ b/test/e2e/tests/portal.spec.js
@@ -22,6 +22,71 @@ test("renders modal inside portal location", async ({ page }) => {
   );
 });
 
+test("teleported element is removed properly", async ({ page }) => {
+  await page.goto("/portal?tick=false");
+  await syncLV(page);
+
+  await expect(
+    page.locator("[data-phx-teleported-src=portal-source]"),
+  ).toHaveCount(1);
+  await page.getByRole("button", { name: "Toggle modal render" }).click();
+  await expect(
+    page.locator("[data-phx-teleported-src=portal-source]"),
+  ).toHaveCount(0);
+  await expect(page.locator("#my-modal")).toHaveCount(0);
+
+  // other modal still exists
+  await expect(
+    page.locator("[data-phx-teleported-src=portal-source-2]"),
+  ).toHaveCount(1);
+
+  // now toggle it again
+  await page.getByRole("button", { name: "Toggle modal render" }).click();
+  await expect(
+    page.locator("[data-phx-teleported-src=portal-source]"),
+  ).toHaveCount(1);
+
+  // now navigate to another page
+  await page.getByRole("button", { name: "Live navigate" }).click();
+  await syncLV(page);
+  // all teleported elements should be gone
+  await expect(page.locator("[data-phx-teleported-src]")).toHaveCount(0);
+});
+
+test("events are routed to correct LiveView", async ({ page }) => {
+  await page.goto("/portal?tick=false");
+  await syncLV(page);
+
+  await expect(page.locator("#nested-event-count")).toHaveText("0");
+  await page
+    .getByRole("button", { name: "Trigger event in nested LV", exact: true })
+    .click();
+  await expect(page.locator("#nested-event-count")).toHaveText("1");
+  await page
+    .getByRole("button", {
+      name: "Trigger event in nested LV (from teleported button)",
+    })
+    .click();
+  await expect(page.locator("#nested-event-count")).toHaveText("2");
+});
+
+test("streams work in teleported LiveComponent", async ({ page }) => {
+  await page.goto("/portal?tick=false");
+  await syncLV(page);
+
+  expect(
+    await page.evaluate(
+      () => document.querySelector("#stream-in-lc").children.length,
+    ),
+  ).toEqual(2);
+  await page.getByRole("button", { name: "Prepend item" }).click();
+  expect(
+    await page.evaluate(
+      () => document.querySelector("#stream-in-lc").children.length,
+    ),
+  ).toEqual(3);
+});
+
 test("tooltip example", async ({ page }) => {
   await page.goto("/portal?tick=false");
   await syncLV(page);


### PR DESCRIPTION
This allows someone to directly teleport into the `<body>`, for example.