### PR TITLE
Fix heading in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,7 +292,7 @@ To enable this, a new callback called `annotate_slot/4` was added. Custom implem
 * Ensure `push_patch` works during form recovery ([#3964](https://github.com/phoenixframework/phoenix_live_view/issues/3964))
 * Fix diff crash in LiveViewTest when rendering structs ([#3970](https://github.com/phoenixframework/phoenix_live_view/pull/3970))
 
-## Enhancements
+### Enhancements
 
 * Include form values from DOM in `Phoenix.LiveViewTest.submit_form/2` and `Phoenix.LiveViewTest.follow_trigger_action/2` to mimic browser behavior ([#3885](https://github.com/phoenixframework/phoenix_live_view/issues/3885))
 * Allow assigning generic hooks to type `Hook` ([#3955](https://github.com/phoenixframework/phoenix_live_view/issues/3955))


### PR DESCRIPTION
Fix incorrect heading level for one of the versions in the CHANGELOG

Here's what is looks like in hexdocs right now:
<img width="327" height="826" alt="image" src="https://github.com/user-attachments/assets/8f137bc3-2768-42a5-a302-56118c610793" />
