### PR TITLE
Update globals based on MDN values

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -20,19 +20,16 @@ defmodule Phoenix.Component.Declarative do
   )
   @globals ~w(
     accesskey
-    alt
     anchor
     autocapitalize
     autocorrect
     autofocus
     class
     contenteditable
-    contextmenu
     dir
     draggable
     enterkeyhint
     exportparts
-    height
     hidden
     id
     inert
@@ -108,20 +105,15 @@ defmodule Phoenix.Component.Declarative do
     onvolumechange
     onwaiting
     part
-    placeholder
     popover
-    rel
     role
     slot
     spellcheck
     style
     tabindex
-    target
     title
     translate
-    type
     virtualkeyboardpolicy
-    width
     writingsuggestions
     xml:base
     xml:lang

--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -21,7 +21,9 @@ defmodule Phoenix.Component.Declarative do
   @globals ~w(
     accesskey
     alt
+    anchor
     autocapitalize
+    autocorrect
     autofocus
     class
     contenteditable
@@ -118,7 +120,9 @@ defmodule Phoenix.Component.Declarative do
     title
     translate
     type
+    virtualkeyboardpolicy
     width
+    writingsuggestions
     xml:base
     xml:lang
   )


### PR DESCRIPTION
Phoenix LiveView global attributes are out of sync compared to HTML specs. Update them.

I split addition and removal in two commits, so removal can easily be reverted if necessary.

Closes #4204
