### PR TITLE
Serialize error reason as JSON

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -1230,7 +1230,7 @@ export default class View {
             finish(null);
           }
         },
-        error: (reason) => reject(new Error(`failed with reason: ${reason}`)),
+        error: (reason) => reject(new Error(`failed with reason: ${JSON.stringify(reason)}`)),
         timeout: () => {
           reject(new Error("timeout"));
           if (this.joinCount === oldJoinCount) {


### PR DESCRIPTION
Based on the fact that Phoenix Channels use a JSON-based serializer [1], assume the error reason is a JSON-serializable object.

Without this step, we get JavaScript's native string representation of the value, which leads to unhelpful error messages such as:

    failed with reason: [object Object]

instead of

    failed with reason: {"reason":"unmatched topic"}

[1]: https://hexdocs.pm/phoenix/1.8.1/writing_a_channels_client.html#message-format

---

- This is an improvement over https://github.com/phoenixframework/phoenix_live_view/pull/3738
- Maybe long-term we might consider custom errors to be easier to match / group in error monitoring tools like Sentry? For now I'm satisfied with keeping LV's implementation as simple as possible.
