### PR TITLE
Optimize gather_keys/2 in Channel to avoid Enum.at/2 on maps

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -826,9 +826,9 @@ defmodule Phoenix.LiveView.Channel do
   defp maybe_merge_meta(value, _raw_payload), do: value
 
   defp gather_keys(%{} = map, acc) do
-    case Enum.at(map, 0) do
-      {key, val} -> gather_keys(val, [key | acc])
-      nil -> acc
+    case :maps.next(:maps.iterator(map)) do
+      {key, val, _iterator} -> gather_keys(val, [key | acc])
+      :none -> acc
     end
   end
 


### PR DESCRIPTION
This proves to be an 1.4x-1.9x speedup of the changed function.

Benchmark:
```elixir
Mix.install([{:benchee, "~> 1.0"}])

defmodule B do
  def original(%{} = m, acc) do
    case Enum.at(m, 0) do
      {k, v} -> original(v, [k | acc])
      nil -> acc
    end
  end

  def original([], acc), do: acc
  def original([%{} = m], acc), do: original(m, acc)
  def original(_, acc), do: acc

  def optimized(%{} = m, acc) do
    case :maps.next(:maps.iterator(m)) do
      {k, v, _} -> optimized(v, [k | acc])
      :none -> acc
    end
  end

  def optimized([], acc), do: acc
  def optimized([%{} = m], acc), do: optimized(m, acc)
  def optimized(_, acc), do: acc
end

input = %{"user" => %{"profile" => %{"name" => "john"}}}

Benchee.run(%{
  "Original" => fn -> B.original(input, []) end,
  "Optimized" => fn -> B.optimized(input, []) end
})
 ```