### PR TITLE
ColocatedAssets (+ ColocatedCSS)

### DIFF
--- a/config/e2e.exs
+++ b/config/e2e.exs
@@ -1,3 +1,5 @@
 import Config
 
 config :logger, :level, :error
+
+config :phoenix_live_view, :root_tag_attribute, "phx-r"

--- a/lib/mix/tasks/compile/phoenix_live_view.ex
+++ b/lib/mix/tasks/compile/phoenix_live_view.ex
@@ -29,7 +29,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
   end
 
   defp compile do
-    Phoenix.LiveView.ColocatedJS.compile()
-    Phoenix.LiveView.ColocatedCSS.compile()
+    Phoenix.LiveView.ColocatedAssets.compile()
   end
 end

--- a/lib/mix/tasks/compile/phoenix_live_view.ex
+++ b/lib/mix/tasks/compile/phoenix_live_view.ex
@@ -2,8 +2,8 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
   @moduledoc """
   A LiveView compiler for HEEx macro components.
 
-  Right now, only `Phoenix.LiveView.ColocatedHook` and `Phoenix.LiveView.ColocatedJS`
-  are handled.
+  Right now, only `Phoenix.LiveView.ColocatedHook`, `Phoenix.LiveView.ColocatedJS`,
+  and `Phoenix.LiveView.ColocatedCSS` are handled.
 
   You must add it to your `mix.exs` as:
 
@@ -30,5 +30,6 @@ defmodule Mix.Tasks.Compile.PhoenixLiveView do
 
   defp compile do
     Phoenix.LiveView.ColocatedJS.compile()
+    Phoenix.LiveView.ColocatedCSS.compile()
   end
 end

--- a/lib/phoenix_component/macro_component.ex
+++ b/lib/phoenix_component/macro_component.ex
@@ -162,18 +162,19 @@ defmodule Phoenix.Component.MacroComponent do
   @doc """
   Returns the stored data from macro components that returned `{:ok, ast, data}`.
 
-  As one macro component can be used multiple times in one module, the result is a list of all data values.
+  As one macro component can be used multiple times in one module, the result is a map of format
 
-  If the component module does not have any macro components defined, an empty list is returned.
+      %{module => list(data)}
+
+  If the component module does not have any macro components defined, an empty map is returned.
   """
-  @spec get_data(module(), module()) :: [term()] | nil
-  def get_data(component_module, macro_component) do
+  @spec get_data(module()) :: map()
+  def get_data(component_module) do
     if Code.ensure_loaded?(component_module) and
          function_exported?(component_module, :__phoenix_macro_components__, 0) do
       component_module.__phoenix_macro_components__()
-      |> Map.get(macro_component, [])
     else
-      []
+      %{}
     end
   end
 

--- a/lib/phoenix_live_view/colocated_assets.ex
+++ b/lib/phoenix_live_view/colocated_assets.ex
@@ -1,0 +1,277 @@
+defmodule Phoenix.LiveView.ColocatedAssets do
+  @moduledoc false
+
+  defstruct [:relative_path, :data]
+
+  @type t() :: %__MODULE__{
+          relative_path: String.t(),
+          data: term()
+        }
+
+  defmodule Entry do
+    @moduledoc false
+    defstruct [:filename, :data, :callback, :component]
+  end
+
+  @callback build_manifests(colocated :: t()) :: list({binary(), binary()})
+  @callback finalize(target_directory :: String.t()) :: :ok
+
+  @optional_callbacks [finalize: 1]
+
+  @doc """
+  Extracts content into the colocated directory.
+
+  Returns an opaque struct that is stored as macro component data
+  for manifest generation.
+
+  The flow is:
+
+    1. MacroComponent transform callback is called.
+    2. The transform callback invokes ColocatedAssets.extract/5,
+       which writes the content to the target directory.
+    3. LiveView compiler invokes ColocatedAssets.compile/0.
+    4. ColocatedAssets builds a list of `%ColocatedAssets{}` structs
+       grouped by callback module and invokes the callback's
+       `build_manifests/1` function.
+
+  """
+  def extract(callback_module, module, filename, text, data) do
+    # _build/dev/phoenix-colocated/otp_app/MyApp.MyComponent/filename
+    target_path =
+      target_dir()
+      |> Path.join(inspect(module))
+
+    File.mkdir_p!(target_path)
+    File.write!(Path.join(target_path, filename), text)
+
+    %Entry{filename: filename, data: data, callback: callback_module}
+  end
+
+  @doc false
+  def compile do
+    # this step runs after all modules have been compiled
+    # so we can write the final manifests and remove outdated files
+    clear_manifests!()
+    callback_colocated_map = clear_outdated_and_get_files!()
+    File.mkdir_p!(target_dir())
+
+    warn_for_outdated_config!()
+
+    Enum.each(configured_callbacks(), fn callback_module ->
+      true = Code.ensure_loaded?(callback_module)
+
+      files =
+        case callback_colocated_map do
+          %{^callback_module => files} ->
+            files
+
+          _ ->
+            []
+        end
+
+      for {name, content} <- callback_module.build_manifests(files) do
+        File.write!(Path.join(target_dir(), name), content)
+      end
+    end)
+
+    maybe_link_node_modules!()
+  end
+
+  defp clear_manifests! do
+    target_dir = target_dir()
+
+    manifests =
+      Path.wildcard(Path.join(target_dir, "*"))
+      |> Enum.filter(&File.regular?(&1))
+
+    for manifest <- manifests, do: File.rm!(manifest)
+  end
+
+  defp clear_outdated_and_get_files! do
+    target_dir = target_dir()
+    modules = subdirectories(target_dir)
+
+    Enum.flat_map(modules, fn module_folder ->
+      module = Module.concat([Path.basename(module_folder)])
+      process_module(module_folder, module)
+    end)
+    |> Enum.group_by(fn {callback, _file} -> callback end, fn {_callback, file} -> file end)
+    |> Map.new()
+  end
+
+  defp process_module(module_folder, module) do
+    with true <- Code.ensure_loaded?(module),
+         data when data != %{} <- Phoenix.Component.MacroComponent.get_data(module),
+         colocated when colocated != [] <- filter_colocated(data) do
+      expected_files = Enum.map(colocated, fn %{filename: filename} -> filename end)
+      files = File.ls!(module_folder)
+
+      outdated_files = files -- expected_files
+
+      for file <- outdated_files do
+        File.rm!(Path.join(module_folder, file))
+      end
+
+      Enum.map(colocated, fn %Entry{} = e ->
+        absolute_path = Path.join(module_folder, e.filename)
+
+        {e.callback,
+         %__MODULE__{relative_path: Path.relative_to(absolute_path, target_dir()), data: e.data}}
+      end)
+    else
+      _ ->
+        # either the module does not exist any more or
+        # does not have any colocated assets
+        File.rm_rf!(module_folder)
+        []
+    end
+  end
+
+  defp filter_colocated(data) do
+    for {macro_component, entries} <- data do
+      Enum.flat_map(entries, fn data ->
+        case data do
+          %Entry{} = d -> [%{d | component: macro_component}]
+          _ -> []
+        end
+      end)
+    end
+    |> List.flatten()
+  end
+
+  defp maybe_link_node_modules! do
+    settings = project_settings()
+
+    case Keyword.get(settings, :node_modules_path, {:fallback, "assets/node_modules"}) do
+      {:fallback, rel_path} ->
+        location = Path.absname(rel_path)
+        do_symlink(location, true)
+
+      path when is_binary(path) ->
+        location = Path.absname(path)
+        do_symlink(location, false)
+    end
+  end
+
+  defp relative_to_target(location) do
+    if function_exported?(Path, :relative_to, 3) do
+      apply(Path, :relative_to, [location, target_dir(), [force: true]])
+    else
+      Path.relative_to(location, target_dir())
+    end
+  end
+
+  defp do_symlink(node_modules_path, is_fallback) do
+    relative_node_modules_path = relative_to_target(node_modules_path)
+
+    with {:error, reason} when reason != :eexist <-
+           File.ln_s(relative_node_modules_path, Path.join(target_dir(), "node_modules")),
+         false <- Keyword.get(global_settings(), :disable_symlink_warning, false) do
+      disable_hint = """
+      If you don't use colocated hooks / js or you don't need to import files from "assets/node_modules"
+      in your hooks, you can simply disable this warning by setting
+
+          config :phoenix_live_view, :colocated_assets,
+            disable_symlink_warning: true
+      """
+
+      IO.warn("""
+      Failed to symlink node_modules folder for Phoenix.LiveView.ColocatedJS: #{inspect(reason)}
+
+      On Windows, you can address this issue by starting your Windows terminal at least once
+      with "Run as Administrator" and then running your Phoenix application.#{is_fallback && "\n\n" <> disable_hint}
+      """)
+    end
+  end
+
+  defp configured_callbacks do
+    [
+      # Hardcoded for now
+      Phoenix.LiveView.ColocatedJS,
+      Phoenix.LiveView.ColocatedCSS
+    ]
+  end
+
+  defp global_settings do
+    Application.get_env(
+      :phoenix_live_view,
+      :colocated_assets,
+      Application.get_env(:phoenix_live_view, :colocated_js, [])
+    )
+  end
+
+  defp project_settings do
+    lv_config =
+      Mix.Project.config()
+      |> Keyword.get(:phoenix_live_view, [])
+
+    Keyword.get_lazy(lv_config, :colocated_assets, fn ->
+      Keyword.get(lv_config, :colocated_js, [])
+    end)
+  end
+
+  defp target_dir do
+    app = to_string(Mix.Project.config()[:app])
+    default = Path.join(Mix.Project.build_path(), "phoenix-colocated")
+
+    global_settings()
+    |> Keyword.get(:target_directory, default)
+    |> Path.join(app)
+  end
+
+  defp subdirectories(path) do
+    Path.wildcard(Path.join(path, "*")) |> Enum.filter(&File.dir?(&1))
+  end
+
+  defp warn_for_outdated_config! do
+    case Application.get_env(:phoenix_live_view, :colocated_js) do
+      nil ->
+        :ok
+
+      _ ->
+        IO.warn("""
+        The :colocated_js configuration option is deprecated!
+
+        Instead of
+
+            config :phoenix_live_view, :colocated_js, ...
+
+        use
+
+            config :phoenix_live_view, :colocated_assets, ...
+
+        instead.
+        """)
+    end
+
+    lv_config =
+      Mix.Project.config()
+      |> Keyword.get(:phoenix_live_view, [])
+
+    case Keyword.get(lv_config, :colocated_js) do
+      nil ->
+        :ok
+
+      _ ->
+        IO.warn("""
+        The :colocated_js configuration option is deprecated!
+
+        Instead of
+
+            [
+              ...,
+              phoenix_live_view: [colocated_js: ...]
+            ]
+
+        use
+
+            [
+              ...,
+              phoenix_live_view: [colocated_assets: ...]
+            ]
+
+        in your mix.exs instead.
+        """)
+    end
+  end
+end

--- a/lib/phoenix_live_view/colocated_assets.ex
+++ b/lib/phoenix_live_view/colocated_assets.ex
@@ -13,10 +13,7 @@ defmodule Phoenix.LiveView.ColocatedAssets do
     defstruct [:filename, :data, :callback, :component]
   end
 
-  @callback build_manifests(colocated :: t()) :: list({binary(), binary()})
-  @callback finalize(target_directory :: String.t()) :: :ok
-
-  @optional_callbacks [finalize: 1]
+  @callback build_manifests(colocated :: list(t())) :: list({binary(), binary()})
 
   @doc """
   Extracts content into the colocated directory.
@@ -91,12 +88,12 @@ defmodule Phoenix.LiveView.ColocatedAssets do
     target_dir = target_dir()
     modules = subdirectories(target_dir)
 
