### PR TITLE
add compile function to Phoenix.LiveView.TagEngine

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -917,17 +917,13 @@ defmodule Phoenix.Component do
       raise "~H requires a variable named \"assigns\" to exist and be set to a map"
     end
 
-    options = [
-      engine: Phoenix.LiveView.TagEngine,
+    Phoenix.LiveView.TagEngine.compile(expr,
       file: __CALLER__.file,
       line: __CALLER__.line + 1,
       caller: __CALLER__,
       indentation: meta[:indentation] || 0,
-      source: expr,
       tag_handler: Phoenix.LiveView.HTMLEngine
-    ]
-
-    EEx.compile_string(expr, options)
+    )
   end
 
   @doc ~S'''

--- a/lib/phoenix_live_view/tag_engine.ex
+++ b/lib/phoenix_live_view/tag_engine.ex
@@ -1,15 +1,14 @@
 defmodule Phoenix.LiveView.TagEngine do
   @moduledoc """
-  An EEx engine that understands tags.
+  Building blocks for tag based `Phoenix.Template.Engine`s.
 
   This cannot be directly used by Phoenix applications.
-  Instead, it is the building block by engines such as
+  Instead, it is the building block for engines such as
   `Phoenix.LiveView.HTMLEngine`.
 
   It is typically invoked like this:
 
-      EEx.compile_string(source,
-        engine: Phoenix.LiveView.TagEngine,
+      Phoenix.LiveView.TagEngine.compile(source,
         line: 1,
         file: path,
         caller: __CALLER__,
@@ -19,6 +18,35 @@ defmodule Phoenix.LiveView.TagEngine do
 
   Where `:tag_handler` implements the behaviour defined by this module.
   """
+
+  @doc """
+  Compiles the given string into Elixir AST.
+
+  The accepted options are:
+
+    * `tag_handler` - Required. The module implementing the `Phoenix.LiveView.TagEngine` behavior.
+    * `caller` - Required. The `Macro.Env`.
+    * `line` - the starting line offset. Defaults to 1.
+    * `file` - the file of the template. Defaults to `"nofile"`.
+    * `indentation` - the indentation of the template. Defaults to 0.
+
+  """
+  def compile(source, options) do
+    options =
+      Keyword.validate!(options, [
+        :caller,
+        :tag_handler,
+        line: 1,
+        indentation: 0,
+        file: "nofile"
+      ])
+      |> Keyword.merge(
+        engine: Phoenix.LiveView.TagEngine,
+        source: source
+      )
+
+    EEx.compile_string(source, options)
+  end
 
   @doc """
   Classify the tag type from the given binary.

--- a/test/phoenix_component/macro_component_integration_test.exs
+++ b/test/phoenix_component/macro_component_integration_test.exs
@@ -347,13 +347,9 @@ defmodule Phoenix.Component.MacroComponentIntegrationTest do
   end
 
   defp eval_heex(source) do
-    EEx.compile_string(source,
-      engine: Phoenix.LiveView.TagEngine,
-      line: 1,
+    Phoenix.LiveView.TagEngine.compile(source,
       file: __ENV__.file,
-      trim: true,
       caller: __ENV__,
-      source: source,
       tag_handler: Phoenix.LiveView.HTMLEngine
     )
     |> Code.eval_quoted(assigns: %{})

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -13,14 +13,11 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
     opts =
       Keyword.merge(opts,
         file: env.file,
-        engine: Phoenix.LiveView.TagEngine,
-        subengine: Phoenix.LiveView.Engine,
         caller: env,
-        source: string,
         tag_handler: Phoenix.LiveView.HTMLEngine
       )
 
-    quoted = EEx.compile_string(string, opts)
+    quoted = Phoenix.LiveView.TagEngine.compile(string, opts)
 
     {result, _} = Code.eval_quoted(quoted, [assigns: assigns], env)
     result
@@ -36,12 +33,9 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
   defmacrop compile(string) do
     quote do
       unquote(
-        EEx.compile_string(string,
+        Phoenix.LiveView.TagEngine.compile(string,
           file: __ENV__.file,
-          engine: Phoenix.LiveView.TagEngine,
-          module: __MODULE__,
           caller: __CALLER__,
-          source: string,
           tag_handler: Phoenix.LiveView.HTMLEngine
         )
       )


### PR DESCRIPTION
This abstracts away the fact that the TagEngine is an EEx.Engine, as that may change in the future.