### PR TITLE
Fix unreachable validation for live router options

### DIFF
--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -79,9 +79,9 @@ defmodule Phoenix.LiveView.Router do
       inside `conn.private` in plug functions.
 
     * `:warn_on_verify` - the boolean for whether matches to this route trigger
-      an unmatched route warning for `Phoenix.VerifiedRoutes`. It is useful to
+      an unmatched route warning for `Phoenix.VerifiedRoutes`. It can be useful to
       ignore an otherwise catch-all route definition from being matched when
-      verifying routes. Defaults `false`.
+      verifying routes. Defaults to `false`.
 
   ## Examples
 

--- a/lib/phoenix_live_view/router.ex
+++ b/lib/phoenix_live_view/router.ex
@@ -78,6 +78,11 @@ defmodule Phoenix.LiveView.Router do
       for example: `%{route_name: :foo, access: :user}`. The data will be available
       inside `conn.private` in plug functions.
 
+    * `:warn_on_verify` - the boolean for whether matches to this route trigger
+      an unmatched route warning for `Phoenix.VerifiedRoutes`. It is useful to
+      ignore an otherwise catch-all route definition from being matched when
+      verifying routes. Defaults `false`.
+
   ## Examples
 
       defmodule MyApp.Router
@@ -396,11 +401,15 @@ defmodule Phoenix.LiveView.Router do
   end
 
   defp validate_live_opts!(opts) do
-    {private, opts} = Keyword.pop(opts, :private, %{})
-    {metadata, opts} = Keyword.pop(opts, :metadata, %{})
-    {warn_on_verify, opts} = Keyword.pop(opts, :warn_on_verify, false)
-
     Enum.each(opts, fn
+      {:warn_on_verify, val} when is_boolean(val) ->
+        :ok
+
+      {:warn_on_verify, bad_val} ->
+        raise ArgumentError, """
+        expected live :warn_on_verify to be a boolean, got: #{inspect(bad_val)}
+        """
+
       {:container, {tag, attrs}} when is_atom(tag) and is_list(attrs) ->
         :ok
 
@@ -417,7 +426,7 @@ defmodule Phoenix.LiveView.Router do
         expected live :as to be an atom, got: #{inspect(bad_val)}
         """
 
-      {key, %{} = meta} when key in [:metadata, :private] and is_map(meta) ->
+      {key, val} when key in [:metadata, :private] and is_map(val) ->
         :ok
 
       {key, bad_val} when key in [:metadata, :private] ->
@@ -434,6 +443,10 @@ defmodule Phoenix.LiveView.Router do
         Got: #{inspect([{key, val}])}
         """
     end)
+
+    {private, opts} = Keyword.pop(opts, :private, %{})
+    {metadata, opts} = Keyword.pop(opts, :metadata, %{})
+    {warn_on_verify, opts} = Keyword.pop(opts, :warn_on_verify, false)
 
     {private, metadata, warn_on_verify, opts}
   end

--- a/test/phoenix_live_view/router_test.exs
+++ b/test/phoenix_live_view/router_test.exs
@@ -349,4 +349,41 @@ defmodule Phoenix.LiveView.RouterTest do
                )
     end
   end
+
+  describe "live option validation" do
+    test "raises ArgumentError when metadata is not a map" do
+      assert_raise ArgumentError, ~r/expected live :metadata to be a map, got: :invalid/, fn ->
+        defmodule InvalidMetadataRouter do
+          import Phoenix.LiveViewTest, only: []
+          use Phoenix.Router
+          import Phoenix.LiveView.Router
+          live("/foo", FooLive, metadata: :invalid)
+        end
+      end
+    end
+
+    test "raises ArgumentError when private is not a map" do
+      assert_raise ArgumentError, ~r/expected live :private to be a map, got: :invalid/, fn ->
+        defmodule InvalidPrivateRouter do
+          import Phoenix.LiveViewTest, only: []
+          use Phoenix.Router
+          import Phoenix.LiveView.Router
+          live("/foo", FooLive, private: :invalid)
+        end
+      end
+    end
+
+    test "raises ArgumentError when warn_on_verify is not a boolean" do
+      assert_raise ArgumentError,
+                   ~r/expected live :warn_on_verify to be a boolean, got: :invalid/,
+                   fn ->
+                     defmodule InvalidWarnOnVerifyRouter do
+                       import Phoenix.LiveViewTest, only: []
+                       use Phoenix.Router
+                       import Phoenix.LiveView.Router
+                       live("/foo", FooLive, warn_on_verify: :invalid)
+                     end
+                   end
+    end
+  end
 end


### PR DESCRIPTION
The previous implementation popped `:private` and `:metadata` from the opts keyword list before checking their validity. Since Keyword.pop removes the keys, those validation clauses in Enum.each were dead code and effectively skipped.

Additionally, this commit documents the :warn_on_verify option in the live macro, as it was previously omitted.
