### PR TITLE
WIP: Relative Query Patching

### DIFF
--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -1,5 +1,6 @@
 import DOM from "./dom";
 import ARIA from "./aria";
+import { parseQueryOps } from "./utils";
 
 const focusStack = [];
 const default_transition_time = 200;
@@ -156,20 +157,21 @@ const JS = {
     }
   },
 
-  exec_navigate(e, eventType, phxEvent, view, sourceEl, el, { href, replace }) {
+  exec_navigate(e, eventType, phxEvent, view, sourceEl, el, { href, replace, query }) {
     view.liveSocket.historyRedirect(
       e,
-      href,
+      parseQueryOps(href, query ?? []),
       replace ? "replace" : "push",
       null,
       sourceEl,
     );
   },
 
-  exec_patch(e, eventType, phxEvent, view, sourceEl, el, { href, replace }) {
+  exec_patch(e, eventType, phxEvent, view, sourceEl, el, { href, replace, query }) {
+    console.log("JS().patch() called")
     view.liveSocket.pushHistoryPatch(
       e,
-      href,
+      parseQueryOps(href, query ?? []),
       replace ? "replace" : "push",
       sourceEl,
     );

--- a/assets/test/js_test.ts
+++ b/assets/test/js_test.ts
@@ -164,7 +164,7 @@ describe("JS", () => {
       js.navigate("/test-url");
       expect(view.liveSocket.historyRedirect).toHaveBeenCalledWith(
         expect.any(CustomEvent),
-        "/test-url",
+        "http://localhost/test-url",
         "push",
         null,
         null,
@@ -173,7 +173,269 @@ describe("JS", () => {
       js.navigate("/test-url", { replace: true });
       expect(view.liveSocket.historyRedirect).toHaveBeenCalledWith(
         expect.any(CustomEvent),
-        "/test-url",
+        "http://localhost/test-url",
+        "replace",
+        null,
+        null,
+      );
+
+      // Query Patching
+      js.navigate("?key1=val1", { replace: true });
+      expect(view.liveSocket.historyRedirect).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/?key1=val1",
+        "replace",
+        null,
+        null,
+      );
+
+      js.navigate("/test-url", {
+        replace: true,
+        query: [["set", [["key1", "val1"]]]],
+      });
+      expect(view.liveSocket.historyRedirect).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val1",
+        "replace",
+        null,
+        null,
+      );
+
+      js.navigate("?key1=val1", {
+        replace: true,
+        query: [["set", [["key1", "val2"]]]],
+      });
+      expect(view.liveSocket.historyRedirect).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/?key1=val2",
+        "replace",
+        null,
+        null,
+      );
+
+      js.navigate("/test-url?key1=val1", {
+        replace: true,
+        query: [["set", [["key1", "val2"]]]],
+      });
+      expect(view.liveSocket.historyRedirect).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val2",
+        "replace",
+        null,
+        null,
+      );
+
+      js.navigate("/test-url", {
+        replace: true,
+        query: [
+          [
+            "set",
+            [
+              ["key1", "val1"],
+              ["key2", "val2"],
+            ],
+          ],
+        ],
+      });
+      expect(view.liveSocket.historyRedirect).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val1&key2=val2",
+        "replace",
+        null,
+        null,
+      );
+
+      js.navigate("/test-url", {
+        replace: true,
+        query: [
+          [
+            "set",
+            [
+              ["key1", "val1"],
+              ["key1", "val2"],
+            ],
+          ],
+        ],
+      });
+      expect(view.liveSocket.historyRedirect).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val1&key1=val2",
+        "replace",
+        null,
+        null,
+      );
+
+      js.navigate("/test-url", {
+        replace: true,
+        query: [["set", [["key1", ["val1", "val2"]]]]],
+      });
+      expect(view.liveSocket.historyRedirect).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val1&key1=val2",
+        "replace",
+        null,
+        null,
+      );
+
+      js.navigate("/test-url?key1=val1", {
+        replace: true,
+        query: [
+          [
+            "merge",
+            [
+              ["key1", "val3"],
+              ["key2", "val2"],
+            ],
+          ],
+        ],
+      });
+      expect(view.liveSocket.historyRedirect).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val3&key2=val2",
+        "replace",
+        null,
+        null,
+      );
+
+      js.navigate("/test-url?key1=val1", {
+        replace: true,
+        query: [
+          [
+            "merge",
+            [
+              ["key1", ["val1", "val3"]],
+              ["key2", "val2"],
+            ],
+          ],
+        ],
+      });
+      expect(view.liveSocket.historyRedirect).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val1&key1=val3&key2=val2",
+        "replace",
+        null,
+        null,
+      );
+
+      js.navigate("/test-url?key1=val1", {
+        replace: true,
+        query: [["toggle", [["key1", "val1"]]]],
+      });
+      expect(view.liveSocket.historyRedirect).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url",
+        "replace",
+        null,
+        null,
+      );
+
+      js.navigate("/test-url", {
+        replace: true,
+        query: [["toggle", [["key1", "val1"]]]],
+      });
+      expect(view.liveSocket.historyRedirect).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val1",
+        "replace",
+        null,
+        null,
+      );
+
+      js.navigate("/test-url?key1=val1", {
+        replace: true,
+        query: [["toggle", [["key1", ["val1", "val2"]]]]],
+      });
+      expect(view.liveSocket.historyRedirect).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val2",
+        "replace",
+        null,
+        null,
+      );
+
+      js.navigate("/test-url?key1=val1", {
+        replace: true,
+        query: [["toggle", [["key1", "val2"]]]],
+      });
+      expect(view.liveSocket.historyRedirect).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val1&key1=val2",
+        "replace",
+        null,
+        null,
+      );
+
+      js.navigate("/test-url?key1=val1&key1=val2", {
+        replace: true,
+        query: [["toggle", [["key1", "val1"]]]],
+      });
+      expect(view.liveSocket.historyRedirect).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val2",
+        "replace",
+        null,
+        null,
+      );
+
+      js.navigate("/test-url?key1=val1", {
+        replace: true,
+        query: [
+          [
+            "add",
+            [
+              ["key1", "val3"],
+              ["key2", "val2"],
+            ],
+          ],
+        ],
+      });
+      expect(view.liveSocket.historyRedirect).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val1&key1=val3&key2=val2",
+        "replace",
+        null,
+        null,
+      );
+
+      js.navigate("/test-url?key1=val1&key2=val2&key3=val3", {
+        replace: true,
+        query: [["remove", ["key1", ["key2", "val2"], ["key3", "val4"]]]],
+      });
+      expect(view.liveSocket.historyRedirect).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key3=val3",
+        "replace",
+        null,
+        null,
+      );
+
+      js.navigate("/test-url?foo=bar", {
+        replace: true,
+        query: [
+          ["set", [["foo", "bar"]]],
+          [
+            "merge",
+            [
+              ["foo", "baz"],
+              ["lorem", "ipsum"],
+            ],
+          ],
+          [
+            "merge",
+            [
+              ["lorem", "ipsum"],
+              ["dolor", "sit"],
+            ],
+          ],
+          ["add", [["foo", "bar"]]],
+          ["add", [["foo", "baz"]]],
+          ["add", [["lorem", ["amet", "quid", "novi"]]]],
+          ["remove", ["foo", "lorem"]],
+        ],
+      });
+      expect(view.liveSocket.historyRedirect).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?dolor=sit",
         "replace",
         null,
         null,
