### PR TITLE
poc HookedWebComponent

### DIFF
--- a/assets/test/hook_types_test.ts
+++ b/assets/test/hook_types_test.ts
@@ -11,6 +11,7 @@
  */
 
 import type { Hook, HooksOptions } from "phoenix_live_view/view_hook";
+import { HookedWebComponent } from "phoenix_live_view";
 
 // Hook with custom state
 interface CounterState {
@@ -120,6 +121,45 @@ const InfiniteScroll: Hook = {
 };
 
 export { InfiniteScroll };
+
+// =============================================================================
+// Test for HookedWebComponent mixin
+// Verifies that web components can use hook functionality with proper typing
+// =============================================================================
+
+class MyCounter extends HookedWebComponent(HTMLElement) {
+  count = 0;
+
+  mounted() {
+    // this.hook should be typed as ViewHook with all its methods
+    this.hook.handleEvent("set_count", (payload: { count: number }) => {
+      this.count = payload.count;
+    });
+
+    // pushEvent should be available
+    this.hook.pushEvent("ready", { id: this.id });
+
+    // pushEventTo should be available
+    this.hook.pushEventTo("#target", "init", {});
+
+    // js() should be available
+    const js = this.hook.js();
+    js.show(this);
+
+    // liveSocket should be accessible
+    console.log(this.hook.liveSocket);
+  }
+
+  updated() {
+    // updated callback works
+    console.log("updated", this.count);
+  }
+}
+
+// Verify the class can be used as a custom element
+customElements.define("my-counter", MyCounter);
+
+export { MyCounter };
 
 // This file is primarily for compile-time type checking via `npm run typecheck:tests`.
 // The dummy test below satisfies Jest's requirement for at least one test.


### PR DESCRIPTION
I'm not sure how useful this is, but if someone is using web components through classes, this could be a nice abstraction over `createHook`. Example for Lit:

```typescript
import { LitElement, html, css } from "lit";
import { customElement, property } from "lit/decorators.js";
import { HookedWebComponent } from "phoenix_live_view";

// Create a base class that combines LitElement with the hook functionality
const HookedLitElement = HookedWebComponent(LitElement);

@customElement("my-counter")
export class MyCounter extends HookedLitElement {

  @property({ type: Number })
  count = 0;

  static styles = css`
    :host {
      display: block;
      padding: 16px;
      border: 2px solid #4f46e5;
      border-radius: 8px;
      font-family: system-ui, sans-serif;
    }
    .counter {
      display: flex;
      align-items: center;
      gap: 16px;
    }
    button {
      padding: 8px 16px;
      font-size: 18px;
      cursor: pointer;
      background: #4f46e5;
      color: white;
      border: none;
      border-radius: 4px;
    }
    button:hover {
      background: #4338ca;
    }
    .value {
      font-size: 24px;
      font-weight: bold;
      min-width: 60px;
      text-align: center;
    }
  `;

  mounted() {
    console.log("MyCounter mounted! Hook is ready:", this.hook);
  }

  updated() {
    console.log("MyCounter updated by LiveView patch");
  }

  private increment() {
    this.count += 1;
    this.hook.pushEvent("increment", {});
  }

  private decrement() {
    this.count -= 1;
    this.hook.pushEvent("decrement", {});
  }

  render() {
    return html`
      <div class="counter">
        <button @click=${this.decrement}>-</button>
        <span class="value">${this.count}</span>
        <button @click=${this.increment}>+</button>
      </div>
    `;
  }
}
```