### PR TITLE
Optimize mount_component private map construction

### DIFF
--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -1147,19 +1147,17 @@ defmodule Phoenix.LiveView.Diff do
     end
   end
 
-  defp mount_component(socket, component, assigns) do
-    private =
-      socket.private
-      |> Map.take([:conn_session, :root_view])
-      |> Map.put(:live_temp, %{})
-      |> Map.put(:children_cids, [])
-      |> Map.put(:lifecycle, %Phoenix.LiveView.Lifecycle{})
-
-    socket =
-      configure_socket_for_component(socket, assigns, private)
-      |> Utils.assign(:flash, %{})
-
-    Utils.maybe_call_live_component_mount!(socket, component)
+  defp mount_component(%{private: parent_private} = socket, component, assigns) do
+    socket
+    |> configure_socket_for_component(assigns, %{
+      conn_session: parent_private[:conn_session],
+      root_view: parent_private[:root_view],
+      live_temp: %{},
+      children_cids: [],
+      lifecycle: %Phoenix.LiveView.Lifecycle{}
+    })
+    |> Utils.assign(:flash, %{})
+    |> Utils.maybe_call_live_component_mount!(component)
   end
 
   defp configure_socket_for_component(socket, assigns, private) do


### PR DESCRIPTION
Avoids 4 intermediate map allocations.

Speed up is ~2x and memory usage is reduced ~5x.

Bench:
```elixir
Mix.install([{:benchee, "~> 1.0"}])

defmodule OldImpl do
  def build_private(parent_private) do
    parent_private
    |> Map.take([:conn_session, :root_view])
    |> Map.put(:live_temp, %{})
    |> Map.put(:children_cids, [])
    |> Map.put(:lifecycle, %{})
  end
end

defmodule NewImpl do
  def build_private(parent_private) do
    %{
      conn_session: parent_private[:conn_session],
      root_view: parent_private[:root_view],
      live_temp: %{},
      children_cids: [],
      lifecycle: %{}
    }
  end
end

parent_private = %{
  conn_session: %{"_csrf_token" => "abc123csrf"},
  root_view: MyApp.SomeLive,
  lifecycle: %{},
  live_temp: %{},
  assign_new: {%{}, []},
  connect_params: %{},
  connect_info: %{},
  live_layout: {MyApp.Layouts, :app},
  phoenix_reloader: nil,
  children_cids: [1, 2, 3]
}

Benchee.run(
  %{
    "old (Map.take + 3x Map.put)" => fn -> OldImpl.build_private(parent_private) end,
    "new (map literal)" => fn -> NewImpl.build_private(parent_private) end
  },
  time: 3,
  warmup: 1,
  memory_time: 1
)
```