### PR TITLE
check children for PHX-SKIP as well

### DIFF
--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -750,7 +750,16 @@ export default class DOMPatch {
     // the case here
     const toTeleport = el.content.firstElementChild;
     // the PHX_SKIP optimization can also apply inside of the <template> elements
-    if (this.skipCIDSibling(toTeleport)) {
+    const isSkipped = this.skipCIDSibling(toTeleport);
+    // Check if all children have skip - if so, we should preserve existing DOM
+    const allChildrenSkipped =
+      !isSkipped &&
+      toTeleport.children.length > 0 &&
+      Array.from(toTeleport.children).every((child) =>
+        this.skipCIDSibling(child),
+      );
+
+    if (isSkipped || allChildrenSkipped) {
       return;
     }
     if (!toTeleport?.id) {


### PR DESCRIPTION
In a short test this fixes https://github.com/phoenixframework/phoenix_live_view/issues/4095

But I suspect the root cause lies somewhere else. Just want to document my findings and will update the PR as I will dig deeper.

EDIT: this only works for the first level of children and not deeply nested nodes