### PR TITLE
Upgrade :esbuild to minimum version when upgrading to 1.1

### DIFF
--- a/lib/phoenix_live_view/igniter/upgrade_to_1_1.ex
+++ b/lib/phoenix_live_view/igniter/upgrade_to_1_1.ex
@@ -128,8 +128,12 @@ if Code.ensure_loaded?(Igniter) do
           config_exs_vsn = Rewrite.Source.version(igniter.rewrite.sources["config/config.exs"])
 
           igniter =
-            Igniter.Project.Config.configure(
-              igniter,
+            igniter
+            |> Igniter.Project.Deps.add_dep(
+              {:esbuild, "~> 0.10", runtime: quote(do: Mix.env() == :dev)},
+              on_exists: :overwrite
+            )
+            |> Igniter.Project.Config.configure(
               "config.exs",
               :esbuild,
               app_name,

--- a/lib/phoenix_live_view/igniter/upgrade_to_1_1.ex
+++ b/lib/phoenix_live_view/igniter/upgrade_to_1_1.ex
@@ -129,9 +129,11 @@ if Code.ensure_loaded?(Igniter) do
 
           igniter =
             igniter
-            |> Igniter.Project.Deps.add_dep(
-              {:esbuild, "~> 0.10", runtime: quote(do: Mix.env() == :dev)},
-              on_exists: :overwrite
+            |> Igniter.Project.Deps.add_dep({:esbuild, "~> 0.10"}, on_exists: :overwrite)
+            |> Igniter.Project.Deps.set_dep_option(
+              :esbuild,
+              :runtime,
+              quote(do: Mix.env() == :dev)
             )
             |> Igniter.Project.Config.configure(
               "config.exs",

--- a/test/phoenix_live_view/igniter/upgrade_to_1_1_test.exs
+++ b/test/phoenix_live_view/igniter/upgrade_to_1_1_test.exs
@@ -280,6 +280,9 @@ defmodule Phoenix.LiveView.Igniter.UpgradeTo1_1Test do
       )
       # yes to esbuild
       |> run_upgrade(input: "y\n")
+      |> assert_has_patch("mix.exs", """
+      + |      {:esbuild, "~> 0.10", runtime: Mix.env() == :dev},
+      """)
       |> assert_has_patch("config/config.exs", """
       - |    args: ~w(js/app.js --bundle --outdir=../priv/static/assets),
       + |    args: ~w(js/app.js --bundle --outdir=../priv/static/assets --alias:@=.),
@@ -308,6 +311,9 @@ defmodule Phoenix.LiveView.Igniter.UpgradeTo1_1Test do
       )
       # yes to esbuild (no deps prompt since no existing deps)
       |> run_upgrade(input: "y\n")
+      |> assert_has_patch("mix.exs", """
+      + |      {:esbuild, "~> 0.10", runtime: Mix.env() == :dev},
+      """)
       |> assert_has_patch("config/config.exs", """
       - |    args: ["js/app.js", "--bundle", "--outdir=../priv/static/assets"],
       + |    args: ["js/app.js", "--bundle", "--outdir=../priv/static/assets", "--alias:@=."],
@@ -333,6 +339,9 @@ defmodule Phoenix.LiveView.Igniter.UpgradeTo1_1Test do
       )
       # yes to esbuild
       |> run_upgrade(input: "y\n")
+      |> assert_has_patch("mix.exs", """
+      + |      {:esbuild, "~> 0.10", runtime: Mix.env() == :dev},
+      """)
       |> assert_has_patch("config/config.exs", """
       - |    args: ~w(js/app.js --bundle --outdir=../priv/static/assets),
       + |    args: ~w(js/app.js --bundle --outdir=../priv/static/assets --alias:@=.),
@@ -361,6 +370,9 @@ defmodule Phoenix.LiveView.Igniter.UpgradeTo1_1Test do
       )
       # yes to esbuild (no deps prompt since no existing deps)
       |> run_upgrade(input: "y\n")
+      |> assert_has_patch("mix.exs", """
+      + |      {:esbuild, "~> 0.10", runtime: Mix.env() == :dev},
+      """)
       |> assert_has_warning(&(&1 =~ "Failed to update esbuild configuration for colocated hooks"))
       |> refute_has_notice()
     end
@@ -381,6 +393,9 @@ defmodule Phoenix.LiveView.Igniter.UpgradeTo1_1Test do
       )
       # no to deps prompt, yes to esbuild
       |> run_upgrade(input: "y\n")
+      |> assert_has_patch("mix.exs", """
+      + |      {:esbuild, "~> 0.10", runtime: Mix.env() == :dev},
+      """)
       |> assert_has_warning(&(&1 =~ "Failed to update esbuild configuration for colocated hooks"))
       |> refute_has_notice()
     end
@@ -444,6 +459,10 @@ defmodule Phoenix.LiveView.Igniter.UpgradeTo1_1Test do
       |> assert_has_patch("mix.exs", """
       + |      {:lazy_html, ">= 0.0.0", only: :test},
       """)
+      |> assert_has_patch("mix.exs", """
+      - |      {:esbuild, "~> 0.8", runtime: Mix.env() == :dev},
+      + |      {:esbuild, "~> 0.10", runtime: Mix.env() == :dev}
+      """)
       |> assert_has_patch("config/dev.exs", """
       - |  reloadable_compilers: [:elixir, :app]
       + |  reloadable_compilers: [:phoenix_live_view, :elixir, :app]
@@ -483,7 +502,8 @@ defmodule Phoenix.LiveView.Igniter.UpgradeTo1_1Test do
           defp deps do
             [
               {:phoenix, "~> 1.7.0"},
-              {:phoenix_live_view, "~> 0.20.0"}
+              {:phoenix_live_view, "~> 0.20.0"},
+              {:esbuild, "~> 0.8", runtime: Mix.env() == :dev},
             ]
           end
         end


### PR DESCRIPTION
This PR is a proposal to upgrade `:esbuild` to the minimum version `0.10` while running Igniter in order to avoid errors on [joining environment variables](https://github.com/phoenixframework/esbuild/blob/main/CHANGELOG.md#v0100-2025-05-27).

Please check my main concern about showing an unclear message because of the usage of `quote`.