-    Enum.flat_map(modules, fn module_folder ->
+    modules
+    |> Enum.flat_map(fn module_folder ->
       module = Module.concat([Path.basename(module_folder)])
       process_module(module_folder, module)
     end)
     |> Enum.group_by(fn {callback, _file} -> callback end, fn {_callback, file} -> file end)
-    |> Map.new()
   end
 
   defp process_module(module_folder, module) do

--- a/lib/phoenix_live_view/colocated_assets.ex
+++ b/lib/phoenix_live_view/colocated_assets.ex
@@ -165,15 +165,17 @@ defmodule Phoenix.LiveView.ColocatedAssets do
            File.ln_s(relative_node_modules_path, Path.join(target_dir(), "node_modules")),
          false <- Keyword.get(global_settings(), :disable_symlink_warning, false) do
       disable_hint = """
-      If you don't use colocated hooks / js or you don't need to import files from "assets/node_modules"
-      in your hooks, you can simply disable this warning by setting
+      If you don't use colocated hooks / js / css or you don't need to import files from "assets/node_modules"
+      in your colocated assets, you can simply disable this warning by setting
 
           config :phoenix_live_view, :colocated_assets,
             disable_symlink_warning: true
       """
 
       IO.warn("""
-      Failed to symlink node_modules folder for Phoenix.LiveView.ColocatedJS: #{inspect(reason)}
+      Failed to symlink node_modules folder for colocated assets: #{inspect(reason)}
+
+      See the documentation for Phoenix.LiveView.ColocatedJS for details.
 
       On Windows, you can address this issue by starting your Windows terminal at least once
       with "Run as Administrator" and then running your Phoenix application.#{is_fallback && "\n\n" <> disable_hint}
@@ -237,7 +239,6 @@ defmodule Phoenix.LiveView.ColocatedAssets do
 
             config :phoenix_live_view, :colocated_assets, ...
 
-        instead.
         """)
     end
 

--- a/lib/phoenix_live_view/colocated_assets.ex
+++ b/lib/phoenix_live_view/colocated_assets.ex
@@ -268,7 +268,7 @@ defmodule Phoenix.LiveView.ColocatedAssets do
               phoenix_live_view: [colocated_assets: ...]
             ]
 
-        in your mix.exs instead.
+        in your mix.exs project configuration.
         """)
     end
   end

--- a/lib/phoenix_live_view/colocated_css.ex
+++ b/lib/phoenix_live_view/colocated_css.ex
@@ -1,0 +1,397 @@
+defmodule Phoenix.LiveView.ColocatedCSS do
+  @moduledoc ~S'''
+  A special HEEx `:type` that extracts any CSS styles from a colocated `<style>` tag at compile time.
+
+  Note: To use `ColocatedCSS`, you need to run Phoenix 1.8+.
+
+  Note: `ColocatedCSS` **must** be defined at the very beginning of the template in which it is used.
+
+  You can use `ColocatedCSS` to define any CSS styles directly in your components, for example:
+
+  ```heex
+  <style :type={Phoenix.LiveView.ColocatedCSS}>
+    .sample-class {
+        background-color: #FFFFFF;
+    }
+  </style>
+  ```
+
+  ## Scoped CSS
+
+  By default, Colocated CSS styles are scoped at compile time to the template in which they are defined.
+  This provides style encapsulation preventing CSS rules within a component from unintentionally applying
+  to elements in other nested components. Scoping is performed via the use of the `@scope` CSS at-rule.
+  For more information, see [the docs on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@scope).
+
+  To prevent Colocated CSS styles from being scoped to the current template you can provide the `global`
+  attribute, for example:
+
+  ```heex
+  <style :type={Phoenix.LiveView.ColocatedCSS} global>
+    .sample-class {
+        background-color: #FFFFFF;
+    }
+  </style>
+  ```
+
+  **Note:** When using Scoped Colocated CSS with implicit `inner_block` slots or named slots, the content
+  provided will be scoped to the parent template which is providing the content, not the component which
+  defines the slot. For example, in the following snippet the elements within [`intersperse/1`](`Phoenix.Component.intersperse/1`)'s
+  `inner_block` and `separator` slots will both be styled by the `.sample-class` rule, not any rules defined within the
+  [`intersperse/1`](`Phoenix.Component.intersperse/1`) component itself:
+
+  ```heex
+  <style :type={Phoenix.LiveView.ColocatedCSS}>
+    .sample-class {
+        background-color: #FFFFFF;
+    }
+  </style>
+  <div class="sample-class">
+    <.intersperse :let={item} enum={[1, 2, 3]}>
+      <:separator>
+        <span class="sample-class">|</span>
+      </:separator>
+      <div class="sample-class">
+        <p>Item {item}</p>
+      </div>
+    </.intersperse>
+  </div>
+  ```
+
+  > #### Warning! {: .warning}
+  >
+  > The `@scope` CSS at-rule is Baseline available as of the end of 2025. To ensure that Scoped CSS will
+  > work on the browsers you need, be sure to check [Can I Use?](https://caniuse.com/css-cascade-scope) for
+  > browser compatibility.
+
+  > #### Tip {: .info}
+  >
+  > When Colocated CSS is scoped via the `@scope` rule, all "local root" elements in the given template serve as scoping roots.
+  > "Local root" elements are the outermost elements of the template itself and the outermost elements of any content passed to
+  > child components' slots. For selectors in your Colocated CSS to target the scoping root, you will need to
+  > specify the scoping root in the selector via the use of the `:scope` pseudo-selector. For more details,
+  > see [the docs on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@scope#scope_pseudo-class_within_scope_blocks).
+
+  ## Internals
+
+  While compiling the template, colocated CSS is extracted into a special folder inside the
+  `Mix.Project.build_path()`, called `phoenix-colocated-css`. This is customizable, as we'll see below,
+  but it is important that it is a directory that is not tracked by version control, because the
+  components are the source of truth for the code. Also, the directory is shared between applications
+  (this also applies to applications in umbrella projects), so it should typically also be a shared
+  directory not specific to a single application.
+
+  The colocated CSS directory follows this structure:
+
+  ```text
+  _build/$MIX_ENV/phoenix-colocated-css/
+  _build/$MIX_ENV/phoenix-colocated-css/my_app/
+  _build/$MIX_ENV/phoenix-colocated-css/my_app/colocated.css
+  _build/$MIX_ENV/phoenix-colocated-css/my_app/MyAppWeb.DemoLive/line_HASH.css
+  _build/$MIX_ENV/phoenix-colocated-css/my_dependency/MyDependency.Module/line_HASH.css
+  ...
+  ```
+
+  Each application has its own folder. Inside, each module also gets its own folder, which allows
+  us to track and clean up outdated code.
+
+  > #### A note on dependencies and umbrella projects {: .info}
+  >
+  > For each application that uses colocated CSS, a separate directory is created
+  > inside the `phoenix-colocated-css` folder. This allows to have clear separation between
+  > styles of dependencies, but also applications inside umbrella projects.
+
+  To use colocated CSS, your bundler needs to be configured to resolve the
+  `phoenix-colocated-css` folder. For new Phoenix applications, this configuration is already included
+  in the esbuild configuration inside `config.exs`:
+
+      config :esbuild,
+        ...
+        my_app: [
+          args:
+            ~w(js/app.js --bundle --target=es2022 --outdir=../priv/static/assets/js --external:/fonts/* --external:/images/* --alias:@=.),
+          cd: Path.expand("../assets", __DIR__),
+          env: %{
+            "NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]
+          }
+        ]
+
+  The important part here is the `NODE_PATH` environment variable, which tells esbuild to also look
+  for packages inside the `deps` folder, as well as the `Mix.Project.build_path()`, which resolves to
+  `_build/$MIX_ENV`. If you use a different bundler, you'll need to configure it accordingly. If it is not
+  possible to configure the `NODE_PATH`, you can also change the folder to which LiveView writes colocated
+  CSS by setting the `:target_directory` option in your `config.exs`:
+
+  ```elixir
+  config :phoenix_live_view, :colocated_css,
+    target_directory: Path.expand("../assets/css/phoenix-colocated-css", __DIR__)
+  ```
+
+  > #### Tip {: .info}
+  >
+  > If you remove or modify the contents of the `:target_directory` folder, you can use
+  > `mix clean --all` and `mix compile` to regenerate all colocated CSS.
+
+  > #### Warning! {: .warning}
+  >
+  > LiveView assumes full ownership over the configured `:target_directory`. When
+  > compiling, it will **delete** any files and folders inside the `:target_directory`,
+  > that it does not associate with a colocated CSS file.
+
+  To bundle and use colocated CSS with esbuild, you can import it like this in your `app.js` file:
+
+  ```javascript
+  import "phoenix-colocated-css/my_app/colocated.css"
+  ```
+
+  Importing CSS in your `app.js` file will cause esbuild to generate a separate `app.css` file.
+  To load it, simply add a second `<link>` to your `root.html.heex` file, like so:
+
+  ```html
+  <link phx-track-static rel="stylesheet" href={~p"/assets/js/app.css"} />
+  ```
+
+  ## Options
+
+  Colocated CSS can be configured through the attributes of the `<style>` tag.
+  The supported attributes are:
+
+    * `global` - If provided, the Colocated CSS rules contained within the `<style>` tag
+      will not be scoped to the template within which it is defined, and will instead act
+      as global CSS rules.
+
+    * `lower-bound` - Configure whether or not the the lower-bound of Scoped Colocated CSS is inclusive, that is,
+      root elements of child components can be styled by the parent component's Colocated CSS. This can be
+      useful for applying styles to the child component's root elements for layout purposes. Valid values are
+      `"inclusive"` and `"exclusive"`. Scoped Colocated CSS defaults to `"exclusive"`, so that styles are entirely
+      scoped to the parent unless otherwise specified.
+  '''
+
+  @behaviour Phoenix.Component.MacroComponent
+
+  alias Phoenix.Component.MacroComponent
+
+  @impl true
+  def transform({"style", attributes, [text_content], _tag_meta} = _ast, meta) do
+    validate_phx_version!()
+
+    opts = Map.new(attributes)
+
+    validate_opts!(opts)
+
+    {scope, data} = extract(opts, text_content, meta)
+
+    # we always drop colocated CSS from the rendered output
+    {:ok, "", data, [root_tag_attribute: {"phx-css", scope}]}
+  end
+
+  def transform(_ast, _meta) do
+    raise ArgumentError, "ColocatedCSS can only be used on style tags"
+  end
+
+  defp validate_phx_version! do
+    phoenix_version = to_string(Application.spec(:phoenix, :vsn))
+
+    if not Version.match?(phoenix_version, "~> 1.8.0-rc.4") do
+      # TODO: bump message to 1.8 once released to avoid confusion
+      raise ArgumentError, ~s|ColocatedCSS requires at least {:phoenix, "~> 1.8.0-rc.4"}|
+    end
+  end
+
+  defp validate_opts!(opts) do
+    Enum.each(opts, fn {key, val} -> validate_opt!({key, val}, Map.delete(opts, key)) end)
+  end
+
+  defp validate_opt!({"global", val}, other_opts) when val in [nil, true] do
+    case other_opts do
+      %{"lower-bound" => _} ->
+        raise ArgumentError,
+              "colocated css must be scoped to use the `lower-bound` attribute, but `global` attribute was provided"
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp validate_opt!({"global", val}, _other_opts) do
+    raise ArgumentError,
+          "expected nil or true for the `global` attribute of colocated css, got: #{inspect(val)}"
+  end
+
+  defp validate_opt!({"lower-bound", val}, _other_opts) when val in ["inclusive", "exclusive"] do
+    :ok
+  end
+
+  defp validate_opt!({"lower-bound", val}, _other_opts) do
+    raise ArgumentError,
+          ~s|expected "inclusive" or "exclusive" for the `lower-bound` attribute of colocated css, got: #{inspect(val)}|
+  end
+
+  defp validate_opt!(_opt, _other_opts), do: :ok
+
+  @doc false
+  def extract(opts, text_content, meta) do
+    # _build/dev/phoenix-colocated-css/otp_app/MyApp.MyComponent/line_no.css
+    target_path = Path.join(target_dir(), inspect(meta.env.module))
+
+    scope = scope(meta)
+    root_tag_attribute = root_tag_attribute()
+
+    upper_bound_selector = ~s|[phx-css="#{scope}"]|
+    lower_bound_selector = ~s|[#{root_tag_attribute}]|
+
+    lower_bound_selector =
+      case opts do
+        %{"lower-bound" => "inclusive"} -> lower_bound_selector <> " > *"
+        _ -> lower_bound_selector
+      end
+
+    styles =
+      case opts do
+        %{"global" => _} ->
+          text_content
+
+        _ ->
+          "@scope (#{upper_bound_selector}) to (#{lower_bound_selector}) { #{text_content} }"
+      end
+
+    filename = "#{meta.env.line}_#{hash(styles)}.css"
+
+    File.mkdir_p!(target_path)
+
+    target_path
+    |> Path.join(filename)
+    |> File.write!(styles)
+
+    {scope, filename}
+  end
+
+  defp scope(meta) do
+    hash("#{meta.env.module}_#{meta.env.line}")
+  end
+
+  defp hash(string) do
+    string
+    |> then(&:crypto.hash(:md5, &1))
+    |> Base.encode32(case: :lower, padding: false)
+  end
+
+  defp root_tag_attribute() do
+    case Application.get_env(:phoenix_live_view, :root_tag_attribute) do
+      configured_attribute when is_binary(configured_attribute) ->
+        configured_attribute
+
+      configured_attribute ->
+        message = """
+        a global :root_tag_attribute must be configured to use colocated css
+
+        Expected global :root_tag_attribute to be a string, got: #{inspect(configured_attribute)}
+
+        The global :root_tag_attribute is usually configured to `"phx-r"`, but it needs to be explicitly enabled in your configuration:
+
+            config :phoenix_live_view, root_tag_attribute: "phx-r"
+
+        You can also use a different value than `"phx-r"`.
+        """
+
+        raise ArgumentError, message
+    end
+  end
+
+  @doc false
+  def compile do
+    # this step runs after all modules have been compiled
+    # so we can write the final css manifest file and remove any
+    # outdated colocated css files
+    clear_manifest!()
+    files = clear_outdated_and_get_files!()
+    write_new_manifest!(files)
+  end
+
+  defp clear_manifest! do
+    target_dir()
+    |> Path.join("*")
+    |> Path.wildcard()
+    |> Enum.filter(&File.regular?(&1))
+    |> Enum.each(&File.rm!(&1))
+  end
+
+  defp clear_outdated_and_get_files! do
+    target_dir = target_dir()
+    modules = subdirectories(target_dir)
+
+    Enum.flat_map(modules, fn module_folder ->
+      module = Module.concat([Path.basename(module_folder)])
+      process_module(module_folder, module)
+    end)
+  end
+
+  defp process_module(module_folder, module) do
+    with true <- Code.ensure_loaded?(module),
+         data when data != [] <- MacroComponent.get_data(module, __MODULE__) do
+      expected_files = data
+      files = File.ls!(module_folder)
+
+      outdated_files = files -- expected_files
+
+      for file <- outdated_files do
+        module_folder
+        |> Path.join(file)
+        |> File.rm!()
+      end
+
+      Enum.map(data, fn filename ->
+        _absolute_file_path = Path.join(module_folder, filename)
+      end)
+    else
+      _ ->
+        # either the module does not exist any more or
+        # does not have any colocated CSS
+        File.rm_rf!(module_folder)
+        []
+    end
+  end
+
+  defp write_new_manifest!(files) do
+    target_dir = target_dir()
+    manifest = Path.join(target_dir, "colocated.css")
+
+    content =
+      if files == [] do
+        # Ensure that the directory exists to write
+        # an empty manifest file in the case that no colocated css
+        # files were generated (which would have already created
+        # the directory)
+        File.mkdir_p!(target_dir)
+
+        ""
+      else
+        Enum.reduce(files, [], fn file, acc ->
+          line = ~s[@import "./#{Path.relative_to(file, target_dir)}";\n]
+          [acc | line]
+        end)
+      end
+
+    File.write!(manifest, content)
+  end
+
+  defp target_dir do
+    default = Path.join(Mix.Project.build_path(), "phoenix-colocated-css")
+    app = to_string(Mix.Project.config()[:app])
+
+    global_settings()
+    |> Keyword.get(:target_directory, default)
+    |> Path.join(app)
+  end
+
+  defp global_settings do
+    Application.get_env(:phoenix_live_view, :colocated_css, [])
+  end
+
+  defp subdirectories(path) do
+    path
+    |> Path.join("*")
+    |> Path.wildcard()
+    |> Enum.filter(&File.dir?(&1))
+  end
+end

--- a/lib/phoenix_live_view/colocated_css.ex
+++ b/lib/phoenix_live_view/colocated_css.ex
@@ -11,7 +11,7 @@ defmodule Phoenix.LiveView.ColocatedCSS do
   ```heex
   <style :type={Phoenix.LiveView.ColocatedCSS}>
     .sample-class {
-        background-color: #FFFFFF;
+      background-color: #FFFFFF;
     }
   </style>
   ```

--- a/lib/phoenix_live_view/colocated_css.ex
+++ b/lib/phoenix_live_view/colocated_css.ex
@@ -29,7 +29,7 @@ defmodule Phoenix.LiveView.ColocatedCSS do
   ```heex
   <style :type={Phoenix.LiveView.ColocatedCSS} global>
     .sample-class {
-        background-color: #FFFFFF;
+      background-color: #FFFFFF;
     }
   </style>
   ```
@@ -43,7 +43,7 @@ defmodule Phoenix.LiveView.ColocatedCSS do
   ```heex
   <style :type={Phoenix.LiveView.ColocatedCSS}>
     .sample-class {
-        background-color: #FFFFFF;
+      background-color: #FFFFFF;
     }
   </style>
   <div class="sample-class">

--- a/lib/phoenix_live_view/colocated_css.ex
+++ b/lib/phoenix_live_view/colocated_css.ex
@@ -221,7 +221,7 @@ defmodule Phoenix.LiveView.ColocatedCSS do
   </.my_component>
   ```
   """
