### PR TITLE
Add LiveDebugger mention in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ community at different stages of development:
 
 * [Fluxon UI](https://fluxonui.com): Elegant and accessible UI components for Phoenix LiveView
 
+## LiveDebugger
+
+[LiveDebugger](https://github.com/software-mansion/live-debugger) is a debugging tool built specifically for Phoenix LiveView applications. It provides a real-time view into your LiveView processes, making it easier to understand the component hierarchy, inspect assigns, trace lifecycle callbacks, and troubleshoot issues more efficiently.
+
+To get started, follow the setup instructions in the [LiveDebugger repository](https://github.com/software-mansion/live-debugger?tab=readme-ov-file#getting-started).
+
 ## What makes LiveView unique?
 
 LiveView is server-centric. You no longer have to worry about managing


### PR DESCRIPTION
Hey 👋 
In this PR I wanted to add a short section to the README about LiveDebugger, with a link to the repo and a quick overview of what it offers. Thought it might be helpful for developers who are already using LiveView.

Let me know if you'd prefer a shorter version or if it should be moved somewhere else in the docs.
Thanks!

### Refs:
GitHub: https://github.com/software-mansion/live-debugger
Docs: https://hexdocs.pm/live_debugger/welcome.html
Hex: https://hex.pm/packages/live_debugger

