### PR TITLE
Add JS.encode/1 function

### DIFF
--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -218,8 +218,87 @@ defmodule Phoenix.LiveView.JS do
 
   defimpl Phoenix.HTML.Safe, for: Phoenix.LiveView.JS do
     def to_iodata(%Phoenix.LiveView.JS{} = js) do
-      Phoenix.HTML.Engine.html_escape(Phoenix.json_library().encode!(js.ops))
+      js
+      |> JS.encode()
+      |> Phoenix.HTML.Engine.html_escape()
     end
+  end
+
+  @doc ~S"""
+  Encodes the JS commands for transmission to the client.
+
+  Most of the time you will not need to call this function directly. JS commands
+  are typically rendered in [HEEx templates](assigns-eex.md), in which they are
+  encoded automatically.
+
+  This function is useful when constructing JS commands dynamically on the
+  server and pushing them to the client via `Phoenix.LiveView.push_event/3`.
+
+  ## Examples
+
+  On the server, dynamically compute some JS commands and push them to the
+  client:
+
+  ```elixir
+  socket
+  |> push_event("myapp:exec_js", %{
+    to: "#items-#{item.id}",
+    js: js_commands_for(item) |> JS.encode()
+  })
+  ```
+
+  On the client, handle the event and execute the commands:
+
+  ```javascript
+  window.addEventListener("phx:myapp:exec_js", e => {
+    const {to, js} = e.detail;
+    const el = document.querySelector(to);
+    if (el && js) {
+      window.liveSocket.execJS(el, js);
+    }
+  });
+  ```
+
+  The common case, though, is having the JS commands stored in an HTML attribute
+  (`phx-*` or `data-*`), such that client-side JavaScript can refer to them
+  later. For example, in a LiveView template:
+
+  ```heex
+  <div id={"items-#{item.id}"} data-js={JS.show()}>
+    Hello!
+  </div>
+  ```
+
+  Now the server can push an event that refers to the `data-js` attribute:
+
+  ```elixir
+  socket
+  |> push_event("myapp:exec_attr", %{
+    to: "#items-#{item.id}",
+    attr: "data-js"
+  })
+  ```
+
+  Finally, on the client, you can read and execute the commands:
+
+  ```javascript
+  window.addEventListener("phx:myapp:exec_attr", e => {
+    const {to, attr} = e.detail;
+    const el = document.querySelector(to);
+    const js = el && attr && el.getAttribute(attr);
+    if (el && js) {
+      window.liveSocket.execJS(el, js);
+    }
+  });
+  ```
+
+  Note how in the code above we didn't need to encode JS commands explicitly,
+  nor to pass them in the event payload, thanks to rendering them in the
+  template.
+
+  """
+  def encode(%JS{} = js) do
+    Phoenix.json_library().encode!(js.ops)
   end
 
   @doc """

--- a/test/phoenix_live_view/js_test.exs
+++ b/test/phoenix_live_view/js_test.exs
@@ -66,7 +66,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.push("inc", value: %{one: 1, two: 2})) ==
-               "[[&quot;push&quot;,{&quot;event&quot;:&quot;inc&quot;,&quot;value&quot;:{&quot;one&quot;:1,&quot;two&quot;:2}}]]"
+               ~S<[["push",{"event":"inc","value":{"one":1,"two":2}}]]>
     end
   end
 
@@ -183,7 +183,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.add_class("show")) ==
-               "[[&quot;add_class&quot;,{&quot;names&quot;:[&quot;show&quot;]}]]"
+               ~S<[["add_class",{"names":["show"]}]]>
     end
   end
 
@@ -302,7 +302,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.remove_class("show")) ==
-               "[[&quot;remove_class&quot;,{&quot;names&quot;:[&quot;show&quot;]}]]"
+               ~S<[["remove_class",{"names":["show"]}]]>
     end
   end
 
@@ -421,7 +421,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.toggle_class("show")) ==
-               "[[&quot;toggle_class&quot;,{&quot;names&quot;:[&quot;show&quot;]}]]"
+               ~S<[["toggle_class",{"names":["show"]}]]>
     end
   end
 
@@ -475,7 +475,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.dispatch("click", to: ".foo")) ==
-               "[[&quot;dispatch&quot;,{&quot;event&quot;:&quot;click&quot;,&quot;to&quot;:&quot;.foo&quot;}]]"
+               ~S<[["dispatch",{"event":"click","to":".foo"}]]>
     end
 
     test "raises when done is a details key and blocking is true" do
@@ -588,7 +588,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.toggle(to: "#modal")) ==
-               "[[&quot;toggle&quot;,{&quot;to&quot;:&quot;#modal&quot;}]]"
+               ~S<[["toggle",{"to":"#modal"}]]>
     end
   end
 
@@ -676,7 +676,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.show(to: "#modal")) ==
-               "[[&quot;show&quot;,{&quot;to&quot;:&quot;#modal&quot;}]]"
+               ~S<[["show",{"to":"#modal"}]]>
     end
   end
 
@@ -756,7 +756,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.hide(to: "#modal")) ==
-               "[[&quot;hide&quot;,{&quot;to&quot;:&quot;#modal&quot;}]]"
+               ~S<[["hide",{"to":"#modal"}]]>
     end
   end
 
@@ -825,7 +825,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.transition("shake", to: "#modal")) ==
-               "[[&quot;transition&quot;,{&quot;to&quot;:&quot;#modal&quot;,&quot;transition&quot;:[[&quot;shake&quot;],[],[]]}]]"
+               ~S<[["transition",{"to":"#modal","transition":[["shake"],[],[]]}]]>
     end
   end
 
@@ -877,7 +877,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.set_attribute({"disabled", "true"})) ==
-               "[[&quot;set_attr&quot;,{&quot;attr&quot;:[&quot;disabled&quot;,&quot;true&quot;]}]]"
+               ~S<[["set_attr",{"attr":["disabled","true"]}]]>
     end
   end
 
@@ -919,7 +919,7 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.remove_attribute("disabled")) ==
-               "[[&quot;remove_attr&quot;,{&quot;attr&quot;:&quot;disabled&quot;}]]"
+               ~S<[["remove_attr",{"attr":"disabled"}]]>
     end
   end
 
@@ -982,10 +982,10 @@ defmodule Phoenix.LiveView.JSTest do
 
     test "encoding" do
       assert js_to_string(JS.toggle_attribute({"disabled", "true"})) ==
-               "[[&quot;toggle_attr&quot;,{&quot;attr&quot;:[&quot;disabled&quot;,&quot;true&quot;]}]]"
+               ~S<[["toggle_attr",{"attr":["disabled","true"]}]]>
 
       assert js_to_string(JS.toggle_attribute({"aria-expanded", "true", "false"})) ==
-               "[[&quot;toggle_attr&quot;,{&quot;attr&quot;:[&quot;aria-expanded&quot;,&quot;true&quot;,&quot;false&quot;]}]]"
+               ~S<[["toggle_attr",{"attr":["aria-expanded","true","false"]}]]>
     end
   end
 
@@ -1017,7 +1017,7 @@ defmodule Phoenix.LiveView.JSTest do
     end
 
     test "encoding" do
-      assert js_to_string(JS.focus()) == "[[&quot;focus&quot;,{}]]"
+      assert js_to_string(JS.focus()) == ~S<[["focus",{}]]>
     end
   end
 
@@ -1055,7 +1055,7 @@ defmodule Phoenix.LiveView.JSTest do
     end
 
     test "encoding" do
-      assert js_to_string(JS.focus_first()) == "[[&quot;focus_first&quot;,{}]]"
+      assert js_to_string(JS.focus_first()) == ~S<[["focus_first",{}]]>
     end
   end
 
@@ -1093,7 +1093,7 @@ defmodule Phoenix.LiveView.JSTest do
     end
 
     test "encoding" do
-      assert js_to_string(JS.push_focus()) == "[[&quot;push_focus&quot;,{}]]"
+      assert js_to_string(JS.push_focus()) == ~S<[["push_focus",{}]]>
     end
   end
 
@@ -1113,7 +1113,7 @@ defmodule Phoenix.LiveView.JSTest do
     end
 
     test "encoding" do
-      assert js_to_string(JS.pop_focus()) == "[[&quot;pop_focus&quot;,{}]]"
+      assert js_to_string(JS.pop_focus()) == ~S<[["pop_focus",{}]]>
     end
   end
 
@@ -1136,8 +1136,7 @@ defmodule Phoenix.LiveView.JSTest do
   defp js_to_string(%JS{} = js) do
     js
     |> Map.update!(:ops, &order_ops_map_keys/1)
-    |> Phoenix.HTML.Safe.to_iodata()
-    |> IO.iodata_to_binary()
+    |> JS.encode()
   end
 
   defp order_ops_map_keys(ops) when is_list(ops) do


### PR DESCRIPTION
The new `JS.encode/1` function transforms the `Phoenix.LiveView.JS` struct into a JSON-serializable value (a binary/string), such that it can be transmitted outside of HEEx templates.

See discussion https://elixirforum.com/t/make-js-t-a-public-data-structure-or-json-serializable/53870?u=rhcarvalho.

(alternative to #4044).