### PR TITLE
ensure connect_params are kept when following redirects

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1876,7 +1876,15 @@ defmodule Phoenix.LiveViewTest do
             "expected LiveView to redirect to #{inspect(expected_to)}, but got #{inspect(to)}"
     end
 
-    conn = Phoenix.ConnTest.ensure_recycled(conn)
+    conn =
+      case conn.private[:live_view_connect_params] do
+        nil ->
+          Phoenix.ConnTest.ensure_recycled(conn)
+
+        params ->
+          recycled_conn = Phoenix.ConnTest.ensure_recycled(conn)
+          Plug.Conn.put_private(recycled_conn, :live_view_connect_params, params)
+      end
 
     if flash = opts[:flash] do
       {Phoenix.ConnTest.put_req_cookie(conn, @flash_cookie, ensure_signed_flash(endpoint, flash)),

--- a/test/phoenix_live_view/integrations/connect_test.exs
+++ b/test/phoenix_live_view/integrations/connect_test.exs
@@ -14,6 +14,22 @@ defmodule Phoenix.LiveView.ConnectTest do
 
       assert render(live) =~ rendered_to_string(~s|params: %{"_mounts" => 0, "connect1" => "1"}|)
     end
+
+    test "are kept when following a redirect from a push_navigate" do
+      conn =
+        Phoenix.ConnTest.build_conn()
+        |> put_connect_params(%{"connect1" => "1"})
+        |> get("/flash-root")
+
+      {:ok, live, _html} = live(conn)
+
+      assert {:ok, live, _html} =
+               live
+               |> render_click("push_navigate", %{"to" => "/connect", "info" => "ok!"})
+               |> follow_redirect(conn, "/connect")
+
+      assert render(live) =~ rendered_to_string(~s|params: %{"_mounts" => 0, "connect1" => "1"}|)
+    end
   end
 
   describe "connect_info" do


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix_live_view/issues/4005.