### PR TITLE
Strip EEx comments in parser when compiling templates

### DIFF
--- a/lib/phoenix_live_view/tag_engine.ex
+++ b/lib/phoenix_live_view/tag_engine.ex
@@ -44,7 +44,7 @@ defmodule Phoenix.LiveView.TagEngine do
         file: "nofile",
         engine: Phoenix.LiveView.Engine
       ])
-      |> Keyword.merge(source: source, trim_eex: false)
+      |> Keyword.merge(source: source, trim_eex: false, strip_eex_comments: true)
 
     source
     |> TagEngine.Parser.parse!(options)

--- a/lib/phoenix_live_view/tag_engine/compiler.ex
+++ b/lib/phoenix_live_view/tag_engine/compiler.ex
@@ -94,11 +94,6 @@ defmodule Phoenix.LiveView.TagEngine.Compiler do
     {state, substate}
   end
 
-  ## Skip EEx comments (<%!-- ... --%>)
-  defp handle_node({:eex_comment, _text}, substate, state) do
-    {state, substate}
-  end
-
   ## HEEx interpolation {...}
   defp handle_node({:body_expr, expr, %{line: line, column: column}}, substate, state) do
     ast = Code.string_to_quoted!(expr, line: line, column: column, file: state.file)

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -1432,6 +1432,7 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
 
       assert eval("  <foo></foo>  ").root == true
       assert eval("\n\n<foo></foo>\n").root == true
+      assert eval("<%!-- comment --%>\n\n<foo></foo>\n").root == true
     end
 
     test "invalid cases" do


### PR DESCRIPTION
Fixes #4144.

When we simplified root tracking in #4125, we did not account for EEx comments (<%!-- ... --%>). Since those are just ignored in the compiler, we can already omit them at the tokenizer level.