### PR TITLE
Add using generic map manipulation on assigns variable to common pitfalls

### DIFF
--- a/guides/server/assigns-eex.md
+++ b/guides/server/assigns-eex.md
@@ -318,3 +318,5 @@ To sum up:
   1. Avoid defining local variables inside HEEx templates, except within Elixir's constructs
 
   2. Avoid passing or accessing the `assigns` variable inside HEEx templates
+
+  3. Only use LiveView specific assign functions to modify the `assigns` variable


### PR DESCRIPTION
Adds a warning about using functions like `Map.put/3` on the `assigns` variable in function components to the `Common Pitfalls` section.

Closes https://github.com/phoenixframework/phoenix_live_view/issues/4039#issuecomment-3461182726

Related:
- https://github.com/phoenixframework/phoenix_live_view/issues/1730
- https://github.com/phoenixframework/phoenix_live_view/issues/3930#issuecomment-3149752034