### PR TITLE
doc: Refer to replaceState instead of pushState in .link replace doc

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -3054,7 +3054,7 @@ defmodule Phoenix.Component do
     default: false,
     doc: """
     When using `:patch` or `:navigate`,
-    should the browser's history be replaced with `pushState`?
+    should the browser's history be replaced with `replaceState`?
     """
   )
 

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -3054,7 +3054,7 @@ defmodule Phoenix.Component do
     default: false,
     doc: """
     When using `:patch` or `:navigate`,
-    should the browser's history be replaced with `replaceState`?
+    should the browser's history be replaced with [`replaceState`](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState)?
     """
   )
 


### PR DESCRIPTION
Referencing the browser API replaceState makes it clear that the browser history entry is being replaced, whereas pushState adds to the history.
