### PR TITLE
Log a message if we can't update an element's value that has focus

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -547,7 +547,9 @@ const DOM = {
           if (target.value === sourceValue) {
             // actually set the value attribute to sync it with the value property
             target.setAttribute("value", source.getAttribute(name));
-          }
+          } else {
+            logError('Skipped updating value on focused element.', target);
+	  }
         }
       }
     }

--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -549,7 +549,7 @@ const DOM = {
             target.setAttribute("value", source.getAttribute(name));
           } else {
             logError('Skipped updating value on focused element.', target);
-	  }
+          }
         }
       }
     }


### PR DESCRIPTION
This is a follow up for https://github.com/phoenixframework/phoenix_live_view/issues/2163

The behavior of not updating an element that has focus is pretty subtle, and easy to miss in the docs.

I'm proposing logging a message when this happens. It really is only needed in development mode, and can probably be a debug message as well, I just wasn't sure the right way to do that in this code base. Happy to change.

But this has bitten so many people over the years that we at least should be warned that it happens. You can see the events in the console with the new value, but it doesn't update.