-  @callback transform(tag_name :: binary(), attrs :: map(), css :: binary(), meta :: keyword()) ::
+  @callback transform(tag_name :: binary(), attrs :: map(), css :: binary(), meta :: map()) ::
               {:ok, binary(), keyword()} | {:error, term()}
 
   defmacro __using__(_) do
@@ -244,13 +244,18 @@ defmodule Phoenix.LiveView.ColocatedCSS do
     validate_phx_version!()
 
     opts = Map.new(attributes)
-    {data, directives} = extract(opts, text_content, meta, module)
 
-    # we always drop colocated CSS from the rendered output
-    {:ok, "", data, directives}
+    case extract(opts, text_content, meta, module) do
+      {data, directives} ->
+        # we always drop colocated CSS from the rendered output
+        {:ok, "", data, directives}
+
+      nil ->
+        {:ok, ""}
+    end
   end
 
-  def __transform__(_ast, _meta) do
+  def __transform__(_ast, _meta, _module) do
     raise ArgumentError, "ColocatedCSS can only be used on style tags"
   end
 
@@ -269,26 +274,32 @@ defmodule Phoenix.LiveView.ColocatedCSS do
       line: meta.env.line
     }
 
-    {styles, directives} =
-      case module.transform("style", opts, text_content, transform_meta) do
-        {:ok, scoped_css, directives} when is_binary(scoped_css) and is_list(directives) ->
-          {scoped_css, directives}
+    case module.transform("style", opts, text_content, transform_meta) do
+      {:ok, styles, directives} when is_binary(styles) and is_list(directives) ->
+        filename = "#{meta.env.line}_#{hash(styles)}.css"
 
-        {:error, reason} ->
-          raise ArgumentError,
-                "#{inspect(module)} returned an error: #{inspect(reason)}"
+        data =
+          Phoenix.LiveView.ColocatedAssets.extract(
+            __MODULE__,
+            meta.env.module,
+            filename,
+            styles,
+            nil
+          )
 
-        other ->
-          raise ArgumentError,
-                "expected the ColocatedCSS implementation to return {:ok, scoped_css, directives} or {:error, term}, got: #{inspect(other)}"
-      end
+        {data, directives}
 
-    filename = "#{meta.env.line}_#{hash(styles)}.css"
+      {:error, reason} ->
+        IO.warn(
+          "ColocatedCSS module #{inspect(module)} returned an error, skipping: #{inspect(reason)}"
+        )
 
-    data =
-      Phoenix.LiveView.ColocatedAssets.extract(__MODULE__, meta.env.module, filename, styles, nil)
+        nil
 
-    {data, directives}
+      other ->
+        raise ArgumentError,
+              "expected the ColocatedCSS implementation to return {:ok, scoped_css, directives} or {:error, term}, got: #{inspect(other)}"
+    end
   end
 
   defp hash(string) do

--- a/lib/phoenix_live_view/colocated_css.ex
+++ b/lib/phoenix_live_view/colocated_css.ex
@@ -186,7 +186,7 @@ defmodule Phoenix.LiveView.ColocatedCSS do
 
   The `directives` needs to be a keyword list that supports the following options:
 
-    * `root_tag_attribute`: A `{key, value}` tuple that will be added a
+    * `root_tag_attribute`: A `{key, value}` tuple that will be added as
        an attribute to all "root tags" of the template defining the scoped CSS tag.
        See the section on root tags below for more information.
     * `tag_attribute`: A `{key, value}` tuple that will be added as an attribute to

--- a/lib/phoenix_live_view/colocated_css.ex
+++ b/lib/phoenix_live_view/colocated_css.ex
@@ -1,76 +1,14 @@
 defmodule Phoenix.LiveView.ColocatedCSS do
   @moduledoc ~S'''
-  A special HEEx `:type` that extracts any CSS styles from a colocated `<style>` tag at compile time.
+  Building blocks for a special HEEx `:type` that extracts any CSS styles
+  from a colocated `<style>` tag at compile time.
+
+  To actually use `ColocatedCSS`, you must define a module including `use Phoenix.LiveView.ColocatedCSS`
+  and implement the `ColocatedCSS` behaviour.
 
   Note: To use `ColocatedCSS`, you need to run Phoenix 1.8+.
 
   Note: `ColocatedCSS` **must** be defined at the very beginning of the template in which it is used.
-
-  You can use `ColocatedCSS` to define any CSS styles directly in your components, for example:
-
-  ```heex
-  <style :type={Phoenix.LiveView.ColocatedCSS}>
-    .sample-class {
-      background-color: #FFFFFF;
-    }
-  </style>
-  ```
-
-  ## Scoped CSS
-
-  By default, Colocated CSS styles are scoped at compile time to the template in which they are defined.
-  This provides style encapsulation preventing CSS rules within a component from unintentionally applying
-  to elements in other nested components. Scoping is performed via the use of the `@scope` CSS at-rule.
-  For more information, see [the docs on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@scope).
-
-  To prevent Colocated CSS styles from being scoped to the current template you can provide the `global`
-  attribute, for example:
-
-  ```heex
-  <style :type={Phoenix.LiveView.ColocatedCSS} global>
-    .sample-class {
-      background-color: #FFFFFF;
-    }
-  </style>
-  ```
-
-  **Note:** When using Scoped Colocated CSS with implicit `inner_block` slots or named slots, the content
-  provided will be scoped to the parent template which is providing the content, not the component which
-  defines the slot. For example, in the following snippet the elements within [`intersperse/1`](`Phoenix.Component.intersperse/1`)'s
-  `inner_block` and `separator` slots will both be styled by the `.sample-class` rule, not any rules defined within the
-  [`intersperse/1`](`Phoenix.Component.intersperse/1`) component itself:
-
-  ```heex
-  <style :type={Phoenix.LiveView.ColocatedCSS}>
-    .sample-class {
-      background-color: #FFFFFF;
-    }
-  </style>
-  <div class="sample-class">
-    <.intersperse :let={item} enum={[1, 2, 3]}>
-      <:separator>
-        <span class="sample-class">|</span>
-      </:separator>
-      <div class="sample-class">
-        <p>Item {item}</p>
-      </div>
-    </.intersperse>
-  </div>
-  ```
-
-  > #### Warning! {: .warning}
-  >
-  > The `@scope` CSS at-rule is Baseline available as of the end of 2025. To ensure that Scoped CSS will
-  > work on the browsers you need, be sure to check [Can I Use?](https://caniuse.com/css-cascade-scope) for
-  > browser compatibility.
-
-  > #### Tip {: .info}
-  >
-  > When Colocated CSS is scoped via the `@scope` rule, all "local root" elements in the given template serve as scoping roots.
-  > "Local root" elements are the outermost elements of the template itself and the outermost elements of any content passed to
-  > child components' slots. For selectors in your Colocated CSS to target the scoping root, you will need to
-  > specify the scoping root in the selector via the use of the `:scope` pseudo-selector. For more details,
-  > see [the docs on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@scope#scope_pseudo-class_within_scope_blocks).
 
   Colocated CSS uses the same folder structures as Colocated JS. See `Phoenix.LiveView.ColocatedJS` for more information.
 
@@ -87,40 +25,232 @@ defmodule Phoenix.LiveView.ColocatedCSS do
   <link phx-track-static rel="stylesheet" href={~p"/assets/js/app.css"} />
   ```
 
-  ## Options
+  ## Global CSS
 
-  Colocated CSS can be configured through the attributes of the `<style>` tag.
-  The supported attributes are:
+  If all you need is global CSS, which is extracted as is, you can define your ColocatedCSS module like this:
 
-    * `global` - If provided, the Colocated CSS rules contained within the `<style>` tag
-      will not be scoped to the template within which it is defined, and will instead act
-      as global CSS rules.
+  ```elixir
+  defmodule MyAppWeb.ColocatedCSS do
+    use Phoenix.LiveView.ColocatedCSS
 
-    * `lower-bound` - Configure whether or not the the lower-bound of Scoped Colocated CSS is inclusive, that is,
-      root elements of child components can be styled by the parent component's Colocated CSS. This can be
-      useful for applying styles to the child component's root elements for layout purposes. Valid values are
-      `"inclusive"` and `"exclusive"`. Scoped Colocated CSS defaults to `"exclusive"`, so that styles are entirely
-      scoped to the parent unless otherwise specified.
+    @impl true
+    def transform("style", _attrs, css, _meta) do
+      {:ok, css, []}
+    end
+  end
+  ```
+
+  ## Scoped CSS
+
+  The idea behind scoped CSS is to restrict the elements that CSS rules apply to
+  to only the elements of the current template / component.
+
+  One way to scope CSS is to use [CSS `@scope` rules](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@scope).
+  A scoped `ColocatedCSS` module using CSS `@scope` can be implemented like this:
+
+  ```elixir
+  defmodule MyAppWeb.ColocatedScopedCSS do
+    use Phoenix.LiveView.ColocatedCSS
+
+    @impl true
+    def transform("style", attrs, css, meta) do
+      validate_opts!(attrs)
+
+      {scope, css} = do_scope(css, attrs, meta)
+
+      {:ok, css, [root_tag_attribute: {"phx-css-#{scope}", true}]}
+    end
+
+    defp validate_opts!(opts) do
+      Enum.each(opts, fn {key, val} -> validate_opt!({key, val}, Map.delete(opts, key)) end)
+    end
+
+    defp validate_opt!({"lower-bound", val}, _other_opts) when val in ["inclusive", "exclusive"] do
+      :ok
+    end
+
+    defp validate_opt!({"lower-bound", val}, _other_opts) do
+      raise ArgumentError,
+            ~s|expected "inclusive" or "exclusive" for the `lower-bound` attribute of colocated css, got: #{inspect(val)}|
+    end
+
+    defp validate_opt!(_opt, _other_opts), do: :ok
+
+    defp do_scope(css, opts, meta) do
+      scope = hash("#{meta.module}_#{meta.line}: #{css}")
+
+      root_tag_attribute = root_tag_attribute()
+
+      upper_bound_selector = ~s|[phx-css-#{scope}]|
+      lower_bound_selector = ~s|[#{root_tag_attribute}]|
+
+      lower_bound_selector =
+        case opts do
+          %{"lower-bound" => "inclusive"} -> lower_bound_selector <> " > *"
+          _ -> lower_bound_selector
+        end
+
+      css = "@scope (#{upper_bound_selector}) to (#{lower_bound_selector}) { #{css} }"
+
+      {scope, css}
+    end
+
+    defp hash(string) do
+      # It is important that we do not pad
+      # the Base32 encoded value as we use it in
+      # an HTML attribute name and = (the padding character)
+      # is not valid.
+      string
+      |> then(&:crypto.hash(:md5, &1))
+      |> Base.encode32(case: :lower, padding: false)
+    end
+
+    defp root_tag_attribute() do
+      case Application.get_env(:phoenix_live_view, :root_tag_attribute) do
+        configured_attribute when is_binary(configured_attribute) ->
+          configured_attribute
+
+        configured_attribute ->
+          message = """
+          a global :root_tag_attribute must be configured to use scoped css
+
+          Expected global :root_tag_attribute to be a string, got: #{inspect(configured_attribute)}
+
+          The global :root_tag_attribute is usually configured to `"phx-r"`, but it needs to be explicitly enabled in your configuration:
+
+              config :phoenix_live_view, root_tag_attribute: "phx-r"
+
+          You can also use a different value than `"phx-r"`.
+          """
+
+          raise ArgumentError, message
+      end
+    end
+  end
+  ```
+
+  This module transforms a given style tag like
+
+  ```heex
+  <%!-- Note that :type accepts aliases as well! --%>
+  <style :type={MyAppWeb.ColocatedScopedCSS}>
+    .my-class { color: red; }
+  </style>
+  ```
+
+  into
+
+  ```css
+  @scope ([phx-css-abc123]) to ([phx-r]) {
+    .my-class { color: red; }
+  }
+  ```
+
+  and if `lower-bound` is set to `inclusive`, it transforms it into
+
+  ```css
+  @scope ([phx-css-abc123]) to ([phx-r] > *) {
+    .my-class { color: red; }
+  }
+  ```
+
+  This applies any styles defined in the colocated CSS block to any element between a local root and a component.
+  It relies on LiveView's global `:root_tag_attribute`, which is an attribute that LiveView adds to all root tags,
+  no matter if colocated CSS is used or not. When the browser encounters a `phx-r` attribute, which in this case
+  is assumed to be the configured global `:root_tag_attribute`, it stops the scoped CSS rule.
+
+  Another way to implement scoped CSS could be to use PostCSS and apply an attribute to all tags in a template.
   '''
 
