### PR TITLE
Disable change tracking when passing dynamic assigns

### DIFF
--- a/test/e2e/support/issues/issue_3919.ex
+++ b/test/e2e/support/issues/issue_3919.ex
@@ -1,0 +1,37 @@
+defmodule Phoenix.LiveViewTest.E2E.Issue3919Live do
+  use Phoenix.LiveView
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, action: %{text: "No red"})}
+  end
+
+  def handle_event("toggle_special", %{}, socket) do
+    new_action =
+      if socket.assigns.action[:attrs] do
+        %{text: "No red"}
+      else
+        %{text: "Red", attrs: %{special: true}}
+      end
+
+    {:noreply, assign(socket, action: new_action)}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <.my_component {@action[:attrs] || %{}}>{@action.text}</.my_component>
+
+    <button phx-click="toggle_special">toggle</button>
+    """
+  end
+
+  attr(:special, :boolean, default: false)
+  slot(:inner_block)
+
+  defp my_component(assigns) do
+    ~H"""
+    <div style={if(@special, do: "background-color: red;")}>
+      {render_slot(@inner_block)}
+    </div>
+    """
+  end
+end

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -196,6 +196,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/3719", Issue3719Live
       live "/3814", Issue3814Live
       live "/3819", Issue3819Live
+      live "/3919", Issue3919Live
     end
   end
 

--- a/test/e2e/tests/issues/3919.spec.js
+++ b/test/e2e/tests/issues/3919.spec.js
@@ -1,0 +1,32 @@
+import { test, expect } from "../../test-fixtures";
+import { syncLV } from "../../utils";
+
+// https://github.com/phoenixframework/phoenix_live_view/issues/3919
+test("attribute defaults are properly considered as changed", async ({
+  page,
+}) => {
+  await page.goto("/issues/3919");
+  await syncLV(page);
+
+  const styledDiv = page.locator("div[style]");
+
+  await expect(styledDiv).toContainText("No red");
+  await expect(styledDiv).not.toHaveAttribute(
+    "style",
+    "background-color: red;",
+  );
+  await page.getByRole("button", { name: "toggle" }).click();
+  await syncLV(page);
+
+  await expect(styledDiv).not.toContainText("No red");
+  await expect(styledDiv).toHaveAttribute("style", "background-color: red;");
+  await page.getByRole("button", { name: "toggle" }).click();
+  await syncLV(page);
+
+  // bug: previously, the red background remained
+  await expect(styledDiv).toContainText("No red");
+  await expect(styledDiv).not.toHaveAttribute(
+    "style",
+    "background-color: red;",
+  );
+});

--- a/test/phoenix_component/rendering_test.exs
+++ b/test/phoenix_component/rendering_test.exs
@@ -175,38 +175,40 @@ defmodule Phoenix.ComponentRenderingTest do
       assigns = %{foo: 1, bar: %{foo: 2}, __changed__: %{}}
       assert eval(~H"<.changed foo={@foo} {@bar} />") == [nil]
 
+      # we cannot perform any change tracking when dynamic assigns are involved
       assigns = %{foo: 1, bar: %{foo: 2}, __changed__: %{bar: true}}
-      assert eval(~H"<.changed foo={@foo} {@bar} />") == [["%{foo: true}"]]
+      assert eval(~H"<.changed foo={@foo} {@bar} />") == [["nil"]]
 
       assigns = %{foo: 1, bar: %{foo: 2}, __changed__: %{foo: true}}
-      assert eval(~H"<.changed foo={@foo} {@bar} />") == [["%{foo: true}"]]
+      assert eval(~H"<.changed foo={@foo} {@bar} />") == [["nil"]]
 
       assigns = %{foo: 1, bar: %{foo: 2}, baz: 3, __changed__: %{baz: true}}
-      assert eval(~H"<.changed foo={@foo} {@bar} baz={@baz} />") == [["%{baz: true}"]]
+      assert eval(~H"<.changed foo={@foo} {@bar} baz={@baz} />") == [["nil"]]
     end
 
     test "with dynamic assigns" do
       assigns = %{foo: %{a: 1, b: 2}, __changed__: %{}}
       assert eval(~H"<.changed {@foo} />") == [nil]
 
+      # we cannot perform any change tracking when dynamic assigns are involved
       assigns = %{foo: %{a: 1, b: 2}, __changed__: %{foo: true}}
-      assert eval(~H"<.changed {@foo} />") == [["%{a: true, b: true}"]]
+      assert eval(~H"<.changed {@foo} />") == [["nil"]]
 
       assigns = %{foo: %{a: 1, b: 2}, bar: 3, __changed__: %{bar: true}}
-      assert eval(~H"<.changed {@foo} bar={@bar} />") == [["%{bar: true}"]]
+      assert eval(~H"<.changed {@foo} bar={@bar} />") == [["nil"]]
 
       assigns = %{foo: %{a: 1, b: 2}, bar: 3, __changed__: %{bar: true}}
-      assert eval(~H"<.changed {%{a: 1, b: 2}} bar={@bar} />") == [["%{bar: true}"]]
+      assert eval(~H"<.changed {%{a: 1, b: 2}} bar={@bar} />") == [["nil"]]
 
       assigns = %{bar: 3, __changed__: %{bar: true}}
 
       assert eval(~H"<.changed {%{a: assigns[:b], b: assigns[:a]}} bar={@bar} />") ==
-               [["%{bar: true}"]]
+               [["nil"]]
 
       assigns = %{a: 1, b: 2, bar: 3, __changed__: %{a: true, b: true, bar: true}}
 
       assert eval(~H"<.changed {%{a: assigns[:b], b: assigns[:a]}} bar={@bar} />") ==
-               [["%{a: true, b: true, bar: true}"]]
+               [["nil"]]
     end
 
     defp wrapper(assigns) do


### PR DESCRIPTION
Closes #3919.
Supersedes https://github.com/phoenixframework/phoenix_live_view/pull/3922.

When passing dynamic assigns to a component, we cannot make any assumptions about what keys are considered changed, therefore we need to disable change tracking.

Consider this example:

When a component is called and it receives dynamic attributes

```heex
<.my_component {@action[:attrs] || %{}}>{@action.text}</.my_component>
```

defined as

```elixir
attr :special, :boolean, default: false

defp my_component(assigns) do
  ~H"""
  <div style={if(@special, do: "background-color: red;")}>
    {render_slot(@inner_block)}
  </div>
  """
end
```

Now assuming it is rendered first with `@action` as `%{text: "No red"}` and then toggling between that and `%{text: "Red", attrs: %{special: true}`:

Previously, once toggled, the background color would be stuck on red, since `special` would not be considered changed, therefore the diff for the style would not be sent.