### PR TITLE
Ensure component only patches are not lost due to locked tree

### DIFF
--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -85,9 +85,25 @@ export default class DOMPatch {
   }
 
   perform(isJoinPatch) {
-    const { view, liveSocket, html, container, targetContainer } = this;
-    if (this.isCIDPatch() && !targetContainer) {
+    const { view, liveSocket, html, container } = this;
+    let targetContainer = this.targetContainer;
+
+    if (this.isCIDPatch() && !this.targetContainer) {
       return;
+    }
+
+    if (this.isCIDPatch()) {
+      // we need to ensure that no parent is locked
+      const closestLock = targetContainer.closest(`[${PHX_REF_LOCK}]`);
+      if (closestLock) {
+        const clonedTree = DOM.private(closestLock, PHX_REF_LOCK);
+        if (clonedTree) {
+          // if a parent is locked with a cloned tree, we need to patch the cloned tree instead
+          targetContainer = clonedTree.querySelector(
+            `[data-phx-component="${this.targetCID}"]`,
+          );
+        }
+      }
     }
 
     const focused = liveSocket.getActiveElement();

--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -93,6 +93,7 @@ export default class DOMPatch {
     }
 
     if (this.isCIDPatch()) {
+      // https://github.com/phoenixframework/phoenix_live_view/pull/3942
       // we need to ensure that no parent is locked
       const closestLock = targetContainer.closest(`[${PHX_REF_LOCK}]`);
       if (closestLock) {

--- a/test/e2e/support/issues/issue_3941.ex
+++ b/test/e2e/support/issues/issue_3941.ex
@@ -1,0 +1,174 @@
+defmodule Phoenix.LiveViewTest.E2E.Issue3941Live do
+  use Phoenix.LiveView, layout: {__MODULE__, :live}
+
+  alias Phoenix.LiveViewTest.E2E.Issue3941Live.Item
+
+  @all_items [
+    "Item_1",
+    "Item_2"
+  ]
+
+  @impl true
+  def mount(_params, _session, socket) do
+    socket =
+      socket
+      |> assign(:selected_items, @all_items)
+      |> assign(:filter_options, @all_items)
+
+    {:ok, socket}
+  end
+
+  def render("live.html", assigns) do
+    ~H"""
+    <meta name="csrf-token" content={Plug.CSRFProtection.get_csrf_token()} />
+    <script src="/assets/phoenix/phoenix.min.js">
+    </script>
+    <script type="module">
+      import {LiveSocket} from "/assets/phoenix_live_view/phoenix_live_view.esm.js"
+      let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
+      let liveSocket = new LiveSocket("/live", window.Phoenix.Socket, {
+        params: {_csrf_token: csrfToken},
+        hooks: {
+          PagePositionNotifier: {
+            mounted() {
+              this.pushEvent("page_position_update", {});
+            },
+          }
+        }
+      })
+      liveSocket.connect()
+    </script>
+
+    {@inner_content}
+    """
+  end
+
+  def render(assigns) do
+    ~H"""
+    <.multi_select id="multi-select" items={@filter_options} selected={@selected_items} />
+    <div :for={item <- @selected_items}>
+      <.live_component
+        module={Item}
+        id={"item-#{item}"}
+        item={item}
+      />
+    </div>
+    """
+  end
+
+  def multi_select(assigns) do
+    ~H"""
+    <div :for={item <- @items}>
+      <label for={"item-select-#{item}"}>
+        <input
+          type="checkbox"
+          phx-click="toggle_item"
+          phx-value-clicked={item}
+          id={"select-#{item}"}
+          name="select"
+          value={item}
+          checked={item in @selected}
+        />
+        {item}
+      </label>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("toggle_item", params = %{"clicked" => clicked_id}, socket) do
+    selected = socket.assigns.selected_items
+
+    selected =
+      case params["value"] do
+        nil ->
+          selected = List.delete(selected, clicked_id)
+
+        value ->
+          selected = selected ++ [value]
+      end
+
+    {:noreply, assign(socket, selected_items: Enum.sort(selected))}
+  end
+
+  def handle_event("page_position_update", _params, socket) do
+    {:noreply, socket}
+  end
+end
+
+defmodule Phoenix.LiveViewTest.E2E.Issue3941Live.Item do
+  use Phoenix.LiveComponent
+  alias Phoenix.LiveViewTest.E2E.Issue3941Live.ItemHeader
+
+  @impl true
+  def update(assigns, socket) do
+    {:ok,
+     socket
+     |> assign(:item, assigns.item)
+     |> assign_unrendered_component_assigns()}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id={"item-#{@item}"} phx-hook="PagePositionNotifier">
+      <.live_component
+        id={"item-header-#{@item}"}
+        module={ItemHeader}
+        item={@item}
+      />
+      <.unrendered_component :if={false} id="unrendered" any_assign={@any_assign} />
+    </div>
+    """
+  end
+
+  defp unrendered_component(_) do
+    raise "SHOULD NOT BE CALLED"
+  end
+
+  defp assign_unrendered_component_assigns(socket) do
+    socket
+    |> assign(:any_assign, true)
+    |> assign_async(
+      :any_assign,
+      fn ->
+        {:ok, %{any_assign: true}}
+      end
+    )
+  end
+end
+
+defmodule Phoenix.LiveViewTest.E2E.Issue3941Live.ItemHeader do
+  use Phoenix.LiveComponent
+
+  def update(assigns, socket) do
+    {:ok,
+     socket
+     |> assign(:item, assigns.item)
+     |> assign_async(
+       :async_assign,
+       fn ->
+         {:ok, %{async_assign: :assign}}
+       end,
+       reset: true
+     )}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div id={"header-#{@item}"}>
+      <.async_result assign={@async_assign}>
+        <:loading>
+          <div id={@item} class="border border-y-0 bg-red-500 text-white">
+            {"#{@item} - I AM LOADING"}
+          </div>
+        </:loading>
+        <div id={@item} class="border border-y-0 bg-green-500 text-white">
+          {"#{@item} - I AM LOADED!"}
+        </div>
+      </.async_result>
+      {inspect(@async_assign)}
+    </div>
+    """
+  end
+end

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -238,6 +238,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/3647", Issue3647Live
       live "/3681", Issue3681Live
       live "/3681/away", Issue3681.AwayLive
+      live "/3941", Issue3941Live
     end
 
     post "/submit", SubmitController, :submit

--- a/test/e2e/tests/issues/3941.spec.js
+++ b/test/e2e/tests/issues/3941.spec.js
@@ -1,0 +1,28 @@
+import { test, expect } from "../../test-fixtures";
+import { syncLV } from "../../utils";
+
+// https://github.com/phoenixframework/phoenix_live_view/issues/3941
+test("component-only patch in locked tree works", async ({ page }) => {
+  await page.goto("/issues/3941");
+  await syncLV(page);
+
+  // the bug was that, because the parent container was locked,
+  // the component only patch was applied and later on the (stale) locked
+  // tree was applied, erasing the patch
+  await expect(page.locator("#Item_1")).toContainText("I AM LOADED");
+  await expect(page.locator("#Item_2")).toContainText("I AM LOADED");
+
+  await page.locator("#select-Item_1").uncheck();
+  await page.locator("#select-Item_2").uncheck();
+
+  await expect(page.locator("#Item_1")).toHaveCount(0);
+  await expect(page.locator("#Item_2")).toHaveCount(0);
+
+  await page.locator("#select-Item_1").check();
+  await expect(page.locator("#Item_1")).toContainText("I AM LOADED");
+  await expect(page.locator("#Item_2")).toHaveCount(0);
+
+  await page.locator("#select-Item_2").check();
+  await expect(page.locator("#Item_1")).toContainText("I AM LOADED");
+  await expect(page.locator("#Item_2")).toContainText("I AM LOADED");
+});


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix_live_view/issues/3941. Possibly related to https://github.com/phoenixframework/phoenix_live_view/issues/3614.

When a component-only diff was applied, we did not account for the component being part of a locked tree. Thus, when the tree was unlocked, the component content was unintentionally restored to a previous state.

We solve this by checking for a locked tree and applying the patch to that instead.