### PR TITLE
Use relative links to LiveView HexDocs in JS docs

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.ts
+++ b/assets/js/phoenix_live_view/live_socket.ts
@@ -92,7 +92,7 @@ export interface LiveSocketOptions {
   /**
    * Callbacks for LiveView hooks.
    *
-   * See [Client hooks via `phx-hook`](https://hexdocs.pm/phoenix_live_view/js-interop.html#client-hooks-via-phx-hook) for more information.
+   * See [Client hooks via `phx-hook`](../../js-interop.html#client-hooks-via-phx-hook) for more information.
    */
   hooks?: HooksOptions;
   /** Callbacks for LiveView uploaders. */
@@ -419,7 +419,7 @@ export default class LiveSocket {
    * Enables debugging.
    *
    * When debugging is enabled, the LiveView client will log debug information to the console.
-   * See [Debugging client events](https://hexdocs.pm/phoenix_live_view/js-interop.html#debugging-client-events) for more information.
+   * See [Debugging client events](../../js-interop.html#debugging-client-events) for more information.
    */
   enableDebug(): void {
     this.sessionStorage.setItem(PHX_LV_DEBUG, "true");
@@ -452,7 +452,7 @@ export default class LiveSocket {
    * Enables latency simulation.
    *
    * When latency simulation is enabled, the LiveView client will add a delay to requests and responses from the server.
-   * See [Simulating Latency](https://hexdocs.pm/phoenix_live_view/js-interop.html#simulating-latency) for more information.
+   * See [Simulating Latency](../../js-interop.html#simulating-latency) for more information.
    */
   enableLatencySim(upperBoundMs: number): void {
     this.enableDebug();
@@ -541,7 +541,7 @@ export default class LiveSocket {
   /**
    * Executes an encoded JS command, targeting the given element.
    *
-   * See [`Phoenix.LiveView.JS`](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.JS.html) for more information.
+   * See [`Phoenix.LiveView.JS`](../../Phoenix.LiveView.JS.html) for more information.
    */
   execJS(
     el: HTMLElement,
@@ -556,7 +556,7 @@ export default class LiveSocket {
    * Returns an object with methods to manipulate the DOM and execute JavaScript.
    * The applied changes integrate with server DOM patching.
    *
-   * See [JavaScript interoperability](https://hexdocs.pm/phoenix_live_view/js-interop.html) for more information.
+   * See [JavaScript interoperability](../../js-interop.html) for more information.
    */
   js(): LiveSocketJSCommands {
     return jsCommands(this, "js");


### PR DESCRIPTION
Makes the links "version-aware", instead of always sending the user to the latest published version in HexDocs. I.e., the JS docs for each LV version would point to the Elixir docs of the corresponding version.

Note: this does cause warnings in the `typedoc` output, as it tries and fails to find files on disk at the relative path. I found no good way to silence that other than completely disabling link validation, which seems worse than the warnings noise.

<details>

```
❯ npm run docs

> phoenix_live_view@1.2.0-rc.2 docs
> typedoc assets/js/phoenix_live_view/index.ts --readme assets/js/phoenix_live_view/README.md --html doc/js

[info] Loaded plugin typedoc-plugin-missing-exports
./assets/js/phoenix_live_view/live_socket.ts:95:39 - [warning] The relative path ../../js-interop.html#client-hooks-via-phx-hook is not a file and will not be copied to the output directory

95       * See [Client hooks via `phx-hook`](../../js-interop.html#client-hooks-via-phx-hook) for more information.

./assets/js/phoenix_live_view/live_socket.ts:422:35 - [warning] The relative path ../../js-interop.html#debugging-client-events is not a file and will not be copied to the output directory

422       * See [Debugging client events](../../js-interop.html#debugging-client-events) for more information.

./assets/js/phoenix_live_view/live_socket.ts:455:30 - [warning] The relative path ../../js-interop.html#simulating-latency is not a file and will not be copied to the output directory

455       * See [Simulating Latency](../../js-interop.html#simulating-latency) for more information.

./assets/js/phoenix_live_view/live_socket.ts:544:33 - [warning] The relative path ../../Phoenix.LiveView.JS.html is not a file and will not be copied to the output directory

544       * See [`Phoenix.LiveView.JS`](../../Phoenix.LiveView.JS.html) for more information.

./assets/js/phoenix_live_view/live_socket.ts:559:39 - [warning] The relative path ../../js-interop.html is not a file and will not be copied to the output directory

559       * See [JavaScript interoperability](../../js-interop.html) for more information.

[info] html generated at ./doc/js
[warning] Found 0 errors and 5 warnings
```

</details>