### PR TITLE
Fix JS error when socket is disconnect during patch redirect

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.js
+++ b/assets/js/phoenix_live_view/live_socket.js
@@ -1025,7 +1025,11 @@ export default class LiveSocket {
 
     this.withPageLoading({ to: href, kind: "patch" }, (done) => {
       this.main.pushLinkPatch(e, href, targetEl, (linkRef) => {
-        this.historyPatch(href, linkState, linkRef);
+        if (!this.isConnected() || !this.main.isMain()) {
+          return Browser.redirect(href);
+        } else {
+          this.historyPatch(href, linkState, linkRef);
+        }
         done();
       });
     });


### PR DESCRIPTION
In the project I'm working on we're getting some `Cannot read properties of null (reading 'id')` errors in the [historyRedirect](https://github.com/phoenixframework/phoenix_live_view/blob/936787fba53764fbfe5d5d12924d334936c356fc/priv/static/phoenix_live_view.js#L6695-L6704) function.

This error happens when we disconnect and redirect the user in `handle_params`. In my tests, when `pushHistoryPatch` is called in this situation the socket was still connected, but it was disconnected when `pushLinkPatch` callback was called. 

To fix the issue this PR updates `pushHistoryPatch` to do the connected check again in the `pushLinkPatch` callback. 