### PR TITLE
Optimize Diff.process_keyed and simplify child_diff assignment

### DIFF
--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -750,11 +750,18 @@ defmodule Phoenix.LiveView.Diff do
       Map.fetch!(previous_prints, key)
 
     vars_changed =
-      Enum.reduce(new_vars, Map.put(previous_vars, :__changed__, %{}), fn
-        {key, value}, acc ->
-          Phoenix.Component.assign(acc, key, value)
+      Enum.reduce(new_vars, %{}, fn {key, value}, changed ->
+        case previous_vars do
+          %{^key => ^value} ->
+            changed
+
+          %{^key => old_val} when is_list(old_val) or is_map(old_val) or is_tuple(old_val) ->
+            Map.put(changed, key, old_val)
+
+          %{} ->
+            Map.put(changed, key, true)
+        end
       end)
-      |> Map.fetch!(:__changed__)
 
     {_counter, child_diff, child_prints, pending, components, template} =
       traverse_dynamic(
@@ -769,21 +776,17 @@ defmodule Phoenix.LiveView.Diff do
     new_prints =
       Map.put(new_prints, key, %{index: index, vars: new_vars, child_prints: child_prints})
 
-    # if the diff is empty, we need to check if the item moved
-    if child_diff == %{} or child_diff == nil do
-      # check if the entry moved, then annotate it with the previous index
-      diff = if previous_index != index, do: Map.put(diff, index, previous_index), else: diff
-      {diff, index + 1, new_prints, pending, components, template}
-    else
-      child_diff =
-        if previous_index != index do
-          [previous_index, child_diff]
-        else
-          child_diff
-        end
+    # Moved entries carry their previous index. If the entry also changed,
+    # wrap the child diff with the previous index so the client can move and patch it.
+    diff =
+      case {child_diff in [%{}, nil], previous_index == index} do
+        {true, true} -> diff
+        {true, false} -> Map.put(diff, index, previous_index)
+        {false, true} -> Map.put(diff, index, child_diff)
+        {false, false} -> Map.put(diff, index, [previous_index, child_diff])
+      end
 
-      {Map.put(diff, index, child_diff), index + 1, new_prints, pending, components, template}
-    end
+    {diff, index + 1, new_prints, pending, components, template}
   end
 
   # it's a new entry

--- a/test/phoenix_live_view/diff_test.exs
+++ b/test/phoenix_live_view/diff_test.exs
@@ -2044,6 +2044,35 @@ defmodule Phoenix.LiveView.DiffTest do
       assert fourth_render == %{0 => %{k: %{0 => 1, 1 => %{0 => "1", 1 => "Third"}, :kc => 2}}}
     end
 
+    test "moved keyed entries with changes include previous index and child diff" do
+      items = [
+        %{id: 1, name: "First"},
+        %{id: 2, name: "Second"}
+      ]
+
+      assigns = %{socket: %Socket{}, items: items, count: 0, __changed__: %{}}
+      {_full_render, fingerprints, components} = render(keyed_comprehension_with_pattern(assigns))
+
+      assigns =
+        Phoenix.Component.assign(assigns, :items, [
+          %{id: 2, name: "Second updated"},
+          %{id: 1, name: "First"}
+        ])
+
+      {diff, _fingerprints, _components} =
+        render(keyed_comprehension_with_pattern(assigns), fingerprints, components)
+
+      assert diff == %{
+               0 => %{
+                 k: %{
+                   0 => [1, %{1 => "Second updated"}],
+                   1 => 0,
+                   :kc => 2
+                 }
+               }
+             }
+    end
+
     test "change tracking when no key is given" do
       items = [
         %{id: 1, name: "First"},


### PR DESCRIPTION
This makes keyed diff processing around 1.5x faster while using around 20% less memory.

Bench:
```elixir
Mix.install([
  {:benchee, "~> 1.5"},
  {:phoenix_live_view, path: "."}
])

defmodule KeyedVarsChangedBench do
  def old_changed(previous_vars, new_vars) do
    new_vars
    |> Enum.reduce(Map.put(previous_vars, :__changed__, %{}), fn {key, value}, acc ->
      Phoenix.Component.assign(acc, key, value)
    end)
    |> Map.fetch!(:__changed__)
  end

  def new_changed(previous_vars, new_vars) do
    Enum.reduce(new_vars, %{}, fn {key, value}, changed ->
      case previous_vars do
        %{^key => ^value} ->
          changed

        %{^key => old_val} when is_list(old_val) or is_map(old_val) or is_tuple(old_val) ->
          Map.put(changed, key, old_val)

        %{} ->
          Map.put(changed, key, true)
      end
    end)
  end

  def inputs(size) do
    previous =
      for i <- 1..size, into: %{} do
        key = :"v#{i}"

        value =
          case rem(i, 4) do
            0 -> i
            1 -> "value-#{i}"
            2 -> %{id: i, meta: %{foo: i, bar: i}}
            3 -> [i, i + 1, i + 2]
          end

        {key, value}
      end

    same = previous

    changed_nested =
      Map.new(previous, fn
        {key, %{meta: meta} = value} -> {key, %{value | meta: %{meta | foo: meta.foo + 1}}}
        pair -> pair
      end)

    mixed =
      Map.new(previous, fn
        {key, value} when is_integer(value) -> {key, value + 1}
        {key, %{meta: meta} = value} -> {key, %{value | meta: %{meta | foo: meta.foo + 1}}}
        pair -> pair
      end)

    [
      {"same/#{size}", previous, same},
      {"nested-changes/#{size}", previous, changed_nested},
      {"mixed/#{size}", previous, mixed}
    ]
  end
end

inputs = Enum.flat_map([5, 20, 100], &KeyedVarsChangedBench.inputs/1)

Benchee.run(
  %{
    "old assign loop" => fn {_name, previous, new} ->
      KeyedVarsChangedBench.old_changed(previous, new)
    end,
    "new reducer" => fn {_name, previous, new} ->
      KeyedVarsChangedBench.new_changed(previous, new)
    end
  },
  inputs: Map.new(inputs, fn {name, previous, new} -> {name, {name, previous, new}} end),
  time: 3,
  memory_time: 1
)
```