### PR TITLE
Add `phx-files-dropzone` To Allow Styling Phoenix Uploads On Drag And Drop

### DIFF
--- a/assets/js/phoenix_live_view/utils.js
+++ b/assets/js/phoenix_live_view/utils.js
@@ -94,3 +94,14 @@ export const channelUploader = function (entries, onError, resp, liveSocket) {
     entryUploader.upload();
   });
 };
+
+export const eventContainsFiles = (e) => {
+  if (e.dataTransfer.types) {
+    for (let i = 0; i < e.dataTransfer.types.length; i++) {
+      if (e.dataTransfer.types[i] === "Files") {
+        return true;
+      }
+    }
+  }
+  return false;
+};


### PR DESCRIPTION
This extends the current Phoenix drop target functionality for Phoenix Uploads by adding (and removing) the `phx-files-dropzone` class to a dropzone element whenever a file is being dragged over it.

The current Phoenix Uploads functionality is very limited - it does not notify anywhere on the DOM that something is being dragged in, making it impossible with plain Phoenix LiveView to enable things like styling elements when files are dragged over a dropzone. This is a very important functionality for good UI, allowing us to show the user that drag and drop is enabled, and comes standard in many uploading libraries that enable uploads for frontend frameworks.

This PR extends the current LiveSocket listeners by adding 2 more:
- `dragenter`
- `dragleave`

These listeners add and remove the `phx-files-dropzone` class respectively, which enables adding a TailwindCSS variant like so:
```css
@custom-variant phx-files-dropzone (.phx-files-dropzone&, .phx-files-dropzone &);
```

This variant can be used similarly to `phx-click-loading` and the other recommended variants that Phoenix ships with, for example like so:
```heex
<div phx-drop-target={@upload.ref} class="phx-files-dropzone:scale-105">
  <.live_file_input upload={@upload} class="file-input-sm" />
</div>
```

In this example, when a file is dragged over the dropzone element, the element grows in size (a very naive example, but it shows the effect of the variant).