### PR TITLE
[fix-4093] update window.location before hook callbacks on push_patch

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -2121,8 +2121,8 @@ export default class View {
             if (this.liveSocket.commitPendingLink(linkRef)) {
               this.href = href;
             }
-            this.applyPendingUpdates();
             callback && callback(linkRef);
+            this.applyPendingUpdates();
           }
         });
       },

--- a/test/e2e/support/issues/issue_4093.ex
+++ b/test/e2e/support/issues/issue_4093.ex
@@ -1,0 +1,34 @@
+defmodule Phoenix.LiveViewTest.E2E.Issue4093Live do
+  # https://github.com/phoenixframework/phoenix_live_view/issues/4093
+  # Verifies that JS.patch updates window.location BEFORE hooks' updated() is called.
+  use Phoenix.LiveView
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, counter: 0)}
+  end
+
+  def handle_params(_params, _uri, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event("patch", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(counter: socket.assigns.counter + 1)
+     |> push_patch(to: "/issues/4093?patched=true")}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <script :type={Phoenix.LiveView.ColocatedHook} name=".UrlTracker">
+      export default {
+        updated() {
+          this.el.setAttribute("data-url-in-updated", window.location.href);
+        }
+      }
+    </script>
+    <div id="tracker" phx-hook=".UrlTracker" data-counter={@counter}></div>
+    <button phx-click="patch">Patch</button>
+    """
+  end
+end

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -203,6 +203,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/3979", Issue3979Live
       live "/4027", Issue4027Live
       live "/4066", Issue4066Live
+      live "/4093", Issue4093Live
     end
   end
 

--- a/test/e2e/tests/issues/4093.spec.js
+++ b/test/e2e/tests/issues/4093.spec.js
@@ -1,0 +1,29 @@
+import { test, expect } from "../../test-fixtures";
+import { syncLV } from "../../utils";
+
+// https://github.com/phoenixframework/phoenix_live_view/issues/4093
+// Verifies that JS.patch updates window.location BEFORE hooks' updated() is called.
+test("hook updated() sees new URL after push_patch", async ({ page }) => {
+  await page.goto("/issues/4093");
+  await syncLV(page);
+
+  // Verify initial state - no patched query param
+  await expect(page).toHaveURL(/\/issues\/4093$/);
+  await expect(page.locator("#tracker")).not.toHaveAttribute(
+    "data-url-in-updated",
+  );
+
+  // Click button which triggers push_patch and updates the hook's content
+  await page.locator("button").click();
+  await syncLV(page);
+
+  // URL should be updated
+  await expect(page).toHaveURL(/\/issues\/4093\?patched=true/);
+
+  // The hook's updated() callback should have seen the NEW URL, not the old one
+  const urlInUpdated = await page
+    .locator("#tracker")
+    .getAttribute("data-url-in-updated");
+
+  expect(urlInUpdated).toMatch(/\/issues\/4093\?patched=true/);
+});


### PR DESCRIPTION
  Changes:
  - view.js: Swapped applyPendingUpdates() to run after callback, ensuring window.location reflects patched URL when hooks' updated() fires
  - Added e2e test verifying hook sees new URL in updated() callback

Discussion #4093 