### PR TITLE
Fix extra spaces being continually added when formatting nested inline tags

### DIFF
--- a/lib/phoenix_live_view/html_algebra.ex
+++ b/lib/phoenix_live_view/html_algebra.ex
@@ -164,7 +164,8 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
       tag_block?(prev_node) and not tag?(next_node) ->
         break(" ")
 
-      text_ends_with_space?(prev_node) or text_starts_with_space?(next_node) ->
+      (text_ends_with_space?(prev_node) or text_starts_with_space?(next_node)) and
+          not text_preserve?(prev_node) ->
         flex_break(" ")
 
       true ->
@@ -198,6 +199,9 @@ defmodule Phoenix.LiveView.HTMLAlgebra do
   defp block_preserve?({:body_expr, _, _}), do: true
   defp block_preserve?({:eex, _, _}), do: true
   defp block_preserve?(_node), do: false
+
+  defp text_preserve?({:text, _, %{mode: :preserve}}), do: true
+  defp text_preserve?(_), do: false
 
   defp to_algebra({:html_comment, block}, context) do
     children = block_to_algebra(block, %{context | mode: :preserve})

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -1518,6 +1518,40 @@ defmodule Phoenix.LiveView.HTMLFormatterTest do
     )
   end
 
+  test "doesn't add extra spaces to inline tags with nested inline tags with leading whitespace" do
+    assert_formatter_doesnt_change("""
+    <a>foo<b>bar</b></a>
+    """)
+
+    assert_formatter_doesnt_change("""
+    <a>foo <b>bar</b></a>
+    """)
+
+    assert_formatter_doesnt_change("""
+    <a> foo<b>bar</b></a>
+    """)
+
+    assert_formatter_doesnt_change("""
+    <a> foo <b>bar</b></a>
+    """)
+
+    assert_formatter_doesnt_change("""
+    <a>foo<b>bar</b></a>
+    """)
+
+    assert_formatter_doesnt_change("""
+    <a>foo <b> bar</b></a>
+    """)
+
+    assert_formatter_doesnt_change("""
+    <a> foo<b>bar </b></a>
+    """)
+
+    assert_formatter_doesnt_change("""
+    <a> foo <b> bar </b></a>
+    """)
+  end
+
   test "treats components with link or button in their name as inline" do
     assert_formatter_doesnt_change("""
     <.styled_link> Foo: </.styled_link>


### PR DESCRIPTION
In the case where an inline tag has a nested inline tag, and there are spaces before and after text in the parent tag, extra spaces are continually appended each time HTML is formatted (ie if formatting on autosave in an editor, this keeps pumping on spaces every time a template is saved)

This is funny when you spam save in neovim, and you see a little HTML tag crawl across the buffer like a worm 😆 - but ends up in way too much git diff spam


https://github.com/user-attachments/assets/1cebe23f-083c-4e66-88b4-4ad26529b354



e.g.

```elixir
str = "<a> foo <b>bar</b></a>"

str
|> Phoenix.LiveView.HTMLFormatter.format([])
# "<a> foo  <b>bar</b></a>\n"

str
|> Phoenix.LiveView.HTMLFormatter.format([])
|> Phoenix.LiveView.HTMLFormatter.format([])
"<a> foo   <b>bar</b></a>\n"

str
|> Phoenix.LiveView.HTMLFormatter.format([])
|> Phoenix.LiveView.HTMLFormatter.format([])
|> Phoenix.LiveView.HTMLFormatter.format([])
"<a> foo    <b>bar</b></a>\n"
```

Check if text whitespace is being preserved, and don't add `flex_break(" ")` if so, just allowing `cond` block to drop down and add `""` as a separator in this case.