### PR TITLE
infinite scroll: add phx-viewport-overrun-target

### DIFF
--- a/assets/js/phoenix_live_view/constants.js
+++ b/assets/js/phoenix_live_view/constants.js
@@ -42,6 +42,7 @@ export const PHX_MAIN = "data-phx-main";
 export const PHX_ROOT_ID = "data-phx-root-id";
 export const PHX_VIEWPORT_TOP = "viewport-top";
 export const PHX_VIEWPORT_BOTTOM = "viewport-bottom";
+export const PHX_VIEWPORT_OVERRUN_TARGET = "viewport-overrun-target";
 export const PHX_TRIGGER_ACTION = "trigger-action";
 export const PHX_HAS_FOCUSED = "phx-has-focused";
 export const FOCUSABLE_INPUTS = [

--- a/assets/js/phoenix_live_view/hooks.js
+++ b/assets/js/phoenix_live_view/hooks.js
@@ -3,6 +3,7 @@ import {
   PHX_LIVE_FILE_UPDATED,
   PHX_PREFLIGHTED_REFS,
   PHX_UPLOAD_REF,
+  PHX_VIEWPORT_OVERRUN_TARGET,
 } from "./constants";
 
 import LiveUploader from "./live_uploader";
@@ -218,9 +219,8 @@ Hooks.InfiniteScroll = {
         scrollBefore = scrollNow;
         return pendingOp();
       }
-      const rect = this.scrollContainer
-        ? this.scrollContainer.firstElementChild.getBoundingClientRect()
-        : this.el.getBoundingClientRect();
+
+      const rect = this.findOverrunTarget();
       const topEvent = this.el.getAttribute(
         this.liveSocket.binding("viewport-top"),
       );
@@ -294,6 +294,24 @@ Hooks.InfiniteScroll = {
         }, remainingTime);
       }
     };
+  },
+
+  findOverrunTarget() {
+    let rect;
+    const overrunTarget = this.el.getAttribute(
+      this.liveSocket.binding(PHX_VIEWPORT_OVERRUN_TARGET),
+    );
+    if (overrunTarget) {
+      const overrunEl = document.getElementById(overrunTarget);
+      if (overrunEl) {
+        rect = overrunEl.getBoundingClientRect();
+      } else {
+        throw new Error("did not find element with id " + overrunTarget);
+      }
+    } else {
+      rect = this.el.getBoundingClientRect();
+    }
+    return rect;
   },
 };
 export default Hooks;


### PR DESCRIPTION
When using the phx-viewport bindings to build an infinite scroll table, the usual padding approach doesn't work on the table body itself, because table bodies don't act like regular block elements. To make this work, the table can be wrapped with an element that gets the padding applied, but we need to tell LiveView which element should be used to determine the `overran` event.

This PR adds a `phx-viewport-overrun-target` attribute that accepts the ID of the element that is used to determine the overran event.

Example of an infinite scroll table with this approach: https://gist.github.com/SteffenDE/613125993362e30443e58558aa3c8ba0