### PR TITLE
Fix formatting of single-line HTML comments

### DIFF
--- a/test/e2e/support/components_live.ex
+++ b/test/e2e/support/components_live.ex
@@ -19,8 +19,8 @@ defmodule Phoenix.LiveViewTest.E2E.ComponentsLive do
     ~H"""
     <div class="p-6">
       <h1 class="text-2xl font-bold mb-6">Phoenix Components Demo</h1>
-      
-    <!-- Tab Navigation -->
+
+      <!-- Tab Navigation -->
       <div class="border-b border-gray-200 mb-6">
         <nav class="-mb-px flex space-x-8">
           <.tab_link tab="focus_wrap" active_tab={@active_tab} patch="/components?tab=focus_wrap">
@@ -28,8 +28,8 @@ defmodule Phoenix.LiveViewTest.E2E.ComponentsLive do
           </.tab_link>
         </nav>
       </div>
-      
-    <!-- Tab Content -->
+
+      <!-- Tab Content -->
       <div class="mt-6">
         <div :if={@active_tab == "focus_wrap"}>
           <.focus_wrap_demo />

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -2345,6 +2345,69 @@ defmodule Phoenix.LiveView.HTMLFormatterTest do
     )
   end
 
+  test "formats HTML comments evenly with the block they belong to" do
+    spaces = String.duplicate(" ", 10)
+
+    input = """
+    <section>
+    <!-- First section -->
+      <div>
+        <h1>Hello</h1>
+      </div>
+      #{spaces}
+      <!-- Second section -->
+      <div>
+        <h1>World</h1>
+      </div>
+      #{spaces}
+      <div>
+        <h1>!</h1>
+      </div>
+
+      #{spaces}
+    <!-- Indentation to be corrected -->
+
+      <div>
+        <button>Click here</button>
+      </div>
+      <!-- No line break before this one -->
+      <div>
+        <button>Cancel</button>
+      </div>
+    </section>
+    """
+
+    expected = """
+    <section>
+      <!-- First section -->
+      <div>
+        <h1>Hello</h1>
+      </div>
+
+      <!-- Second section -->
+      <div>
+        <h1>World</h1>
+      </div>
+
+      <div>
+        <h1>!</h1>
+      </div>
+
+      <!-- Indentation to be corrected -->
+
+      <div>
+        <button>Click here</button>
+      </div>
+      <!-- No line break before this one -->
+      <div>
+        <button>Cancel</button>
+      </div>
+    </section>
+    """
+
+    assert_formatter_output(input, expected)
+  end
+
   test "handle EEx comments" do
     assert_formatter_doesnt_change("""
     <div>


### PR DESCRIPTION
This fixes two idiosyncracies of the `PhoenixLiveView.HTMLFormatter` when there were HTML comments above blocks:

1. The single-line comment itself would be outdented compared to the other blocks at that level of the tree, like:
    ```html
    <div>
      <div>Block 1</div>

    <!-- This should have been indented 2 more spaces -->
      <div>Block 2</div>
    </div>
    ```
2. The empty line preceding a single-line comment had whitespace added equal to where the single-line comment *should* have been indented. This one's kind of hard to show, so bear with me as I replace spaces with the `X` character:
    ```html
    <div>
    XX<div>Block 1</div>
    XX
    <!-- This line has n-2 spaces of indentation, but the preceding line contains exactly n spaces -->
    XX<div>Block 2</div>
    </div>
    ```

The fix is kind of convoluted (treating the preceding and successive spaces as their own text nodes for the sake of the HTML algebra computation), but I played with it for a while and couldn't come up with a better solution. Certainly open to better ideas!