### PR TITLE
Fix follow_redirect/3 doc example for regular redirects

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1831,8 +1831,8 @@ defmodule Phoenix.LiveViewTest do
 
   Or in the case of an error tuple:
 
-      assert {:error, {:redirect, %{to: "/somewhere"}}} = result = live(conn, "my-path")
-      {:ok, conn} = follow_redirect(result, conn)
+      assert {:error, {:live_redirect, %{to: "/somewhere"}}} = result = live(conn, "my-path")
+      {:ok, view, html} = follow_redirect(result, conn)
 
   `follow_redirect/3` expects a connection as second argument.
   This is the connection that will be used to perform the underlying

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1832,7 +1832,7 @@ defmodule Phoenix.LiveViewTest do
   Or in the case of an error tuple:
 
       assert {:error, {:redirect, %{to: "/somewhere"}}} = result = live(conn, "my-path")
-      {:ok, view, html} = follow_redirect(result, conn)
+      {:ok, conn} = follow_redirect(result, conn)
 
   `follow_redirect/3` expects a connection as second argument.
   This is the connection that will be used to perform the underlying


### PR DESCRIPTION
For `:redirect` the return tuple of `follow_redirect` is `{:ok, conn}`.
The 3 tuple is for `:live_redirect`.

So to match the previous line's logic this has to be the `{:ok, conn}`. 

The function below that shows the correct return value:
https://github.com/phoenixframework/phoenix_live_view/blob/a7d9c368ae1630106995ccc6f397975b5884155d/lib/phoenix_live_view/test/live_view_test.ex#L1862

 