### PR TITLE
DOM patching: Fall back to PHX_MAGIC_ID if node ID was touched by client hook

### DIFF
--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -148,6 +148,18 @@ export default class DOMPatch {
           if (isJoinPatch) {
             return node.id;
           }
+
+          // If ID was set by JavaScript (via hooks), use PHX_MAGIC_ID for matching.
+          // This ensures morphdom can match elements even when JS modifies their IDs.
+          // Check sticky operations to detect JS-set IDs.
+          const stickyAttrs = DOM.getSticky(node, "attrs", [[], []]);
+          const [sets, _removes] = stickyAttrs;
+          const hasJsSetId = sets.some(([attr, _val]) => attr === "id");
+
+          if (hasJsSetId) {
+            return node.getAttribute && node.getAttribute(PHX_MAGIC_ID);
+          }
+
           return (
             node.id || (node.getAttribute && node.getAttribute(PHX_MAGIC_ID))
           );

--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -149,14 +149,9 @@ export default class DOMPatch {
             return node.id;
           }
 
-          // If ID was set by JavaScript (via hooks), use PHX_MAGIC_ID for matching.
+          // If ID was touched by JavaScript hook, use PHX_MAGIC_ID for matching.
           // This ensures morphdom can match elements even when JS modifies their IDs.
-          // Check sticky operations to detect JS-set IDs.
-          const stickyAttrs = DOM.getSticky(node, "attrs", [[], []]);
-          const [sets, _removes] = stickyAttrs;
-          const hasJsSetId = sets.some(([attr, _val]) => attr === "id");
-
-          if (hasJsSetId) {
+          if (DOM.private(node, "clientsideIdAttribute")) {
             return node.getAttribute && node.getAttribute(PHX_MAGIC_ID);
           }
 

--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -600,6 +600,11 @@ const JS = {
       .filter((attr) => !alteredAttrs.includes(attr))
       .concat(removes);
 
+    // If element ID is touched via JavaScript, mark it for cheap lookup during morphdom
+    if (sets.some(([attr, _val]) => attr === "id")) {
+      DOM.putPrivate(el, "clientsideIdAttribute", true);
+    }
+
     DOM.putSticky(el, "attrs", (currentEl) => {
       newRemoves.forEach((attr) => currentEl.removeAttribute(attr));
       newSets.forEach(([attr, val]) => currentEl.setAttribute(attr, val));

--- a/assets/test/phx_skip_js_id_test.ts
+++ b/assets/test/phx_skip_js_id_test.ts
@@ -1,7 +1,6 @@
 import { Socket } from "phoenix";
 import LiveSocket from "phoenix_live_view/live_socket";
 import ViewHook from "phoenix_live_view/view_hook";
-import DOM from "phoenix_live_view/dom";
 import { simulateJoinedView, liveViewDOM } from "./test_helpers";
 
 describe("phx-skip with JavaScript-set DOM IDs", () => {

--- a/assets/test/phx_skip_js_id_test.ts
+++ b/assets/test/phx_skip_js_id_test.ts
@@ -4,7 +4,7 @@ import ViewHook from "phoenix_live_view/view_hook";
 import { simulateJoinedView, liveViewDOM } from "./test_helpers";
 
 describe("phx-skip with JavaScript-set DOM IDs", () => {
-  let liveSocket: LiveSocket;
+  let liveSocket: LiveSocket | null;
 
   beforeEach(() => {
     global.Phoenix = { Socket };
@@ -27,9 +27,10 @@ describe("phx-skip with JavaScript-set DOM IDs", () => {
 
     const view = simulateJoinedView(el, liveSocket);
     const targetEl = el.querySelector('[data-phx-magic-id="span-magic"]');
+    if (!targetEl) throw new Error("Target element not found");
 
-    const hook = new ViewHook(view, targetEl, {});
-    hook.js().setAttribute(targetEl, "id", "js-set-id");
+    const hook = new ViewHook(view, targetEl as HTMLElement, {});
+    hook.js().setAttribute(targetEl as HTMLElement, "id", "js-set-id");
 
     const updateDiff = {
       s: [
@@ -44,7 +45,7 @@ describe("phx-skip with JavaScript-set DOM IDs", () => {
 
     const afterUpdate = el.querySelector("#js-set-id");
     expect(afterUpdate).not.toBeNull();
-    expect(afterUpdate.id).toBe("js-set-id");
-    expect(afterUpdate.textContent).toBe("content");
+    expect(afterUpdate!.id).toBe("js-set-id");
+    expect(afterUpdate!.textContent).toBe("content");
   });
 });

--- a/assets/test/phx_skip_js_id_test.ts
+++ b/assets/test/phx_skip_js_id_test.ts
@@ -1,6 +1,7 @@
 import { Socket } from "phoenix";
 import LiveSocket from "phoenix_live_view/live_socket";
 import ViewHook from "phoenix_live_view/view_hook";
+import DOM from "phoenix_live_view/dom";
 import { simulateJoinedView, liveViewDOM } from "./test_helpers";
 
 describe("phx-skip with JavaScript-set DOM IDs", () => {
@@ -27,7 +28,6 @@ describe("phx-skip with JavaScript-set DOM IDs", () => {
 
     const view = simulateJoinedView(el, liveSocket);
     const targetEl = el.querySelector('[data-phx-magic-id="span-magic"]');
-    if (!targetEl) throw new Error("Target element not found");
 
     const hook = new ViewHook(view, targetEl as HTMLElement, {});
     hook.js().setAttribute(targetEl as HTMLElement, "id", "js-set-id");

--- a/assets/test/phx_skip_js_id_test.ts
+++ b/assets/test/phx_skip_js_id_test.ts
@@ -1,0 +1,50 @@
+import { Socket } from "phoenix";
+import LiveSocket from "phoenix_live_view/live_socket";
+import ViewHook from "phoenix_live_view/view_hook";
+import { simulateJoinedView, liveViewDOM } from "./test_helpers";
+
+describe("phx-skip with JavaScript-set DOM IDs", () => {
+  let liveSocket: LiveSocket;
+
+  beforeEach(() => {
+    global.Phoenix = { Socket };
+    global.document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    liveSocket && liveSocket.destroyAllViews();
+    liveSocket = null;
+  });
+
+  test("preserves element when JS sets ID and backend sends phx-skip", () => {
+    liveSocket = new LiveSocket("/live", Socket);
+    const initialContent = `
+        <span data-phx-magic-id="span-magic">content</span>
+    `;
+
+    const el = liveViewDOM(initialContent);
+    document.body.appendChild(el);
+
+    const view = simulateJoinedView(el, liveSocket);
+    const targetEl = el.querySelector('[data-phx-magic-id="span-magic"]');
+
+    const hook = new ViewHook(view, targetEl, {});
+    hook.js().setAttribute(targetEl, "id", "js-set-id");
+
+    const updateDiff = {
+      s: [
+        `
+        <span data-phx-skip data-phx-magic-id="span-magic">content</span>
+    `,
+      ],
+      fingerprint: 124,
+    };
+
+    view.update(updateDiff, []);
+
+    const afterUpdate = el.querySelector("#js-set-id");
+    expect(afterUpdate).not.toBeNull();
+    expect(afterUpdate.id).toBe("js-set-id");
+    expect(afterUpdate.textContent).toBe("content");
+  });
+});

--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -481,3 +481,28 @@ The command interface returned by `js()` above offers the following functions:
 - `patch(href, opts = {})` - sends a patch event to the server and updates the browser's pushState history. Options: `replace`. For more details, see `Phoenix.LiveView.JS.patch/1`.
 - `exec(encodedJS)` - *only via Client hook `this.js()`*: executes encoded JS command in the context of the hook's root node. The encoded JS command should be constructed via `Phoenix.LiveView.JS` and is usually stored as an HTML attribute. Example: `this.js().exec(this.el.getAttribute('phx-remove'))`.
 - `exec(el, encodedJS)` - *only via `liveSocket.js()`*: executes encoded JS command in the context of any element.
+
+### Client-side ID manipulation
+
+When working with element IDs from client-side hooks, there are important limitations to be aware of:
+
+**Setting IDs via `setAttribute`**
+
+If you need to set or modify element IDs from client-side JavaScript (for example, to auto-generate IDs for accessibility), you **must** use the `js().setAttribute()` method:
+
+```javascript
+Hooks.MyHook = {
+  mounted() {
+    // ✓ Correct - uses js().setAttribute()
+    this.js().setAttribute(this.el, "id", "my-generated-id")
+  }
+}
+```
+
+**Important limitations:**
+
+- **Direct DOM manipulation is not supported**: Setting IDs directly via `node.id = "..."` or other direct DOM manipulation methods will cause DOM patching issues. Always use `js().setAttribute()` instead.
+
+- **Replacing server-assigned IDs is not supported**: If the server has already assigned an ID to an element, you cannot replace it with a different ID from the client side. Client-side IDs should only be set on elements that have no server-assigned ID.
+
+These limitations exist because LiveView's DOM patching relies on element IDs for efficient node matching. When you use `js().setAttribute()` to set an ID, LiveView marks the element internally so that DOM patching can handle it correctly.

--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -484,25 +484,16 @@ The command interface returned by `js()` above offers the following functions:
 
 ### Client-side ID manipulation
 
-When working with element IDs from client-side hooks, there are important limitations to be aware of:
-
-**Setting IDs via `setAttribute`**
-
-If you need to set or modify element IDs from client-side JavaScript (for example, to auto-generate IDs for accessibility), you **must** use the `js().setAttribute()` method:
+If you need to set element IDs from client-side JavaScript (for example, to auto-generate IDs for accessibility), you **must** use the `js().setAttribute()` method:
 
 ```javascript
 Hooks.MyHook = {
   mounted() {
-    // ✓ Correct - uses js().setAttribute()
     this.js().setAttribute(this.el, "id", "my-generated-id")
   }
 }
 ```
 
-**Important limitations:**
+Setting IDs directly via `node.id = "..."` or other direct DOM manipulation methods will cause DOM patching issues. Always use `js().setAttribute()` instead.
 
-- **Direct DOM manipulation is not supported**: Setting IDs directly via `node.id = "..."` or other direct DOM manipulation methods will cause DOM patching issues. Always use `js().setAttribute()` instead.
-
-- **Replacing server-assigned IDs is not supported**: If the server has already assigned an ID to an element, you cannot replace it with a different ID from the client side. Client-side IDs should only be set on elements that have no server-assigned ID.
-
-These limitations exist because LiveView's DOM patching relies on element IDs for efficient node matching. When you use `js().setAttribute()` to set an ID, LiveView marks the element internally so that DOM patching can handle it correctly.
+If the server has already assigned an ID to an element, you cannot replace it with a different ID from the client side. Client-side IDs should only be set on elements that have no server-assigned ID.


### PR DESCRIPTION
**Context for proposal**

I'm working on a [UI component library](https://github.com/plausible/prima) with the idea to create an API similar to HeadlessUI / BaseUI. One of the features I'd like to implement is auto-generated IDs for children of the root component. In the following example I've added the desired IDs as comments:

```elixir
~H"""
<.dropdown id="account-dropdown">
  <.dropdown_trigger>Account</.dropdown_trigger> <!-- #account-dropdown-trigger -->
  <.dropdown_menu> <!-- #account-dropdown-menu -->
    <.dropdown_item>Settings<.dropdown_item> <!-- #account-dropdown-menuitem-1 -->
    <.dropdown_item>Log out</.dropdown_item> <!-- #account-dropdown-menuitem-2 -->
  </.dropdown_menu>
</.dropdown>
"""
```

Auto-generating these based on the root component's ID is more convenient for the user and avoids copy-paste errors. In my opinion it's one of these cases where implicitness is really good because the IDs will always be consistent, avoids human error, and keeps the code less noisy. The generated IDs are completely predictable based on the root element.

Generating the IDs in the client hook is straightforward so I went with that. The hook also binds aria-labels so it it makes sense for it to deal with the IDs it binds as well.

**The Problem**

It worked fine until I ran into a case where a component is animated while receiving a liveview patch. I don't fully understand what parts of the setup are critical for this, but what happens is that the `phx-skip` optimization gets applied and it completely breaks rendering. The problem seems to be that during DOM patching, Liveview assumes that the DOM ID was set by the backend and it expects the update patch for that DOM node to have the same ID. Since the ID was in fact set by the client, morphdom fails to match nodes and rendering breaks in various interesting ways.

This logic is on line 152 in dom_patch.js

https://github.com/phoenixframework/phoenix_live_view/blob/03320071c5b83481afd5f64488c7123399f117c8/assets/js/phoenix_live_view/dom_patch.js#L142-L154

**The Solution**

My proposal is that:
1. When a DOM ID has been touched via `this.js().setAttribute()`
2. Then we ignore that DOM ID in morphdom node matching logic

So in pseudo-code the line:

```
return node.id || node.getAttribute(PHX_MAGIC_ID)
```

becomes:


```
return (!hasClientSetID(node) && node.id) || node.getAttribute(PHX_MAGIC_ID)
```

Where we fall back to PHX_MAGIC_ID when the ID has been touched by the client hook.

I've confirmed that it works as expected for the use-case that motivated this investigation in the first place.

**Questions for maintainers**

First of all - do you agree it's a problem worth fixing?

If so, we can talk about the specific solution. Currently it adds an array scan in presumably very performance-sensitive part of the DOM patching code which seems suboptimal. I don't have a strong intuition about the performance characteristics here so I'm looking to get feedback on it. If checking that the ID has been touched by the client is indeed too expensive, I can look into optimizing that at the cost of more complexity. The current solution is nice in that it's very straight-forward.

The solution is also currently incomplete in that it doesn't account for the client-side _overriding_ a backend ID. It only works when the backend assigns no ID at all so it can fall back to the `PHX_MAGIC_ID` attribute. A more completely solution would be to also remember the backend-assigned ID when it is overridden by the client, and restore it for morphing purposes. I do not have a use-case for that and I can see why one would discourage this kind of pattern. And since it requires more complexity, my intuition is to stay away from it unless there's evidence it would be a useful addition.