### PR TITLE
Use `form.element.namedItem` to track associated inputs.

### DIFF
--- a/assets/js/phoenix_live_view/dom.js
+++ b/assets/js/phoenix_live_view/dom.js
@@ -354,9 +354,13 @@ const DOM = {
         if (form && this.once(form, "bind-debounce")) {
           form.addEventListener("submit", () => {
             Array.from(new FormData(form).entries(), ([name]) => {
-              const input = form.querySelector(`[name="${name}"]`);
-              this.incCycle(input, DEBOUNCE_TRIGGER);
-              this.deletePrivate(input, THROTTLED);
+              const namedItem = form.elements.namedItem(name);
+              const input =
+                namedItem instanceof RadioNodeList ? namedItem[0] : namedItem;
+              if (input) {
+                this.incCycle(input, DEBOUNCE_TRIGGER);
+                this.deletePrivate(input, THROTTLED);
+              }
             });
           });
         }


### PR DESCRIPTION
Closes #4102. A couple tests are failing, but they were already failing when I first cloned the repo.

Before, it was required that all form elements be nested under the form. However, forms are allowed to have inputs located elsewhere as long as they use the `form="my-form-id"` attribute.

This changes it to use `form.elements.namedItem(name)`. `form.elements` is already used in `resetForm` so this change is consistent with existing code.

Note that radio/checkboxes with the same names will return a list, whereas `querySelector` only returned the first result, so I'm only matching on the first element to match existing behavior. I'm not familiar enough with what exactly `incCycle`/`deletePrivate` are doing, but I can update this to run those functions on all matching elements if needed.