### PR TITLE
Don't send exit messages on a normal async exit

### DIFF
--- a/lib/phoenix_live_view/async.ex
+++ b/lib/phoenix_live_view/async.ex
@@ -290,10 +290,11 @@ defmodule Phoenix.LiveView.Async do
           Channel.report_async_result(ref, async_kind, ref, cid, key, {:ok, result})
         catch
           catch_kind, reason ->
-            Process.unlink(lv_pid)
             caught_result = to_exit(catch_kind, reason, __STACKTRACE__)
             Channel.report_async_result(ref, async_kind, ref, cid, key, caught_result)
             :erlang.raise(catch_kind, reason, __STACKTRACE__)
+        after
+          Process.unlink(lv_pid)
         end
     end
   end

--- a/test/phoenix_live_view/integrations/start_async_test.exs
+++ b/test/phoenix_live_view/integrations/start_async_test.exs
@@ -75,6 +75,15 @@ defmodule Phoenix.LiveView.StartAsyncTest do
       assert_receive {:exit, _pid, :boom}, 1000
     end
 
+    test "does not leak normal task exit to handle_info when trapping exits", %{conn: conn} do
+      {:ok, lv, _html} =
+        live_isolated(conn, Phoenix.LiveViewTest.Support.StartAsyncLive.TrapExitLeak)
+
+      # The LiveView deliberately does not handle exit messages,
+      # so we'd expect it to crash if the exit leaks
+      assert render_async(lv) =~ "complete"
+    end
+
     test "complex key task", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/start_async?test=complex_key")
 

--- a/test/support/live_views/start_async.ex
+++ b/test/support/live_views/start_async.ex
@@ -186,6 +186,28 @@ defmodule Phoenix.LiveViewTest.Support.StartAsyncLive do
   end
 end
 
+defmodule Phoenix.LiveViewTest.Support.StartAsyncLive.TrapExitLeak do
+  use Phoenix.LiveView
+
+  def render(assigns) do
+    ~H"<div>{@result}</div>"
+  end
+
+  def mount(_params, _session, socket) do
+    Process.flag(:trap_exit, true)
+    {:ok, socket |> assign(result: :loading) |> start_async(:task, fn -> :done end)}
+  end
+
+  def handle_async(:task, {:ok, _result}, socket) do
+    {:noreply, assign(socket, result: :complete)}
+  end
+
+  # handle_info that deliberately doesn't handle {:EXIT, _, _}
+  def handle_info(:noop, socket) do
+    {:noreply, socket}
+  end
+end
+
 defmodule Phoenix.LiveViewTest.Support.StartAsyncLive.LC do
   use Phoenix.LiveComponent
 


### PR DESCRIPTION
Previously, when running in a process trapping exits, a normal exit would trigger a `handle_info({:EXIT, pid, :normal}, socket)`

To fix this, we unlink the live view process on an async success. This does not impact abnormal exits, which still send the message.

This was  detected was by using PhoenixTest.Playwright, which sets up the `Ecto.SQL.Sandbox` using the recommended recommended way of trapping exits for browser tests.

It may be the case that if a user is trapping exits, then they should get the normal exit, but if that is the case, there's currently not an easy way to get the pid for the async task without digging into `conn.private`