### PR TITLE
Warn instead of error for phx-hook without id attribute

### DIFF
--- a/lib/phoenix_live_view/tag_engine.ex
+++ b/lib/phoenix_live_view/tag_engine.ex
@@ -1549,10 +1549,21 @@ defmodule Phoenix.LiveView.TagEngine do
   end
 
   defp validate_phx_attrs!([], meta, state, attr, false)
-       when attr in ["phx-update", "phx-hook"] do
+       when attr == "phx-update" do
     message = "attribute \"#{attr}\" requires the \"id\" attribute to be set"
 
     raise_syntax_error!(message, meta, state)
+  end
+
+  defp validate_phx_attrs!([], meta, state, attr, false)
+       when attr == "phx-hook" do
+    message = "attribute \"#{attr}\" requires the \"id\" attribute to be set"
+    line = meta[:line] || state.caller.line
+
+    IO.warn(
+      message,
+      Macro.Env.stacktrace(%{state.caller | line: line})
+    )
   end
 
   defp validate_phx_attrs!([], _meta, _state, _attr, _id?), do: :ok


### PR DESCRIPTION
# Fixes #4010 
- instead of giving an error it gives warn if id is missing