### PR TITLE
Update phx-change examples to have a DOM id

### DIFF
--- a/guides/cheatsheets/html-attrs.cheatmd
+++ b/guides/cheatsheets/html-attrs.cheatmd
@@ -77,7 +77,7 @@ Attribute values can be:
 #### lib/hello_web/live/hello_live.html.heex
 
 ```heex
-<form phx-change="validate" phx-submit="save">
+<form id="my-form" phx-change="validate" phx-submit="save">
   <input type="text" name="name" phx-debounce="500" phx-throttle="500" />
   <button type="submit" phx-disable-with="Saving...">Save</button>
 </form>

--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -192,7 +192,7 @@ For example, to avoid validating an email until the field is blurred, while vali
 the username at most every 2 seconds after a user changes the field:
 
 ```heex
-<form phx-change="validate" phx-submit="save">
+<form id="my-form" phx-change="validate" phx-submit="save">
   <input type="text" name="user[email]" phx-debounce="blur"/>
   <input type="text" name="user[username]" phx-debounce="2000"/>
 </form>

--- a/guides/client/form-bindings.md
+++ b/guides/client/form-bindings.md
@@ -10,7 +10,7 @@ saving, your form would use both `phx-change` and `phx-submit` bindings.
 Let's get started with an example:
 
 ```heex
-<.form for={@form} phx-change="validate" phx-submit="save">
+<.form for={@form} id="my-form" phx-change="validate" phx-submit="save">
   <.input type="text" field={@form[:username]} />
   <.input type="email" field={@form[:email]} />
   <button>Save</button>
@@ -87,9 +87,9 @@ a different component. This can be accomplished by annotating the input itself
 with `phx-change`, for example:
 
 ```heex
-<.form for={@form} phx-change="validate" phx-submit="save">
+<.form for={@form} id="my-form" phx-change="validate" phx-submit="save">
   ...
-  <.input field={@form[:email]}  phx-change="email_changed" phx-target={@myself} />
+  <.input field={@form[:email]} phx-change="email_changed" phx-target={@myself} />
 </.form>
 ```
 
@@ -276,7 +276,7 @@ After the form is reset, a `phx-change` event is emitted with the `_target` para
 containing the reset `name`. For example, the following element:
 
 ```heex
-<form phx-change="changed">
+<form id="my-form" phx-change="changed">
   ...
   <button type="reset" name="reset">Reset</button>
 </form>
@@ -377,7 +377,7 @@ with the following rules in your `app.css`:
 You can show and hide content with the following markup:
 
 ```heex
-<form phx-change="update">
+<form id="my-form" phx-change="update">
   <div class="while-submitting">Please wait while we save our content...</div>
   <div class="inputs">
     <input type="text" name="text" value={@text}>

--- a/guides/server/uploads.md
+++ b/guides/server/uploads.md
@@ -50,7 +50,7 @@ to render a file input for the upload:
 ```heex
 <%!-- lib/my_app_web/live/upload_live.html.heex --%>
 
-<form id="upload-form" phx-submit="save" phx-change="validate">
+<form id="upload-form" phx-change="validate" phx-submit="save">
   <.live_file_input upload={@uploads.avatar} />
   <button type="submit">Upload</button>
 </form>

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -772,7 +772,7 @@ defmodule Phoenix.Component do
   caller. For an example, see how `form/1` works:
 
   ```heex
-  <.form :let={f} for={@form} phx-change="validate" phx-submit="save">
+  <.form :let={f} for={@form} id="my-form" phx-change="validate" phx-submit="save">
     <.input field={f[:username]} type="text" />
     ...
   </.form>
@@ -2285,6 +2285,7 @@ defmodule Phoenix.Component do
   ```heex
   <.form
     for={@form}
+    id="my-form"
     phx-change="change_name"
   >
     <.input field={@form[:email]} />
@@ -2308,9 +2309,10 @@ defmodule Phoenix.Component do
   ```heex
   <.form
     for={@form}
-    multipart
+    id="my-form"
     phx-change="change_user"
     phx-submit="save_user"
+    multipart
   >
     ...
     <input type="submit" value="Save" />
@@ -2333,6 +2335,7 @@ defmodule Phoenix.Component do
   <.form
     :let={form}
     for={@changeset}
+    id="my-form"
     phx-change="change_user"
   >
   ```
@@ -2557,6 +2560,7 @@ defmodule Phoenix.Component do
   ```heex
   <.form
     for={@form}
+    id="my-form"
     phx-change="change_name"
   >
     <.inputs_for :let={f_nested} field={@form[:nested]}>


### PR DESCRIPTION
It is good practice to set a stable `id` on forms that use `phx-change` so that automatic recovery of input values can work.

https://hexdocs.pm/phoenix_live_view/form-bindings.html#recovery-following-crashes-or-disconnects
> By default, all forms marked with phx-change and having id attribute
> will recover input values automatically [...]

This commit revises all occurrences of `phx-change=...` in documentation and:

1. Make sure the form has an `id` attribute, so that LiveView users skimming the docs are reminded of this best practice.
2. Organize the attributes in a consistent order: `for`, `id`, `phx-change`, `phx-submit`. This is the same order as in the `phx.gen.live` generator template in Phoenix.