### PR TITLE
view_hook.ts: Allow Hooks with type parameters in HooksOptions

### DIFF
--- a/assets/js/phoenix_live_view/view_hook.ts
+++ b/assets/js/phoenix_live_view/view_hook.ts
@@ -464,6 +464,6 @@ export class ViewHook<E extends HTMLElement = HTMLElement>
   }
 }
 
-export type HooksOptions = Record<string, typeof ViewHook | Hook>;
+export type HooksOptions = Record<string, typeof ViewHook | Hook<any, any>>;
 
 export default ViewHook;


### PR DESCRIPTION
`HooksOptions` should accept `Hook` types with type parameters that differ from the defaults.