### PR TITLE
test: add test for multiline textarea rendering

### DIFF
--- a/lib/phoenix_live_view/test/tree_dom.ex
+++ b/lib/phoenix_live_view/test/tree_dom.ex
@@ -66,6 +66,7 @@ defmodule Phoenix.LiveViewTest.TreeDOM do
     tree
     |> node_to_text()
     |> Enum.join()
+    # This causes linebreaks to be removed from textarea
     |> String.replace(~r/[\s]+/, " ")
     |> String.trim()
   end

--- a/test/phoenix_live_view/integrations/elements_test.exs
+++ b/test/phoenix_live_view/integrations/elements_test.exs
@@ -611,6 +611,17 @@ defmodule Phoenix.LiveView.ElementsTest do
   end
 
   describe "submit_form" do
+    test "submits textarea with newline characters", %{live: view} do
+      view
+      |> form("#form")
+      |> render_submit()
+
+      expected_string_in_event =
+        "textarea_with_newlines\" => \"This is a test.\\nIt has multiple\\nlines of text.\""
+
+      assert last_event(view) =~ expected_string_in_event
+    end
+
     test "raises if element is not a form", %{live: view, conn: conn} do
       assert_raise ArgumentError,
                    ~r"given element did not return a form",

--- a/test/support/live_views/elements.ex
+++ b/test/support/live_views/elements.ex
@@ -203,6 +203,7 @@ defmodule Phoenix.LiveViewTest.Support.ElementsLive do
       </select>
       <textarea name="hello[textarea]">Text</textarea>
       <textarea name="hello[textarea_empty]"></textarea>
+      <textarea name="hello[textarea_with_newlines]"><%= @multiline_text %></textarea>
       <!-- Mimic textarea from Phoenix.HTML -->
       <textarea name="hello[textarea_nl]">
     Text</textarea>
@@ -274,6 +275,7 @@ defmodule Phoenix.LiveViewTest.Support.ElementsLive do
       socket
       |> assign(:event, nil)
       |> assign(:trigger_action, false)
+      |> assign(:multiline_text, "This is a test.\nIt has multiple\nlines of text.")
 
     {:ok, socket}
   end


### PR DESCRIPTION
This is a draft PR to reproduce in tests an issue where linebreaks are not preserved in `textarea` in the test helpers.

For demonstrating #3929