### PR TITLE
ignore structs when resolving templates

### DIFF
--- a/lib/phoenix_live_view/test/diff.ex
+++ b/lib/phoenix_live_view/test/diff.ex
@@ -113,7 +113,7 @@ defmodule Phoenix.LiveViewTest.Diff do
     resolve_templates(Map.put(rendered, @static, Map.fetch!(template, static)), template)
   end
 
-  defp resolve_templates(rendered, template) when is_map(rendered) do
+  defp resolve_templates(rendered, template) when is_map(rendered) and not is_struct(rendered) do
     Map.new(rendered, fn {k, v} -> {k, resolve_templates(v, template)} end)
   end
 

--- a/test/phoenix_live_view/test/diff_test.exs
+++ b/test/phoenix_live_view/test/diff_test.exs
@@ -3,6 +3,8 @@ defmodule Phoenix.LiveViewTest.DiffTest do
 
   alias Phoenix.LiveViewTest.Diff
 
+  defstruct [:foo]
+
   describe "merge_diff" do
     test "merges unless static" do
       assert Diff.merge_diff(%{0 => "bar", s: "foo"}, %{0 => "baz"}) ==
@@ -40,6 +42,13 @@ defmodule Phoenix.LiveViewTest.DiffTest do
       }
 
       assert Diff.merge_diff(base, diff) == result
+    end
+
+    test "ignores structs when resolving templates" do
+      assert Diff.merge_diff(%{0 => %{}}, %{
+               0 => %{:s => 1, 0 => %__MODULE__{foo: :bar}},
+               :p => %{1 => ["foo", "bar"]}
+             }) == %{0 => %{0 => %__MODULE__{foo: :bar}, :s => ["foo", "bar"]}, :streams => []}
     end
   end
 end


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix_live_view/pull/3970.