### PR TITLE
Ensure pending ops run after form recovery

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -130,7 +130,11 @@ export default class View {
       onDone && onDone();
     };
     this.stopCallback = function () {};
-    this.pendingJoinOps = this.parent ? null : [];
+    // usually, only the root LiveView stores pending
+    // join operations for all children (and itself),
+    // but in case of rejoins (joinCount > 1) each child
+    // stores its own events instead
+    this.pendingJoinOps = [];
     this.viewHooks = {};
     this.formSubmits = [];
     this.children = this.parent ? null : {};
@@ -470,6 +474,14 @@ export default class View {
   }
 
   applyJoinPatch(live_patch, html, streams, events) {
+    // in case of rejoins, we need to manually perform all
+    // pending ops
+    if (this.joinCount > 1) {
+      if (this.pendingJoinOps.length) {
+        this.pendingJoinOps.forEach((cb) => typeof cb === "function" && cb());
+        this.pendingJoinOps = [];
+      }
+    }
     this.attachTrueDocEl();
     const patch = new DOMPatch(this, this.el, this.id, html, streams, null);
     patch.markPrunableContentForRemoval();
@@ -927,7 +939,12 @@ export default class View {
   onChannel(event, cb) {
     this.liveSocket.onChannel(this.channel, event, (resp) => {
       if (this.isJoinPending()) {
-        this.root.pendingJoinOps.push([this, () => cb(resp)]);
+        // in case this is a rejoin (joinCount > 1) we store our own join ops
+        if (this.joinCount > 1) {
+          this.pendingJoinOps.push(() => cb(resp));
+        } else {
+          this.root.pendingJoinOps.push([this, () => cb(resp)]);
+        }
       } else {
         this.liveSocket.requestDOMUpdate(() => cb(resp));
       }

--- a/test/e2e/support/form_live.ex
+++ b/test/e2e/support/form_live.ex
@@ -1,19 +1,108 @@
-defmodule Phoenix.LiveViewTest.E2E.FormLive do
-  use Phoenix.LiveView
+for type <- [FormLive, FormLiveNested] do
+  defmodule Module.concat(Phoenix.LiveViewTest.E2E, type) do
+    use Phoenix.LiveView
 
-  alias Phoenix.LiveView.JS
+    alias Phoenix.LiveView.JS
 
-  @compile {:no_warn_undefined, Phoenix.LiveViewTest.E2E.Hooks}
+    @compile {:no_warn_undefined, Phoenix.LiveViewTest.E2E.Hooks}
 
-  defmodule FormComponent do
-    use Phoenix.LiveComponent
+    defmodule FormComponent do
+      use Phoenix.LiveComponent
 
-    @impl Phoenix.LiveComponent
-    def mount(socket) do
-      {:ok, assign(socket, :submitted, false)}
+      @impl Phoenix.LiveComponent
+      def mount(socket) do
+        {:ok, assign(socket, :submitted, false)}
+      end
+
+      @impl Phoenix.LiveComponent
+      def handle_event("validate", params, socket) do
+        {:noreply, assign(socket, :params, Map.merge(socket.assigns.params, params))}
+      end
+
+      def handle_event("save", _params, socket) do
+        {:noreply, assign(socket, :submitted, true)}
+      end
+
+      def handle_event("custom-recovery", _params, socket) do
+        {:noreply,
+         assign(
+           socket,
+           :params,
+           Map.merge(socket.assigns.params, %{"b" => "custom value from server"})
+         )}
+      end
+
+      def handle_event("patch-recovery", _params, socket) do
+        {:noreply, push_patch(socket, to: "/form?patched=true")}
+      end
+
+      @impl Phoenix.LiveComponent
+      def render(assigns) do
+        ~H"""
+        <div>
+          <Phoenix.LiveViewTest.E2E.FormLive.my_form params={@params} phx-target={@myself} />
+
+          <p :if={@submitted}>LC Form was submitted!</p>
+        </div>
+        """
+      end
     end
 
-    @impl Phoenix.LiveComponent
+    @impl Phoenix.LiveView
+    def mount(params, session, socket) do
+      # if we're nested we need to manually add the on_mount hook
+      # as the live_session doesn't apply
+      socket =
+        if socket.parent_pid do
+          {:cont, socket} =
+            Phoenix.LiveViewTest.E2E.Hooks.on_mount(:default, params, session, socket)
+
+          socket
+        else
+          socket
+        end
+
+      params =
+        case params do
+          :not_mounted_at_router -> session
+          _ -> params
+        end
+
+      {:ok,
+       socket
+       |> assign(
+         :params,
+         Enum.into(params, %{
+           "a" => "foo",
+           "b" => "bar",
+           "c" => "baz",
+           "id" => "test-form",
+           "phx-change" => "validate"
+         })
+       )
+       |> update_params(params)
+       |> assign(:submitted, false)}
+    end
+
+    if type === FormLive do
+      def handle_params(_, _, socket), do: {:noreply, socket}
+    end
+
+    def update_params(socket, %{"no-id" => _}) do
+      update(socket, :params, &Map.delete(&1, "id"))
+    end
+
+    def update_params(socket, %{"no-change-event" => _}) do
+      update(socket, :params, &Map.delete(&1, "phx-change"))
+    end
+
+    def update_params(socket, %{"js-change" => _}) do
+      update(socket, :params, &Map.put(&1, "phx-change", JS.push("validate")))
+    end
+
+    def update_params(socket, _), do: socket
+
+    @impl Phoenix.LiveView
     def handle_event("validate", params, socket) do
       {:noreply, assign(socket, :params, Map.merge(socket.assigns.params, params))}
     end
@@ -31,138 +120,63 @@ defmodule Phoenix.LiveViewTest.E2E.FormLive do
        )}
     end
 
-    @impl Phoenix.LiveComponent
+    def handle_event("patch-recovery", _params, socket) do
+      {:noreply, push_patch(socket, to: "/form?patched=true")}
+    end
+
+    def handle_event("button-test", _params, socket) do
+      {:noreply, socket}
+    end
+
+    @impl Phoenix.LiveView
     def render(assigns) do
       ~H"""
-      <div>
-        <Phoenix.LiveViewTest.E2E.FormLive.my_form params={@params} phx-target={@myself} />
+      <.my_form :if={!@params["live-component"]} params={@params} />
+      <.live_component
+        :if={@params["live-component"]}
+        id="form-component"
+        module={__MODULE__.FormComponent}
+        params={@params}
+      />
 
-        <p :if={@submitted}>LC Form was submitted!</p>
-      </div>
+      <p :if={@submitted}>Form was submitted!</p>
       """
     end
-  end
 
-  @impl Phoenix.LiveView
-  def mount(params, session, socket) do
-    # if we're nested we need to manually add the on_mount hook
-    # as the live_session doesn't apply
-    socket =
-      if socket.parent_pid do
-        {:cont, socket} =
-          Phoenix.LiveViewTest.E2E.Hooks.on_mount(:default, params, session, socket)
-
-        socket
-      else
-        socket
-      end
-
-    params =
-      case params do
-        :not_mounted_at_router -> session
-        _ -> params
-      end
-
-    {:ok,
-     socket
-     |> assign(
-       :params,
-       Enum.into(params, %{
-         "a" => "foo",
-         "b" => "bar",
-         "c" => "baz",
-         "id" => "test-form",
-         "phx-change" => "validate"
-       })
-     )
-     |> update_params(params)
-     |> assign(:submitted, false)}
-  end
-
-  def update_params(socket, %{"no-id" => _}) do
-    update(socket, :params, &Map.delete(&1, "id"))
-  end
-
-  def update_params(socket, %{"no-change-event" => _}) do
-    update(socket, :params, &Map.delete(&1, "phx-change"))
-  end
-
-  def update_params(socket, %{"js-change" => _}) do
-    update(socket, :params, &Map.put(&1, "phx-change", JS.push("validate")))
-  end
-
-  def update_params(socket, _), do: socket
-
-  @impl Phoenix.LiveView
-  def handle_event("validate", params, socket) do
-    {:noreply, assign(socket, :params, Map.merge(socket.assigns.params, params))}
-  end
-
-  def handle_event("save", _params, socket) do
-    {:noreply, assign(socket, :submitted, true)}
-  end
-
-  def handle_event("custom-recovery", _params, socket) do
-    {:noreply,
-     assign(
-       socket,
-       :params,
-       Map.merge(socket.assigns.params, %{"b" => "custom value from server"})
-     )}
-  end
-
-  def handle_event("button-test", _params, socket) do
-    {:noreply, socket}
-  end
-
-  @impl Phoenix.LiveView
-  def render(assigns) do
-    ~H"""
-    <.my_form :if={!@params["live-component"]} params={@params} />
-    <.live_component
-      :if={@params["live-component"]}
-      id="form-component"
-      module={__MODULE__.FormComponent}
-      params={@params}
-    />
-
-    <p :if={@submitted}>Form was submitted!</p>
-    """
-  end
-
-  def my_form(assigns) do
-    ~H"""
-    <form
-      id={@params["id"]}
-      phx-submit="save"
-      phx-change={@params["phx-change"]}
-      phx-auto-recover={@params["phx-auto-recover"]}
-      phx-no-usage-tracking={@params["phx-no-usage-tracking-form"]}
-      phx-target={assigns[:"phx-target"]}
-      class="myformclass"
-    >
-      <fieldset disabled={@params["disabled-fieldset"]}>
-        <input type="text" name="a" readonly value={@params["a"]} />
-        <input type="text" name="b" value={@params["b"]} />
-      </fieldset>
-      <input
-        type="text"
-        name="c"
-        value={@params["c"]}
-        phx-no-usage-tracking={@params["phx-no-usage-tracking-input"]}
-      />
-      <select name="d">
-        {Phoenix.HTML.Form.options_for_select(["foo", "bar", "baz"], @params["d"])}
-      </select>
-      <button type="submit" phx-disable-with="Submitting" phx-click={JS.dispatch("test")}>
-        Submit with JS
-      </button>
-      <button id="submit" type="submit" phx-disable-with="Submitting">Submit</button>
-      <button type="button" phx-click="button-test" phx-disable-with="Loading">
-        Non-form Button
-      </button>
-    </form>
-    """
+    def my_form(assigns) do
+      ~H"""
+      <form
+        id={@params["id"]}
+        phx-submit="save"
+        phx-change={@params["phx-change"]}
+        phx-auto-recover={@params["phx-auto-recover"]}
+        phx-no-usage-tracking={@params["phx-no-usage-tracking-form"]}
+        phx-target={assigns[:"phx-target"]}
+        class="myformclass"
+      >
+        <fieldset disabled={@params["disabled-fieldset"]}>
+          <input type="text" name="a" readonly value={@params["a"]} />
+          <input type="text" name="b" value={@params["b"]} />
+        </fieldset>
+        <input
+          type="text"
+          name="c"
+          value={@params["c"]}
+          phx-no-usage-tracking={@params["phx-no-usage-tracking-input"]}
+        />
+        <select name="d">
+          {Phoenix.HTML.Form.options_for_select(["foo", "bar", "baz"], @params["d"])}
+        </select>
+        <button type="submit" phx-disable-with="Submitting" phx-click={JS.dispatch("test")}>
+          Submit with JS
+        </button>
+        <button id="submit" type="submit" phx-disable-with="Submitting">Submit</button>
+        <button type="button" phx-click="button-test" phx-disable-with="Loading">
+          Non-form Button
+        </button>
+      </form>
+      """
+    end
   end
 end
 
@@ -175,7 +189,7 @@ defmodule Phoenix.LiveViewTest.E2E.NestedFormLive do
 
   def render(assigns) do
     ~H"""
-    {live_render(@socket, Phoenix.LiveViewTest.E2E.FormLive,
+    {live_render(@socket, Phoenix.LiveViewTest.E2E.FormLiveNested,
       id: "nested",
       layout: nil,
       session: @params

--- a/test/e2e/tests/forms.spec.js
+++ b/test/e2e/tests/forms.spec.js
@@ -305,6 +305,27 @@ for (const path of ["/form/nested", "/form"]) {
           ]),
         );
       });
+
+      // nested LiveViews don't support handle_params
+      if (path === "/form") {
+        test("navigation during recovery is properly handled by the client", async ({
+          page,
+        }) => {
+          await page.goto(
+            `${path}?phx-auto-recover=patch-recovery&${additionalParams}`,
+          );
+          await syncLV(page);
+
+          await page.evaluate(
+            () =>
+              new Promise((resolve) => window.liveSocket.disconnect(resolve)),
+          );
+          await expect(page.locator(".phx-loading")).toHaveCount(1);
+
+          await page.evaluate(() => window.liveSocket.connect());
+          await expect(page).toHaveURL(/\patched=true/);
+        });
+      }
     });
   }
 


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix_live_view/issues/3964.

When a LiveView is not fully mounted, pending events are pushed into pendingJoinOps. In case of a rejoin, pendingJoinOps were never executed though, so a push_patch during form recovery would get lost.

This is caused by us special casing the first join from rejoins.

On the first join, quoting the code:

> In order to provide a better experience, we want to join all LiveViews
> first and only then apply their patches.

All child LiveViews are joined and report their status to the root view. During that time, pending events are pushed into the root view's pendingJoinOps. The second join skips the acknowledgements and immediately applies the patches. Previously, pending events (most likely only due to form recovery as that is the only thing we do in between applying the mount diff and onJoinComplete) would get lost.

Now, each child LiveView checks if it's a rejoin and instead of pushing into the root views pendingJoinOps, push into its own buffer instead. Then we handle all pending events in onJoinComplete. During the first mount, all pendingJoinOps are already handled before calling onJoinComplete, so there should never be a case where this collides (I think).