### PR TITLE
change type definition for unspecified keys in Hook

### DIFF
--- a/assets/js/phoenix_live_view/view_hook.ts
+++ b/assets/js/phoenix_live_view/view_hook.ts
@@ -204,7 +204,7 @@ export interface Hook<T = object> {
   reconnected?: (this: T & HookInterface) => void;
 
   // Allow custom methods with any signature and custom properties
-  [key: string]: ((this: T & HookInterface, ...args: any[]) => any) | any;
+  [key: PropertyKey]: any;
 }
 
 /**


### PR DESCRIPTION
Support all valid keys for object and simplify the type in general.