### PR TITLE
package.json: list type exports.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
   "unpkg": "./priv/static/phoenix_live_view.min.js",
   "jsdelivr": "./priv/static/phoenix_live_view.min.js",
   "exports": {
-    "import": "./priv/static/phoenix_live_view.esm.js",
+    "import": {
+      "default": "./priv/static/phoenix_live_view.esm.js",
+      "types": "./assets/js/types/index.d.ts"
+    },
     "require": "./priv/static/phoenix_live_view.cjs.js"
   },
   "author": "Chris McCord <chris@chrismccord.com> (http://www.phoenixframework.org)",


### PR DESCRIPTION
Without something like this, we get the following when using moduleResolution "bundler":

```
js/app.ts:3:34 - error TS7016: Could not find a declaration file for module 'phoenix_live_view'.
'[...]/node_modules/phoenix_live_view/priv/static/phoenix_live_view.esm.js' implicitly has an 'any' type.

  There are types at '[...]/node_modules/phoenix_live_view/assets/js/types/index.d.ts', but this result
  could not be resolved when respecting package.json "exports". The 'phoenix_live_view' library may need
  to update its package.json or typings.

3 import { Hook, LiveSocket } from "phoenix_live_view"
                                   ~~~~~~~~~~~~~~~~~~~
```

I'm not confident this is the correct solution for all cases, but I do confirm it means my types resolve correctly!