### PR TITLE
fix: Convert URI struct to string in live_redirect test helper

### DIFF
--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -234,13 +234,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
             throw(stop_redirect(state, view.topic, {:redirect, opts}))
 
           {^ref, {:error, %{reason: reason}}} when reason in ~w(stale unauthorized) ->
-            redir_to =
-              case redirect_url do
-                %URI{} = uri -> URI.to_string(uri)
-                nil -> url
-              end
-
-            throw(stop_redirect(state, view.topic, {:redirect, %{to: redir_to}}))
+            throw(stop_redirect(state, view.topic, {:redirect, %{to: redirect_url || url}}))
 
           {^ref, {:error, reason}} ->
             throw({:stop, reason, state})

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1920,7 +1920,7 @@ defmodule Phoenix.LiveViewTest do
 
     url =
       case Keyword.fetch!(opts, :to) do
-        "/" <> _ = path -> URI.merge(root.uri, path)
+        "/" <> _ = path -> root.uri |> URI.merge(path) |> URI.to_string()
         url -> url
       end
 

--- a/test/phoenix_live_view/integrations/navigation_test.exs
+++ b/test/phoenix_live_view/integrations/navigation_test.exs
@@ -3,6 +3,7 @@ defmodule Phoenix.LiveView.NavigationTest do
 
   import Phoenix.ConnTest
   import Phoenix.LiveViewTest
+  import Phoenix.LiveView.TelemetryTestHelpers
 
   alias Phoenix.LiveViewTest.TreeDOM
   alias Phoenix.LiveViewTest.Support.Endpoint
@@ -222,6 +223,17 @@ defmodule Phoenix.LiveView.NavigationTest do
       assert {:ok, _classlist_live, html} = live_redirect(thermo_live, to: "/classlist")
 
       assert html =~ ~s|class="foo bar"|
+    end
+
+    # https://github.com/phoenixframework/phoenix_live_view/pull/4247
+    test "passes a string uri to handle_params on the redirected-to view", %{conn: conn} do
+      attach_telemetry([:phoenix, :live_view, :handle_params])
+
+      assert {:ok, thermo_live, _html} = live(conn, "/thermo")
+      assert {:ok, _thermo_live, _html} = live_redirect(thermo_live, to: "/thermo/123")
+
+      assert_receive {:event, [:phoenix, :live_view, :handle_params, :start], _,
+                      %{uri: "http://www.example.com/thermo/123"}}
     end
   end
 


### PR DESCRIPTION
Fix in the test helpers to more closely match production behaviour.

When redirecting to a URL starting with `/` in the `__live_redirect__` helper, we set the URL to a `URI` struct. This is then passed to any hooks which are attached to `handle_params`. As the typespec for this function is that the URI is a string, this can cause downstream issues.

Noticed specifically in a recent [commit](https://github.com/getsentry/sentry-elixir/commit/040f20d7e738fe9b199cd107d3c2f17a1af77136) to the Sentry library which adds scrubbing of the URI in their  `handle_params` hook.
 
When a test is run which redirected to `/` with the Sentry hook attached, it crashes as the URI is a struct not a string.

This fix converts the URI to a string.