### PR TITLE
Fix typo in JS docs

### DIFF
--- a/assets/js/phoenix_live_view/index.ts
+++ b/assets/js/phoenix_live_view/index.ts
@@ -246,7 +246,7 @@ export interface LiveSocketInstanceInterface {
    */
   execJS(el: HTMLElement, encodedJS: string, eventType?: string | null): void;
   /**
-   * Returns an object with methods to manipluate the DOM and execute JavaScript.
+   * Returns an object with methods to manipulate the DOM and execute JavaScript.
    * The applied changes integrate with server DOM patching.
    *
    * See [JavaScript interoperability](https://hexdocs.pm/phoenix_live_view/js-interop.html) for more information.

--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -225,7 +225,7 @@ export default class LiveSocket {
   }
 
   /**
-   * Returns an object with methods to manipluate the DOM and execute JavaScript.
+   * Returns an object with methods to manipulate the DOM and execute JavaScript.
    * The applied changes integrate with server DOM patching.
    *
    * @returns {import("./js_commands").LiveSocketJSCommands}

--- a/assets/js/phoenix_live_view/view_hook.ts
+++ b/assets/js/phoenix_live_view/view_hook.ts
@@ -66,7 +66,7 @@ export interface HookInterface<E extends HTMLElement = HTMLElement> {
   reconnected?: () => void;
 
   /**
-   * Returns an object with methods to manipluate the DOM and execute JavaScript.
+   * Returns an object with methods to manipulate the DOM and execute JavaScript.
    * The applied changes integrate with server DOM patching.
    */
   js(): HookJSCommands;

--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -35,7 +35,7 @@ The `liveSocket` instance exposes the following methods:
 - `enableLatencySim(milliseconds)` - turns on latency simulation, see [Simulating latency](#simulating-latency)
 - `disableLatencySim()` - turns off latency simulation
 - `execJS(el, encodedJS)` - executes encoded JavaScript in the context of the element
-- `js()` - returns an object with methods to manipluate the DOM and execute JavaScript. The applied changes integrate with server DOM patching. See [JS commands](#js-commands).
+- `js()` - returns an object with methods to manipulate the DOM and execute JavaScript. The applied changes integrate with server DOM patching. See [JS commands](#js-commands).
 
 ## Debugging client events
 
@@ -184,7 +184,7 @@ The above life-cycle callbacks have in-scope access to the following attributes:
     on the server-side. Dispatching new uploads triggers an input change event which will be sent to the
     LiveComponent or LiveView the `selectorOrTarget` is defined in, where its value can be either a query selector or an
     actual DOM element. If the query selector returns more than one live file input, an error will be logged.
-  * `js()` - returns an object with methods to manipluate the DOM and execute JavaScript. The applied changes integrate with server DOM patching. See [JS commands](#js-commands).
+  * `js()` - returns an object with methods to manipulate the DOM and execute JavaScript. The applied changes integrate with server DOM patching. See [JS commands](#js-commands).
 
 For example, the markup for a controlled input for phone-number formatting could be written
 like this:


### PR DESCRIPTION
s/manipluate/manipulate