### PR TITLE
wait for asyncs using separate process

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -385,7 +385,6 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   def handle_call({@prefix, :async_pids}, _from, state) do
-    dbg(state)
     pids = state |> all_asyncs() |> Map.keys()
     {:reply, {:ok, pids}, state}
   end

--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -283,44 +283,50 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
 
     with {:ok, pid} <- Supervisor.start_child(state.test_supervisor, spec) do
       cleaner_fun = fn ->
-        async_pids =
-          try do
-            {:ok, pids} = Phoenix.LiveView.Channel.async_pids(pid)
-            pids
-          catch
-            :exit, _ ->
-              []
-          end
+        Process.flag(:trap_exit, true)
 
-        timeout = Application.fetch_env!(:ex_unit, :assert_receive_timeout)
-        timeout_ref = make_ref()
-        Process.send_after(self(), {timeout_ref, :timeout}, timeout)
+        receive do
+          {:EXIT, _from, _reason} ->
+            async_pids =
+              try do
+                {:ok, pids} = Phoenix.LiveView.Channel.async_pids(pid)
+                pids
+              catch
+                :exit, _ ->
+                  []
+              end
 
-        async_pids
-        |> Enum.map(&Process.monitor/1)
-        |> Enum.each(fn ref ->
-          receive do
-            {^timeout_ref, :timeout} ->
-              raise RuntimeError, "expected async processes to finish within #{timeout}ms"
+            timeout = Application.fetch_env!(:ex_unit, :assert_receive_timeout)
+            timeout_ref = make_ref()
+            Process.send_after(self(), {timeout_ref, :timeout}, timeout)
 
-            {:DOWN, ^ref, :process, _pid, _reason} ->
-              :ok
-          end
-        end)
+            async_pids
+            |> Enum.map(&Process.monitor/1)
+            |> Enum.each(fn ref ->
+              receive do
+                {^timeout_ref, :timeout} ->
+                  raise RuntimeError, "expected async processes to finish within #{timeout}ms"
 
-        if !Process.cancel_timer(timeout_ref) do
-          receive do
-            {^timeout_ref, :timeout} -> :noop
-          after
-            0 -> :noop
-          end
+                {:DOWN, ^ref, :process, _pid, _reason} ->
+                  :ok
+              end
+            end)
+
+            if !Process.cancel_timer(timeout_ref) do
+              receive do
+                {^timeout_ref, :timeout} -> :noop
+              after
+                0 -> :noop
+              end
+            end
         end
       end
 
       cleaner_spec = %{
         id: make_ref(),
         start: {Task, :start_link, [cleaner_fun]},
-        restart: :temporary
+        restart: :temporary,
+        shutdown: 1000
       }
 
       {:ok, _} = Supervisor.start_child(state.test_supervisor, cleaner_spec)


### PR DESCRIPTION
There's something weird going on replacing the LV state with a reference, maybe I'm just stupid.

cc @josevalim 

This could be an option

```elixir
# disable
config :phoenix_live_view, :test_wait_for_asyncs, false
```

```elixir
# timeout
config :phoenix_live_view, :test_wait_for_asyncs, 1000
```