### PR TITLE
Class attribute type

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -3559,7 +3559,7 @@ defmodule Phoenix.Component do
     doc: "A CSS selector that identifies the target. The target must be unique."
   )
 
-  attr.(:class, :string, default: nil, doc: "The class to apply to the portal wrapper.")
+  attr.(:class, :any, default: nil, doc: "The class to apply to the portal wrapper.")
   attr.(:container, :string, default: "div", doc: "The HTML tag to use as the portal wrapper.")
   slot.(:inner_block, required: true)
 

--- a/test/e2e/support/portal.ex
+++ b/test/e2e/support/portal.ex
@@ -185,7 +185,7 @@ defmodule Phoenix.LiveViewTest.E2E.PortalLive do
   end
 
   attr :type, :string, default: nil
-  attr :class, :string, default: nil
+  attr :class, :any, default: nil
   attr :rest, :global, include: ~w(disabled form name value)
 
   slot :inner_block, required: true


### PR DESCRIPTION
Applies changes from https://github.com/phoenixframework/phoenix/pull/6398 to LiveView

This PR applies the same `class` attribute type broadening to LiveView components, ensuring type consistency between Phoenix and Phoenix LiveView.

**Benefits:**
- Fixes compilation warnings for valid `class` usage patterns
- Makes component usage more flexible and convenient