### PR TITLE
Mention Colocated Hooks compilation order release change in 1.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,27 @@ We're planning to make the private `Phoenix.Component.MacroComponent` API that w
 
 Note: Colocated hooks require Phoenix 1.8+.
 
+> [!NOTE]
+> #### Compilation order
+>
+> Colocated hooks are only written when the corresponding component is compiled.
+> Therefore, whenever you need to access a colocated hook, you need to ensure
+> `mix compile` runs first. This automatically happens in development.
+>
+> If you have a custom mix alias, instead of
+> 
+> ```
+> release: ["assets.deploy", "release"]
+> ```
+> 
+> do
+>
+> ```
+> release: ["compile", "assets.deploy", "release"]
+> ```
+> 
+> to ensure that all colocated hooks are extracted before esbuild or any other bundler runs.
+
 ## Change tracking in comprehensions
 
 One pitfall when rendering collections in LiveView was that they were not change tracked. If you had code like this:


### PR DESCRIPTION
The note is present in `Phoenix.LiveView.ColocatedHook`, but it's easy to miss when doing an upgrade.

<img width="631" height="762" alt="Screenshot 2025-07-31 at 13 54 54" src="https://github.com/user-attachments/assets/3da49122-2dac-4c86-9fbf-b5c9eb2541c7" />

Some people, including myself, got caught by this - adding the Elixir Slack screenshot for posterity.