### PR TITLE
Fix warning when importing `phoenix_live_view`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "jsdelivr": "./priv/static/phoenix_live_view.min.js",
   "exports": {
     "import": {
-      "default": "./priv/static/phoenix_live_view.esm.js",
-      "types": "./assets/js/types/index.d.ts"
+      "types": "./assets/js/types/index.d.ts",
+      "default": "./priv/static/phoenix_live_view.esm.js"
     },
     "require": "./priv/static/phoenix_live_view.cjs.js"
   },


### PR DESCRIPTION
This fixes the following warning that is encountered when trying to import `phoenix_live_view`:

```
▲ [WARNING] The condition "types" here will never be used as it comes after "default" [package.json]

    ../deps/phoenix_live_view/package.json:14:6:
      14 │       "types": "./assets/js/types/index.d.ts"
         ╵       ~~~~~~~

  The "default" condition comes earlier and will always be chosen:

    ../deps/phoenix_live_view/package.json:13:6:
      13 │       "default": "./priv/static/phoenix_live_view.esm.js",
         ╵       ~~~~~~~~~
```

Fixes #3925 