@@ -190,7 +452,7 @@ describe("JS", () => {
       js.patch("/test-url");
       expect(view.liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
         expect.any(CustomEvent),
-        "/test-url",
+        "http://localhost/test-url",
         "push",
         null,
       );
@@ -198,7 +460,252 @@ describe("JS", () => {
       js.patch("/test-url", { replace: true });
       expect(view.liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
         expect.any(CustomEvent),
-        "/test-url",
+        "http://localhost/test-url",
+        "replace",
+        null,
+      );
+
+      // Query Patching
+      js.patch("?key1=val1", { replace: true });
+      expect(view.liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/?key1=val1",
+        "replace",
+        null,
+      );
+
+      js.patch("/test-url", {
+        replace: true,
+        query: [["set", [["key1", "val1"]]]],
+      });
+      expect(view.liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val1",
+        "replace",
+        null,
+      );
+
+      js.patch("?key1=val1", {
+        replace: true,
+        query: [["set", [["key1", "val2"]]]],
+      });
+      expect(view.liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/?key1=val2",
+        "replace",
+        null,
+      );
+
+      js.patch("/test-url?key1=val1", {
+        replace: true,
+        query: [["set", [["key1", "val2"]]]],
+      });
+      expect(view.liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val2",
+        "replace",
+        null,
+      );
+
+      js.patch("/test-url", {
+        replace: true,
+        query: [
+          [
+            "set",
+            [
+              ["key1", "val1"],
+              ["key2", "val2"],
+            ],
+          ],
+        ],
+      });
+      expect(view.liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val1&key2=val2",
+        "replace",
+        null,
+      );
+
+      js.patch("/test-url", {
+        replace: true,
+        query: [
+          [
+            "set",
+            [
+              ["key1", "val1"],
+              ["key1", "val2"],
+            ],
+          ],
+        ],
+      });
+      expect(view.liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val1&key1=val2",
+        "replace",
+        null,
+      );
+
+      js.patch("/test-url", {
+        replace: true,
+        query: [["set", [["key1", ["val1", "val2"]]]]],
+      });
+      expect(view.liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val1&key1=val2",
+        "replace",
+        null,
+      );
+
+      js.patch("/test-url?key1=val1", {
+        replace: true,
+        query: [
+          [
+            "merge",
+            [
+              ["key1", "val3"],
+              ["key2", "val2"],
+            ],
+          ],
+        ],
+      });
+      expect(view.liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val3&key2=val2",
+        "replace",
+        null,
+      );
+
+      js.patch("/test-url?key1=val1", {
+        replace: true,
+        query: [
+          [
+            "merge",
+            [
+              ["key1", ["val1", "val3"]],
+              ["key2", "val2"],
+            ],
+          ],
+        ],
+      });
+      expect(view.liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val1&key1=val3&key2=val2",
+        "replace",
+        null,
+      );
+
+      js.patch("/test-url?key1=val1", {
+        replace: true,
+        query: [["toggle", [["key1", "val1"]]]],
+      });
+      expect(view.liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url",
+        "replace",
+        null,
+      );
+
+      js.patch("/test-url", {
+        replace: true,
+        query: [["toggle", [["key1", "val1"]]]],
+      });
+      expect(view.liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val1",
+        "replace",
+        null,
+      );
+
+      js.patch("/test-url?key1=val1", {
+        replace: true,
+        query: [["toggle", [["key1", ["val1", "val2"]]]]],
+      });
+      expect(view.liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val2",
+        "replace",
+        null,
+      );
+
+      js.patch("/test-url?key1=val1", {
+        replace: true,
+        query: [["toggle", [["key1", "val2"]]]],
+      });
+      expect(view.liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val1&key1=val2",
+        "replace",
+        null,
+      );
+
+      js.patch("/test-url?key1=val1&key1=val2", {
+        replace: true,
+        query: [["toggle", [["key1", "val1"]]]],
+      });
+      expect(view.liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val2",
+        "replace",
+        null,
+      );
+
+      js.patch("/test-url?key1=val1", {
+        replace: true,
+        query: [
+          [
+            "add",
+            [
+              ["key1", "val3"],
+              ["key2", "val2"],
+            ],
+          ],
+        ],
+      });
+      expect(view.liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key1=val1&key1=val3&key2=val2",
+        "replace",
+        null,
+      );
+
+      js.patch("/test-url?key1=val1&key2=val2&key3=val3", {
+        replace: true,
+        query: [["remove", ["key1", ["key2", "val2"], ["key3", "val4"]]]],
+      });
+      expect(view.liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?key3=val3",
+        "replace",
+        null,
+      );
+
+      js.patch("/test-url?foo=bar", {
+        replace: true,
+        query: [
+          ["set", [["foo", "bar"]]],
+          [
+            "merge",
+            [
+              ["foo", "baz"],
+              ["lorem", "ipsum"],
+            ],
+          ],
+          [
+            "merge",
+            [
+              ["lorem", "ipsum"],
+              ["dolor", "sit"],
+            ],
+          ],
+          ["add", [["foo", "bar"]]],
+          ["add", [["foo", "baz"]]],
+          ["add", [["lorem", ["amet", "quid", "novi"]]]],
+          ["remove", ["foo", "lorem"]],
+        ],
+      });
+      expect(view.liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+        expect.any(CustomEvent),
+        "http://localhost/test-url?dolor=sit",
         "replace",
         null,
       );

--- a/assets/test/live_socket_test.ts
+++ b/assets/test/live_socket_test.ts
@@ -417,7 +417,7 @@ describe("liveSocket.js()", () => {
     js.navigate("/test-url");
     expect(liveSocket.historyRedirect).toHaveBeenCalledWith(
       expect.any(CustomEvent),
-      "/test-url",
+      "http://localhost/test-url",
       "push",
       null,
       null,
@@ -426,7 +426,269 @@ describe("liveSocket.js()", () => {
     js.navigate("/test-url", { replace: true });
     expect(liveSocket.historyRedirect).toHaveBeenCalledWith(
       expect.any(CustomEvent),
-      "/test-url",
+      "http://localhost/test-url",
+      "replace",
+      null,
+      null,
+    );
+
+    // Query Patching
+    js.navigate("?key1=val1", { replace: true });
+    expect(liveSocket.historyRedirect).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/?key1=val1",
+      "replace",
+      null,
+      null,
+    );
+
+    js.navigate("/test-url", {
+      replace: true,
+      query: [["set", [["key1", "val1"]]]],
+    });
+    expect(liveSocket.historyRedirect).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val1",
+      "replace",
+      null,
+      null,
+    );
+
+    js.navigate("?key1=val1", {
+      replace: true,
+      query: [["set", [["key1", "val2"]]]],
+    });
+    expect(liveSocket.historyRedirect).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/?key1=val2",
+      "replace",
+      null,
+      null,
+    );
+
+    js.navigate("/test-url?key1=val1", {
+      replace: true,
+      query: [["set", [["key1", "val2"]]]],
+    });
+    expect(liveSocket.historyRedirect).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val2",
+      "replace",
+      null,
+      null,
+    );
+
+    js.navigate("/test-url", {
+      replace: true,
+      query: [
+        [
+          "set",
+          [
+            ["key1", "val1"],
+            ["key2", "val2"],
+          ],
+        ],
+      ],
+    });
+    expect(liveSocket.historyRedirect).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val1&key2=val2",
+      "replace",
+      null,
+      null,
+    );
+
+    js.navigate("/test-url", {
+      replace: true,
+      query: [
+        [
+          "set",
+          [
+            ["key1", "val1"],
+            ["key1", "val2"],
+          ],
+        ],
+      ],
+    });
+    expect(liveSocket.historyRedirect).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val1&key1=val2",
+      "replace",
+      null,
+      null,
+    );
+
+    js.navigate("/test-url", {
+      replace: true,
+      query: [["set", [["key1", ["val1", "val2"]]]]],
+    });
+    expect(liveSocket.historyRedirect).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val1&key1=val2",
+      "replace",
+      null,
+      null,
+    );
+
+    js.navigate("/test-url?key1=val1", {
+      replace: true,
+      query: [
+        [
+          "merge",
+          [
+            ["key1", "val3"],
+            ["key2", "val2"],
+          ],
+        ],
+      ],
+    });
+    expect(liveSocket.historyRedirect).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val3&key2=val2",
+      "replace",
+      null,
+      null,
+    );
+
+    js.navigate("/test-url?key1=val1", {
+      replace: true,
+      query: [
+        [
+          "merge",
+          [
+            ["key1", ["val1", "val3"]],
+            ["key2", "val2"],
+          ],
+        ],
+      ],
+    });
+    expect(liveSocket.historyRedirect).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val1&key1=val3&key2=val2",
+      "replace",
+      null,
+      null,
+    );
+
+    js.navigate("/test-url?key1=val1", {
+      replace: true,
+      query: [["toggle", [["key1", "val1"]]]],
+    });
+    expect(liveSocket.historyRedirect).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url",
+      "replace",
+      null,
+      null,
+    );
+
+    js.navigate("/test-url", {
+      replace: true,
+      query: [["toggle", [["key1", "val1"]]]],
+    });
+    expect(liveSocket.historyRedirect).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val1",
+      "replace",
+      null,
+      null,
+    );
+
+    js.navigate("/test-url?key1=val1", {
+      replace: true,
+      query: [["toggle", [["key1", ["val1", "val2"]]]]],
+    });
+    expect(liveSocket.historyRedirect).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val2",
+      "replace",
+      null,
+      null,
+    );
+
+    js.navigate("/test-url?key1=val1", {
+      replace: true,
+      query: [["toggle", [["key1", "val2"]]]],
+    });
+    expect(liveSocket.historyRedirect).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val1&key1=val2",
+      "replace",
+      null,
+      null,
+    );
+
+    js.navigate("/test-url?key1=val1&key1=val2", {
+      replace: true,
+      query: [["toggle", [["key1", "val1"]]]],
+    });
+    expect(liveSocket.historyRedirect).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val2",
+      "replace",
+      null,
+      null,
+    );
+
+    js.navigate("/test-url?key1=val1", {
+      replace: true,
+      query: [
+        [
+          "add",
+          [
+            ["key1", "val3"],
+            ["key2", "val2"],
+          ],
+        ],
+      ],
+    });
+    expect(liveSocket.historyRedirect).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val1&key1=val3&key2=val2",
+      "replace",
+      null,
+      null,
+    );
+
+    js.navigate("/test-url?key1=val1&key2=val2&key3=val3", {
+      replace: true,
+      query: [["remove", ["key1", ["key2", "val2"], ["key3", "val4"]]]],
+    });
+    expect(liveSocket.historyRedirect).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key3=val3",
+      "replace",
+      null,
+      null,
+    );
+
+    js.navigate("/test-url?foo=bar", {
+      replace: true,
+      query: [
+        ["set", [["foo", "bar"]]],
+        [
+          "merge",
+          [
+            ["foo", "baz"],
+            ["lorem", "ipsum"],
+          ],
+        ],
+        [
+          "merge",
+          [
+            ["lorem", "ipsum"],
+            ["dolor", "sit"],
+          ],
+        ],
+        ["add", [["foo", "bar"]]],
+        ["add", [["foo", "baz"]]],
+        ["add", [["lorem", ["amet", "quid", "novi"]]]],
+        ["remove", ["foo", "lorem"]],
+      ],
+    });
+    expect(liveSocket.historyRedirect).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?dolor=sit",
       "replace",
       null,
       null,
