### PR TITLE
Fix stream_async return error message

### DIFF
--- a/lib/phoenix_live_view/async.ex
+++ b/lib/phoenix_live_view/async.ex
@@ -208,7 +208,7 @@ defmodule Phoenix.LiveView.Async do
       else
         raise ArgumentError, """
         expected stream_async to return {:ok, Enumerable.t()}, {:ok, Enumerable.t(), opts} or {:error, reason} but the result
-        is does not implement the Enumerable protocol
+        does not implement the Enumerable protocol
         """
       end
     end

--- a/lib/phoenix_live_view/async.ex
+++ b/lib/phoenix_live_view/async.ex
@@ -207,7 +207,7 @@ defmodule Phoenix.LiveView.Async do
         :ok
       else
         raise ArgumentError, """
-        expected stream_async to return {:ok, Enumerable.t()}, {:ok, Enumerable.t(), options} or {:error, reason} but the result
+        expected stream_async to return {:ok, Enumerable.t()}, {:ok, Enumerable.t(), opts} or {:error, reason} but the result
         is does not implement the Enumerable protocol
         """
       end
@@ -229,7 +229,7 @@ defmodule Phoenix.LiveView.Async do
 
         other ->
           raise ArgumentError, """
-          expected stream_async to return {:ok, Enumerable.t()} or {:error, reason}, got: #{inspect(other)}
+          expected stream_async to return {:ok, Enumerable.t()}, {:ok, Enumerable.t(), opts} or {:error, reason}, got: #{inspect(other)}
           """
       end
     end

--- a/test/phoenix_live_view/integrations/stream_async_test.exs
+++ b/test/phoenix_live_view/integrations/stream_async_test.exs
@@ -18,7 +18,7 @@ defmodule Phoenix.LiveView.StreamAsyncTest do
       {:ok, lv, _html} = live(conn, "/stream_async?test=bad_return")
 
       assert render_async(lv) =~
-               "expected stream_async to return {:ok, Enumerable.t()} or {:error, reason}, got: 123"
+               "expected stream_async to return {:ok, Enumerable.t()}, {:ok, Enumerable.t(), opts} or {:error, reason}, got: 123"
     end
 
     test "not enumerable", %{conn: conn} do
@@ -188,7 +188,7 @@ defmodule Phoenix.LiveView.StreamAsyncTest do
       {:ok, lv, _html} = live(conn, "/stream_async?test=lc_bad_return")
 
       assert render_async(lv) =~
-               "expected stream_async to return {:ok, Enumerable.t()} or {:error, reason}, got: 123"
+               "expected stream_async to return {:ok, Enumerable.t()}, {:ok, Enumerable.t(), opts} or {:error, reason}, got: 123"
     end
 
     test "not enumerable", %{conn: conn} do


### PR DESCRIPTION
Changed to `opts` also to be consistent and to have a shorter message.