### PR TITLE
Use checkbox default value 'on' in LiveViewTest

### DIFF
--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -1442,7 +1442,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
 
   defp form_defaults("input", node, name, acc) do
     type = TreeDOM.attribute(node, "type") || "text"
-    value = TreeDOM.attribute(node, "value") || ""
+    value = TreeDOM.attribute(node, "value") || default_value(type)
 
     cond do
       type in ["radio", "checkbox"] ->
@@ -1568,7 +1568,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
     type = TreeDOM.attribute(node, "type") || "text"
 
     if type in ["radio", "checkbox", "hidden"] do
-      value = TreeDOM.attribute(node, "value") || ""
+      value = TreeDOM.attribute(node, "value") || default_value(type)
       {[type | types], [value | values]}
     else
       {[type | types], values}
@@ -1591,6 +1591,9 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
   defp collect_values(_tag, _node, types, values) do
     {types, values}
   end
+
+  defp default_value("checkbox"), do: "on"
+  defp default_value(_type), do: ""
 
   defp fill_in_name("", name), do: name
   defp fill_in_name(prefix, name), do: prefix <> "[" <> name <> "]"

--- a/test/phoenix_live_view/integrations/elements_test.exs
+++ b/test/phoenix_live_view/integrations/elements_test.exs
@@ -784,6 +784,11 @@ defmodule Phoenix.LiveView.ElementsTest do
                    end
     end
 
+    test "fill in checkbox without value (default: on)", %{live: view} do
+      assert view |> form("#form", hello: [checkbox_no_value: "on"]) |> render_change
+      assert last_event(view) =~ ~s|"checkbox_no_value" => "on"|
+    end
+
     test "fill in multiple checkbox", %{live: view} do
       assert_raise ArgumentError,
                    "value for checkbox \"hello[multiple-checkbox][]\" must be one of [\"1\", \"2\", \"3\"], got: \"unknown\"",

--- a/test/support/live_views/elements.ex
+++ b/test/support/live_views/elements.ex
@@ -161,6 +161,7 @@ defmodule Phoenix.LiveViewTest.Support.ElementsLive do
       <input name="hello[checkbox]" type="checkbox" value="1" />
       <input name="hello[checkbox]" type="checkbox" value="2" checked />
       <input name="hello[checkbox]" type="checkbox" value="3" />
+      <input name="hello[checkbox_no_value]" type="checkbox" />
       <input name="hello[not-checked-checkbox]" type="checkbox" value="1" />
       <input name="hello[disabled-checkbox]" type="checkbox" value="1" checked disabled />
       <input name="hello[multiple-checkbox][]" type="checkbox" value="1" />


### PR DESCRIPTION
As per the HTML spec, inputs with type `checkbox` have a default value of `on`.

> On getting, if the element has a [value](https://html.spec.whatwg.org/multipage/input.html#attr-input-value) content attribute, return that attribute's value; otherwise, return the string "on".
> https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox)

This PR allows `form("#form", checkbox_no_value: "on")`, which previously resulted in an error.