### PR TITLE
Fix form recovery in firefox for external inputs

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -2157,10 +2157,12 @@ export default class View {
               return false;
             }
             return true;
-          }
+          },
         });
         // next up, we also need to clone any elements with form="id" parameter
-        const externalElements = document.querySelectorAll(`[form="${CSS.escape(form.id)}"]`);
+        const externalElements = document.querySelectorAll(
+          `[form="${CSS.escape(form.id)}"]`,
+        );
         Array.from(externalElements).forEach((el) => {
           const clonedEl = /** @type {HTMLElement} */ (el.cloneNode(true));
           morphdom(clonedEl, el);

--- a/test/e2e/support/form_live.ex
+++ b/test/e2e/support/form_live.ex
@@ -181,7 +181,7 @@ for type <- [FormLive, FormLiveNested] do
         <select name="d">
           {Phoenix.HTML.Form.options_for_select(["foo", "bar", "baz"], @params["d"])}
         </select>
-        <input :if={@params["id"]} type="text" name="e" form={@params["id"]} value={@params["e"] } />
+        <input :if={@params["id"]} type="text" name="e" form={@params["id"]} value={@params["e"]} />
         <button type="submit" phx-disable-with="Submitting" phx-click={JS.dispatch("test")}>
           Submit with JS
         </button>
@@ -191,7 +191,7 @@ for type <- [FormLive, FormLiveNested] do
         </button>
       </form>
 
-      <input :if={@params["id"]} type="text" name="f" form={@params["id"]} value={@params["f"] } />
+      <input :if={@params["id"]} type="text" name="f" form={@params["id"]} value={@params["f"]} />
       """
     end
   end

--- a/test/e2e/tests/forms.spec.js
+++ b/test/e2e/tests/forms.spec.js
@@ -171,7 +171,7 @@ for (const path of ["/form/nested", "/form"]) {
             c: "hello world",
             d: "bar",
             e: "inside",
-            f: "outside"
+            f: "outside",
           });
         });
 
@@ -346,7 +346,7 @@ for (const path of ["/form/nested", "/form"]) {
             _unused_e: "",
             e: "",
             _unused_f: "",
-            f: ""
+            f: "",
           });
         });
 
@@ -887,7 +887,9 @@ test("phx-no-usage-tracking on an input is applied correctly and no unused field
 });
 
 function formPayload(events) {
-  const event = events.find((e) => e.type === "sent" && e.payload.includes('"event":"validate"'));
+  const event = events.find(
+    (e) => e.type === "sent" && e.payload.includes('"event":"validate"'),
+  );
   const parsed = JSON.parse(event.payload);
   return querystring.parse(parsed[4].value);
 }


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix_live_view/issues/4021.

In Firefox, if you clone a form element and it contains nodes with `form` attribute pointing to an ID, those elements are not considered to be part of the cloned form's elements. We handle this by omitting them from the cloned form and adding them without form parameter.