-  @behaviour Phoenix.Component.MacroComponent
+  @doc """
+  Callback invoked for each colocated CSS tag.
+
+  The callback receives the tag name, the string attributes and a map of metadata.
+
+  For example, for the following tag:
+
+  ```heex
+  <style :type={MyAppWeb.ColocatedCSS} data-scope="my-scope" foo={@bar}>
+    .my-class { color: red; }
+  </style>
+  ```
+
+  The callback would receive the following arguments:
+
+    * tag_name: `"style"`
+    * attrs: %{"data-scope" => "my-scope"}
+    * meta: `%{file: "path/to/file.ex", module: MyApp.MyModule, line: 10}`
+
+  The callback must return either `{:ok, scoped_css, directives}` or `{:error, reason}`.
+  If an error is returned, it will be logged and the CSS will not be extracted.
+
+  The `directives` needs to be a keyword list that supports the following options:
+
+    * `root_tag_attribute`: A `{key, value}` tuple that will be added a
+       an attribute to all "root tags" of the template defining the scoped CSS tag.
+       See the section on root tags below for more information.
+    * `tag_attribute`: A `{key, value}` tuple that will be added as an attribute to
+       all HTML tags in the template defining the scoped CSS tag.
+
+  ## Root tags
+
+  In a HEEx template, all outermost tags are considered "root tags" and are
+  affected by the `root_tag_attribute` directive. If a template uses components,
+  the slots of those components are considered as root tags as well.
+
+  Here's an example showing which elements would be considered root tags:
+
+  ```heex
+  <div>                              <---- root tag
+    <span>Hello</span>               <---- not a root tag
+
+    <.my_component>
+      <p>World</p>                   <---- root tag
+    </.my_component>
+  </div>
+
+  <.my_component>
+    <span>World</span>               <---- root tag
+
+    <:a_named_slot>
+      <div>                          <---- root tag
+        Foo
+        <p>Bar</p>                   <---- not a root tag
+      </div>
+    </:a_named_slot>
+  </.my_component>
+  ```
+  """
+  @callback transform(tag_name :: binary(), attrs :: map(), css :: binary(), meta :: keyword()) ::
+              {:ok, binary(), keyword()} | {:error, term()}
+
+  defmacro __using__(_) do
+    # implements the MacroComponent behaviour
+    # but we don't add @behaviour to prevent users to need to differentiate
+    # @impl true for the ColocatedCSS behaviour itself
+    quote do
+      @behaviour unquote(__MODULE__)
+
+      def transform(ast, meta) do
+        Phoenix.LiveView.ColocatedCSS.__transform__(ast, meta, __MODULE__)
+      end
+    end
+  end
+
   @behaviour Phoenix.LiveView.ColocatedAssets
 
-  @impl true
-  def transform({"style", attributes, [text_content], _tag_meta} = _ast, meta) do
+  @doc false
+  def __transform__({"style", attributes, [text_content], _tag_meta} = _ast, meta, module) do
     validate_phx_version!()
 
     opts = Map.new(attributes)
-
-    validate_opts!(opts)
-
-    {scope, data} = extract(opts, text_content, meta)
+    {data, directives} = extract(opts, text_content, meta, module)
 
     # we always drop colocated CSS from the rendered output
-    {:ok, "", data, [root_tag_attribute: {"phx-css-#{scope}", true}]}
+    {:ok, "", data, directives}
   end
 
-  def transform(_ast, _meta) do
+  def __transform__(_ast, _meta) do
     raise ArgumentError, "ColocatedCSS can only be used on style tags"
   end
 
@@ -132,58 +262,25 @@ defmodule Phoenix.LiveView.ColocatedCSS do
     end
   end
 
-  defp validate_opts!(opts) do
-    Enum.each(opts, fn {key, val} -> validate_opt!({key, val}, Map.delete(opts, key)) end)
-  end
+  defp extract(opts, text_content, meta, module) do
+    transform_meta = %{
+      module: meta.env.module,
+      file: meta.env.file,
+      line: meta.env.line
+    }
 
-  defp validate_opt!({"global", val}, other_opts) when val in [nil, true] do
-    case other_opts do
-      %{"lower-bound" => _} ->
-        raise ArgumentError,
-              "colocated css must be scoped to use the `lower-bound` attribute, but `global` attribute was provided"
+    {styles, directives} =
+      case module.transform("style", opts, text_content, transform_meta) do
+        {:ok, scoped_css, directives} when is_binary(scoped_css) and is_list(directives) ->
+          {scoped_css, directives}
 
-      _ ->
-        :ok
-    end
-  end
+        {:error, reason} ->
+          raise ArgumentError,
+                "#{inspect(module)} returned an error: #{inspect(reason)}"
 