@@ -442,7 +704,7 @@ describe("liveSocket.js()", () => {
     js.patch("/test-url");
     expect(liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
       expect.any(CustomEvent),
-      "/test-url",
+      "http://localhost/test-url",
       "push",
       null,
     );
@@ -450,7 +712,252 @@ describe("liveSocket.js()", () => {
     js.patch("/test-url", { replace: true });
     expect(liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
       expect.any(CustomEvent),
-      "/test-url",
+      "http://localhost/test-url",
+      "replace",
+      null,
+    );
+
+    // Query Patching
+    js.patch("?key1=val1", { replace: true });
+    expect(liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/?key1=val1",
+      "replace",
+      null,
+    );
+
+    js.patch("/test-url", {
+      replace: true,
+      query: [["set", [["key1", "val1"]]]],
+    });
+    expect(liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val1",
+      "replace",
+      null,
+    );
+
+    js.patch("?key1=val1", {
+      replace: true,
+      query: [["set", [["key1", "val2"]]]],
+    });
+    expect(liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/?key1=val2",
+      "replace",
+      null,
+    );
+
+    js.patch("/test-url?key1=val1", {
+      replace: true,
+      query: [["set", [["key1", "val2"]]]],
+    });
+    expect(liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val2",
+      "replace",
+      null,
+    );
+
+    js.patch("/test-url", {
+      replace: true,
+      query: [
+        [
+          "set",
+          [
+            ["key1", "val1"],
+            ["key2", "val2"],
+          ],
+        ],
+      ],
+    });
+    expect(liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val1&key2=val2",
+      "replace",
+      null,
+    );
+
+    js.patch("/test-url", {
+      replace: true,
+      query: [
+        [
+          "set",
+          [
+            ["key1", "val1"],
+            ["key1", "val2"],
+          ],
+        ],
+      ],
+    });
+    expect(liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val1&key1=val2",
+      "replace",
+      null,
+    );
+
+    js.patch("/test-url", {
+      replace: true,
+      query: [["set", [["key1", ["val1", "val2"]]]]],
+    });
+    expect(liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val1&key1=val2",
+      "replace",
+      null,
+    );
+
+    js.patch("/test-url?key1=val1", {
+      replace: true,
+      query: [
+        [
+          "merge",
+          [
+            ["key1", "val3"],
+            ["key2", "val2"],
+          ],
+        ],
+      ],
+    });
+    expect(liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val3&key2=val2",
+      "replace",
+      null,
+    );
+
+    js.patch("/test-url?key1=val1", {
+      replace: true,
+      query: [
+        [
+          "merge",
+          [
+            ["key1", ["val1", "val3"]],
+            ["key2", "val2"],
+          ],
+        ],
+      ],
+    });
+    expect(liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val1&key1=val3&key2=val2",
+      "replace",
+      null,
+    );
+
+    js.patch("/test-url?key1=val1", {
+      replace: true,
+      query: [["toggle", [["key1", "val1"]]]],
+    });
+    expect(liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url",
+      "replace",
+      null,
+    );
+
+    js.patch("/test-url", {
+      replace: true,
+      query: [["toggle", [["key1", "val1"]]]],
+    });
+    expect(liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val1",
+      "replace",
+      null,
+    );
+
+    js.patch("/test-url?key1=val1", {
+      replace: true,
+      query: [["toggle", [["key1", ["val1", "val2"]]]]],
+    });
+    expect(liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val2",
+      "replace",
+      null,
+    );
+
+    js.patch("/test-url?key1=val1", {
+      replace: true,
+      query: [["toggle", [["key1", "val2"]]]],
+    });
+    expect(liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val1&key1=val2",
+      "replace",
+      null,
+    );
+
+    js.patch("/test-url?key1=val1&key1=val2", {
+      replace: true,
+      query: [["toggle", [["key1", "val1"]]]],
+    });
+    expect(liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val2",
+      "replace",
+      null,
+    );
+
+    js.patch("/test-url?key1=val1", {
+      replace: true,
+      query: [
+        [
+          "add",
+          [
+            ["key1", "val3"],
+            ["key2", "val2"],
+          ],
+        ],
+      ],
+    });
+    expect(liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key1=val1&key1=val3&key2=val2",
+      "replace",
+      null,
+    );
+
+    js.patch("/test-url?key1=val1&key2=val2&key3=val3", {
+      replace: true,
+      query: [["remove", ["key1", ["key2", "val2"], ["key3", "val4"]]]],
+    });
+    expect(liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?key3=val3",
+      "replace",
+      null,
+    );
+
+    js.patch("/test-url?foo=bar", {
+      replace: true,
+      query: [
+        ["set", [["foo", "bar"]]],
+        [
+          "merge",
+          [
+            ["foo", "baz"],
+            ["lorem", "ipsum"],
+          ],
+        ],
+        [
+          "merge",
+          [
+            ["lorem", "ipsum"],
+            ["dolor", "sit"],
+          ],
+        ],
+        ["add", [["foo", "bar"]]],
+        ["add", [["foo", "baz"]]],
+        ["add", [["lorem", ["amet", "quid", "novi"]]]],
+        ["remove", ["foo", "lorem"]],
+      ],
+    });
+    expect(liveSocket.pushHistoryPatch).toHaveBeenCalledWith(
+      expect.any(CustomEvent),
+      "http://localhost/test-url?dolor=sit",
       "replace",
       null,
     );


### PR DESCRIPTION
This is the first draft of the document-relative query param patching described in: https://elixirforum.com/t/add-params-opt-to-js-patch-and-js-navigate-and-opt-to-merge-phx-value/69743/11

In addition to the keys mentioned in that thread, I also added a `:toggle` operation that toggles a matching key value pair in the query params. This is a very useful operation for the sorting and filtering logic I currently use on my website, and I imagine it would be helpful to have built-in to liveview.

I am opening this PR as a draft in case anyone wants to take an early look at it and give feedback on the API design, but I haven't been able to test anything e2e yet, so it's not ready for formal review.

e2e tests are failing on main branch when I clone the repo fresh, and I haven't figured out how to get the built assets to get used when pointing a project at the local branch with the `:path` option in mix.exs, so I haven't been able to test this feature out on an actual website yet either.

I added some unit tests for the `JS.patch` and `JS.navigate` javascript functions, and everything is passing, so I think the query param parsing logic is working as expected client-side. I just need to test everything e2e and refine the API.