### PR TITLE
Use Covariant Notation For Hook Generic 

### DIFF
--- a/assets/js/phoenix_live_view/view_hook.ts
+++ b/assets/js/phoenix_live_view/view_hook.ts
@@ -159,7 +159,7 @@ export interface HookInterface {
 
 // based on https://github.com/DefinitelyTyped/DefinitelyTyped/blob/fac1aa75acdddbf4f1a95e98ee2297b54ce4b4c9/types/phoenix_live_view/hooks.d.ts#L26
 // licensed under MIT
-export interface Hook<T = object> {
+export interface Hook<T = never> {
   /**
    * The mounted callback.
    *

--- a/assets/js/phoenix_live_view/view_hook.ts
+++ b/assets/js/phoenix_live_view/view_hook.ts
@@ -159,7 +159,7 @@ export interface HookInterface {
 
 // based on https://github.com/DefinitelyTyped/DefinitelyTyped/blob/fac1aa75acdddbf4f1a95e98ee2297b54ce4b4c9/types/phoenix_live_view/hooks.d.ts#L26
 // licensed under MIT
-export interface Hook<T = never> {
+export interface Hook<out T = object> {
   /**
    * The mounted callback.
    *


### PR DESCRIPTION
closes #3955 
using [covariant](https://www.typescriptlang.org/docs/handbook/2/generics.html#:~:text=//%20Covariant%20annotation) notation for hook generics. 