### PR TITLE
Allow live_file_input to sync non-data attributes except value

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -520,18 +520,23 @@ const DOM = {
   // merge attributes from source to target
   // if an element is ignored, we only merge data attributes
   // including removing data attributes that are no longer in the source
+  // for upload inputs, we merge all attributes except value to preserve file selection
   mergeAttrs(target, source, opts = {}) {
     const exclude = new Set(opts.exclude || []);
     const isIgnored = opts.isIgnored;
+    const isUploadInput = opts.isUploadInput;
     const sourceAttrs = source.attributes;
     for (let i = sourceAttrs.length - 1; i >= 0; i--) {
       const name = sourceAttrs[i].name;
       if (!exclude.has(name)) {
         const sourceValue = source.getAttribute(name);
-        if (
-          target.getAttribute(name) !== sourceValue &&
-          (!isIgnored || (isIgnored && name.startsWith("data-")))
-        ) {
+        // For upload inputs: sync all attrs except value (to preserve file selection)
+        // For regular ignored elements: only sync data-* attrs
+        const shouldSync =
+          !isIgnored ||
+          name.startsWith("data-") ||
+          (isUploadInput && name !== "value");
+        if (target.getAttribute(name) !== sourceValue && shouldSync) {
           target.setAttribute(name, sourceValue);
         }
       } else {
@@ -556,7 +561,16 @@ const DOM = {
     for (let i = targetAttrs.length - 1; i >= 0; i--) {
       const name = targetAttrs[i].name;
       if (isIgnored) {
-        if (
+        if (isUploadInput) {
+          // For upload inputs: remove attrs not in source (except value and pending attrs)
+          if (
+            !source.hasAttribute(name) &&
+            !PHX_PENDING_ATTRS.includes(name) &&
+            name !== "value"
+          ) {
+            target.removeAttribute(name);
+          }
+        } else if (
           name.startsWith("data-") &&
           !source.hasAttribute(name) &&
           !PHX_PENDING_ATTRS.includes(name)

--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -334,6 +334,7 @@ export default class DOMPatch {
             this.trackBefore("updated", fromEl, toEl);
             DOM.mergeAttrs(fromEl, toEl, {
               isIgnored: DOM.isIgnored(fromEl, phxUpdate),
+              isUploadInput: DOM.isUploadInput(fromEl),
             });
             updates.push(fromEl);
             DOM.applyStickyOperations(fromEl);
@@ -364,7 +365,10 @@ export default class DOMPatch {
               (!this.undoRef || !ref.isLockUndoneBy(this.undoRef))
             ) {
               if (DOM.isUploadInput(fromEl)) {
-                DOM.mergeAttrs(fromEl, toEl, { isIgnored: true });
+                DOM.mergeAttrs(fromEl, toEl, {
+                  isIgnored: true,
+                  isUploadInput: true,
+                });
                 this.trackBefore("updated", fromEl, toEl);
                 updates.push(fromEl);
               }

--- a/test/e2e/support/issues/issue_4078.ex
+++ b/test/e2e/support/issues/issue_4078.ex
@@ -1,0 +1,63 @@
+defmodule Phoenix.LiveViewTest.E2E.Issue4078Live do
+  # https://github.com/phoenixframework/phoenix_live_view/issues/4078
+  #
+  # live_file_input uses data-phx-update="ignore" to preserve file selection,
+  # but this was blocking updates to attributes like class, disabled, and style.
+  # This test verifies these attributes can now be changed dynamically.
+  use Phoenix.LiveView, layout: {__MODULE__, :live}
+
+  def render("live.html", assigns) do
+    ~H"""
+    <meta name="csrf-token" content={Plug.CSRFProtection.get_csrf_token()} />
+    <script src="/assets/phoenix/phoenix.min.js">
+    </script>
+    <script type="module">
+      import {LiveSocket} from "/assets/phoenix_live_view/phoenix_live_view.esm.js"
+      let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
+      let liveSocket = new LiveSocket("/live", window.Phoenix.Socket, {
+        params: {_csrf_token: csrfToken},
+      })
+      liveSocket.connect()
+    </script>
+    {@inner_content}
+    """
+  end
+
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:disabled?, true)
+     |> assign(:custom_class, "initial-class")
+     |> allow_upload(:avatar, accept: ~w(.jpg .jpeg .png .txt), max_entries: 2)}
+  end
+
+  def handle_event("validate", _params, socket), do: {:noreply, socket}
+
+  def handle_event("toggle-disabled", _params, socket) do
+    {:noreply, assign(socket, :disabled?, !socket.assigns.disabled?)}
+  end
+
+  def handle_event("toggle-class", _params, socket) do
+    new_class =
+      if socket.assigns.custom_class == "initial-class",
+        do: "updated-class",
+        else: "initial-class"
+
+    {:noreply, assign(socket, :custom_class, new_class)}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <form id="upload-form" phx-change="validate">
+      <.live_file_input upload={@uploads.avatar} disabled={@disabled?} class={@custom_class} />
+    </form>
+
+    <button id="toggle-disabled" type="button" phx-click="toggle-disabled">Toggle Disabled</button>
+    <button id="toggle-class" type="button" phx-click="toggle-class">Toggle Class</button>
+
+    <article :for={entry <- @uploads.avatar.entries} class="upload-entry">
+      <span class="entry-name">{entry.client_name}</span>
+    </article>
+    """
+  end
+end

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -244,6 +244,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/3681", Issue3681Live
       live "/3681/away", Issue3681.AwayLive
       live "/3941", Issue3941Live
+      live "/4078", Issue4078Live
     end
 
     post "/submit", SubmitController, :submit

--- a/test/e2e/tests/issues/4078.spec.js
+++ b/test/e2e/tests/issues/4078.spec.js
@@ -1,0 +1,92 @@
+import { test, expect } from "../../test-fixtures";
+import { syncLV } from "../../utils";
+
+// https://github.com/phoenixframework/phoenix_live_view/issues/4078
+// live_file_input should respect changing assigns like disabled and class
+
+test("live_file_input respects disabled attribute changes", async ({
+  page,
+}) => {
+  await page.goto("/issues/4078");
+  await syncLV(page);
+
+  const input = page.locator("#upload-form input[type='file']");
+
+  // Initially disabled
+  await expect(input).toBeDisabled();
+
+  // Click to enable
+  await page.locator("#toggle-disabled").click();
+  await syncLV(page);
+
+  // Should now be enabled
+  await expect(input).not.toBeDisabled();
+
+  // Click to disable again
+  await page.locator("#toggle-disabled").click();
+  await syncLV(page);
+
+  // Should be disabled again
+  await expect(input).toBeDisabled();
+});
+
+test("live_file_input respects class attribute changes", async ({ page }) => {
+  await page.goto("/issues/4078");
+  await syncLV(page);
+
+  const input = page.locator("#upload-form input[type='file']");
+
+  // Initially has initial-class
+  await expect(input).toHaveClass(/initial-class/);
+
+  // Click to change class
+  await page.locator("#toggle-class").click();
+  await syncLV(page);
+
+  // Should have updated-class
+  await expect(input).toHaveClass(/updated-class/);
+
+  // Click to change class back
+  await page.locator("#toggle-class").click();
+  await syncLV(page);
+
+  // Should have initial-class again
+  await expect(input).toHaveClass(/initial-class/);
+});
+
+test("live_file_input preserves files when attributes change", async ({
+  page,
+}) => {
+  await page.goto("/issues/4078");
+  await syncLV(page);
+
+  // First enable the input
+  await page.locator("#toggle-disabled").click();
+  await syncLV(page);
+
+  const input = page.locator("#upload-form input[type='file']");
+  await expect(input).not.toBeDisabled();
+
+  // Select a file
+  await input.setInputFiles({
+    name: "test.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("test content"),
+  });
+  await syncLV(page);
+
+  // Verify file is selected (entry should appear)
+  await expect(page.locator(".upload-entry")).toBeVisible();
+  await expect(page.locator(".entry-name")).toContainText("test.txt");
+
+  // Change class attribute - file should remain selected
+  await page.locator("#toggle-class").click();
+  await syncLV(page);
+
+  // Verify file is still selected after class change
+  await expect(page.locator(".upload-entry")).toBeVisible();
+  await expect(page.locator(".entry-name")).toContainText("test.txt");
+
+  // Verify class was changed
+  await expect(input).toHaveClass(/updated-class/);
+});


### PR DESCRIPTION
Modified mergeAttrs to accept isUploadInput option that allows syncing all attributes except value for upload inputs.

Does it makes sense?
Discussion in https://github.com/phoenixframework/phoenix_live_view/issues/4078