### PR TITLE
Deep clone form for form recovery

### DIFF
--- a/test/e2e/support/form_dynamic_inputs_live.ex
+++ b/test/e2e/support/form_dynamic_inputs_live.ex
@@ -76,38 +76,40 @@ defmodule Phoenix.LiveViewTest.E2E.FormDynamicInputsLive do
       phx-submit="save"
       style="display: flex; flex-direction: column; gap: 4px; max-width: 500px;"
     >
-      <input
-        type="text"
-        id={@form[:name].id}
-        name={@form[:name].name}
-        value={@form[:name].value}
-        placeholder="name"
-      />
-      <.inputs_for :let={ef} field={@form[:users]} default={[]}>
-        <div style="padding: 4px; border: 1px solid gray;">
-          <input type="hidden" name="my_form[users_sort][]" value={ef.index} />
-          <input
-            type="text"
-            id={ef[:name].id}
-            name={ef[:name].name}
-            value={ef[:name].value}
-            placeholder="name"
-          />
+      <fieldset>
+        <input
+          type="text"
+          id={@form[:name].id}
+          name={@form[:name].name}
+          value={@form[:name].value}
+          placeholder="name"
+        />
+        <.inputs_for :let={ef} field={@form[:users]} default={[]}>
+          <div style="padding: 4px; border: 1px solid gray;">
+            <input type="hidden" name="my_form[users_sort][]" value={ef.index} />
+            <input
+              type="text"
+              id={ef[:name].id}
+              name={ef[:name].name}
+              value={ef[:name].value}
+              placeholder="name"
+            />
 
-          <button
-            :if={!@checkboxes}
-            type="button"
-            name="my_form[users_drop][]"
-            value={ef.index}
-            phx-click={JS.dispatch("change")}
-          >
-            Remove
-          </button>
-          <label :if={@checkboxes}>
-            <input type="checkbox" name="my_form[users_drop][]" value={ef.index} /> Remove
-          </label>
-        </div>
-      </.inputs_for>
+            <button
+              :if={!@checkboxes}
+              type="button"
+              name="my_form[users_drop][]"
+              value={ef.index}
+              phx-click={JS.dispatch("change")}
+            >
+              Remove
+            </button>
+            <label :if={@checkboxes}>
+              <input type="checkbox" name="my_form[users_drop][]" value={ef.index} /> Remove
+            </label>
+          </div>
+        </.inputs_for>
+      </fieldset>
 
       <input type="hidden" name="my_form[users_drop][]" />
 

--- a/test/e2e/support/form_live.ex
+++ b/test/e2e/support/form_live.ex
@@ -141,8 +141,10 @@ defmodule Phoenix.LiveViewTest.E2E.FormLive do
       phx-target={assigns[:"phx-target"]}
       class="myformclass"
     >
-      <input type="text" name="a" readonly value={@params["a"]} />
-      <input type="text" name="b" value={@params["b"]} />
+      <fieldset disabled={@params["disabled-fieldset"]}>
+        <input type="text" name="a" readonly value={@params["a"]} />
+        <input type="text" name="b" value={@params["b"]} />
+      </fieldset>
       <input
         type="text"
         name="c"


### PR DESCRIPTION
The previous algorithm had a flaw:

```javascript
const clonedForm = form.cloneNode(false);
DOM.copyPrivates(clonedForm, form);
Array.from(form.elements).forEach((el) => {
  morphdom(clonedEl, el);
  DOM.copyPrivates(clonedEl, el);
  clonedForm.appendChild(clonedEl);
}
```

While this kept the size of the clonedForm minimal and includes all elements, it did not consider `<fieldset>` elements. If you had something like this:

```html
<form>
  <fieldset>
    <input name="foo" value="bar">
  </fieldset>
</form>
```

`form.elements` would return `[fieldset, input]`, thus we would actually include the input twice.

Furthermore, imagine someone did `<fieldset disabled>` which disables all inputs inside and should exclude them from the form payload. But with the old code, LiveView would copy the input separately. Because it is not disabled, it would be included in the recovery payload.

The fix is to actually copy the whole form and then query the DOM for any associated elements `[form=${form.id}]` to include them.

In the future, we should consider simplifying this code to serialize the form early and not need to clone DOM nodes, but for now, I think it is fine.

Closes #3914.