### PR TITLE
Fix warning in LiveViewTest when keyed comprehension is empty

### DIFF
--- a/lib/phoenix_live_view/test/diff.ex
+++ b/lib/phoenix_live_view/test/diff.ex
@@ -77,19 +77,23 @@ defmodule Phoenix.LiveViewTest.Diff do
     target_keyed = target[@keyed]
 
     merged_keyed =
-      0..(source_keyed[@keyed_count] - 1)
-      |> Map.new(fn key ->
-        value =
-          case source_keyed[key] do
-            nil -> target_keyed[key]
-            value when is_number(value) -> target_keyed[value]
-            value when is_map(value) -> deep_merge_diff(target_keyed[key], value)
-            [old_key, value] -> deep_merge_diff(target_keyed[old_key], value)
-          end
+      case source_keyed[@keyed_count] do
+        0 ->
+          %{@keyed_count => 0}
 
-        {key, value}
-      end)
-      |> Map.put(@keyed_count, source_keyed[@keyed_count])
+        count ->
+          for pos <- 0..(count - 1), into: %{@keyed_count => count} do
+            value =
+              case source_keyed[pos] do
+                nil -> target_keyed[pos]
+                value when is_number(value) -> target_keyed[value]
+                value when is_map(value) -> deep_merge_diff(target_keyed[pos], value)
+                [old_pos, value] -> deep_merge_diff(target_keyed[old_pos], value)
+              end
+
+            {pos, value}
+          end
+      end
 
     Map.put(target, @keyed, merged_keyed)
   end

--- a/test/phoenix_live_view/test/diff_test.exs
+++ b/test/phoenix_live_view/test/diff_test.exs
@@ -20,7 +20,7 @@ defmodule Phoenix.LiveViewTest.DiffTest do
           0 => %{0 => "A"},
           1 => %{0 => "B"},
           2 => %{0 => "C", 1 => %{0 => "var1", :s => ["", ""]}},
-          :kc => 3
+          kc: 3
         }
       }
 
@@ -28,7 +28,7 @@ defmodule Phoenix.LiveViewTest.DiffTest do
         k: %{
           0 => 1,
           1 => [2, %{1 => %{0 => "var2"}}],
-          :kc => 2
+          kc: 2
         }
       }
 
@@ -36,8 +36,30 @@ defmodule Phoenix.LiveViewTest.DiffTest do
         k: %{
           0 => %{0 => "B"},
           1 => %{0 => "C", 1 => %{0 => "var2", :s => ["", ""]}},
-          :kc => 2
+          kc: 2
         },
+        streams: []
+      }
+
+      assert Diff.merge_diff(base, diff) == result
+    end
+
+    test "no warning when keyed count is 0" do
+      base = %{
+        k: %{
+          0 => %{0 => "A"},
+          1 => %{0 => "B"},
+          2 => %{0 => "C", 1 => %{0 => "var1", :s => ["", ""]}},
+          :kc => 3
+        }
+      }
+
+      diff = %{
+        k: %{kc: 0}
+      }
+
+      result = %{
+        k: %{kc: 0},
         streams: []
       }
 


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix_live_view/pull/3978.

Cu-Authored-By: Victor Rodrigues <vitumail@gmail.com>