### PR TITLE
Use moveBefore if supported when reordering stream items

### DIFF
--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -648,23 +648,42 @@ export default class DOMPatch {
     }
 
     if (streamAt === 0) {
-      el.parentElement.insertBefore(el, el.parentElement.firstElementChild);
+      this.moveOrInsertBefore(el.parentElement, el, el.parentElement.firstElementChild);
     } else if (streamAt > 0) {
       const children = Array.from(el.parentElement.children);
       const oldIndex = children.indexOf(el);
       if (streamAt >= children.length - 1) {
-        el.parentElement.appendChild(el);
+        this.moveOrInsertBefore(el.parentElement, el, null);
       } else {
         const sibling = children[streamAt];
         if (oldIndex > streamAt) {
-          el.parentElement.insertBefore(el, sibling);
+          this.moveOrInsertBefore(el.parentElement, el, sibling);
         } else {
-          el.parentElement.insertBefore(el, sibling.nextElementSibling);
+          this.moveOrInsertBefore(el.parentElement, el, sibling.nextElementSibling);
         }
       }
     }
 
     this.maybeLimitStream(el);
+  }
+
+  // Reorder a child within its parent. When supported, use the atomic
+  // moveBefore (https://developer.mozilla.org/en-US/docs/Web/API/Node/moveBefore)
+  // so connected custom elements (and other state-bearing nodes like iframes)
+  // are not disconnected and reconnected by the move. Falls back to
+  // insertBefore otherwise. Passing `ref === null` moves to the end.
+  // See also https://github.com/phoenixframework/phoenix_live_view/issues/4212.
+  moveOrInsertBefore(parent, child, ref) {
+    if (typeof parent.moveBefore === "function") {
+      try {
+        parent.moveBefore(child, ref);
+        return;
+      } catch {
+        // moveBefore can throw (e.g. HierarchyRequestError) in cases where
+        // an atomic move is not possible; fall back to insertBefore.
+      }
+    }
+    parent.insertBefore(child, ref);
   }
 
   maybeLimitStream(el) {

--- a/assets/js/phoenix_live_view/dom_patch.js
+++ b/assets/js/phoenix_live_view/dom_patch.js
@@ -648,7 +648,11 @@ export default class DOMPatch {
     }
 
     if (streamAt === 0) {
-      this.moveOrInsertBefore(el.parentElement, el, el.parentElement.firstElementChild);
+      this.moveOrInsertBefore(
+        el.parentElement,
+        el,
+        el.parentElement.firstElementChild,
+      );
     } else if (streamAt > 0) {
       const children = Array.from(el.parentElement.children);
       const oldIndex = children.indexOf(el);
@@ -659,7 +663,11 @@ export default class DOMPatch {
         if (oldIndex > streamAt) {
           this.moveOrInsertBefore(el.parentElement, el, sibling);
         } else {
-          this.moveOrInsertBefore(el.parentElement, el, sibling.nextElementSibling);
+          this.moveOrInsertBefore(
+            el.parentElement,
+            el,
+            sibling.nextElementSibling,
+          );
         }
       }
     }

--- a/test/e2e/support/issues/issue_4212.ex
+++ b/test/e2e/support/issues/issue_4212.ex
@@ -1,0 +1,58 @@
+defmodule Phoenix.LiveViewTest.E2E.Issue4212Live do
+  use Phoenix.LiveView
+
+  @items [
+    %{id: "a", name: "A"},
+    %{id: "b", name: "B"},
+    %{id: "c", name: "C"}
+  ]
+
+  def mount(_params, _session, socket) do
+    socket =
+      socket
+      |> stream(:items, @items)
+      |> assign(:counter, 0)
+      |> assign(:render_in_root, fn assigns ->
+        ~H"""
+        <script>
+          window.__lvCustomElLog = [];
+          class LvCustomEl extends HTMLElement {
+            connectedCallback() {
+              window.__lvCustomElLog.push({ type: "connected", id: this.id });
+            }
+            disconnectedCallback() {
+              window.__lvCustomElLog.push({ type: "disconnected", id: this.id });
+            }
+            connectedMoveCallback() {
+              window.__lvCustomElLog.push({ type: "moved", id: this.id });
+            }
+          }
+          customElements.define("lv-custom-el", LvCustomEl);
+        </script>
+        """
+      end)
+
+    {:ok, socket}
+  end
+
+  def handle_event("insert_at_1", _params, socket) do
+    n = socket.assigns.counter + 1
+    item = %{id: "new#{n}", name: "New #{n}"}
+
+    {:noreply,
+     socket
+     |> assign(:counter, n)
+     |> stream_insert(:items, item, at: 1)}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <button id="insert-at-1" phx-click="insert_at_1">Insert at 1</button>
+    <ul id="items" phx-update="stream">
+      <li :for={{dom_id, item} <- @streams.items} id={dom_id}>
+        <lv-custom-el id={"el-#{item.id}"}>{item.name}</lv-custom-el>
+      </li>
+    </ul>
+    """
+  end
+end

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -215,6 +215,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/4121", Issue4121Live
       live "/4147", Issue4147Live
       live "/4209", Issue4209Live
+      live "/4212", Issue4212Live
     end
   end
 

--- a/test/e2e/tests/issues/4212.spec.js
+++ b/test/e2e/tests/issues/4212.spec.js
@@ -1,0 +1,59 @@
+import { test, expect } from "../../test-fixtures";
+import { syncLV } from "../../utils";
+
+// https://github.com/phoenixframework/phoenix_live_view/issues/4212
+//
+// stream_insert(..., at: idx) used to call insertBefore() inside
+// maybeReOrderStream, which detaches and re-attaches the moved DOM node and
+// fires extra disconnectedCallback / connectedCallback cycles on custom
+// elements. The fix routes the reorder through the atomic moveBefore() API
+// when the runtime supports it. We assert that connectedMoveCallback fires
+// (direct evidence that moveBefore was used) and that no spurious
+// disconnect happened on the just-inserted element.
+test("stream_insert with :at uses atomic moveBefore for the reorder", async ({
+  page,
+}) => {
+  await page.goto("/issues/4212");
+  await syncLV(page);
+
+  const moveBeforeSupported = await page.evaluate(
+    () => typeof Element.prototype.moveBefore === "function",
+  );
+  if (!moveBeforeSupported) {
+    // eslint-disable-next-line playwright/no-skipped-test
+    test.skip();
+  }
+
+  // wait for the SSR'd custom elements to be observable; we don't make a
+  // strict assertion on the initial-mount log because morphdom's join-time
+  // reconciliation can produce extra disconnect/connect cycles outside the
+  // maybeReOrderStream path covered by this fix.
+  await expect
+    .poll(async () =>
+      await page.evaluate(
+        () =>
+          window.__lvCustomElLog.filter((e) => e.type === "connected").length,
+      ),
+    )
+    .toBeGreaterThanOrEqual(3);
+
+  await page.evaluate(() => (window.__lvCustomElLog = []));
+
+  await page.locator("#insert-at-1").click();
+  await syncLV(page);
+
+  // The new element is added by morphdom's addChild (-> connectedCallback),
+  // and then maybeReOrderStream moves it to the at: 1 position. With the
+  // moveBefore fix, that reorder must produce a connectedMoveCallback and
+  // must NOT produce a disconnect on the just-inserted element.
+  const log = await page.evaluate(() => window.__lvCustomElLog);
+  const newEvents = log.filter((e) => e.id === "el-new1");
+
+  expect(newEvents).toEqual(
+    expect.arrayContaining([
+      { type: "connected", id: "el-new1" },
+      { type: "moved", id: "el-new1" },
+    ]),
+  );
+  expect(newEvents.filter((e) => e.type === "disconnected")).toEqual([]);
+});

--- a/test/e2e/tests/issues/4212.spec.js
+++ b/test/e2e/tests/issues/4212.spec.js
@@ -29,11 +29,12 @@ test("stream_insert with :at uses atomic moveBefore for the reorder", async ({
   // reconciliation can produce extra disconnect/connect cycles outside the
   // maybeReOrderStream path covered by this fix.
   await expect
-    .poll(async () =>
-      await page.evaluate(
-        () =>
-          window.__lvCustomElLog.filter((e) => e.type === "connected").length,
-      ),
+    .poll(
+      async () =>
+        await page.evaluate(
+          () =>
+            window.__lvCustomElLog.filter((e) => e.type === "connected").length,
+        ),
     )
     .toBeGreaterThanOrEqual(3);
 


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix_live_view/issues/4212.