### PR TITLE
example should use ast_to_string

### DIFF
--- a/lib/phoenix_component/macro_component.ex
+++ b/lib/phoenix_component/macro_component.ex
@@ -70,7 +70,7 @@ defmodule Phoenix.Component.MacroComponent do
   #
   #     @impl true
   #     def transform({"pre", attrs, children}, _meta) do
-  #       markdown = Phoenix.Component.MacroComponent.to_string(children)
+  #       markdown = Phoenix.Component.MacroComponent.ast_to_string(children)
   #       html_doc = MDEx.to_html!(markdown)
   #
   #       {:ok, {"div", attrs, [html_doc]}}


### PR DESCRIPTION
Having said this, I think some other things need to be changed as well to make the example working again, the transform tuple seems to take 4 params, similar to the return tuple.