-  defp validate_opt!({"global", val}, _other_opts) do
-    raise ArgumentError,
-          "expected nil or true for the `global` attribute of colocated css, got: #{inspect(val)}"
-  end
-
-  defp validate_opt!({"lower-bound", val}, _other_opts) when val in ["inclusive", "exclusive"] do
-    :ok
-  end
-
-  defp validate_opt!({"lower-bound", val}, _other_opts) do
-    raise ArgumentError,
-          ~s|expected "inclusive" or "exclusive" for the `lower-bound` attribute of colocated css, got: #{inspect(val)}|
-  end
-
-  defp validate_opt!(_opt, _other_opts), do: :ok
-
-  @doc false
-  def extract(opts, text_content, meta) do
-    scope = scope(text_content, meta)
-    root_tag_attribute = root_tag_attribute()
-
-    upper_bound_selector = ~s|[phx-css-#{scope}]|
-    lower_bound_selector = ~s|[#{root_tag_attribute}]|
-
-    lower_bound_selector =
-      case opts do
-        %{"lower-bound" => "inclusive"} -> lower_bound_selector <> " > *"
-        _ -> lower_bound_selector
-      end
-
-    styles =
-      case opts do
-        %{"global" => _} ->
-          text_content
-
-        _ ->
-          "@scope (#{upper_bound_selector}) to (#{lower_bound_selector}) { #{text_content} }"
+        other ->
+          raise ArgumentError,
+                "expected the ColocatedCSS implementation to return {:ok, scoped_css, directives} or {:error, term}, got: #{inspect(other)}"
       end
 
     filename = "#{meta.env.line}_#{hash(styles)}.css"
@@ -191,43 +288,13 @@ defmodule Phoenix.LiveView.ColocatedCSS do
     data =
       Phoenix.LiveView.ColocatedAssets.extract(__MODULE__, meta.env.module, filename, styles, nil)
 
-    {scope, data}
-  end
-
-  defp scope(text_content, meta) do
-    hash("#{meta.env.module}_#{meta.env.line}: #{text_content}")
+    {data, directives}
   end
 
   defp hash(string) do
-    # It is important that we do not pad
-    # the Base32 encoded value as we use it in
-    # an HTML attribute name and = (the padding character)
-    # is not valid.
     string
     |> then(&:crypto.hash(:md5, &1))
     |> Base.encode32(case: :lower, padding: false)
-  end
-
-  defp root_tag_attribute() do
-    case Application.get_env(:phoenix_live_view, :root_tag_attribute) do
-      configured_attribute when is_binary(configured_attribute) ->
-        configured_attribute
-
-      configured_attribute ->
-        message = """
-        a global :root_tag_attribute must be configured to use colocated css
-
-        Expected global :root_tag_attribute to be a string, got: #{inspect(configured_attribute)}
-
-        The global :root_tag_attribute is usually configured to `"phx-r"`, but it needs to be explicitly enabled in your configuration:
-
-            config :phoenix_live_view, root_tag_attribute: "phx-r"
-
-        You can also use a different value than `"phx-r"`.
-        """
-
-        raise ArgumentError, message
-    end
   end
 
   @impl Phoenix.LiveView.ColocatedAssets

--- a/lib/phoenix_live_view/tag_engine/compiler.ex
+++ b/lib/phoenix_live_view/tag_engine/compiler.ex
@@ -27,6 +27,7 @@ defmodule Phoenix.LiveView.TagEngine.Compiler do
       caller: Keyword.fetch!(opts, :caller),
       source: Keyword.fetch!(opts, :source),
       tag_handler: tag_handler,
+      tag_attributes: Keyword.get_values(directives, :tag_attribute),
       root_tag_attribute: Application.get_env(:phoenix_live_view, :root_tag_attribute),
       root_tag_attributes: Keyword.get_values(directives, :root_tag_attribute),
       # The following keys are updated when traversing nodes
@@ -486,6 +487,7 @@ defmodule Phoenix.LiveView.TagEngine.Compiler do
     text =
       "<#{name}"
       |> maybe_add_phx_loc(state, meta)
+      |> maybe_add_tag_attributes(state, meta)
       |> maybe_add_root_tag_attributes(state, meta)
 
     substate = state.engine.handle_text(substate, meta, text)
@@ -498,6 +500,22 @@ defmodule Phoenix.LiveView.TagEngine.Compiler do
       "#{text} data-phx-loc=\"#{meta[:line]}\""
     else
       text
+    end
+  end
+
+  defp maybe_add_tag_attributes(text, state, _meta) do
+    case state do
+      %{tag_attributes: [_ | _] = attributes} ->
+        attrs =
+          attributes
+          |> Phoenix.HTML.attributes_escape()
+          |> Phoenix.HTML.safe_to_string()
+
+        # Phoenix.HTML.attributes_escape/1 adds a leading space automatically
+        "#{text}#{attrs}"
+
+      _ ->
+        text
     end
   end
 

--- a/lib/phoenix_live_view/tag_engine/parser.ex
+++ b/lib/phoenix_live_view/tag_engine/parser.ex
@@ -707,7 +707,7 @@ defmodule Phoenix.LiveView.TagEngine.Parser do
        when type in [:tag_attribute, :root_tag_attribute] do
     throw_syntax_error!(
       """
-      expected {name, value} for :root_tag_attribute directive from macro component #{inspect(module)}, got: #{inspect(other)}
+      expected {name, value} for :#{type} directive from macro component #{inspect(module)}, got: #{inspect(other)}
 
       name must be a compile-time string, and value must be a compile-time string or true
       """,

--- a/lib/phoenix_live_view/tag_engine/parser.ex
+++ b/lib/phoenix_live_view/tag_engine/parser.ex
@@ -694,14 +694,17 @@ defmodule Phoenix.LiveView.TagEngine.Parser do
     directives
   end
 
-  defp validate_directive!(_module, :root_tag_attribute, nil, _), do: :ok
+  defp validate_directive!(_module, type, nil, _)
+       when type in [:tag_attribute, :root_tag_attribute], do: :ok
 
-  defp validate_directive!(_module, :root_tag_attribute, {name, value}, _meta)
-       when is_binary(name) and (is_binary(value) or value == true) do
+  defp validate_directive!(_module, type, {name, value}, _meta)
+       when type in [:tag_attribute, :root_tag_attribute] and
+              is_binary(name) and (is_binary(value) or value == true) do
     :ok
   end
 
-  defp validate_directive!(module, :root_tag_attribute, other, meta) do
+  defp validate_directive!(module, type, other, meta)
+       when type in [:tag_attribute, :root_tag_attribute] do
     throw_syntax_error!(
       """
       expected {name, value} for :root_tag_attribute directive from macro component #{inspect(module)}, got: #{inspect(other)}

--- a/test/e2e/support/colocated_live.ex
+++ b/test/e2e/support/colocated_live.ex
@@ -71,6 +71,7 @@ defmodule Phoenix.LiveViewTest.E2E.ColocatedLive do
       // initialize js exec handler from colocated js
       colocated.js_exec(liveSocket);
     </script>
+    <link rel="stylesheet" href="/assets/colocated_css/colocated.css" />
 
     {@inner_content}
     """
@@ -157,6 +158,13 @@ defmodule Phoenix.LiveViewTest.E2E.ColocatedLive do
     end
     </pre>
 
+    <.global_colocated_css />
+    <p data-test="global" class="test-global-css">Should have red background</p>
+    <.scoped_colocated_css />
+    <p data-test="scoped" class="test-scoped-css">Should have no background (out of scope)</p>
+    <.scoped_inclusive_lower_bound_colocated_css />
+    <.scoped_exclusive_lower_bound_colocated_css />
+
     <.lv_code_sample />
     """
   end
@@ -189,5 +197,156 @@ defmodule Phoenix.LiveViewTest.E2E.ColocatedLive do
     end
     </pre>
     '''
+  end
+
+  defp global_colocated_css(assigns) do
+    ~H"""
+    <style :type={Phoenix.LiveView.ColocatedCSS} global>
+      .test-global-css { background-color: rgb(255, 0, 0); }
+    </style>
+    """
+  end
+
+  defp scoped_colocated_css(assigns) do
+    ~H"""
+    <style :type={Phoenix.LiveView.ColocatedCSS}>
+      .test-scoped-css { background-color: rgb(0, 0, 255); }
+    </style>
+    <div>
+      <span data-test-scoped="blue" class="test-scoped-css">Should have blue background</span>
+      <.scoped_css_inner_block_one>
+        <span data-test-scoped="none" class="test-scoped-css">
+          Should have no background (scope root)
+          <span data-test-scoped="blue" class="test-scoped-css">
+            Should have blue background
+          </span>
+        </span>
+      </.scoped_css_inner_block_one>
+      <.scoped_css_inner_block_one>
+        <span data-test-scoped="none" class="test-scoped-css">
+          Should have no background (scope root)
+          <span data-test-scoped="blue" class="test-scoped-css">
+            Should have blue background
+          </span>
+        </span>
+      </.scoped_css_inner_block_one>
+      <.scoped_css_inner_block_two>
+        <span data-test-scoped="none" class="test-scoped-css">
+          Should have no background (scope root)
+          <span data-test-scoped="blue" class="test-scoped-css">
+            Should have blue background
+          </span>
+        </span>
+      </.scoped_css_inner_block_two>
+      <.scoped_css_slot_one>
+        <:test>
+          <span data-test-scoped="none" class="test-scoped-css">
+            Should have no background (scope root)
+            <span data-test-scoped="blue" class="test-scoped-css">
+              Should have blue background
+            </span>
+          </span>
+        </:test>
+      </.scoped_css_slot_one>
+      <.scoped_css_slot_two>
+        <:test>
+          <span data-test-scoped="none" class="test-scoped-css">
+            Should have no background (scope root)
+            <span data-test-scoped="blue" class="test-scoped-css">
+              Should have blue background
+            </span>
+          </span>
+        </:test>
+      </.scoped_css_slot_two>
+    </div>
+    """
+  end
+
+  slot :inner_block, required: true
+
+  defp scoped_css_inner_block_one(assigns) do
+    ~H"""
+    {render_slot(@inner_block)}
+    """
+  end
+
+  slot :inner_block, required: true
+
+  defp scoped_css_inner_block_two(assigns) do
+    ~H"""
+    <style :type={Phoenix.LiveView.ColocatedCSS}>
+      .test-scoped-css { background-color: rgb(255, 255, 0); }
+    </style>
+    <div>
+      <span data-test-scoped="yellow" class="test-scoped-css">Should have yellow background</span>
+      {render_slot(@inner_block)}
+    </div>
+    """
+  end
+
+  slot :test, required: true
+
+  defp scoped_css_slot_one(assigns) do
+    ~H"""
+    {render_slot(@test)}
+    """
+  end
+
+  slot :test, required: true
+
+  defp scoped_css_slot_two(assigns) do
+    ~H"""
+    <style :type={Phoenix.LiveView.ColocatedCSS}>
+      .test-scoped-css { background-color: rgb(0, 255, 0); }
+    </style>
+    <div>
+      <span data-test-scoped="green" class="test-scoped-css">Should have green background</span>
+      {render_slot(@test)}
+    </div>
+    """
+  end
+
+  defp scoped_exclusive_lower_bound_colocated_css(assigns) do
+    ~H"""
+    <style :type={Phoenix.LiveView.ColocatedCSS}>
+      .container:where(:scope) {
+        display: flex;
+
+        > * {
+          flex: 1;
+        }
+      }
+    </style>
+    <div data-test-lower-bound-container class="container">
+      <.flex_items should_flex?={false} />
+    </div>
+    """
+  end
+
+  defp scoped_inclusive_lower_bound_colocated_css(assigns) do
+    ~H"""
+    <style :type={Phoenix.LiveView.ColocatedCSS} lower-bound="inclusive">
+      .container:where(:scope) {
+        display: flex;
+
+        > * {
+          flex: 1;
+        }
+      }
+    </style>
+    <div data-test-lower-bound-container class="container">
+      <.flex_items should_flex?={true} />
+    </div>
+    """
+  end
+
+  attr :should_flex?, :boolean, required: true
+
+  defp flex_items(assigns) do
+    ~H"""
+    <p :for={x <- 1..3} data-test-inclusive={if @should_flex?, do: "yes", else: "no"}>
+      {if @should_flex?, do: "Should", else: "Shouldn't"} Flex {x}
+    </p>
+    """
   end
 end

--- a/test/e2e/support/colocated_live.ex
+++ b/test/e2e/support/colocated_live.ex
@@ -71,7 +71,7 @@ defmodule Phoenix.LiveViewTest.E2E.ColocatedLive do
       // initialize js exec handler from colocated js
       colocated.js_exec(liveSocket);
     </script>
-    <link rel="stylesheet" href="/assets/colocated_css/colocated.css" />
+    <link rel="stylesheet" href="/assets/colocated/colocated.css" />
 
     {@inner_content}
     """

--- a/test/e2e/support/colocated_live.ex
+++ b/test/e2e/support/colocated_live.ex
@@ -35,6 +35,8 @@ defmodule Phoenix.LiveViewTest.E2E.ColocatedLive do
   end
 
   alias Phoenix.LiveView.ColocatedHook, as: Hook
+  alias Phoenix.LiveViewTest.Support.ColocatedScopedCSS, as: ScopedCSS
+  alias Phoenix.LiveViewTest.Support.ColocatedGlobalCSS, as: GlobalCSS
   alias Phoenix.LiveView.JS
 
   def mount(_params, _session, socket) do
@@ -201,7 +203,7 @@ defmodule Phoenix.LiveViewTest.E2E.ColocatedLive do
 
   defp global_colocated_css(assigns) do
     ~H"""
-    <style :type={Phoenix.LiveView.ColocatedCSS} global>
+    <style :type={GlobalCSS}>
       .test-global-css { background-color: rgb(255, 0, 0); }
     </style>
     """
@@ -209,7 +211,7 @@ defmodule Phoenix.LiveViewTest.E2E.ColocatedLive do
 
   defp scoped_colocated_css(assigns) do
     ~H"""
-    <style :type={Phoenix.LiveView.ColocatedCSS}>
+    <style :type={ScopedCSS}>
       .test-scoped-css { background-color: rgb(0, 0, 255); }
     </style>
     <div>
@@ -274,7 +276,7 @@ defmodule Phoenix.LiveViewTest.E2E.ColocatedLive do
 
   defp scoped_css_inner_block_two(assigns) do
     ~H"""
-    <style :type={Phoenix.LiveView.ColocatedCSS}>
+    <style :type={ScopedCSS}>
       .test-scoped-css { background-color: rgb(255, 255, 0); }
     </style>
     <div>
@@ -296,7 +298,7 @@ defmodule Phoenix.LiveViewTest.E2E.ColocatedLive do
 
   defp scoped_css_slot_two(assigns) do
     ~H"""
-    <style :type={Phoenix.LiveView.ColocatedCSS}>
+    <style :type={ScopedCSS}>
       .test-scoped-css { background-color: rgb(0, 255, 0); }
     </style>
     <div>
@@ -308,7 +310,7 @@ defmodule Phoenix.LiveViewTest.E2E.ColocatedLive do
 
   defp scoped_exclusive_lower_bound_colocated_css(assigns) do
     ~H"""
-    <style :type={Phoenix.LiveView.ColocatedCSS}>
+    <style :type={ScopedCSS}>
       .container:where(:scope) {
         display: flex;
 
@@ -325,7 +327,7 @@ defmodule Phoenix.LiveViewTest.E2E.ColocatedLive do
 
   defp scoped_inclusive_lower_bound_colocated_css(assigns) do
     ~H"""
-    <style :type={Phoenix.LiveView.ColocatedCSS} lower-bound="inclusive">
+    <style :type={ScopedCSS} lower-bound="inclusive">
       .container:where(:scope) {
         display: flex;
 

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -283,6 +283,10 @@ defmodule Phoenix.LiveViewTest.E2E.Endpoint do
     from: Path.join(Mix.Project.build_path(), "phoenix-colocated/phoenix_live_view"),
     at: "/assets/colocated"
 
+  plug Plug.Static,
+    from: Path.join(Mix.Project.build_path(), "phoenix-colocated-css/phoenix_live_view"),
+    at: "/assets/colocated_css"
+
   plug Plug.Static, from: System.tmp_dir!(), at: "/tmp"
 
   plug :health_check
@@ -322,8 +326,9 @@ end
 
 IO.puts("Starting e2e server on port #{Phoenix.LiveViewTest.E2E.Endpoint.config(:http)[:port]}")
 
-# we need to manually compile the colocated hooks / js
+# we need to manually compile the colocated hooks / js and css
 Phoenix.LiveView.ColocatedJS.compile()
+Phoenix.LiveView.ColocatedCSS.compile()
 
 if not IEx.started?() do
   # when running the test server manually, we halt after

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -283,10 +283,6 @@ defmodule Phoenix.LiveViewTest.E2E.Endpoint do
     from: Path.join(Mix.Project.build_path(), "phoenix-colocated/phoenix_live_view"),
     at: "/assets/colocated"
 
-  plug Plug.Static,
-    from: Path.join(Mix.Project.build_path(), "phoenix-colocated-css/phoenix_live_view"),
-    at: "/assets/colocated_css"
-
   plug Plug.Static, from: System.tmp_dir!(), at: "/tmp"
 
   plug :health_check
@@ -327,8 +323,7 @@ end
 IO.puts("Starting e2e server on port #{Phoenix.LiveViewTest.E2E.Endpoint.config(:http)[:port]}")
 
 # we need to manually compile the colocated hooks / js and css
-Phoenix.LiveView.ColocatedJS.compile()
-Phoenix.LiveView.ColocatedCSS.compile()
+Phoenix.LiveView.ColocatedAssets.compile()
 
 if not IEx.started?() do
   # when running the test server manually, we halt after

--- a/test/e2e/tests/colocated.spec.js
+++ b/test/e2e/tests/colocated.spec.js
@@ -41,3 +41,85 @@ test("custom macro component works (syntax highlighting)", async ({ page }) => {
     page.locator("pre").nth(1).getByText("@temperature"),
   ).toHaveClass("na");
 });
+
+test("global colocated css works", async ({ page }) => {
+  await page.goto("/colocated");
+  await syncLV(page);
+
+  await expect(page.locator('[data-test="global"]')).toHaveCSS(
+    "background-color",
+    "rgb(255, 0, 0)",
+  );
+});
+
+test("scoped colocated css works", async ({ page }) => {
+  await page.goto("/colocated");
+  await syncLV(page);
+
+  await expect(page.locator('[data-test="scoped"]')).toHaveCSS(
+    "background-color",
+    "rgba(0, 0, 0, 0)",
+  );
+
+  const blueLocator = page.locator('[data-test-scoped="blue"]');
+
+  await expect(blueLocator).toHaveCount(6);
+
+  for (const shouldBeBlue in blueLocator.all()) {
+    await expect(shouldBeBlue).toHaveCSS("background-color", "rgb(0, 0, 255)");
+  }
+
+  const noneLocator = page.locator('[data-test-scoped="none"]');
+
+  await expect(noneLocator).toHaveCount(5);
+
+  for (const shouldBeTransparent in noneLocator.all()) {
+    await expect(shouldBeTransparent).toHaveCSS(
+      "background-color",
+      "rgba(0, 0, 0, 0)",
+    );
+  }
+
+  await expect(page.locator('[data-test-scoped="yellow"]')).toHaveCSS(
+    "background-color",
+    "rgb(255, 255, 0)",
+  );
+
+  await expect(page.locator('[data-test-scoped="green"]')).toHaveCSS(
+    "background-color",
+    "rgb(0, 255, 0)",
+  );
+});
+
+test("scoped colocated css lower bound inclusive/exclusive works", async ({
+  page,
+}) => {
+  await page.goto("/colocated");
+  await syncLV(page);
+
+  const lowerBoundContainerLocator = page.locator(
+    "[data-test-lower-bound-container]",
+  );
+
+  await expect(lowerBoundContainerLocator).toHaveCount(2);
+
+  for (const shouldBeFlex in lowerBoundContainerLocator.all()) {
+    await expect(shouldBeFlex).toHaveCSS("display", "flex");
+  }
+
+  const inclusiveFlexItemsLocator = page.locator('[data-test-inclusive="yes"]');
+
+  await expect(inclusiveFlexItemsLocator).toHaveCount(3);
+
+  for (const shouldFlex in inclusiveFlexItemsLocator.all()) {
+    await expect(shouldFlex).toHaveCSS("flex", "1");
+  }
+
+  const exclusiveFlexItemsLocator = page.locator('[data-test-inclusive="yes"]');
+
+  await expect(exclusiveFlexItemsLocator).toHaveCount(3);
+
+  for (const shouldntFlex in exclusiveFlexItemsLocator.all()) {
+    await expect(shouldntFlex).not().toHaveCSS("flex", "1");
+  }
+});

--- a/test/e2e/tests/colocated.spec.js
+++ b/test/e2e/tests/colocated.spec.js
@@ -71,7 +71,7 @@ test("scoped colocated css works", async ({ page, browserName }) => {
 
   await expect(blueLocator).toHaveCount(6);
 
-  for (const shouldBeBlue in blueLocator.all()) {
+  for (const shouldBeBlue of await blueLocator.all()) {
     await expect(shouldBeBlue).toHaveCSS("background-color", "rgb(0, 0, 255)");
   }
 
@@ -79,7 +79,7 @@ test("scoped colocated css works", async ({ page, browserName }) => {
 
   await expect(noneLocator).toHaveCount(5);
 
-  for (const shouldBeTransparent in noneLocator.all()) {
+  for (const shouldBeTransparent of await noneLocator.all()) {
     await expect(shouldBeTransparent).toHaveCSS(
       "background-color",
       "rgba(0, 0, 0, 0)",
@@ -109,7 +109,7 @@ test("scoped colocated css lower bound inclusive/exclusive works", async ({
 
   await expect(lowerBoundContainerLocator).toHaveCount(2);
 
-  for (const shouldBeFlex in lowerBoundContainerLocator.all()) {
+  for (const shouldBeFlex of await lowerBoundContainerLocator.all()) {
     await expect(shouldBeFlex).toHaveCSS("display", "flex");
   }
 
@@ -117,15 +117,15 @@ test("scoped colocated css lower bound inclusive/exclusive works", async ({
 
   await expect(inclusiveFlexItemsLocator).toHaveCount(3);
 
-  for (const shouldFlex in inclusiveFlexItemsLocator.all()) {
+  for (const shouldFlex of await inclusiveFlexItemsLocator.all()) {
     await expect(shouldFlex).toHaveCSS("flex", "1");
   }
 
-  const exclusiveFlexItemsLocator = page.locator('[data-test-inclusive="yes"]');
+  const exclusiveFlexItemsLocator = page.locator('[data-test-inclusive="no"]');
 
   await expect(exclusiveFlexItemsLocator).toHaveCount(3);
 
-  for (const shouldntFlex in exclusiveFlexItemsLocator.all()) {
+  for (const shouldntFlex of await exclusiveFlexItemsLocator.all()) {
     await expect(shouldntFlex).not().toHaveCSS("flex", "1");
   }
 });

--- a/test/e2e/tests/colocated.spec.js
+++ b/test/e2e/tests/colocated.spec.js
@@ -99,7 +99,14 @@ test("scoped colocated css works", async ({ page, browserName }) => {
 
 test("scoped colocated css lower bound inclusive/exclusive works", async ({
   page,
+  browserName,
 }) => {
+  // TODO: revisit when
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1980526
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1914188
+  // are fixed.
+  test.skip(browserName === "firefox", "Currently broken");
+
   await page.goto("/colocated");
   await syncLV(page);
 
@@ -118,7 +125,7 @@ test("scoped colocated css lower bound inclusive/exclusive works", async ({
   await expect(inclusiveFlexItemsLocator).toHaveCount(3);
 
   for (const shouldFlex of await inclusiveFlexItemsLocator.all()) {
-    await expect(shouldFlex).toHaveCSS("flex", "1");
+    await expect(shouldFlex).toHaveCSS("flex", "1 1 0%");
   }
 
   const exclusiveFlexItemsLocator = page.locator('[data-test-inclusive="no"]');
@@ -126,6 +133,6 @@ test("scoped colocated css lower bound inclusive/exclusive works", async ({
   await expect(exclusiveFlexItemsLocator).toHaveCount(3);
 
   for (const shouldntFlex of await exclusiveFlexItemsLocator.all()) {
-    await expect(shouldntFlex).not().toHaveCSS("flex", "1");
+    await expect(shouldntFlex).toHaveCSS("flex", "0 1 auto");
   }
 });

--- a/test/e2e/tests/colocated.spec.js
+++ b/test/e2e/tests/colocated.spec.js
@@ -52,7 +52,13 @@ test("global colocated css works", async ({ page }) => {
   );
 });
 
-test("scoped colocated css works", async ({ page }) => {
+test("scoped colocated css works", async ({ page, browserName }) => {
+  // TODO: revisit when
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1980526
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1914188
+  // are fixed.
+  test.skip(browserName === "firefox", "Currently broken");
+
   await page.goto("/colocated");
   await syncLV(page);
 

--- a/test/phoenix_component/macro_component_integration_test.exs
+++ b/test/phoenix_component/macro_component_integration_test.exs
@@ -340,7 +340,7 @@ defmodule Phoenix.Component.MacroComponentIntegrationTest do
       end
     end
 
-    assert data = MacroComponent.get_data(TestComponentWithData1, MyMacroComponent)
+    assert %{MyMacroComponent => data} = MacroComponent.get_data(TestComponentWithData1)
     assert length(data) == 2
 
     assert Enum.find(data, fn %{opts: opts} -> opts == %{"baz" => nil, "foo" => "bar"} end)

--- a/test/phoenix_component/macro_component_test.exs
+++ b/test/phoenix_component/macro_component_test.exs
@@ -63,19 +63,19 @@ defmodule Phoenix.Component.MacroComponentTest do
     end
   end
 
-  describe "get_data/2" do
-    test "returns an empty list if the component module does not exist" do
-      assert MacroComponent.get_data(IDoNotExist, MyMacroComponent) == []
+  describe "get_data/1" do
+    test "returns an empty map if the component module does not exist" do
+      assert MacroComponent.get_data(IDoNotExist) == %{}
     end
 
-    test "returns an empty list if the component does not define any macro components" do
+    test "returns an empty map if the component does not define any macro components" do
       defmodule MyComponent do
         use Phoenix.Component
 
         def render(assigns), do: ~H""
       end
 
-      assert MacroComponent.get_data(MyComponent, MyMacroComponent) == []
+      assert MacroComponent.get_data(MyComponent) == %{}
     end
   end
 end

--- a/test/phoenix_live_view/colocated_css_test.exs
+++ b/test/phoenix_live_view/colocated_css_test.exs
@@ -152,12 +152,12 @@ defmodule Phoenix.LiveView.ColocatedCSSTest do
       file_contents = File.read!(style)
 
       file_contents =
-        Regex.replace(~r/phx-css=".+?"/, file_contents, ~s|phx-css="SCOPE_HERE"|)
+        Regex.replace(~r/\[phx-css-.+?\]/, file_contents, ~s|[phx-css-SCOPE_HERE]|)
 
       # The scope is a generated value, so for testing reliability we just replace it with a known
       # value to assert against.
       assert file_contents ==
-               ~s|@scope ([phx-css="SCOPE_HERE"]) to ([phx-r]) { \n  .sample-class { background-color: #FFFFFF; }\n }|
+               ~s|@scope ([phx-css-SCOPE_HERE]) to ([phx-r]) { \n  .sample-class { background-color: #FFFFFF; }\n }|
 
       # now write the manifest manually as we are in a test
       Phoenix.LiveView.ColocatedCSS.compile()
@@ -217,12 +217,12 @@ defmodule Phoenix.LiveView.ColocatedCSSTest do
       file_contents = File.read!(style)
 
       file_contents =
-        Regex.replace(~r/phx-css=".+?"/, file_contents, ~s|phx-css="SCOPE_HERE"|)
+        Regex.replace(~r/\[phx-css-.+?\]/, file_contents, ~s|[phx-css-SCOPE_HERE]|)
 
       # The scope is a generated value, so for testing reliability we just replace it with a known
       # value to assert against.
       assert file_contents ==
-               ~s|@scope ([phx-css="SCOPE_HERE"]) to ([phx-r] > *) { \n  .sample-class { background-color: #FFFFFF; }\n }|
+               ~s|@scope ([phx-css-SCOPE_HERE]) to ([phx-r] > *) { \n  .sample-class { background-color: #FFFFFF; }\n }|
 
       # now write the manifest manually as we are in a test
       Phoenix.LiveView.ColocatedCSS.compile()

--- a/test/phoenix_live_view/colocated_css_test.exs
+++ b/test/phoenix_live_view/colocated_css_test.exs
@@ -1,0 +1,284 @@
+defmodule Phoenix.LiveView.ColocatedCSSTest do
+  # we set async: false because we call the colocated CSS compiler
+  # and it reads / writes to a shared folder, and also because
+  # we manipulate the Application env for :root_tag_attribute
+  use ExUnit.Case, async: false
+
+  alias Phoenix.LiveView.TagEngine.Tokenizer.ParseError
+
+  setup do
+    Application.put_env(:phoenix_live_view, :root_tag_attribute, "phx-r")
+    on_exit(fn -> Application.delete_env(:phoenix_live_view, :root_tag_attribute) end)
+  end
+
+  describe "global styles" do
+    test "are extracted and available under manifest import" do
+      defmodule TestGlobalComponent do
+        use Phoenix.Component
+
+        def fun(assigns) do
+          ~H"""
+          <style :type={Phoenix.LiveView.ColocatedCSS} global>
+            .sample-class { background-color: #FFFFFF; }
+          </style>
+          """
+        end
+      end
+
+      assert module_folders =
+               File.ls!(
+                 Path.join(Mix.Project.build_path(), "phoenix-colocated-css/phoenix_live_view")
+               )
+
+      assert folder =
+               Enum.find(module_folders, fn folder ->
+                 folder =~ ~r/#{inspect(__MODULE__)}\.TestGlobalComponent$/
+               end)
+
+      assert [style] =
+               Path.wildcard(
+                 Path.join(
+                   Mix.Project.build_path(),
+                   "phoenix-colocated-css/phoenix_live_view/#{folder}/*.css"
+                 )
+               )
+
+      assert File.read!(style) == "\n  .sample-class { background-color: #FFFFFF; }\n"
+
+      # now write the manifest manually as we are in a test
+      Phoenix.LiveView.ColocatedCSS.compile()
+
+      assert manifest =
+               File.read!(
+                 Path.join(
+                   Mix.Project.build_path(),
+                   "phoenix-colocated-css/phoenix_live_view/colocated.css"
+                 )
+               )
+
+      path =
+        Path.relative_to(
+          style,
+          Path.join(Mix.Project.build_path(), "phoenix-colocated-css/phoenix_live_view/")
+        )
+
+      # style is in manifest
+      assert manifest =~ ~s[@import "./#{path}";\n]
+    after
+      :code.delete(__MODULE__.TestGlobalComponent)
+      :code.purge(__MODULE__.TestGlobalComponent)
+    end
+
+    test "raises for invalid global attribute value" do
+      message = ~r/expected nil or true for the `global` attribute of colocated css, got: "bad"/
+
+      assert_raise ParseError,
+                   message,
+                   fn ->
+                     defmodule TestBadGlobalAttrComponent do
+                       use Phoenix.Component
+
+                       def fun(assigns) do
+                         ~H"""
+                         <style :type={Phoenix.LiveView.ColocatedCSS} global="bad">
+                           .sample-class { background-color: #FFFFFF; }
+                         </style>
+                         """
+                       end
+                     end
+                   end
+    after
+      :code.delete(__MODULE__.TestBadGlobalAttrComponent)
+      :code.purge(__MODULE__.TestBadGlobalAttrComponent)
+    end
+
+    test "raises if scoped css specific options are provided" do
+      message =
+        ~r/colocated css must be scoped to use the `lower-bound` attribute, but `global` attribute was provided/
+
+      assert_raise ParseError,
+                   message,
+                   fn ->
+                     defmodule TestScopedAttrWhileGlobalComponent do
+                       use Phoenix.Component
+
+                       def fun(assigns) do
+                         ~H"""
+                         <style :type={Phoenix.LiveView.ColocatedCSS} global lower-bound="inclusive">
+                           .sample-class { background-color: #FFFFFF; }
+                         </style>
+                         """
+                       end
+                     end
+                   end
+    after
+      :code.delete(__MODULE__.TestScopedAttrWhileGlobalComponent)
+      :code.purge(__MODULE__.TestScopedAttrWhileGlobalComponent)
+    end
+  end
+
+  describe "scoped styles" do
+    test "with exclusive (default) lower-bound is extracted and available under manifest import" do
+      defmodule TestScopedExclusiveComponent do
+        use Phoenix.Component
+
+        def fun(assigns) do
+          ~H"""
+          <style :type={Phoenix.LiveView.ColocatedCSS}>
+            .sample-class { background-color: #FFFFFF; }
+          </style>
+          """
+        end
+      end
+
+      assert module_folders =
+               File.ls!(
+                 Path.join(Mix.Project.build_path(), "phoenix-colocated-css/phoenix_live_view")
+               )
+
+      assert folder =
+               Enum.find(module_folders, fn folder ->
+                 folder =~ ~r/#{inspect(__MODULE__)}\.TestScopedExclusiveComponent$/
+               end)
+
+      assert [style] =
+               Path.wildcard(
+                 Path.join(
+                   Mix.Project.build_path(),
+                   "phoenix-colocated-css/phoenix_live_view/#{folder}/*.css"
+                 )
+               )
+
+      file_contents = File.read!(style)
+
+      file_contents =
+        Regex.replace(~r/phx-css=".+?"/, file_contents, ~s|phx-css="SCOPE_HERE"|)
+
+      # The scope is a generated value, so for testing reliability we just replace it with a known
+      # value to assert against.
+      assert file_contents ==
+               ~s|@scope ([phx-css="SCOPE_HERE"]) to ([phx-r]) { \n  .sample-class { background-color: #FFFFFF; }\n }|
+
+      # now write the manifest manually as we are in a test
+      Phoenix.LiveView.ColocatedCSS.compile()
+
+      assert manifest =
+               File.read!(
+                 Path.join(
+                   Mix.Project.build_path(),
+                   "phoenix-colocated-css/phoenix_live_view/colocated.css"
+                 )
+               )
+
+      path =
+        Path.relative_to(
+          style,
+          Path.join(Mix.Project.build_path(), "phoenix-colocated-css/phoenix_live_view/")
+        )
+
+      # style is in manifest
+      assert manifest =~ ~s[@import "./#{path}";\n]
+    after
+      :code.delete(__MODULE__.TestScopedExclusiveComponent)
+      :code.purge(__MODULE__.TestScopedExclusiveComponent)
+    end
+
+    test "with inclusive lower-bound is extracted and available under manifest import" do
+      defmodule TestScopedInclusiveComponent do
+        use Phoenix.Component
+
+        def fun(assigns) do
+          ~H"""
+          <style :type={Phoenix.LiveView.ColocatedCSS} lower-bound="inclusive">
+            .sample-class { background-color: #FFFFFF; }
+          </style>
+          """
+        end
+      end
+
+      assert module_folders =
+               File.ls!(
+                 Path.join(Mix.Project.build_path(), "phoenix-colocated-css/phoenix_live_view")
+               )
+
+      assert folder =
+               Enum.find(module_folders, fn folder ->
+                 folder =~ ~r/#{inspect(__MODULE__)}\.TestScopedInclusiveComponent$/
+               end)
+
+      assert [style] =
+               Path.wildcard(
+                 Path.join(
+                   Mix.Project.build_path(),
+                   "phoenix-colocated-css/phoenix_live_view/#{folder}/*.css"
+                 )
+               )
+
+      file_contents = File.read!(style)
+
+      file_contents =
+        Regex.replace(~r/phx-css=".+?"/, file_contents, ~s|phx-css="SCOPE_HERE"|)
+
+      # The scope is a generated value, so for testing reliability we just replace it with a known
+      # value to assert against.
+      assert file_contents ==
+               ~s|@scope ([phx-css="SCOPE_HERE"]) to ([phx-r] > *) { \n  .sample-class { background-color: #FFFFFF; }\n }|
+
+      # now write the manifest manually as we are in a test
+      Phoenix.LiveView.ColocatedCSS.compile()
+
+      assert manifest =
+               File.read!(
+                 Path.join(
+                   Mix.Project.build_path(),
+                   "phoenix-colocated-css/phoenix_live_view/colocated.css"
+                 )
+               )
+
+      path =
+        Path.relative_to(
+          style,
+          Path.join(Mix.Project.build_path(), "phoenix-colocated-css/phoenix_live_view/")
+        )
+
+      # style is in manifest
+      assert manifest =~ ~s[@import "./#{path}";\n]
+    after
+      :code.delete(__MODULE__.TestScopedInclusiveComponent)
+      :code.purge(__MODULE__.TestScopedInclusiveComponent)
+    end
+
+    test "raises for invalid lower-bound attribute value" do
+      message =
+        ~r/expected "inclusive" or "exclusive" for the `lower-bound` attribute of colocated css, got: "unknown"/
+
+      assert_raise ParseError,
+                   message,
+                   fn ->
+                     defmodule TestBadLowerBoundAttrComponent do
+                       use Phoenix.Component
+
+                       def fun(assigns) do
+                         ~H"""
+                         <style :type={Phoenix.LiveView.ColocatedCSS} lower-bound="unknown">
+                           .sample-class { background-color: #FFFFFF; }
+                         </style>
+                         """
+                       end
+                     end
+                   end
+    after
+      :code.delete(__MODULE__.TestBadLowerBoundAttrComponent)
+      :code.purge(__MODULE__.TestBadLowerBoundAttrComponent)
+    end
+  end
+
+  test "writes empty manifest when no colocated styles exist" do
+    manifest =
+      Path.join(Mix.Project.build_path(), "phoenix-colocated-css/phoenix_live_view/colocated.css")
+
+    Phoenix.LiveView.ColocatedCSS.compile()
+    assert File.exists?(manifest)
+    assert File.read!(manifest) == ""
+  end
+end

--- a/test/phoenix_live_view/colocated_css_test.exs
+++ b/test/phoenix_live_view/colocated_css_test.exs
@@ -27,7 +27,7 @@ defmodule Phoenix.LiveView.ColocatedCSSTest do
 
       assert module_folders =
                File.ls!(
-                 Path.join(Mix.Project.build_path(), "phoenix-colocated-css/phoenix_live_view")
+                 Path.join(Mix.Project.build_path(), "phoenix-colocated/phoenix_live_view")
                )
 
       assert folder =
@@ -39,27 +39,27 @@ defmodule Phoenix.LiveView.ColocatedCSSTest do
                Path.wildcard(
                  Path.join(
                    Mix.Project.build_path(),
-                   "phoenix-colocated-css/phoenix_live_view/#{folder}/*.css"
+                   "phoenix-colocated/phoenix_live_view/#{folder}/*.css"
                  )
                )
 
       assert File.read!(style) == "\n  .sample-class { background-color: #FFFFFF; }\n"
 
       # now write the manifest manually as we are in a test
-      Phoenix.LiveView.ColocatedCSS.compile()
+      Phoenix.LiveView.ColocatedAssets.compile()
 
       assert manifest =
                File.read!(
                  Path.join(
                    Mix.Project.build_path(),
-                   "phoenix-colocated-css/phoenix_live_view/colocated.css"
+                   "phoenix-colocated/phoenix_live_view/colocated.css"
                  )
                )
 
       path =
         Path.relative_to(
           style,
-          Path.join(Mix.Project.build_path(), "phoenix-colocated-css/phoenix_live_view/")
+          Path.join(Mix.Project.build_path(), "phoenix-colocated/phoenix_live_view/")
         )
 
       # style is in manifest
@@ -133,7 +133,7 @@ defmodule Phoenix.LiveView.ColocatedCSSTest do
 
       assert module_folders =
                File.ls!(
-                 Path.join(Mix.Project.build_path(), "phoenix-colocated-css/phoenix_live_view")
+                 Path.join(Mix.Project.build_path(), "phoenix-colocated/phoenix_live_view")
                )
 
       assert folder =
@@ -145,7 +145,7 @@ defmodule Phoenix.LiveView.ColocatedCSSTest do
                Path.wildcard(
                  Path.join(
                    Mix.Project.build_path(),
-                   "phoenix-colocated-css/phoenix_live_view/#{folder}/*.css"
+                   "phoenix-colocated/phoenix_live_view/#{folder}/*.css"
                  )
                )
 
@@ -160,20 +160,20 @@ defmodule Phoenix.LiveView.ColocatedCSSTest do
                ~s|@scope ([phx-css-SCOPE_HERE]) to ([phx-r]) { \n  .sample-class { background-color: #FFFFFF; }\n }|
 
       # now write the manifest manually as we are in a test
-      Phoenix.LiveView.ColocatedCSS.compile()
+      Phoenix.LiveView.ColocatedAssets.compile()
 
       assert manifest =
                File.read!(
                  Path.join(
                    Mix.Project.build_path(),
-                   "phoenix-colocated-css/phoenix_live_view/colocated.css"
+                   "phoenix-colocated/phoenix_live_view/colocated.css"
                  )
                )
 
       path =
         Path.relative_to(
           style,
-          Path.join(Mix.Project.build_path(), "phoenix-colocated-css/phoenix_live_view/")
+          Path.join(Mix.Project.build_path(), "phoenix-colocated/phoenix_live_view/")
         )
 
       # style is in manifest
@@ -198,7 +198,7 @@ defmodule Phoenix.LiveView.ColocatedCSSTest do
 
       assert module_folders =
                File.ls!(
-                 Path.join(Mix.Project.build_path(), "phoenix-colocated-css/phoenix_live_view")
+                 Path.join(Mix.Project.build_path(), "phoenix-colocated/phoenix_live_view")
                )
 
       assert folder =
@@ -210,7 +210,7 @@ defmodule Phoenix.LiveView.ColocatedCSSTest do
                Path.wildcard(
                  Path.join(
                    Mix.Project.build_path(),
-                   "phoenix-colocated-css/phoenix_live_view/#{folder}/*.css"
+                   "phoenix-colocated/phoenix_live_view/#{folder}/*.css"
                  )
                )
 
@@ -225,20 +225,20 @@ defmodule Phoenix.LiveView.ColocatedCSSTest do
                ~s|@scope ([phx-css-SCOPE_HERE]) to ([phx-r] > *) { \n  .sample-class { background-color: #FFFFFF; }\n }|
 
       # now write the manifest manually as we are in a test
-      Phoenix.LiveView.ColocatedCSS.compile()
+      Phoenix.LiveView.ColocatedAssets.compile()
 
       assert manifest =
                File.read!(
                  Path.join(
                    Mix.Project.build_path(),
-                   "phoenix-colocated-css/phoenix_live_view/colocated.css"
+                   "phoenix-colocated/phoenix_live_view/colocated.css"
                  )
                )
 
       path =
         Path.relative_to(
           style,
-          Path.join(Mix.Project.build_path(), "phoenix-colocated-css/phoenix_live_view/")
+          Path.join(Mix.Project.build_path(), "phoenix-colocated/phoenix_live_view/")
         )
 
       # style is in manifest
@@ -275,9 +275,9 @@ defmodule Phoenix.LiveView.ColocatedCSSTest do
 
   test "writes empty manifest when no colocated styles exist" do
     manifest =
-      Path.join(Mix.Project.build_path(), "phoenix-colocated-css/phoenix_live_view/colocated.css")
+      Path.join(Mix.Project.build_path(), "phoenix-colocated/phoenix_live_view/colocated.css")
 
-    Phoenix.LiveView.ColocatedCSS.compile()
+    Phoenix.LiveView.ColocatedAssets.compile()
     assert File.exists?(manifest)
     assert File.read!(manifest) == ""
   end

--- a/test/phoenix_live_view/colocated_css_test.exs
+++ b/test/phoenix_live_view/colocated_css_test.exs
@@ -18,7 +18,7 @@ defmodule Phoenix.LiveView.ColocatedCSSTest do
 
         def fun(assigns) do
           ~H"""
-          <style :type={Phoenix.LiveView.ColocatedCSS} global>
+          <style :type={Phoenix.LiveViewTest.Support.ColocatedGlobalCSS}>
             .sample-class { background-color: #FFFFFF; }
           </style>
           """
@@ -68,53 +68,6 @@ defmodule Phoenix.LiveView.ColocatedCSSTest do
       :code.delete(__MODULE__.TestGlobalComponent)
       :code.purge(__MODULE__.TestGlobalComponent)
     end
-
-    test "raises for invalid global attribute value" do
-      message = ~r/expected nil or true for the `global` attribute of colocated css, got: "bad"/
-
-      assert_raise ParseError,
-                   message,
-                   fn ->
-                     defmodule TestBadGlobalAttrComponent do
-                       use Phoenix.Component
-
-                       def fun(assigns) do
-                         ~H"""
-                         <style :type={Phoenix.LiveView.ColocatedCSS} global="bad">
-                           .sample-class { background-color: #FFFFFF; }
-                         </style>
-                         """
-                       end
-                     end
-                   end
-    after
-      :code.delete(__MODULE__.TestBadGlobalAttrComponent)
-      :code.purge(__MODULE__.TestBadGlobalAttrComponent)
-    end
-
-    test "raises if scoped css specific options are provided" do
-      message =
-        ~r/colocated css must be scoped to use the `lower-bound` attribute, but `global` attribute was provided/
-
-      assert_raise ParseError,
-                   message,
-                   fn ->
-                     defmodule TestScopedAttrWhileGlobalComponent do
-                       use Phoenix.Component
-
-                       def fun(assigns) do
-                         ~H"""
-                         <style :type={Phoenix.LiveView.ColocatedCSS} global lower-bound="inclusive">
-                           .sample-class { background-color: #FFFFFF; }
-                         </style>
-                         """
-                       end
-                     end
-                   end
-    after
-      :code.delete(__MODULE__.TestScopedAttrWhileGlobalComponent)
-      :code.purge(__MODULE__.TestScopedAttrWhileGlobalComponent)
-    end
   end
 
   describe "scoped styles" do
@@ -124,7 +77,7 @@ defmodule Phoenix.LiveView.ColocatedCSSTest do
 
         def fun(assigns) do
           ~H"""
-          <style :type={Phoenix.LiveView.ColocatedCSS}>
+          <style :type={Phoenix.LiveViewTest.Support.ColocatedScopedCSS}>
             .sample-class { background-color: #FFFFFF; }
           </style>
           """
@@ -189,7 +142,7 @@ defmodule Phoenix.LiveView.ColocatedCSSTest do
 
         def fun(assigns) do
           ~H"""
-          <style :type={Phoenix.LiveView.ColocatedCSS} lower-bound="inclusive">
+          <style :type={Phoenix.LiveViewTest.Support.ColocatedScopedCSS} lower-bound="inclusive">
             .sample-class { background-color: #FFFFFF; }
           </style>
           """
@@ -260,7 +213,7 @@ defmodule Phoenix.LiveView.ColocatedCSSTest do
 
                        def fun(assigns) do
                          ~H"""
-                         <style :type={Phoenix.LiveView.ColocatedCSS} lower-bound="unknown">
+                         <style :type={Phoenix.LiveViewTest.Support.ColocatedScopedCSS} lower-bound="unknown">
                            .sample-class { background-color: #FFFFFF; }
                          </style>
                          """

--- a/test/phoenix_live_view/colocated_hook_test.exs
+++ b/test/phoenix_live_view/colocated_hook_test.exs
@@ -42,7 +42,7 @@ defmodule Phoenix.LiveView.ColocatedHookTest do
     assert File.read!(script) =~ "Hello, world!"
 
     # now write the manifest manually as we are in a test
-    Phoenix.LiveView.ColocatedJS.compile()
+    Phoenix.LiveView.ColocatedAssets.compile()
 
     assert manifest =
              File.read!(

--- a/test/phoenix_live_view/colocated_js_test.exs
+++ b/test/phoenix_live_view/colocated_js_test.exs
@@ -43,7 +43,7 @@ defmodule Phoenix.LiveView.ColocatedJSTest do
            """
 
     # now write the manifest manually as we are in a test
-    Phoenix.LiveView.ColocatedJS.compile()
+    Phoenix.LiveView.ColocatedAssets.compile()
 
     assert manifest =
              File.read!(
@@ -104,7 +104,7 @@ defmodule Phoenix.LiveView.ColocatedJSTest do
            """
 
     # now write the manifest manually as we are in a test
-    Phoenix.LiveView.ColocatedJS.compile()
+    Phoenix.LiveView.ColocatedAssets.compile()
 
     relative_script_path =
       Path.relative_to(
@@ -168,7 +168,7 @@ defmodule Phoenix.LiveView.ColocatedJSTest do
            """
 
     # now write the manifest manually as we are in a test
-    Phoenix.LiveView.ColocatedJS.compile()
+    Phoenix.LiveView.ColocatedAssets.compile()
 
     relative_script_path =
       Path.relative_to(
@@ -214,7 +214,7 @@ defmodule Phoenix.LiveView.ColocatedJSTest do
 
   test "writes empty index.js when no colocated scripts exist" do
     manifest = Path.join(Mix.Project.build_path(), "phoenix-colocated/phoenix_live_view/index.js")
-    Phoenix.LiveView.ColocatedJS.compile()
+    Phoenix.LiveView.ColocatedAssets.compile()
     assert File.exists?(manifest)
     assert File.read!(manifest) == "export const hooks = {};\nexport default {};"
   end
@@ -227,7 +227,7 @@ defmodule Phoenix.LiveView.ColocatedJSTest do
     end
 
     File.mkdir_p!(Path.join(node_path, "foo"))
-    Phoenix.LiveView.ColocatedJS.compile()
+    Phoenix.LiveView.ColocatedAssets.compile()
 
     symlink =
       Path.join(

--- a/test/support/colocated_css.ex
+++ b/test/support/colocated_css.ex
@@ -1,0 +1,87 @@
+defmodule Phoenix.LiveViewTest.Support.ColocatedScopedCSS do
+  use Phoenix.LiveView.ColocatedCSS
+
+  @impl true
+  def transform("style", attrs, css, meta) do
+    validate_opts!(attrs)
+
+    {scope, css} = do_scope(css, attrs, meta)
+
+    {:ok, css, [root_tag_attribute: {"phx-css-#{scope}", true}]}
+  end
+
+  defp validate_opts!(opts) do
+    Enum.each(opts, fn {key, val} -> validate_opt!({key, val}, Map.delete(opts, key)) end)
+  end
+
+  defp validate_opt!({"lower-bound", val}, _other_opts) when val in ["inclusive", "exclusive"] do
+    :ok
+  end
+
+  defp validate_opt!({"lower-bound", val}, _other_opts) do
+    raise ArgumentError,
+          ~s|expected "inclusive" or "exclusive" for the `lower-bound` attribute of colocated css, got: #{inspect(val)}|
+  end
+
+  defp validate_opt!(_opt, _other_opts), do: :ok
+
+  defp do_scope(css, opts, meta) do
+    scope = hash("#{meta.module}_#{meta.line}: #{css}")
+
+    root_tag_attribute = root_tag_attribute()
+
+    upper_bound_selector = ~s|[phx-css-#{scope}]|
+    lower_bound_selector = ~s|[#{root_tag_attribute}]|
+
+    lower_bound_selector =
+      case opts do
+        %{"lower-bound" => "inclusive"} -> lower_bound_selector <> " > *"
+        _ -> lower_bound_selector
+      end
+
+    css = "@scope (#{upper_bound_selector}) to (#{lower_bound_selector}) { #{css} }"
+
+    {scope, css}
+  end
+
+  defp hash(string) do
+    # It is important that we do not pad
+    # the Base32 encoded value as we use it in
+    # an HTML attribute name and = (the padding character)
+    # is not valid.
+    string
+    |> then(&:crypto.hash(:md5, &1))
+    |> Base.encode32(case: :lower, padding: false)
+  end
+
+  defp root_tag_attribute() do
+    case Application.get_env(:phoenix_live_view, :root_tag_attribute) do
+      configured_attribute when is_binary(configured_attribute) ->
+        configured_attribute
+
+      configured_attribute ->
+        message = """
+        a global :root_tag_attribute must be configured to use scoped css
+
+        Expected global :root_tag_attribute to be a string, got: #{inspect(configured_attribute)}
+
+        The global :root_tag_attribute is usually configured to `"phx-r"`, but it needs to be explicitly enabled in your configuration:
+
+            config :phoenix_live_view, root_tag_attribute: "phx-r"
+
+        You can also use a different value than `"phx-r"`.
+        """
+
+        raise ArgumentError, message
+    end
+  end
+end
+
+defmodule Phoenix.LiveViewTest.Support.ColocatedGlobalCSS do
+  use Phoenix.LiveView.ColocatedCSS
+
+  @impl true
+  def transform("style", _attrs, css, _meta) do
+    {:ok, css, []}
+  end
+end


### PR DESCRIPTION
Supersedes https://github.com/phoenixframework/phoenix_live_view/pull/4133.

So the idea here is to have a generic way to colocate "assets" (currently JS + CSS) where template parts are extracted to a `phoenix-colocated` folder with a specific structure:

```
_build/$MIX_ENV/phoenix-colocated/
_build/$MIX_ENV/phoenix-colocated/my_app/
_build/$MIX_ENV/phoenix-colocated/my_app/manifest
_build/$MIX_ENV/phoenix-colocated/my_app/MyAppWeb.DemoLive/line_HASH
_build/$MIX_ENV/phoenix-colocated/my_dependency/MyDependency.Module/line_HASH
```

This fits both colocated JS (hooks) and CSS, which can share the same folder layout using different manifest files. The question is if this is the right level of abstraction. It allows us to extract all of the common code into `ColocatedAssets`, but it assumes that all types of colocated assets can work with this layout.

I'm also not quite happy that the `configured_callbacks` in ColocatedAssets still need to hardcode the list of supported modules. It would be great if dependencies could (theoretically, the API is private for now) also implement colocated assets without us needing to change LiveView code. For example, I could imagine colocated CSS being implemented by annotating all tags with an attribute and then using a `postcss` plugin that rewrites the CSS rules (similar to https://github.com/SteffenDE/liveview_colocated_demo/blob/main/lib/colocated_demo_web/colocated_css.ex).

Example of PostCSS scoping: https://github.com/SteffenDE/phx_colocated_postcss_example/commit/9ec8372b7708f64217b7e38ab98fbd37ed8774a1