### PR TITLE
Prevent pattern in `:let` from leading to uncovered line

### DIFF
--- a/lib/phoenix_live_view/tag_engine.ex
+++ b/lib/phoenix_live_view/tag_engine.ex
@@ -1399,7 +1399,7 @@ defmodule Phoenix.LiveView.TagEngine do
         quote line: line do
           unquote(pattern) -> unquote(ast)
         end ++
-          quote line: line, generated: true do
+          quote generated: true do
             other ->
               Phoenix.LiveView.TagEngine.__unmatched_let__!(
                 unquote(Macro.to_string(pattern)),


### PR DESCRIPTION
See also https://github.com/SteffenDE/macro_generated_line_coverage_issue.