### PR TITLE
root tracking for macro components

### DIFF
--- a/lib/phoenix_live_view/tag_engine.ex
+++ b/lib/phoenix_live_view/tag_engine.ex
@@ -366,8 +366,6 @@ defmodule Phoenix.LiveView.TagEngine do
   defp maybe_prune_text_after_macro_component("", tokens), do: prune_text(tokens)
   defp maybe_prune_text_after_macro_component(_ast, tokens), do: tokens
 
-  defp prune_text_after_slot(tokens), do: prune_text(tokens)
-
   defp prune_text([{:text, text, meta} | tokens]),
     do: [{:text, String.trim_leading(text), meta} | tokens]
 
@@ -633,7 +631,7 @@ defmodule Phoenix.LiveView.TagEngine do
     assigns = wrap_special_slot(special, merge_component_attrs(roots, attrs, line))
 
     add_slot(state, slot_name, assigns, attr_info, tag_meta, special)
-    |> continue(prune_text_after_slot(tokens))
+    |> continue(prune_text(tokens))
   end
 
   # Slot (with inner content)
@@ -669,7 +667,7 @@ defmodule Phoenix.LiveView.TagEngine do
     state
     |> add_slot(slot_name, assigns, inner, tag_meta, special)
     |> pop_substate_from_stack()
-    |> continue(prune_text_after_slot(tokens))
+    |> continue(prune_text(tokens))
   end
 
   # Local function component (self close)

--- a/test/phoenix_component/macro_component_integration_test.exs
+++ b/test/phoenix_component/macro_component_integration_test.exs
@@ -311,35 +311,51 @@ defmodule Phoenix.Component.MacroComponentIntegrationTest do
     assert Enum.find(data, fn %{opts: opts} -> opts == %{"id" => "2"} end)
   end
 
-  describe "root tracking" do
-    @endpoint Phoenix.LiveViewTest.Support.Endpoint
+  test "root tracking" do
+    assert eval_heex("<div :type={MyComponent}>Test</div>").root
 
-    test "does not count as root" do
-      defmodule TestLVDoesNotCountAsRoot do
-        use Phoenix.LiveView
+    refute eval_heex("""
+           <div :type={MyComponent}>Test</div>
+           <span>Another</span>
+           """).root
 
-        defmodule LC do
-          use Phoenix.LiveComponent
+    Process.put(
+      :new_ast,
+      {:div, [{"id", "1"}],
+       [
+         {"span", [{"class", "\"foo\""}], ["Test"], %{}},
+         {"span", [{"class", "'foo'"}], ["Test"], %{}}
+       ], %{}}
+    )
 
-          def render(assigns) do
-            ~H"""
-            <div :type={MyComponent}></div>
-            """
-          end
-        end
+    assert eval_heex("<div :type={MyComponent}>Test</div>").root
 
-        def render(assigns) do
-          ~H"""
-          <.live_component module={LC} id="my-lc" />
-          """
-        end
-      end
+    Process.put(:new_ast, "")
 
-      assert_raise ArgumentError,
-                   ~r/Stateful components must have a single static HTML tag at the root/,
-                   fn ->
-                     live_isolated(Phoenix.ConnTest.build_conn(), TestLVDoesNotCountAsRoot)
-                   end
-    end
+    assert eval_heex("""
+           <div :type={MyComponent}>Test</div><span>Another</span>
+           """).root
+
+    Process.put(:new_ast, "some text")
+
+    refute eval_heex("""
+           <div :type={MyComponent}>Test</div><span>Another</span>
+           """).root
+  end
+
+  defp eval_heex(source) do
+    require Phoenix.Component
+
+    EEx.compile_string(source,
+      engine: Phoenix.LiveView.TagEngine,
+      line: 1,
+      file: __ENV__.file,
+      trim: true,
+      caller: __ENV__,
+      source: source,
+      tag_handler: Phoenix.LiveView.HTMLEngine
+    )
+    |> Code.eval_quoted(assigns: %{})
+    |> elem(0)
   end
 end

--- a/test/phoenix_component/macro_component_integration_test.exs
+++ b/test/phoenix_component/macro_component_integration_test.exs
@@ -339,7 +339,8 @@ defmodule Phoenix.Component.MacroComponentIntegrationTest do
     Process.put(:new_ast, "some text")
 
     refute eval_heex("""
-           <div :type={MyComponent}>Test</div><span>Another</span>
+           <div :type={MyComponent}>Test</div>
+           <span>Another</span>
            """).root
   end
 


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix_live_view/issues/3877.

I'm not sure though if we want this, since it would still fail if you do

```elixir
# inside LiveComponent
def render(assigns) do
  ~H"""
  <script :type={ColocatedHook} ...>...</script>

  <div>
    ...
  </div>
  """
end
```

because the extra whitespace between the colocated hook and the div counts as text that sets root to false.

So in practice, this may not help much.