### PR TITLE
Adds JS commands to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ $ mix test
 
 Running all JavaScript tests:
 ```bash
+$ npm install
 $ npm run setup
 $ npm run test
 ```
@@ -218,6 +219,13 @@ Checking test coverage:
 ```bash
 $ npm run cover
 $ npm run cover:report
+```
+
+Format the files:
+
+```bash
+$ mix format
+$ npm run js:format
 ```
 
 JS contributions are very welcome, but please do not include an updated `priv/static/phoenix_live_view.js` in pull requests. The maintainers will update it as part of the release process.


### PR DESCRIPTION
I added commands for formatting the code and also added the `npm install` step to running the JS tests since the Elixir command block also includes `mix deps.get` and it might be non-obvious to do that step first for folks like me with zero JS expertise :D