### PR TITLE
don't enumerate a struct with `Map.new` in `diff.ex`

### DIFF
--- a/lib/phoenix_live_view/test/diff.ex
+++ b/lib/phoenix_live_view/test/diff.ex
@@ -113,6 +113,13 @@ defmodule Phoenix.LiveViewTest.Diff do
     resolve_templates(Map.put(rendered, @static, Map.fetch!(template, static)), template)
   end
 
+  defp resolve_templates(%struct{} = rendered, template) do
+    struct!(
+      struct,
+      Map.new(Map.from_struct(rendered), fn {k, v} -> {k, resolve_templates(v, template)} end)
+    )
+  end
+
   defp resolve_templates(rendered, template) when is_map(rendered) do
     Map.new(rendered, fn {k, v} -> {k, resolve_templates(v, template)} end)
   end


### PR DESCRIPTION
This resolves an issue encountered while upgrading to 1.1

The stack traces shows `1.2.0-dev` because I cloned it locally while testing, but the error is present in prior versions.

```elixir
  1) test_name (MyApp.MyTest)
     test/my_app/my_test.exs:117
     ** (EXIT from #PID<0.1149.0>) an exception was raised:
         ** (Protocol.UndefinedError) protocol Enumerable not implemented for type Ash.CiString (a struct). This protocol is implemented for the following type(s): DBConnection.PrepareStream, DBConnection.Stream, Date.Range, Ecto.Adapters.SQL.Stream, File.Stream, Floki.HTMLTree, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, Iter, Jason.OrderedObject, LazyHTML, List, Map, MapSet, Phoenix.LiveView.LiveStream, Postgrex.Stream, Range, Req.Response.Async, Rewrite, Stream, StreamData

     Got value:

         #Ash.CiString<"admin4868@example.com">

             (elixir 1.18.3) lib/enum.ex:1: Enumerable.impl_for!/1
             (elixir 1.18.3) lib/enum.ex:166: Enumerable.reduce/3
             (elixir 1.18.3) lib/enum.ex:4515: Enum.map/2
             (elixir 1.18.3) lib/map.ex:262: Map.new_from_enum/2
             (phoenix_live_view 1.2.0-dev) lib/phoenix_live_view/test/diff.ex:118: anonymous fn/2 in Phoenix.LiveViewTest.Diff.resolve_templates/2
             (elixir 1.18.3) lib/map.ex:257: Map.do_map/2
             (elixir 1.18.3) lib/map.ex:257: Map.do_map/2
             (elixir 1.18.3) lib/map.ex:251: Map.new_from_map/2
             (phoenix_live_view 1.2.0-dev) lib/phoenix_live_view/test/diff.ex:74: Phoenix.LiveViewTest.Diff.deep_merge_diff/2
             (phoenix_live_view 1.2.0-dev) lib/phoenix_live_view/test/diff.ex:19: Phoenix.LiveViewTest.Diff.merge_diff/2
             (phoenix_live_view 1.2.0-dev) lib/phoenix_live_view/test/client_proxy.ex:225: Phoenix.LiveViewTest.ClientProxy.mount_view/4
             (phoenix_live_view 1.2.0-dev) lib/phoenix_live_view/test/client_proxy.ex:172: Phoenix.LiveViewTest.ClientProxy.init/1
             (stdlib 6.2.2) gen_server.erl:2229: :gen_server.init_it/2
             (stdlib 6.2.2) gen_server.erl:2184: :gen_server.init_it/6
             (stdlib 6.2.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
```