### PR TITLE
Make bug report template easier to fill

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,10 +26,6 @@ assignees: ''
 ```
 
 ```
-* Does the problem persist after removing "assets/node_modules" and trying again?
-- [ ] Yes
-- [ ] No
-- [ ] Not applicable
 
 ### Actual behavior
 


### PR DESCRIPTION
This is an attempt to make it easier for users to fill out the bug report template by requiring less edits to copy-paste the relevant information.

Hopefully, this translates into better reports that deviate less from the template and less friction for maintainers to triage issues.