### PR TITLE
Fix change tracking docs on `:key`

### DIFF
--- a/guides/server/assigns-eex.md
+++ b/guides/server/assigns-eex.md
@@ -264,7 +264,7 @@ a comprehension are only sent once, regardless of the number of items.
 Furthermore, LiveView tracks changes within the collection given to the
 comprehension. In the ideal case, if only a single entry in `@posts`
 changes, only this entry is sent again. By default, the index is used
-to track changes. This means that if an entry is appended, most items
+to track changes. This means that if an entry is prepended, all items
 will be considered changed and sent again. To optimize this, you can
 also pass a `:key` on tags in HEEx:
 


### PR DESCRIPTION
Given the default `:key` is the index of the element, appending should cause only the new element to be sent to the client.

Conversely, if an item is prepended, or, more generally, inserted anywhere within the list, then all subsequent elements will be considered changed. In the worse case that means all elements will be sent to the client.

See https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.Engine.html#module-comprehensions, which correctly talks about prepeding, not appending.