### PR TITLE
Optimize keyed_to_iodata by iterating backward

### DIFF
--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -62,7 +62,7 @@ defmodule Phoenix.LiveView.Diff do
     if !keyed or keyed[@keyed_count] == 0 do
       {[], components}
     else
-      keyed_to_iodata(0, keyed[@keyed_count], keyed, static, components, template, mapper, [])
+      keyed_to_iodata(keyed[@keyed_count] - 1, keyed, static, components, template, mapper, [])
     end
   end
 
@@ -82,15 +82,15 @@ defmodule Phoenix.LiveView.Diff do
     {binary, components}
   end
 
-  defp keyed_to_iodata(index, limit, keyed, static, components, template, mapper, acc)
-       when index < limit do
+  defp keyed_to_iodata(index, keyed, static, components, template, mapper, acc)
+       when index >= 0 do
     diff = Map.fetch!(keyed, index)
     {iodata, components} = to_iodata(Map.put(diff, @static, static), components, template, mapper)
-    keyed_to_iodata(index + 1, limit, keyed, static, components, template, mapper, [iodata | acc])
+    keyed_to_iodata(index - 1, keyed, static, components, template, mapper, [iodata | acc])
   end
 
-  defp keyed_to_iodata(_index, _limit, _keyed, _static, components, _template, _mapper, acc) do
-    {Enum.reverse(acc), components}
+  defp keyed_to_iodata(_index, _keyed, _static, components, _template, _mapper, acc) do
+    {acc, components}
   end
 
   defp one_to_iodata([last], _parts, _counter, acc, components, _template, _mapper) do


### PR DESCRIPTION
Iterating backward avoids `Enum.reverse/1`, simplifies recursion, and speeds up rendering of large comprehensions.

With 1000 items the benchmark showed a stable 5% speedup.

Benchmark:
```elixir
defmodule DiffBench do
  def run do
    static = ["<div>", "</div>"]
    
    keyed_diffs = 
      Map.new(0..999, fn i ->
        {i, %{0 => to_string(i)}}
      end)
      |> Map.put(:kc, 1000)

    diff = %{
      :s => static,
      :k => keyed_diffs
    }

    Benchee.run(
      %{
        "to_iodata/1 (1000 items)" => fn ->
          Phoenix.LiveView.Diff.to_iodata(diff)
        end
      },
      time: 3,
      warmup: 1
    )
  end
end

DiffBench.run()
```