### PR TITLE
handle redirects in handle_params for patch navigation (closes #4094)

### DIFF
--- a/assets/js/phoenix_live_view/view.js
+++ b/assets/js/phoenix_live_view/view.js
@@ -2117,6 +2117,9 @@ export default class View {
         this.liveSocket.requestDOMUpdate(() => {
           if (resp.link_redirect) {
             this.liveSocket.replaceMain(href, null, callback, linkRef);
+          } else if (resp.redirect) {
+            // handled by bindChannel
+            return;
           } else {
             if (this.liveSocket.commitPendingLink(linkRef)) {
               this.href = href;

--- a/test/e2e/support/issues/issue_4094.ex
+++ b/test/e2e/support/issues/issue_4094.ex
@@ -1,0 +1,21 @@
+defmodule Phoenix.LiveViewTest.E2E.Issue4094Live do
+  use Phoenix.LiveView, layout: {__MODULE__, :live}
+
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  def handle_params(params, _uri, socket) do
+    if params["foo"] == "bar" do
+      {:noreply, redirect(socket, to: "/navigation/a")}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def render(assigns) do
+    ~H"""
+    <.link patch="/issues/4094?foo=bar">Patch</.link>
+    """
+  end
+end

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -203,6 +203,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/3979", Issue3979Live
       live "/4027", Issue4027Live
       live "/4066", Issue4066Live
+      live "/4094", Issue4094Live
     end
   end
 

--- a/test/e2e/tests/issues/4094.spec.js
+++ b/test/e2e/tests/issues/4094.spec.js
@@ -1,0 +1,20 @@
+import { test, expect } from "../../test-fixtures";
+import { syncLV } from "../../utils";
+
+// https://github.com/phoenixframework/phoenix_live_view/issues/4094
+test("no errors when handle_params redirects", async ({ page }) => {
+  const jsErrors = [];
+  page.on("pageerror", (error) => {
+    jsErrors.push(error.message);
+  });
+
+  await page.goto("/issues/4094");
+  await syncLV(page);
+
+  // Clicking a link that redirects in handle_params would throw an exception
+  // on the client.
+  await page.click("a");
+
+  await expect(page).toHaveURL("/navigation/a");
+  expect(jsErrors).toHaveLength(0);
+});


### PR DESCRIPTION
Closes #4094.