### PR TITLE
Consider defaults as changed

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -1327,10 +1327,10 @@ defmodule Phoenix.Component.Declarative do
 
     new_changed =
       Enum.reduce(defaults_keys, changed, fn key, changed ->
-        if Map.has_key?(changed, key) or Map.has_key?(given, key) do
+        if Map.has_key?(given, key) do
           changed
         else
-          Map.put(changed, key, true)
+          Map.put_new(changed, key, true)
         end
       end)
 

--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -884,6 +884,19 @@ defmodule Phoenix.LiveView.Engine do
   def to_component_dynamic(
         static,
         dynamic,
+        static_changed,
+        _keys,
+        _assigns,
+        _changed,
+        _vars_changed_vars,
+        _vars_changed
+      )
+      when dynamic == %{},
+      do: Map.put(static, :__changed__, static_changed)
+
+  def to_component_dynamic(
+        static,
+        dynamic,
         _static_changed,
         _keys,
         _assigns,
@@ -915,7 +928,10 @@ defmodule Phoenix.LiveView.Engine do
   end
 
   defp merge_dynamic_static_changed(dynamic, static, changed) do
-    dynamic |> Map.merge(static) |> Map.put(:__changed__, changed)
+    dynamic
+    |> Map.merge(static)
+    |> Map.put(:__changed__, changed)
+    |> Map.put(:__dynamic_assigns__, true)
   end
 
   defp component_changed(:all, _assigns, _changed, _vars_changed_vars, _vars_changed), do: true

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -1745,4 +1745,48 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
       end
     end
   end
+
+  attr :one, :integer, default: 1
+  attr :two, :integer, default: 2
+
+  def throw_defaults(assigns) do
+    assigns = Phoenix.Component.assign(assigns, :foo, :bar)
+    throw(assigns)
+  end
+
+  test "defaults are considered as changed" do
+    try do
+      throw_defaults(%{__changed__: %{}})
+    catch
+      assigns ->
+        assert Phoenix.Component.changed?(assigns, :one)
+        assert Phoenix.Component.changed?(assigns, :two)
+    else
+      _ -> flunk("Should have thrown")
+    end
+  end
+
+  test "defaults are not considered as changed when same value" do
+    try do
+      throw_defaults(%{__changed__: %{}, one: 1})
+    catch
+      assigns ->
+        refute Phoenix.Component.changed?(assigns, :one)
+        assert Phoenix.Component.changed?(assigns, :two)
+    else
+      _ -> flunk("Should have thrown")
+    end
+  end
+
+  test "defaults do not override existing changed" do
+    try do
+      throw_defaults(%{__changed__: %{one: 2}, one: 1})
+    catch
+      assigns ->
+        assert assigns.__changed__.one == 2
+        assert assigns.__changed__.two == true
+    else
+      _ -> flunk("Should have thrown")
+    end
+  end
 end

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -615,8 +615,8 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     assert_raise FunctionClauseError, fn -> StructTypes.example(%{other: 2, uri: :not_uri}) end
 
     uri = URI.parse("/relative")
-    assert StructTypes.example(%{other: 1, uri: uri}) == "one"
-    assert StructTypes.example(%{other: 2, uri: uri}) == "two"
+    assert StructTypes.example(%{other: 1, uri: uri, __changed__: nil}) == "one"
+    assert StructTypes.example(%{other: 2, uri: uri, __changed__: nil}) == "two"
   end
 
   test "provides attr defaults" do

--- a/test/phoenix_component/declarative_assigns_test.exs
+++ b/test/phoenix_component/declarative_assigns_test.exs
@@ -1746,47 +1746,49 @@ defmodule Phoenix.ComponentDeclarativeAssignsTest do
     end
   end
 
-  attr :one, :integer, default: 1
-  attr :two, :integer, default: 2
+  describe "__dynamic_assigns__" do
+    attr :one, :integer, default: 1
+    attr :two, :integer, default: 2
 
-  def throw_defaults(assigns) do
-    assigns = Phoenix.Component.assign(assigns, :foo, :bar)
-    throw(assigns)
-  end
-
-  test "defaults are considered as changed" do
-    try do
-      throw_defaults(%{__changed__: %{}})
-    catch
-      assigns ->
-        assert Phoenix.Component.changed?(assigns, :one)
-        assert Phoenix.Component.changed?(assigns, :two)
-    else
-      _ -> flunk("Should have thrown")
+    def throw_defaults(assigns) do
+      assigns = Phoenix.Component.assign(assigns, :foo, :bar)
+      throw(assigns)
     end
-  end
 
-  test "defaults are not considered as changed when same value" do
-    try do
-      throw_defaults(%{__changed__: %{}, one: 1})
-    catch
-      assigns ->
-        refute Phoenix.Component.changed?(assigns, :one)
-        assert Phoenix.Component.changed?(assigns, :two)
-    else
-      _ -> flunk("Should have thrown")
+    test "defaults are considered as changed" do
+      try do
+        throw_defaults(%{__changed__: %{}, __dynamic_assigns__: true})
+      catch
+        assigns ->
+          assert Phoenix.Component.changed?(assigns, :one)
+          assert Phoenix.Component.changed?(assigns, :two)
+      else
+        _ -> flunk("Should have thrown")
+      end
     end
-  end
 
-  test "defaults do not override existing changed" do
-    try do
-      throw_defaults(%{__changed__: %{one: 2}, one: 1})
-    catch
-      assigns ->
-        assert assigns.__changed__.one == 2
-        assert assigns.__changed__.two == true
-    else
-      _ -> flunk("Should have thrown")
+    test "defaults are not considered as changed when same value" do
+      try do
+        throw_defaults(%{__changed__: %{}, one: 1, __dynamic_assigns__: true})
+      catch
+        assigns ->
+          refute Phoenix.Component.changed?(assigns, :one)
+          assert Phoenix.Component.changed?(assigns, :two)
+      else
+        _ -> flunk("Should have thrown")
+      end
+    end
+
+    test "defaults do not override existing changed" do
+      try do
+        throw_defaults(%{__changed__: %{one: 2}, one: 1, __dynamic_assigns__: true})
+      catch
+        assigns ->
+          assert assigns.__changed__.one == 2
+          assert assigns.__changed__.two == true
+      else
+        _ -> flunk("Should have thrown")
+      end
     end
   end
 end

--- a/test/phoenix_component/rendering_test.exs
+++ b/test/phoenix_component/rendering_test.exs
@@ -175,40 +175,38 @@ defmodule Phoenix.ComponentRenderingTest do
       assigns = %{foo: 1, bar: %{foo: 2}, __changed__: %{}}
       assert eval(~H"<.changed foo={@foo} {@bar} />") == [nil]
 
-      # we cannot perform any change tracking when dynamic assigns are involved
       assigns = %{foo: 1, bar: %{foo: 2}, __changed__: %{bar: true}}
-      assert eval(~H"<.changed foo={@foo} {@bar} />") == [["nil"]]
+      assert eval(~H"<.changed foo={@foo} {@bar} />") == [["%{foo: true}"]]
 
       assigns = %{foo: 1, bar: %{foo: 2}, __changed__: %{foo: true}}
-      assert eval(~H"<.changed foo={@foo} {@bar} />") == [["nil"]]
+      assert eval(~H"<.changed foo={@foo} {@bar} />") == [["%{foo: true}"]]
 
       assigns = %{foo: 1, bar: %{foo: 2}, baz: 3, __changed__: %{baz: true}}
-      assert eval(~H"<.changed foo={@foo} {@bar} baz={@baz} />") == [["nil"]]
+      assert eval(~H"<.changed foo={@foo} {@bar} baz={@baz} />") == [["%{baz: true}"]]
     end
 
     test "with dynamic assigns" do
       assigns = %{foo: %{a: 1, b: 2}, __changed__: %{}}
       assert eval(~H"<.changed {@foo} />") == [nil]
 
-      # we cannot perform any change tracking when dynamic assigns are involved
       assigns = %{foo: %{a: 1, b: 2}, __changed__: %{foo: true}}
-      assert eval(~H"<.changed {@foo} />") == [["nil"]]
+      assert eval(~H"<.changed {@foo} />") == [["%{a: true, b: true}"]]
 
       assigns = %{foo: %{a: 1, b: 2}, bar: 3, __changed__: %{bar: true}}
-      assert eval(~H"<.changed {@foo} bar={@bar} />") == [["nil"]]
+      assert eval(~H"<.changed {@foo} bar={@bar} />") == [["%{bar: true}"]]
 
       assigns = %{foo: %{a: 1, b: 2}, bar: 3, __changed__: %{bar: true}}
-      assert eval(~H"<.changed {%{a: 1, b: 2}} bar={@bar} />") == [["nil"]]
+      assert eval(~H"<.changed {%{a: 1, b: 2}} bar={@bar} />") == [["%{bar: true}"]]
 
       assigns = %{bar: 3, __changed__: %{bar: true}}
 
       assert eval(~H"<.changed {%{a: assigns[:b], b: assigns[:a]}} bar={@bar} />") ==
-               [["nil"]]
+               [["%{bar: true}"]]
 
       assigns = %{a: 1, b: 2, bar: 3, __changed__: %{a: true, b: true, bar: true}}
 
       assert eval(~H"<.changed {%{a: assigns[:b], b: assigns[:a]}} bar={@bar} />") ==
-               [["nil"]]
+               [["%{a: true, b: true, bar: true}"]]
     end
 
     defp wrapper(assigns) do

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -51,7 +51,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
   end
 
   def assigns_component(assigns) do
-    ~H"{inspect(Map.delete(assigns, :__changed__))}"
+    ~H"{inspect(Map.drop(assigns, [:__changed__, :__dynamic_assigns__]))}"
   end
 
   def textarea(assigns) do


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix_live_view/issues/3919.

When a component is called and it receives dynamic attributes

```heex
<.my_component {@action[:attrs] || %{}}>{@action.text}</.my_component>
```

defined as

```elixir
attr :special, :boolean, default: false

defp my_component(assigns) do
  ~H"""
  <div style={if(@special, do: "background-color: red;")}>
    {render_slot(@inner_block)}
  </div>
  """
end
```

Now assuming it is rendered first with `@action` as `%{text: "No red"}`
and then toggling between that and `%{text: "Red", attrs: %{special: true}`:

Previously, once toggled, the background color would be stuck on red, since `special` would not be considered changed, therefore the diff for the style would not be sent.

We fix this by setting all defaults to be changed when they are not explicitly given with the same value as the default.

Minimal example showing that this is broken on 1.0 as well:

```elixir
Mix.install([
  {:phoenix_playground, "~> 0.1.7"},
  {:phoenix_live_view, "== 1.0.17"}
])

defmodule DemoLive do
  use Phoenix.LiveView

  def mount(_params, _session, socket) do
    {:ok, assign(socket, action: %{text: "No red"})}
  end

  def handle_event("toggle_special", %{}, socket) do
    new_action =
      if socket.assigns.action[:attrs] do
        %{text: "No red"}
      else
        %{text: "Red", attrs: %{special: true}}
      end

    {:noreply, assign(socket, action: new_action)}
  end

  def render(assigns) do
    ~H"""
    <.my_component {@action[:attrs] || %{}}>{@action.text}</.my_component>

    <button phx-click="toggle_special">toggle</button>
    """
  end

  attr(:special, :boolean, default: false)
  slot(:inner_block)

  defp my_component(assigns) do
    ~H"""
    <div style={if(@special, do: "background-color: red;")}>
      {render_slot(@inner_block)}
    </div>
    """
  end
end

PhoenixPlayground.start(live: DemoLive)
```