### PR TITLE
Add warning or auto-create form id when one is not provided

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -2522,6 +2522,16 @@ defmodule Phoenix.Component do
       end
 
     attrs =
+      case assigns[:id] do
+        nil ->
+          IO.warn("No id given to form (form recovery won’t work)")
+          Keyword.put(attrs, :id, form.name <> "-form")
+
+        _id ->
+          attrs
+      end
+
+    attrs =
       case Keyword.pop(attrs, :multipart, false) do
         {false, attrs} -> attrs
         {true, attrs} -> Keyword.put(attrs, :enctype, "multipart/form-data")


### PR DESCRIPTION
Form auto recover only works when an id is set on a form.
I have repeatedly found that I forget to set an id on `<.form >` and then wonder for a moment why the form goes blank after a server error.
This pull request includes to suggested options:
1. Issue a warning
2. Auto create an id attribute if one is not provided.