### PR TITLE
Resolve moved comprehensions in test client proxy

### DIFF
--- a/test/phoenix_live_view/test/diff_test.exs
+++ b/test/phoenix_live_view/test/diff_test.exs
@@ -11,5 +11,35 @@ defmodule Phoenix.LiveViewTest.DiffTest do
       assert Diff.merge_diff(%{s: "foo", d: []}, %{s: "bar"}) ==
                %{s: "bar", streams: []}
     end
+
+    test "resolves moved comprehensions" do
+      base = %{
+        k: %{
+          0 => %{0 => "A"},
+          1 => %{0 => "B"},
+          2 => %{0 => "C", 1 => %{0 => "var1", :s => ["", ""]}},
+          :kc => 3
+        }
+      }
+
+      diff = %{
+        k: %{
+          0 => 1,
+          1 => [2, %{1 => %{0 => "var2"}}],
+          :kc => 2
+        }
+      }
+
+      result = %{
+        k: %{
+          0 => %{0 => "B"},
+          1 => %{0 => "C", 1 => %{0 => "var2", :s => ["", ""]}},
+          :kc => 2
+        },
+        streams: []
+      }
+
+      assert Diff.merge_diff(base, diff) == result
+    end
   end
 end


### PR DESCRIPTION
[Example liveivew app](https://github.com/achempion/comprehensions_demo/commit/65e7c70cf38d8355a9aaec47abccadf80050fd74)
[Related PR that added comprehension support](https://github.com/phoenixframework/phoenix_live_view/pull/3865)

When changing order of items that liveview renders with comprehensions, it raises an error: ` expected a map, got: [1, %{1 => %{0 => "test2"}}]`. It happens only in test ENV.

This PR adds support for `ClientProxy` to resolve moved comprehensions, mimicking the js logic added in [related PR](https://github.com/phoenixframework/phoenix_live_view/pull/3865/files#diff-9f139357c1e651029d78dab584420ff07bb7d67349814662aba368fc590cc985R257).

<details>
  <summary>Full error from the liveview app</summary>
   
```elixir
** (BadMapError) expected a map, got: [1, %{1 => %{0 => "test2"}}]
    (phoenix_live_view 1.1.8) lib/phoenix_live_view/diff.ex:68: anonymous fn/6 in Phoenix.LiveView.Diff.to_iodata/4
    (elixir 1.15.6) lib/enum.ex:1825: anonymous fn/3 in Enum.map_reduce/3
    (elixir 1.15.6) lib/enum.ex:4379: Enum.reduce_range/5
    (elixir 1.15.6) lib/enum.ex:2514: Enum.map_reduce/3
    (phoenix_live_view 1.1.8) lib/phoenix_live_view/diff.ex:94: Phoenix.LiveView.Diff.one_to_iodata/7
    (phoenix_live_view 1.1.8) lib/phoenix_live_view/diff.ex:50: Phoenix.LiveView.Diff.to_iodata/2
    (phoenix_live_view 1.1.8) lib/phoenix_live_view/test/diff.ex:117: Phoenix.LiveViewTest.Diff.render_diff/1
    (phoenix_live_view 1.1.8) lib/phoenix_live_view/test/client_proxy.ex:862: Phoenix.LiveViewTest.ClientProxy.merge_rendered/3
    (phoenix_live_view 1.1.8) lib/phoenix_live_view/test/client_proxy.ex:957: Phoenix.LiveViewTest.ClientProxy.handle_reply/2
    (phoenix_live_view 1.1.8) lib/phoenix_live_view/test/client_proxy.ex:493: Phoenix.LiveViewTest.ClientProxy.handle_info/2
    (stdlib 5.0) gen_server.erl:1077: :gen_server.try_handle_info/3
    (stdlib 5.0) gen_server.erl:1165: :gen_server.handle_msg/6
    (stdlib 5.0) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
Last message: {:EXIT, #PID<0.824.0>, {{:badmap, [1, %{1 => %{0 => "test2"}}]}, [{Phoenix.LiveView.Diff, :"-to_iodata/4-fun-0-", 6, [file: ~c"lib/phoenix_live_view/diff.ex", line: 68]}, {Enum, :"-map_reduce/3-fun-0-", 3, [file: ~c"lib/enum.ex", line: 1825]}, {Enum, :reduce_range, 5, [file: ~c"lib/enum.ex", line: 4379]}, {Enum, :map_reduce, 3, [file: ~c"lib/enum.ex", line: 2514]}, {Phoenix.LiveView.Diff, :one_to_iodata, 7, [file: ~c"lib/phoenix_live_view/diff.ex", line: 94]}, {Phoenix.LiveView.Diff, :to_iodata, 2, [file: ~c"lib/phoenix_live_view/diff.ex", line: 50]}, {Phoenix.LiveViewTest.Diff, :render_diff, 1, [file: ~c"lib/phoenix_live_view/test/diff.ex", line: 117]}, {Phoenix.LiveViewTest.ClientProxy, :merge_rendered, 3, [file: ~c"lib/phoenix_live_view/test/client_proxy.ex", line: 862]}, {Phoenix.LiveViewTest.ClientProxy, :handle_reply, 2, [file: ~c"lib/phoenix_live_view/test/client_proxy.ex", line: 957]}, {Phoenix.LiveViewTest.ClientProxy, :handle_info, 2, [file: ~c"lib/phoenix_live_view/test/client_proxy.ex", line: 493]}, {:gen_server, :try_handle_info, 3, [file: ~c"gen_server.erl", line: 1077]}, {:gen_server, :handle_msg, 6, [file: ~c"gen_server.erl", line: 1165]}, {:proc_lib, :init_p_do_apply, 3, [file: ~c"proc_lib.erl", line: 241]}]}}
```