### PR TITLE
handle locks on skipped nodes

### DIFF
--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -54,7 +54,11 @@ export default class DOMPatch {
       afterphxChildAdded: [],
       aftertransitionsDiscarded: [],
     };
-    this.withChildren = opts.withChildren || opts.undoRef || false;
+    // unlock patches pass undoRef and must morph the locked element itself, not
+    // only its children. The first client ref is 0, so this must check for the
+    // option's presence rather than truthiness.
+    this.withChildren =
+      opts.withChildren || opts.undoRef !== undefined || false;
     this.undoRef = opts.undoRef;
   }
 
@@ -105,6 +109,12 @@ export default class DOMPatch {
           targetContainer = clonedTree.querySelector(
             `[data-phx-component="${this.targetCID}"]`,
           );
+          // The visible DOM can still contain the target CID while the locked
+          // clone has gone stale and no longer does. In that case there is no
+          // safe clone target for this component diff, so leave the visible DOM
+          // locked and wait for a later patch instead of throwing or patching
+          // outside the locked tree.
+          if (!targetContainer) return;
         }
       }
     }
@@ -309,7 +319,16 @@ export default class DOMPatch {
             phxViewportBottom,
           );
           DOM.cleanChildNodes(toEl, phxUpdate);
+          const isFocusedFormEl =
+            focused && fromEl.isSameNode(focused) && DOM.isFormInput(fromEl);
+          const focusedSelectChanged =
+            isFocusedFormEl && this.isChangedSelect(fromEl, toEl);
           if (this.skipCIDSibling(toEl)) {
+            // A skipped update returns before the normal update path below, so
+            // it must still perform the lock bookkeeping that keeps private
+            // cloned trees in sync.
+            this.maybeCloneLockedElement(fromEl, isFocusedFormEl);
+            this.copyNestedPrivateLock(fromEl, toEl);
             // if this is a live component used in a stream, we may need to reorder it
             this.maybeReOrderStream(fromEl);
             return false;
@@ -354,30 +373,7 @@ export default class DOMPatch {
           // We keep a reference to the cloned tree in the element's private data, and
           // on ack (view.undoRefs), we morph the cloned tree with the true fromEl in the DOM to
           // apply any changes that happened while the element was locked.
-          const isFocusedFormEl =
-            focused && fromEl.isSameNode(focused) && DOM.isFormInput(fromEl);
-          const focusedSelectChanged =
-            isFocusedFormEl && this.isChangedSelect(fromEl, toEl);
-          if (fromEl.hasAttribute(PHX_REF_SRC)) {
-            const ref = new ElementRef(fromEl);
-            // only perform the clone step if this is not a patch that unlocks
-            if (
-              ref.lockRef &&
-              (!this.undoRef || !ref.isLockUndoneBy(this.undoRef))
-            ) {
-              DOM.applyStickyOperations(fromEl);
-              const isLocked = fromEl.hasAttribute(PHX_REF_LOCK);
-              const clone = isLocked
-                ? DOM.private(fromEl, PHX_REF_LOCK) || fromEl.cloneNode(true)
-                : null;
-              if (clone) {
-                DOM.putPrivate(fromEl, PHX_REF_LOCK, clone);
-                if (!isFocusedFormEl) {
-                  fromEl = clone;
-                }
-              }
-            }
-          }
+          fromEl = this.maybeCloneLockedElement(fromEl, isFocusedFormEl);
 
           // nested view handling
           if (DOM.isPhxChild(toEl)) {
@@ -391,14 +387,10 @@ export default class DOMPatch {
             return false;
           }
 
-          // if we are undoing a lock, copy potentially nested clones over
-          if (this.undoRef && DOM.private(toEl, PHX_REF_LOCK)) {
-            DOM.putPrivate(
-              fromEl,
-              PHX_REF_LOCK,
-              DOM.private(toEl, PHX_REF_LOCK),
-            );
-          }
+          // If we are undoing a lock, copy potentially nested clones over.
+          // This keeps an inner locked subtree's private clone alive while an
+          // ancestor lock is being reconciled.
+          this.copyNestedPrivateLock(fromEl, toEl);
           // now copy regular DOM.private data
           DOM.copyPrivates(toEl, fromEl);
 
@@ -720,6 +712,39 @@ export default class DOMPatch {
 
   skipCIDSibling(el) {
     return el.nodeType === Node.ELEMENT_NODE && el.hasAttribute(PHX_SKIP);
+  }
+
+  maybeCloneLockedElement(fromEl, isFocusedFormEl) {
+    if (!fromEl.hasAttribute(PHX_REF_SRC)) return fromEl;
+
+    const ref = new ElementRef(fromEl);
+    // Only perform the clone step while the element remains locked. lockRef can
+    // be 0 for the first event, so compare against null/undefined explicitly.
+    if (
+      ref.lockRef === null ||
+      (this.undoRef !== undefined && ref.isLockUndoneBy(this.undoRef))
+    ) {
+      return fromEl;
+    }
+
+    DOM.applyStickyOperations(fromEl);
+    const clone = fromEl.hasAttribute(PHX_REF_LOCK)
+      ? DOM.private(fromEl, PHX_REF_LOCK) || fromEl.cloneNode(true)
+      : null;
+    if (!clone) return fromEl;
+
+    DOM.putPrivate(fromEl, PHX_REF_LOCK, clone);
+    return isFocusedFormEl ? fromEl : clone;
+  }
+
+  copyNestedPrivateLock(fromEl, toEl) {
+    // During unlock morphs, toEl may be the private clone that accumulated a
+    // nested locked subtree. Copy that private clone back to fromEl before the
+    // outer unlock finishes so the nested element can apply its own ack later.
+    // undoRef can be 0, so presence is checked with undefined.
+    if (this.undoRef === undefined || !DOM.private(toEl, PHX_REF_LOCK)) return;
+
+    DOM.putPrivate(fromEl, PHX_REF_LOCK, DOM.private(toEl, PHX_REF_LOCK));
   }
 
   targetCIDContainer(html) {

--- a/test/e2e/support/issues/issue_4209.ex
+++ b/test/e2e/support/issues/issue_4209.ex
@@ -1,0 +1,82 @@
+defmodule Phoenix.LiveViewTest.E2E.Issue4209Live do
+  use Phoenix.LiveView
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, outside_count: 0)}
+  end
+
+  def handle_info(:bump_outside, socket) do
+    {:noreply, update(socket, :outside_count, &(&1 + 1))}
+  end
+
+  def handle_info(:update_child, socket) do
+    send_update(__MODULE__.ChildComponent, id: "locked-child", label: "child 1")
+    {:noreply, socket}
+  end
+
+  defp locked_panel(assigns) do
+    ~H"""
+    <div id="locked-panel" phx-hook=".LockedPanel">
+      <.live_component module={__MODULE__.ChildComponent} id="locked-child" label="child 0" />
+      <button id="start-locked-update" type="button">Start locked update</button>
+    </div>
+    <script :type={Phoenix.LiveView.ColocatedHook} name=".LockedPanel">
+      export default {
+        mounted() {
+          this.el
+            .querySelector("#start-locked-update")
+            .addEventListener("click", () => {
+              this.pushEventTo("#slow-target-child", "hold-lock", {});
+            });
+        },
+      };
+    </script>
+    """
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div id="outside-count">{@outside_count}</div>
+    <.locked_panel />
+    <div id="slow-target">
+      {live_render(@socket, __MODULE__.SlowTargetLive,
+        id: "slow-target-live",
+        session: %{"parent" => self()}
+      )}
+    </div>
+    """
+  end
+
+  defmodule ChildComponent do
+    use Phoenix.LiveComponent
+
+    def render(assigns) do
+      ~H"""
+      <div id="locked-child-content">
+        <span id="locked-child-label">{@label}</span>
+      </div>
+      """
+    end
+  end
+
+  defmodule SlowTargetLive do
+    use Phoenix.LiveView
+
+    def mount(_params, %{"parent" => parent}, socket) do
+      {:ok, assign(socket, parent: parent)}
+    end
+
+    def handle_event("hold-lock", _params, socket) do
+      send(socket.assigns.parent, :bump_outside)
+      send(socket.assigns.parent, :update_child)
+      Process.sleep(800)
+      {:noreply, socket}
+    end
+
+    def render(assigns) do
+      ~H"""
+      <div id="slow-target-child">slow target</div>
+      """
+    end
+  end
+end

--- a/test/e2e/test-fixtures.js
+++ b/test/e2e/test-fixtures.js
@@ -33,6 +33,8 @@ const pageChecks = async (page, ignoreJSErrors) => {
         .expect(unhandledErrors, "Detected an unhandled JavaScript Error!")
         .toEqual([]);
     }
+
+    await expect(page.locator("[data-phx-skip]")).toHaveCount(0);
   };
 
   return { cleanup };

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -214,6 +214,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/4107", Issue4107Live
       live "/4121", Issue4121Live
       live "/4147", Issue4147Live
+      live "/4209", Issue4209Live
     end
   end
 

--- a/test/e2e/tests/issues/4209.spec.js
+++ b/test/e2e/tests/issues/4209.spec.js
@@ -1,0 +1,47 @@
+import { test, expect } from "../../test-fixtures";
+import { syncLV } from "../../utils";
+
+test("skipped locked ancestor keeps nested component patches private until unlock", async ({
+  page,
+}) => {
+  // This reproduces an issue where a locked element itself was skipped (data-phx-skip).
+  // We have a hook on the skip element, which sends an event to a child LiveView.
+  // Because the child LiveView is deliberately slow to process that event, the lock
+  // stays active for a while. During that time, the child also sends an update to
+  // the parent, which bumps a counter both outside and inside the locked panel.
+  // The important regression assertion is that the child label remains "child 0"
+  // while #locked-panel is still locked:
+  // the "child 1" patch must be written to the private locked clone and only become
+  // visible after the lock is acked.
+  await page.goto("/issues/4209");
+  await syncLV(page);
+
+  await expect(page.locator("#outside-count")).toHaveText("0");
+  await expect(page.locator("#locked-child-label")).toHaveText("child 0");
+
+  await page.getByRole("button", { name: "Start locked update" }).click();
+
+  await expect(page.locator("#locked-panel")).toHaveAttribute(
+    "data-phx-ref-lock",
+    "0",
+  );
+
+  await expect(page.locator("#outside-count")).toHaveText("1");
+
+  await page.waitForTimeout(150);
+  await expect(page.locator("#locked-panel")).toHaveAttribute(
+    "data-phx-ref-lock",
+    "0",
+  );
+  // This assertion would fail previously, because the locked panel was skipped
+  // with the magic ID optimization.
+  await expect(page.locator("#locked-child-label")).toHaveText("child 0");
+
+  await syncLV(page);
+
+  await expect(page.locator("#locked-child-label")).toHaveText("child 1");
+  await expect(page.locator("#locked-panel")).not.toHaveAttribute(
+    "data-phx-ref-lock",
+    "0",
+  );
+});


### PR DESCRIPTION
Closes #4209.

Also fixes an issue where the initial ref 0 could accidentally be treated as falsy.