### PR TITLE
fix: reference consume_uploaded_entries in allow_upload error msg

### DIFF
--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -19,7 +19,7 @@ defmodule Phoenix.LiveView.Upload do
         raise ArgumentError, """
         cannot allow_upload on an existing upload with active entries.
 
-        Use cancel_upload and/or consume_upload to handle the active entries before allowing a new upload.
+        Use cancel_upload and/or consume_uploaded_entries to handle the active entries before allowing a new upload.
         """
     end
 

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -19,7 +19,8 @@ defmodule Phoenix.LiveView.Upload do
         raise ArgumentError, """
         cannot allow_upload on an existing upload with active entries.
 
-        Use cancel_upload and/or consume_uploaded_entries to handle the active entries before allowing a new upload.
+        Consume or cancel the existing entries before allowing a new upload.
+        See cancel_upload, consume_uploaded_entry, or consume_uploaded_entries.
         """
     end
 


### PR DESCRIPTION
There is no `consume_upload` function.