### PR TITLE
Enable `:handle_event` hooks to reply from LiveComponents

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -757,6 +757,9 @@ defmodule Phoenix.LiveView.Channel do
             {:halt, %Socket{} = component_socket} ->
               component_socket
 
+            {:halt, %{} = reply, %Socket{} = component_socket} ->
+              Utils.put_reply(component_socket, reply)
+
             {:cont, %Socket{} = component_socket} ->
               case component.handle_event(event, val, component_socket) do
                 {:noreply, component_socket} ->

--- a/test/phoenix_live_view/integrations/hooks_test.exs
+++ b/test/phoenix_live_view/integrations/hooks_test.exs
@@ -317,6 +317,32 @@ defmodule Phoenix.LiveView.HooksTest do
              "** (UndefinedFunctionError) function Phoenix.LiveViewTest.Support.HooksEventComponent.handle_event/3 is undefined"
   end
 
+  test "attach_hook with reply and detach_hook with a handle_event live component socket", %{
+    conn: conn
+  } do
+    {:ok, lv, _html} = live(conn, "/lifecycle/components/handle_event?reply=true")
+    lv |> element("#attach") |> render_click()
+    lv |> element("#hook") |> render_click()
+    assert_reply(lv, %{counter: 1})
+    assert render_async(lv) =~ "counter: 1"
+
+    lv |> element("#hook") |> render_click()
+    assert_reply(lv, %{counter: 2})
+    assert render_async(lv) =~ "counter: 2"
+
+    lv |> element("#detach-component-hook") |> render_click()
+    Process.flag(:trap_exit, true)
+
+    assert ExUnit.CaptureLog.capture_log(fn ->
+             try do
+               lv |> element("#hook") |> render_click()
+             catch
+               :exit, _ -> :ok
+             end
+           end) =~
+             "** (UndefinedFunctionError) function Phoenix.LiveViewTest.Support.HooksEventComponent.handle_event/3 is undefined"
+  end
+
   test "attach_hook raises when given a live component socket", %{conn: conn} do
     {:ok, lv, _html} = live(conn, "/lifecycle/components/handle_info")
 


### PR DESCRIPTION
As noted in the documentation for `Phoenix.LiveView.attach_hook/4`:

> Hooks attached to the `:handle_event` stage are able to reply to client events by returning `{:halt, reply, socket}`.

However, doing so from within a LiveComponent, where `:handle_event` hooks are supported, resulted in an error (see below for a minimal app reproducing the bug):

```
** (ArgumentError) invalid return from PhoenixPlayground.Router.DelegateLive.handle_event/3 callback.

Expected one of:

    {:noreply, %Socket{}}
    {:reply, map, %Socket{}}

Got: {:halt, %{"hello" => "world"}, #Phoenix.LiveView.Socket<...>}
```

Looking through the source of the functions in the stack trace, I noticed that `Phoenix.LiveView.Channel.inner_component_handle_event/4` was missing a case for `{:halt, reply, socket}` return values from hooks. By adding the missing case, the bug now appears to be resolved.

## Reproducible example

```elixir
Mix.install([
  {:phoenix_playground, "~> 0.1.8"},
  {:phoenix_live_view, "~> 1.1.13"}
])

defmodule DemoComponent do
  use Phoenix.Component

  def display(assigns) do
    ~H"""
    <div id="my-client-hook" phx-hook="ClientHook">DemoComponent</div>

    <script>
    window.hooks.ClientHook = {
      mounted() {
        this.pushEventTo(this.el, "ClientHook:mounted", {hello: "world"}, (reply) => {
          console.log("received reply:", reply)
        });
      }
    };
    </script>
    """
  end
end

defmodule DemoLiveComponent do
  use Phoenix.LiveComponent

  def render(assigns) do
    ~H"""
    <div>
      <h2>DemoLiveComponent</h2>
      <DemoComponent.display />
    </div>
    """
  end

  def mount(socket) do
    socket =
      attach_hook(socket, :reply_on_client_hook_mounted, :handle_event, fn
        "ClientHook:mounted", params, socket ->
          {:halt, params, socket}
  
        _, _, socket ->
          {:cont, socket}
      end)
  
    {:ok, socket}
  end
end

defmodule DemoLive do
  use Phoenix.LiveView

  def mount(_params, _session, socket) do
    {:ok, socket}
  end

  def render(assigns) do
    ~H"""
    <h1>DemoLive</h1>
    <.live_component module={DemoLiveComponent} id="demo-live-component" />
    """
  end
end

PhoenixPlayground.start(live: DemoLive, port: 9001)
```