### PR TITLE
Fix phx-hook examples missing DOM id

### DIFF
--- a/guides/client/form-bindings.md
+++ b/guides/client/form-bindings.md
@@ -448,7 +448,7 @@ Hooks.CustomFormSubmission = {
 This hook can be set on your form as such:
 
 ```heex
-<form phx-hook="CustomFormSubmission">
+<form id="my-form" phx-hook="CustomFormSubmission">
   <input type="text" name="text" value={@text}>
 </form>
 ```


### PR DESCRIPTION
See https://hexdocs.pm/phoenix_live_view/js-interop.html#client-hooks-via-phx-hook
> Note: when using phx-hook, a unique DOM ID must always be set.