### PR TITLE
Support latest Elixir and Erlang/OTP versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,23 +14,26 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - elixir: 1.15.4
-            otp: 25.3
+          - elixir: "1.15"
+            otp: "25"
 
-          - elixir: 1.16.3
-            otp: 26.2
+          - elixir: "1.16"
+            otp: "26"
 
-          - elixir: 1.18.4
-            otp: 27.3
+          - elixir: "1.18"
+            otp: "27"
+
+          - elixir: "1.19"
+            otp: "28"
 
           # update coverage report as well
-          - elixir: 1.19.1
-            otp: 28.1
+          - elixir: "1.20"
+            otp: "29"
             lint: lint
 
           # run against latest Elixir to catch warnings early
-          - elixir: main-otp-28
-            otp: maint-28
+          - elixir: "main-otp-29"
+            otp: "maint-29"
 
     runs-on: ubuntu-latest
 
@@ -103,8 +106,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: 1.19.1
-            otp: 28.1
+          - elixir: "1.20"
+            otp: "29"
 
     runs-on: ubuntu-latest
     steps:
@@ -168,8 +171,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: 1.19.1
-            otp: 28.1
+          - elixir: "1.20"
+            otp: "29"
 
     runs-on: ubuntu-latest
     container:
@@ -247,8 +250,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: 1.19.1
-            otp: 28.1
+          - elixir: "1.20"
+            otp: "29"
 
     steps:
       - name: Checkout

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -349,12 +349,7 @@ defmodule Phoenix.LiveView.Channel do
       nil -> :noop
     end
 
-    new_socket =
-      Enum.reduce(socket.assigns, socket, fn {key, val}, socket ->
-        Utils.force_assign(socket, key, val)
-      end)
-
-    handle_changed(state, new_socket, nil)
+    handle_changed(state, socket, nil, nil, true)
   end
 
   def handle_info(msg, %{socket: socket} = state) do
@@ -836,10 +831,10 @@ defmodule Phoenix.LiveView.Channel do
   defp gather_keys([%{} = map], acc), do: gather_keys(map, acc)
   defp gather_keys(_, acc), do: acc
 
-  defp handle_changed(state, %Socket{} = new_socket, ref, pending_live_patch \\ nil) do
+  defp handle_changed(state, %Socket{} = new_socket, ref, pending_live_patch \\ nil, force? \\ false) do
     new_state = %{state | socket: new_socket}
 
-    case maybe_diff(new_state, false) do
+    case maybe_diff(new_state, force?) do
       {:diff, diff, new_state} ->
         {:noreply,
          new_state

--- a/test/phoenix_live_view/integrations/live_reload_test.exs
+++ b/test/phoenix_live_view/integrations/live_reload_test.exs
@@ -37,12 +37,12 @@ defmodule Phoenix.LiveView.LiveReloadTest do
     {:ok, lv, _html} = live(conn, "/live-reload")
     assert render(lv) =~ "<div>Version 1</div>"
 
+    Application.put_env(:phoenix_live_view, :vsn, 2)
+
     send(
       socket.channel_pid,
       {:file_event, self(), {"lib/test_auth_web/live/user_live.ex", :created}}
     )
-
-    Application.put_env(:phoenix_live_view, :vsn, 2)
 
     assert_receive {:phoenix_live_reload, :live_view, "lib/test_auth_web/live/user_live.ex"}
     assert render(lv) =~ "<div>Version 2</div>"
@@ -61,12 +61,12 @@ defmodule Phoenix.LiveView.LiveReloadTest do
     {:ok, lv, _html} = live(conn, "/live-reload")
     assert render(lv) =~ "<div>Version 1</div>"
 
+    Application.put_env(:phoenix_live_view, :vsn, 2)
+
     send(
       socket.channel_pid,
       {:file_event, self(), {"lib/test_auth_web/live/user_live.ex", :created}}
     )
-
-    Application.put_env(:phoenix_live_view, :vsn, 2)
 
     assert_receive {:phoenix_live_reload, :live_view, "lib/test_auth_web/live/user_live.ex"}
     assert_receive :reloaded, 1000


### PR DESCRIPTION
List of changes:
- add Elixir 1.20 / OTP 29 to the mix_test matrix as the lint/coverage entry
- keep Elixir 1.19 / OTP 28 as a regular test entry
- bump main-otp-28 / maint-28 to main-otp-29 / maint-29
- bump npm_test, e2e_test, and coverage_report to Elixir 1.20 / OTP 29
- quote all version values and use loose major.minor strings