### PR TITLE
Optimize Enum.into with Map.new and MapSet.new

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -1183,7 +1183,7 @@ defmodule Phoenix.Component.Declarative do
 
           # slot with attributes
           _ ->
-            slot_attr_defs = Enum.into(attrs, %{}, &{&1.name, &1})
+            slot_attr_defs = Map.new(attrs, &{&1.name, &1})
             required_attrs = for {attr_name, %{required: true}} <- slot_attr_defs, do: attr_name
 
             for %{attrs: slot_attrs, line: slot_line, root: false} <- slot_values,

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -1503,7 +1503,7 @@ defmodule Phoenix.LiveView do
   def send_update(pid \\ self(), module_or_cid, assigns)
 
   def send_update(pid, module, assigns) when is_atom(module) and is_pid(pid) do
-    assigns = Enum.into(assigns, %{})
+    assigns = Map.new(assigns)
 
     id =
       assigns[:id] ||
@@ -1513,7 +1513,7 @@ defmodule Phoenix.LiveView do
   end
 
   def send_update(pid, %Phoenix.LiveComponent.CID{} = cid, assigns) when is_pid(pid) do
-    assigns = Enum.into(assigns, %{})
+    assigns = Map.new(assigns)
 
     Phoenix.LiveView.Channel.send_update(pid, cid, assigns)
   end
@@ -1547,14 +1547,14 @@ defmodule Phoenix.LiveView do
 
   def send_update_after(pid, %Phoenix.LiveComponent.CID{} = cid, assigns, time_in_milliseconds)
       when is_integer(time_in_milliseconds) and is_pid(pid) do
-    assigns = Enum.into(assigns, %{})
+    assigns = Map.new(assigns)
 
     Phoenix.LiveView.Channel.send_update_after(pid, cid, assigns, time_in_milliseconds)
   end
 
   def send_update_after(pid, module, assigns, time_in_milliseconds)
       when is_atom(module) and is_integer(time_in_milliseconds) and is_pid(pid) do
-    assigns = Enum.into(assigns, %{})
+    assigns = Map.new(assigns)
 
     id =
       assigns[:id] ||

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -1558,7 +1558,7 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   defp delete_components(state, cids) do
-    upload_cids = Enum.into(state.upload_names, MapSet.new(), fn {_name, {_ref, cid}} -> cid end)
+    upload_cids = MapSet.new(state.upload_names, fn {_name, {_ref, cid}} -> cid end)
 
     Enum.flat_map_reduce(cids, state, fn cid, acc ->
       {deleted_cids, new_components} = Diff.delete_component(cid, acc.components)
@@ -1701,7 +1701,7 @@ defmodule Phoenix.LiveView.Channel do
   defp socket_asyncs(private, cid) do
     case private do
       %{live_async: ref_pids} ->
-        Enum.into(ref_pids, %{}, fn {key, {ref, pid, kind}} -> {pid, {key, ref, cid, kind}} end)
+        Map.new(ref_pids, fn {key, {ref, pid, kind}} -> {pid, {key, ref, cid, kind}} end)
 
       %{} ->
         %{}


### PR DESCRIPTION
## Summary
* Replaces `Enum.into(enumerable, %{})` with `Map.new(enumerable)` which is faster and cleaner.
* Replaces `Enum.into(enumerable, %{}, transform)` with `Map.new(enumerable, transform)` which is significantly faster and uses less memory.
* Replaces `Enum.into(enumerable, MapSet.new(), transform)` with `MapSet.new(enumerable, transform)` which is faster and cleaner.