### PR TITLE
Handle missing component CIDs in resolve_components_xrefs

### DIFF
--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -4,6 +4,8 @@ defmodule Phoenix.LiveView.Diff do
   # handled here.
   @moduledoc false
 
+  require Logger
+
   alias Phoenix.LiveView.{
     Component,
     Comprehension,
@@ -76,10 +78,16 @@ defmodule Phoenix.LiveView.Diff do
   end
 
   defp to_iodata(cid, components, _template, mapper) when is_integer(cid) do
-    # Resolve component pointers and update the component entries
     components = resolve_components_xrefs(cid, components)
-    {iodata, components} = to_iodata(Map.fetch!(components, cid), components, nil, mapper)
-    {mapper.(cid, iodata), components}
+
+    case components do
+      %{^cid => component_diff} ->
+        {iodata, components} = to_iodata(component_diff, components, nil, mapper)
+        {mapper.(cid, iodata), components}
+
+      %{} ->
+        {[], components}
+    end
   end
 
   defp to_iodata(binary, components, _template, _mapper) when is_binary(binary) do
@@ -102,10 +110,35 @@ defmodule Phoenix.LiveView.Diff do
     case components[cid] do
       %{@static => static} = diff when is_integer(static) ->
         static = abs(static)
-        components = resolve_components_xrefs(static, components)
-        Map.put(components, cid, deep_merge(components[static], Map.delete(diff, @static)))
+
+        case components[static] do
+          nil ->
+            Logger.debug(
+              "Dropping component CID #{cid}: cross-reference target CID #{static} missing"
+            )
+
+            Map.delete(components, cid)
+
+          _ ->
+            components = resolve_components_xrefs(static, components)
+
+            case components[static] do
+              nil ->
+                Logger.debug(
+                  "Dropping component CID #{cid}: cross-reference target CID #{static} removed during resolution"
+                )
+
+                Map.delete(components, cid)
+
+              resolved ->
+                Map.put(components, cid, deep_merge(resolved, Map.delete(diff, @static)))
+            end
+        end
 
       %{} ->
+        components
+
+      nil ->
         components
     end
   end

--- a/test/phoenix_live_view/diff_test.exs
+++ b/test/phoenix_live_view/diff_test.exs
@@ -83,6 +83,43 @@ defmodule Phoenix.LiveView.DiffTest do
     map |> Diff.to_iodata() |> IO.iodata_to_binary()
   end
 
+  describe "to_iodata - resolve_components_xrefs" do
+    test "handles missing component CID referenced by cross-reference" do
+      rendered = %{
+        0 => 1,
+        :c => %{
+          1 => %{0 => "hello", :s => -2}
+        },
+        :s => ["<div>", "</div>"]
+      }
+
+      assert rendered_to_binary(rendered) == "<div></div>"
+    end
+
+    test "handles chain of cross-references where leaf target is missing" do
+      rendered = %{
+        0 => 3,
+        :c => %{
+          3 => %{0 => "content", :s => -2},
+          2 => %{0 => "inner", :s => -1}
+        },
+        :s => ["<div>", "</div>"]
+      }
+
+      assert rendered_to_binary(rendered) == "<div></div>"
+    end
+
+    test "handles CID referenced in template but missing from components" do
+      rendered = %{
+        0 => 42,
+        :c => %{},
+        :s => ["<div>", "</div>"]
+      }
+
+      assert rendered_to_binary(rendered) == "<div></div>"
+    end
+  end
+
   describe "to_iodata" do
     test "with subtrees chain" do
       assert rendered_to_binary(%{


### PR DESCRIPTION
`resolve_components_xrefs/2` crashes with `CaseClauseError` when a component CID
is removed between diff cycles but still referenced via `:s` cross-reference pointers.
This can happen during stream resets where components are removed and re-added across
two diff cycles, leaving stale CID references.

Three cases are now handled gracefully instead of crashing:

- Cross-reference target CID was removed from the components map
- Chain of cross-references (CID 3 → CID 2 → CID 1) where recursive resolution
  removes the intermediate target
- CID referenced in the rendered tree but missing from the components map entirely

Related to #1247.