### PR TITLE
Fix LiveView crash on upload channel join failure

### DIFF
--- a/assets/js/phoenix_live_view/entry_uploader.js
+++ b/assets/js/phoenix_live_view/entry_uploader.js
@@ -30,7 +30,7 @@ export default class EntryUploader {
     this.uploadChannel
       .join()
       .receive("ok", (_data) => this.readNextChunk())
-      .receive("error", (reason) => this.error(reason));
+      .receive("error", ({ reason }) => this.error(reason));
   }
 
   isDone() {

--- a/assets/test/entry_uploader_test.ts
+++ b/assets/test/entry_uploader_test.ts
@@ -1,0 +1,27 @@
+import EntryUploader from "phoenix_live_view/entry_uploader";
+
+describe("EntryUploader", () => {
+  test("passes channel-error reply reason as string to entry.error", () => {
+    let errorCb;
+    let fakeChannel = {
+      onError: jest.fn(),
+      leave: jest.fn(),
+      join: () => ({
+        receive(kind, cb) {
+          if (kind === "error") errorCb = cb;
+          return this;
+        },
+      }),
+    };
+    let fakeLiveSocket = { channel: () => fakeChannel };
+    let entry = { ref: "0", metadata: () => ({}), error: jest.fn() };
+    let config = { chunk_size: 1024, chunk_timeout: 5000 };
+
+    new EntryUploader(entry, config, fakeLiveSocket).upload();
+
+    // Reply payload arrives as {reason: "..."}, not as a string.
+    errorCb({ reason: "join crashed" });
+
+    expect(entry.error).toHaveBeenCalledWith("join crashed");
+  });
+});


### PR DESCRIPTION
## Problem

When an upload channel's `join/3` raises, Phoenix replies with
`{reason: "..."}`. `entry_uploader.js` was forwarding that payload
object to `entry.error()` instead of destructuring the reason, so the
server's "progress" event received `{"error" => {"reason" => binary}}`,
a shape no `update_progress/4` clause matched. The resulting
`FunctionClauseError` took down the parent LiveView and every
in-flight upload entry in the session.

The same file's chunk-upload error path already destructures the
reply (`({ reason }) => this.error(reason)`).

## Fix

`entry_uploader.js`: destructure the reply in the `.receive("error", cb)`
callback so `entry.error(reason)` gets the string, matching the
chunk-upload error path in the same file.