### PR TITLE
Optimize traverse_dynamic for nil and binary entries

### DIFF
--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -625,7 +625,7 @@ defmodule Phoenix.LiveView.Diff do
          template,
          changed?
        )
-       when (is_nil(entry) or is_binary(entry)) and not is_map_key(children, counter) do
+       when is_nil(entry) or (is_binary(entry) and not is_map_key(children, counter)) do
     traverse_dynamic(
       entries,
       counter + 1,

--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -616,28 +616,6 @@ defmodule Phoenix.LiveView.Diff do
   end
 
   defp traverse_dynamic(
-         [nil | entries],
-         counter,
-         diff,
-         children,
-         pending,
-         components,
-         template,
-         changed?
-       ) do
-    traverse_dynamic(
-      entries,
-      counter + 1,
-      diff,
-      children,
-      pending,
-      components,
-      template,
-      changed?
-    )
-  end
-
-  defp traverse_dynamic(
          [entry | entries],
          counter,
          diff,
@@ -647,11 +625,11 @@ defmodule Phoenix.LiveView.Diff do
          template,
          changed?
        )
-       when is_binary(entry) and not is_map_key(children, counter) do
+       when (is_nil(entry) or is_binary(entry)) and not is_map_key(children, counter) do
     traverse_dynamic(
       entries,
       counter + 1,
-      Map.put(diff, counter, entry),
+      if(is_binary(entry), do: Map.put(diff, counter, entry), else: diff),
       children,
       pending,
       components,

--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -615,11 +615,38 @@ defmodule Phoenix.LiveView.Diff do
     traverse_dynamic(dynamic, 0, %{}, children, pending, components, template, changed?)
   end
 
-  defp traverse_dynamic([nil | entries], counter, diff, children, pending, components, template, changed?) do
-    traverse_dynamic(entries, counter + 1, diff, children, pending, components, template, changed?)
+  defp traverse_dynamic(
+         [nil | entries],
+         counter,
+         diff,
+         children,
+         pending,
+         components,
+         template,
+         changed?
+       ) do
+    traverse_dynamic(
+      entries,
+      counter + 1,
+      diff,
+      children,
+      pending,
+      components,
+      template,
+      changed?
+    )
   end
 
-  defp traverse_dynamic([entry | entries], counter, diff, children, pending, components, template, changed?)
+  defp traverse_dynamic(
+         [entry | entries],
+         counter,
+         diff,
+         children,
+         pending,
+         components,
+         template,
+         changed?
+       )
        when is_binary(entry) and not is_map_key(children, counter) do
     traverse_dynamic(
       entries,

--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -615,6 +615,24 @@ defmodule Phoenix.LiveView.Diff do
     traverse_dynamic(dynamic, 0, %{}, children, pending, components, template, changed?)
   end
 
+  defp traverse_dynamic([nil | entries], counter, diff, children, pending, components, template, changed?) do
+    traverse_dynamic(entries, counter + 1, diff, children, pending, components, template, changed?)
+  end
+
+  defp traverse_dynamic([entry | entries], counter, diff, children, pending, components, template, changed?)
+       when is_binary(entry) and not is_map_key(children, counter) do
+    traverse_dynamic(
+      entries,
+      counter + 1,
+      Map.put(diff, counter, entry),
+      children,
+      pending,
+      components,
+      template,
+      changed?
+    )
+  end
+
   defp traverse_dynamic(
          [entry | entries],
          counter,

--- a/test/phoenix_live_view/diff_test.exs
+++ b/test/phoenix_live_view/diff_test.exs
@@ -71,6 +71,20 @@ defmodule Phoenix.LiveView.DiffTest do
     }
   end
 
+  defp dynamic_child_entry_rendered(mode) do
+    child = %Rendered{
+      static: ["<span>", "</span>"],
+      dynamic: fn track_changes? -> if track_changes?, do: [nil], else: ["hi"] end,
+      fingerprint: 456
+    }
+
+    %Rendered{
+      static: ["<div>", "</div>"],
+      dynamic: fn _ -> [if(mode == :child, do: child, else: nil)] end,
+      fingerprint: 123
+    }
+  end
+
   defp render(
          rendered,
          fingerprints \\ Diff.new_fingerprints(),
@@ -333,6 +347,41 @@ defmodule Phoenix.LiveView.DiffTest do
 
       assert diffed_render == %{0 => "hi"}
       assert fingerprints == tree
+    end
+
+    test "manages child fingerprints during nil and binary transitions" do
+      # 1. Initial render: Child is present
+      {_, fingerprints, components} = render(dynamic_child_entry_rendered(:child))
+      assert fingerprints == {123, %{0 => {456, %{}}}}
+
+      # 2. Transition to nil: Fingerprint MUST be preserved
+      {second_render, fingerprints, components} =
+        render(dynamic_child_entry_rendered(nil), fingerprints, components)
+
+      assert second_render == %{}
+      assert fingerprints == {123, %{0 => {456, %{}}}}
+
+      # 3. Transition to binary: Fingerprint MUST be cleared
+      rendered_bin = %Rendered{
+        static: ["<div>", "</div>"],
+        dynamic: fn _ -> ["a string"] end,
+        fingerprint: 123
+      }
+
+      {third_render, fingerprints, components} =
+        render(rendered_bin, fingerprints, components)
+
+      assert third_render == %{0 => "a string"}
+      assert fingerprints == {123, %{}}
+
+      # 4. Transition back to child: Must full render because fingerprint was cleared
+      {fourth_render, fingerprints, _components} =
+        render(dynamic_child_entry_rendered(:child), fingerprints, components)
+
+      assert fourth_render ==
+               %{0 => %{0 => "hi", :s => 0}, :p => %{0 => ["<span>", "</span>"]}}
+
+      assert fingerprints == {123, %{0 => {456, %{}}}}
     end
 
     test "detects change in nested fingerprint" do


### PR DESCRIPTION
Short-circuit the traversal of nil (unchanged) and binary entries to avoid function call overhead and map lookups.

In the benchmarks I ran I have seen a significant speedup (~1.5x) for real world like templates.