### PR TITLE
fix variable tainting

### DIFF
--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -942,14 +942,14 @@ defmodule Phoenix.LiveView.Engine do
          {name, _, context} = expr,
          {type, map} = vars,
          assigns,
-         _caller,
+         caller,
          nest
        )
        when is_atom(name) and is_atom(context) and is_map_key(map, name) and type != :tainted do
     if map[name] == :change_track do
       {expr, vars, Map.put(assigns, {:vars_changed, [name | nest]}, true)}
     else
-      {expr, vars, assigns}
+      analyze(expr, vars, assigns, caller)
     end
   end
 

--- a/test/phoenix_live_view/diff_test.exs
+++ b/test/phoenix_live_view/diff_test.exs
@@ -750,6 +750,50 @@ defmodule Phoenix.LiveView.DiffTest do
              }
     end
 
+    defp fake_form(assigns) do
+      ~H"""
+      {render_slot(@inner_block, @form)}
+      """
+    end
+
+    defp access_let(assigns) do
+      ~H"""
+      <.fake_form :let={f} form={@form}>
+        {f[:name].value}
+      </.fake_form>
+      """
+    end
+
+    test ":let + access" do
+      assigns = %{socket: %Socket{}, form: %{name: %{value: "foo"}}}
+
+      {full_render, fingerprints, components} = render(access_let(assigns))
+
+      assert full_render == %{
+               0 => %{0 => %{0 => "foo", :s => ["\n  ", "\n"]}, :s => ["", ""]},
+               :s => ["", ""]
+             }
+
+      {full_render, _fingerprints, _components} =
+        render(access_let(assigns), fingerprints, components)
+
+      assert full_render == %{0 => %{0 => %{0 => "foo"}}}
+
+      assigns = Map.put(assigns, :__changed__, %{})
+
+      {full_render, _fingerprints, _components} =
+        render(access_let(assigns), fingerprints, components)
+
+      assert full_render == %{}
+
+      assigns = Map.put(assigns, :__changed__, %{form: true})
+
+      {full_render, _fingerprints, _components} =
+        render(access_let(assigns), fingerprints, components)
+
+      assert full_render == %{0 => %{0 => %{0 => "foo"}}}
+    end
+
     def render_multiple_slots(assigns) do
       ~H"""
       <div>


### PR DESCRIPTION
Relates to: https://github.com/phoenixframework/phoenix_live_view/pull/3837/files

We've been missing an analyze call which would for example cause

```heex
<.form :let={f} for={@changeset}>
  {f[:field].value}
</.form>
```

to not re-render when changeset is changed.