### PR TITLE
Fix JS.hide selector examples

### DIFF
--- a/guides/client/syncing-changes.md
+++ b/guides/client/syncing-changes.md
@@ -129,7 +129,7 @@ For example, imagine that you want to immediately remove an element from the pag
 If the element you want to delete is not the clicked button, but its parent (or other element), you can pass a selector to hide:
 
 ```heex
-<button phx-click={JS.push("delete") |> JS.hide("#post-row-13")}>Delete</button>
+<button phx-click={JS.push("delete") |> JS.hide(to: "#post-row-13")}>Delete</button>
 ```
 
 Or if you'd rather add a class instead:

--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -1247,7 +1247,7 @@ defmodule Phoenix.LiveView.JS do
   ## Examples
 
   ```heex
-  <div id="modal" phx-remove={JS.hide("#modal")}>...</div>
+  <div id="modal" phx-remove={JS.hide()}>...</div>
   <button phx-click={JS.exec("phx-remove", to: "#modal")}>close</button>
   ```
   """


### PR DESCRIPTION
Use the supported selector option only when hiding an element other than the command source.
