### PR TITLE
Revise `pushEvent` / `pushEventTo` docs

### DIFF
--- a/assets/js/phoenix_live_view/view_hook.ts
+++ b/assets/js/phoenix_live_view/view_hook.ts
@@ -78,38 +78,45 @@ export interface HookInterface<E extends HTMLElement = HTMLElement> {
   js(): HookJSCommands;
 
   /**
-   * Pushes an event to the server.
+   * Pushes an event to the server and invokes a callback with the server's reply.
+   *
+   * **Note:** this version silently ignores push errors.
+   * Use the {@link pushEvent | promise-returning version} to handle errors.
+   *
+   * @param event - The event name.
+   * @param payload - The payload to send to the server. Defaults to an empty object.
+   * @param onReply - A callback to handle the server's reply.
+   */
+  pushEvent(event: string, payload: any, onReply: OnReply): void;
+  /**
+   * Pushes an event to the server and returns a Promise that resolves with the server's reply.
+   *
+   * The promise will be rejected in case of errors
+   * such as a disconnected state, timeout, or the server rejecting the event.
    *
    * @param event - The event name.
    * @param [payload] - The payload to send to the server. Defaults to an empty object.
-   * @param [onReply] - A callback to handle the server's reply.
-   *
-   * When onReply is not provided, the method returns a Promise that
-   * When onReply is provided, the method returns void.
+   * @returns A promise that fulfills or rejects with the server's reply.
    */
-  pushEvent(event: string, payload: any, onReply: OnReply): void;
   pushEvent(event: string, payload?: any): Promise<any>;
 
   /**
-   * Pushed a targeted event to the server.
+   * Pushes a targeted event to the server and invokes a callback with the server's reply.
    *
    * It sends the event to the LiveComponent or LiveView the `selectorOrTarget` is defined in,
    * where its value can be either a query selector, an actual DOM element, or a CID (component id)
    * returned by the `@myself` assign.
    *
-   * If the query selector returns more than one element it will send the event to all of them,
-   * even if all the elements are in the same LiveComponent or LiveView. Because of this,
-   * if no callback is passed, a promise is returned that matches the return value of
-   * [`Promise.allSettled()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled#return_value).
-   * Individual fulfilled values are of the format `{ reply, ref }`, where `reply` is the server's reply.
+   * If the selector matches multiple elements, the event is sent to all of them,
+   * even if they belong to the same LiveComponent or LiveView.
+   *
+   * **Note:** this version silently ignores push errors.
+   * Use the {@link pushEventTo | promise-returning version} to handle errors.
    *
    * @param selectorOrTarget - The selector, element, or CID to target.
    * @param event - The event name.
-   * @param [payload] - The payload to send to the server. Defaults to an empty object.
-   * @param [onReply] - A callback to handle the server's reply.
-   *
-   * When onReply is not provided, the method returns a Promise.
-   * When onReply is provided, the method returns void.
+   * @param payload - The payload to send to the server. Defaults to an empty object.
+   * @param onReply - A callback to handle the server's reply.
    */
   pushEventTo(
     selectorOrTarget: PhxTarget,
@@ -117,6 +124,27 @@ export interface HookInterface<E extends HTMLElement = HTMLElement> {
     payload: object,
     onReply: OnReply,
   ): void;
+  /**
+   * Pushes a targeted event to the server and returns a Promise that resolves with the server's reply.
+   *
+   * It sends the event to the LiveComponent or LiveView the `selectorOrTarget` is defined in,
+   * where its value can be either a query selector, an actual DOM element, or a CID (component id)
+   * returned by the `@myself` assign.
+   *
+   * If the selector matches multiple elements, the event is sent to all of them,
+   * even if they belong to the same LiveComponent or LiveView.
+   * Because of this, it returns a single promise that matches the return value of
+   * [`Promise.allSettled()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled#return_value).
+   * Individual fulfilled values are of the format `{ reply, ref }`, where `reply` is the server's reply.
+   *
+   * The individual promises will be rejected in case of errors
+   * such as a disconnected state, timeout, or the server rejecting the event.
+   *
+   * @param selectorOrTarget - The selector, element, or CID to target.
+   * @param event - The event name.
+   * @param [payload] - The payload to send to the server. Defaults to an empty object.
+   * @returns A promise that resolves when the event has been handled by all targets.
+   */
   pushEventTo(
     selectorOrTarget: PhxTarget,
     event: string,

--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -169,15 +169,16 @@ The above life-cycle callbacks have in-scope access to the following attributes:
   * `el` - attribute referencing the bound DOM node
   * `liveSocket` - the reference to the underlying `LiveSocket` instance
   * `pushEvent(event, payload, (reply, ref) => ...)` - method to push an event from the client to the LiveView server.
-    If no callback function is passed, a promise that resolves to the `reply` is returned.
+    Omitting the callback returns a promise that resolves to the `reply`.
+    **Note:** the callback version silently ignores errors.
   * `pushEventTo(selectorOrTarget, event, payload, (reply, ref) => ...)` - method to push targeted events from the client
-    to LiveViews and LiveComponents. It sends the event to the LiveComponent or LiveView the `selectorOrTarget` is
-    defined in, where its value can be either a query selector or an actual DOM element. If the query selector returns
-    more than one element it will send the event to all of them, even if all the elements are in the same LiveComponent
-    or LiveView. `pushEventTo` supports passing the node element e.g. `this.el` instead of selector e.g. `"#" + this.el.id`
-    as the first parameter for target.
-    As there can be multiple targets, if no callback is passed, a promise is returned that matches the return value of
-    [`Promise.allSettled()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled#return_value). Individual fulfilled values are of the format `{ reply, ref }`.
+    to LiveViews and LiveComponents. The `selectorOrTarget` can be a DOM element (such as `this.el`) or a query
+    selector string. The event is sent to the LiveComponent or LiveView owning the targeted element(s). If a selector
+    matches multiple elements, the event is sent to all of them, even if they belong to the same LiveComponent or LiveView.
+    Omitting the callback returns a promise matching
+    [`Promise.allSettled()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled#return_value),
+    where fulfilled values are of the format `{ reply, ref }`.
+    **Note:** the callback version silently ignores errors.
   * `handleEvent(event, (payload) => ...)` - method to handle an event pushed from the server. Returns a value that can be passed to `removeHandleEvent` to remove the event handler.
   * `removeHandleEvent(ref)` - method to remove an event handler added via `handleEvent`
   * `upload(name, files)` - method to inject a list of file-like objects into an uploader.


### PR DESCRIPTION
For the TS API docs, document each method signature independently, so that each one can focus on its particular behavior. This makes the generated API docs easier to consume and link to.

For the summarized JS interop guide, mention that the callback version of those methods silently ignores errors as the key distinction between the two versions.

Rephrase the `pushEventTo` guide prose to avoid discussing the `selectorOrTarget` parameter twice.

Closes #4075.