### PR TITLE
Export getFileURLForUpload from phoenix_live_view on JS client

### DIFF
--- a/assets/js/phoenix_live_view/hooks.js
+++ b/assets/js/phoenix_live_view/hooks.js
@@ -46,10 +46,8 @@ const Hooks = {
       this.inputEl = document.getElementById(
         this.el.getAttribute(PHX_UPLOAD_REF),
       );
-      LiveUploader.getEntryDataURL(this.inputEl, this.ref, (url) => {
-        this.url = url;
-        this.el.src = url;
-      });
+      this.url = LiveUploader.getEntryDataURL(this.inputEl, this.ref);
+      this.el.src = this.url;
     },
     destroyed() {
       URL.revokeObjectURL(this.url);

--- a/assets/js/phoenix_live_view/index.ts
+++ b/assets/js/phoenix_live_view/index.ts
@@ -15,6 +15,7 @@ import { logError } from "./utils";
 import type { EncodedJS, LiveSocketJSCommands } from "./js_commands";
 import type { Hook, HooksOptions } from "./view_hook";
 import type { Socket as PhoenixSocket } from "phoenix";
+import LiveUploader from "./live_uploader";
 
 /**
  * Options for configuring the LiveSocket instance.
@@ -350,4 +351,23 @@ function createHook(el: HTMLElement, callbacks: Hook): ViewHook {
   return hook;
 }
 
-export { LiveSocket, isUsedInput, createHook, ViewHook, Hook, HooksOptions };
+function getFileURLForUpload(
+  input: HTMLElement,
+  uploadRef: string,
+): string | null {
+  const file = LiveUploader.activeFiles(input).find(
+    (file) => LiveUploader.genFileRef(file) == uploadRef,
+  );
+  if (!file) return null;
+  return URL.createObjectURL(file);
+}
+
+export {
+  LiveSocket,
+  isUsedInput,
+  createHook,
+  ViewHook,
+  Hook,
+  HooksOptions,
+  getFileURLForUpload,
+};

--- a/assets/js/phoenix_live_view/index.ts
+++ b/assets/js/phoenix_live_view/index.ts
@@ -351,6 +351,19 @@ function createHook(el: HTMLElement, callbacks: Hook): ViewHook {
   return hook;
 }
 
+/** Returns an object URL for the file matching the given upload ref,
+ * or `null` if no matching file is found.
+ *
+ * @param input - The file input element associated with the upload.
+ * @param uploadRef - The upload ref identifying the file entry.
+ *
+ * @example
+ *
+ * import { getFileURLForUpload } from "phoenix_live_view"
+ *
+ * let url = getFileURLForUpload(inputEl, uploadRef)
+ * if (url) { imgEl.src = url }
+ */
 function getFileURLForUpload(
   input: HTMLElement,
   uploadRef: string,

--- a/assets/js/phoenix_live_view/index.ts
+++ b/assets/js/phoenix_live_view/index.ts
@@ -368,11 +368,7 @@ function getFileURLForUpload(
   input: HTMLElement,
   uploadRef: string,
 ): string | null {
-  const file = LiveUploader.activeFiles(input).find(
-    (file) => LiveUploader.genFileRef(file) == uploadRef,
-  );
-  if (!file) return null;
-  return URL.createObjectURL(file);
+  return LiveUploader.getEntryDataURL(input, uploadRef);
 }
 
 export {

--- a/assets/js/phoenix_live_view/live_uploader.js
+++ b/assets/js/phoenix_live_view/live_uploader.js
@@ -22,11 +22,12 @@ export default class LiveUploader {
     }
   }
 
-  static getEntryDataURL(inputEl, ref, callback) {
+  static getEntryDataURL(inputEl, ref) {
     const file = this.activeFiles(inputEl).find(
       (file) => this.genFileRef(file) === ref,
     );
-    callback(URL.createObjectURL(file));
+    if (!file) return null;
+    return URL.createObjectURL(file);
   }
 
   static hasUploadsInProgress(formEl) {

--- a/assets/test/index_test.ts
+++ b/assets/test/index_test.ts
@@ -1,7 +1,13 @@
-import { LiveSocket, isUsedInput, ViewHook } from "phoenix_live_view";
+import {
+  LiveSocket,
+  isUsedInput,
+  getFileURLForUpload,
+  ViewHook,
+} from "phoenix_live_view";
 import * as LiveSocket2 from "phoenix_live_view/live_socket";
 import ViewHook2 from "phoenix_live_view/view_hook";
 import DOM from "phoenix_live_view/dom";
+import LiveUploader from "phoenix_live_view/live_uploader";
 
 describe("Named Imports", () => {
   test("LiveSocket is equal to the actual LiveSocket", () => {
@@ -20,5 +26,35 @@ describe("isUsedInput", () => {
     expect(isUsedInput(input)).toBeFalsy();
     DOM.putPrivate(input, "phx-has-focused", true);
     expect(isUsedInput(input)).toBe(true);
+  });
+});
+
+function uploadInput(activeRefs: string = ""): HTMLInputElement {
+  const input = document.createElement("input");
+  input.type = "file";
+  input.setAttribute("data-phx-active-refs", activeRefs);
+  input.setAttribute("data-phx-done-refs", "");
+  input.setAttribute("data-phx-preflighted-refs", "");
+  return input;
+}
+
+describe("getFileURLForUpload", () => {
+  beforeEach(() => {
+    global.URL.createObjectURL = jest.fn(() => "blob:http://localhost/fake");
+  });
+
+  test("returns a URL for a file matching the ref", () => {
+    const file = new File(["hello"], "test.txt", { type: "text/plain" });
+    const ref = LiveUploader.genFileRef(file);
+    const input = uploadInput(ref);
+    DOM.putPrivate(input, "files", [file]);
+
+    expect(getFileURLForUpload(input, ref)).toBe("blob:http://localhost/fake");
+    expect(URL.createObjectURL).toHaveBeenCalledWith(file);
+  });
+
+  test("returns null when no file matches the ref", () => {
+    const input = uploadInput();
+    expect(getFileURLForUpload(input, "999")).toBeNull();
   });
 });

--- a/assets/test/index_test.ts
+++ b/assets/test/index_test.ts
@@ -28,33 +28,3 @@ describe("isUsedInput", () => {
     expect(isUsedInput(input)).toBe(true);
   });
 });
-
-function uploadInput(activeRefs: string = ""): HTMLInputElement {
-  const input = document.createElement("input");
-  input.type = "file";
-  input.setAttribute("data-phx-active-refs", activeRefs);
-  input.setAttribute("data-phx-done-refs", "");
-  input.setAttribute("data-phx-preflighted-refs", "");
-  return input;
-}
-
-describe("getFileURLForUpload", () => {
-  beforeEach(() => {
-    global.URL.createObjectURL = jest.fn(() => "blob:http://localhost/fake");
-  });
-
-  test("returns a URL for a file matching the ref", () => {
-    const file = new File(["hello"], "test.txt", { type: "text/plain" });
-    const ref = LiveUploader.genFileRef(file);
-    const input = uploadInput(ref);
-    DOM.putPrivate(input, "files", [file]);
-
-    expect(getFileURLForUpload(input, ref)).toBe("blob:http://localhost/fake");
-    expect(URL.createObjectURL).toHaveBeenCalledWith(file);
-  });
-
-  test("returns null when no file matches the ref", () => {
-    const input = uploadInput();
-    expect(getFileURLForUpload(input, "999")).toBeNull();
-  });
-});

--- a/assets/test/index_test.ts
+++ b/assets/test/index_test.ts
@@ -1,13 +1,7 @@
-import {
-  LiveSocket,
-  isUsedInput,
-  getFileURLForUpload,
-  ViewHook,
-} from "phoenix_live_view";
+import { LiveSocket, isUsedInput, ViewHook } from "phoenix_live_view";
 import * as LiveSocket2 from "phoenix_live_view/live_socket";
 import ViewHook2 from "phoenix_live_view/view_hook";
 import DOM from "phoenix_live_view/dom";
-import LiveUploader from "phoenix_live_view/live_uploader";
 
 describe("Named Imports", () => {
   test("LiveSocket is equal to the actual LiveSocket", () => {


### PR DESCRIPTION
Closes #4164 

Hi, I'm not sure if PRs are welcome on this issue, but I've been wanting to do some OSS contributions lately and gave this a try since it felt straightforward based on the issue discussion. I used the existing static functions to export the function.

I've made a [gist](https://gist.github.com/sukidhar/63bb5a47e8fe34af2f4c81e95b5413df) and tested it.

<img width="678" height="533" alt="Screenshot 2026-04-26 at 1 09 41 PM" src="https://github.com/user-attachments/assets/df5dd4ff-10ec-4d80-9ac1-81b47395b992" /> <br>

Not a perfect sample, but it worked with the code change and no tests are broken, so I went ahead and opened the PR. I also added some tests. Happy to change anything based on feedback. 
