### PR TITLE
Fix docs: correct push_event behavior on redirect

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -770,8 +770,8 @@ defmodule Phoenix.LiveView do
   handling the given `event`. If you need to scope events, then
   this must be done by namespacing them.
 
-  Events pushed during `push_navigate` are currently discarded,
-  as the LiveView is immediately dismounted.
+  Events pushed during `push_navigate` (or any redirect) are sent to the
+  client before the redirection happens.
 
   ## Hook example
 

--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -265,10 +265,11 @@ defmodule Phoenix.LiveView.Utils do
   @doc """
   Annotates the changes with the event to be pushed.
 
-  By default, events are dispatched on the JavaScript side only after
-  the current patch is invoked. Therefore, if the LiveView
-  redirects, the events won't be invoked. If the `dispatch: :before` option
-  is passed, this event will be dispatched before patching the DOM.
+  By default, events are dispatched on the JavaScript side after
+  the current patch is invoked. If the LiveView redirects,
+  any pending events are dispatched before the redirection occurs.
+  If the `dispatch: :before` option is passed, this event will be
+  dispatched before patching the DOM.
   """
   def push_event(%Socket{} = socket, event, %{} = payload, opts) do
     opts = Keyword.validate!(opts, [:dispatch])


### PR DESCRIPTION
Update the docs for `push_event/3` to reflect that events pushed during a redirect (such as `push_navigate/2`) are sent to the client before the redirection happens, rather than being discarded.

History:
c01e90b3
cb7db8bb
968bd54e

Test showing events sent during redirect:
[test/phoenix_live_view/integrations/event_test.exs:55](https://github.com/phoenixframework/phoenix_live_view/blob/eac99580e7db005d4c6faf46f49d8aa94957d20f/test/phoenix_live_view/integrations/event_test.exs#L55)