### PR TITLE
Optimize live stream insert enumeration

### DIFF
--- a/lib/phoenix_live_view/live_stream.ex
+++ b/lib/phoenix_live_view/live_stream.ex
@@ -101,7 +101,8 @@ defmodule Phoenix.LiveView.LiveStream do
         # the inserts are stored in reverse insert order, so we need to reverse them
         # before rendering; we also remove duplicates to only use the most recent
         # inserts, which, as the items are reversed, are first
-        do_reduce(uniq_inserts(stream.inserts, [], %{}), acc, fun)
+        inserts = uniq_inserts(stream.inserts, [], %{})
+        do_reduce(inserts, acc, fun)
       else
         raise ArgumentError, """
         streams can only be consumed directly by a for comprehension.

--- a/lib/phoenix_live_view/live_stream.ex
+++ b/lib/phoenix_live_view/live_stream.ex
@@ -101,17 +101,7 @@ defmodule Phoenix.LiveView.LiveStream do
         # the inserts are stored in reverse insert order, so we need to reverse them
         # before rendering; we also remove duplicates to only use the most recent
         # inserts, which, as the items are reversed, are first
-        {inserts, _} =
-          for {id, _, _, _, _} = insert <- stream.inserts, reduce: {[], %{}} do
-            {inserts, ids} ->
-              case ids do
-                # skip duplicates
-                %{^id => true} -> {inserts, ids}
-                %{} -> {[insert | inserts], Map.put(ids, id, true)}
-              end
-          end
-
-        do_reduce(inserts, acc, fun)
+        do_reduce(uniq_inserts(stream.inserts, [], %{}), acc, fun)
       else
         raise ArgumentError, """
         streams can only be consumed directly by a for comprehension.
@@ -129,6 +119,14 @@ defmodule Phoenix.LiveView.LiveStream do
     defp do_reduce([{dom_id, _at, item, _limit, _update_only} | tail], {:cont, acc}, fun) do
       do_reduce(tail, fun.({dom_id, item}, acc), fun)
     end
+
+    defp uniq_inserts([{id, _, _, _, _} | rest], inserts, ids) when is_map_key(ids, id),
+      do: uniq_inserts(rest, inserts, ids)
+
+    defp uniq_inserts([{id, _, _, _, _} = insert | rest], inserts, ids),
+      do: uniq_inserts(rest, [insert | inserts], Map.put(ids, id, true))
+
+    defp uniq_inserts([], inserts, _ids), do: inserts
 
     # Returns a function that slices the data structure contiguously.
     def slice(%LiveStream{}), do: raise(RuntimeError, "not implemented")


### PR DESCRIPTION
Replace for ... reduce with a tail-recursive helper for stream insert de-duping.
Benchee shows a minimal speedup on average, with consistently lower memory use.
