### PR TITLE
Clarify external upload error message

### DIFF
--- a/lib/phoenix_live_view/upload_config.ex
+++ b/lib/phoenix_live_view/upload_config.ex
@@ -180,7 +180,7 @@ defmodule Phoenix.LiveView.UploadConfig do
           raise ArgumentError, """
           invalid :external value provided to allow_upload.
 
-          Only an anonymous function receiving the socket as an argument is supported. Got:
+          Only a 2-arity function receiving the upload entry and socket is supported. Got:
 
           #{inspect(other)}
           """


### PR DESCRIPTION
A few lines above the error message the code checks for: ` {:ok, func} when is_function(func, 2)`