### PR TITLE
Document handle_event takes payload, not unsigned_params

### DIFF
--- a/lib/phoenix_live_component.ex
+++ b/lib/phoenix_live_component.ex
@@ -608,11 +608,7 @@ defmodule Phoenix.LiveComponent do
 
   @callback render(assigns :: Socket.assigns()) :: Phoenix.LiveView.Rendered.t()
 
-  @callback handle_event(
-              event :: binary,
-              unsigned_params :: term(),
-              socket :: Socket.t()
-            ) ::
+  @callback handle_event(event :: binary, payload :: term(), socket :: Socket.t()) ::
               {:noreply, Socket.t()} | {:reply, map, Socket.t()}
 
   @callback handle_async(

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -313,15 +313,14 @@ defmodule Phoenix.LiveView do
   @doc """
   Invoked to handle events sent by the client.
 
-  It receives the `event` name, the event payload as a map,
-  and the socket.
+  It receives the `event` name, the event payload, and the socket.
 
   It must return `{:noreply, socket}`, where `:noreply` means
   no additional information is sent to the client, or
   `{:reply, map(), socket}`, where the given `map()` is encoded
   and sent as a reply to the client.
   """
-  @callback handle_event(event :: binary, term(), socket :: Socket.t()) ::
+  @callback handle_event(event :: binary, payload :: term(), socket :: Socket.t()) ::
               {:noreply, Socket.t()} | {:reply, map, Socket.t()}
 
   @doc """


### PR DESCRIPTION
Similar to `handle_in` in `Phoenix.Channel`.
And the payload must not be a map.

Follows up on
c6c6f01406a7c8d0d2b05d0bcae05b62981a8c3b and d7f58acf47d58f469db5351c76ea71130ec94f77

Original message:

Update payload type in hooks and `handle_event`

Phoenix's `Channel.push` declares the payload type as `Object` (treated as a generic interface that covers all JS values).

In JS, `Object` refers to anything including numbers, strings, arrays, objects, and in TS it is more strict that `any` when type checking, e.g. one cannot call arbitrary methods on it.

Make `pushEvent` and `pushEventTo` payload type match, preferring `unknown` over `Object` to satisfy
https://typescript-eslint.io/rules/no-wrapper-object-types/ and https://typescript-eslint.io/rules/no-explicit-any#alternatives-to-any.

Document that the payload must be serializable, default config is JSON.