### PR TITLE
Fix whitespace handling in HEEx compiler EEx nodes

### DIFF
--- a/lib/phoenix_live_view/tag_engine/compiler.ex
+++ b/lib/phoenix_live_view/tag_engine/compiler.ex
@@ -176,21 +176,22 @@ defmodule Phoenix.LiveView.TagEngine.Compiler do
     #
     # Afterwards, the placeholders are replaced with the compiled content.
     #
-    {quoted, combined_expr, _current_line} =
-      Enum.reduce(blocks, {[], expr, line}, fn
-        {children, clause_expr, clause_meta}, {quoted, acc_expr, prev_line} ->
+    {quoted, combined_expr, _current_line, _seen_clause?} =
+      Enum.reduce(blocks, {[], expr, line, false}, fn
+        {children, clause_expr, clause_meta}, {quoted, acc_expr, prev_line, seen_clause?} ->
           # Calculate newlines needed to reach this clause's line
           clause_line = clause_meta.line
           newlines = String.duplicate("\n", clause_line - prev_line)
 
-          if all_spaces?(children) do
+          if all_spaces?(children) and not seen_clause? and
+               leading_stab_clause?(clause_expr, acc_expr) do
             # This handles the case where the start expression is immediately followed
             # by a middle expression, since we don't want to generate
             # case @status do __EEX__(0); :connecting -> __EEX__(1) ...
             # (we need to skip adding the first placeholder)
             # and instead generate
             # case @status do :connecting -> __EEX__(0); ...
-            {quoted, acc_expr <> newlines <> " " <> clause_expr, clause_line}
+            {quoted, acc_expr <> newlines <> " " <> clause_expr, clause_line, true}
           else
             inner_substate = state.engine.handle_begin(substate)
             {_state, inner_substate} = handle_node(children, inner_substate, state)
@@ -200,7 +201,7 @@ defmodule Phoenix.LiveView.TagEngine.Compiler do
             placeholder = "__EEX__(#{key});"
             quoted = [{key, clause_ast} | quoted]
             acc_expr = acc_expr <> " " <> placeholder <> newlines <> " " <> clause_expr
-            {quoted, acc_expr, clause_line}
+            {quoted, acc_expr, clause_line, true}
           end
       end)
 
@@ -456,6 +457,44 @@ defmodule Phoenix.LiveView.TagEngine.Compiler do
       {:text, text, _} -> String.trim_leading(text) == ""
       _ -> false
     end)
+  end
+
+  defp leading_stab_clause?(clause_expr, acc_expr) do
+    clause_expr = String.trim(clause_expr)
+    after? = starts_with_keyword?(clause_expr, "after")
+
+    ends_with?(clause_expr, "->") and
+      not starts_with_keyword?(clause_expr, "rescue") and
+      not starts_with_keyword?(clause_expr, "catch") and
+      not starts_with_keyword?(clause_expr, "else") and
+      (not after? or leading_receive?(acc_expr))
+  end
+
+  defp leading_receive?(expr) do
+    expr
+    |> String.trim_leading()
+    |> starts_with_keyword?("receive")
+  end
+
+  defp starts_with_keyword?(expr, keyword) do
+    expr_size = byte_size(expr)
+    keyword_size = byte_size(keyword)
+
+    expr_size >= keyword_size and
+      :binary.match(expr, keyword, scope: {0, keyword_size}) == {0, keyword_size} and
+      (expr_size == keyword_size or whitespace?(:binary.at(expr, keyword_size)))
+  end
+
+  defp ends_with?(expr, suffix) do
+    expr_size = byte_size(expr)
+    suffix_size = byte_size(suffix)
+
+    expr_size >= suffix_size and
+      :binary.match(expr, suffix, scope: {expr_size - suffix_size, suffix_size}) != :nomatch
+  end
+
+  defp whitespace?(char) do
+    char in [?\s, ?\t, ?\n, ?\r, ?\f, ?\v]
   end
 
   # Replace __EEX__(key) placeholders with actual compiled content

--- a/lib/phoenix_live_view/tag_engine/compiler.ex
+++ b/lib/phoenix_live_view/tag_engine/compiler.ex
@@ -183,8 +183,7 @@ defmodule Phoenix.LiveView.TagEngine.Compiler do
           clause_line = clause_meta.line
           newlines = String.duplicate("\n", clause_line - prev_line)
 
-          if all_spaces?(children) and not seen_clause? and
-               leading_stab_clause?(clause_expr, acc_expr) do
+          if all_spaces?(children) and not seen_clause? and stab_clause?(clause_expr) do
             # This handles the case where the start expression is immediately followed
             # by a middle expression, since we don't want to generate
             # case @status do __EEX__(0); :connecting -> __EEX__(1) ...
@@ -459,42 +458,10 @@ defmodule Phoenix.LiveView.TagEngine.Compiler do
     end)
   end
 
-  defp leading_stab_clause?(clause_expr, acc_expr) do
-    clause_expr = String.trim(clause_expr)
-    after? = starts_with_keyword?(clause_expr, "after")
-
-    ends_with?(clause_expr, "->") and
-      not starts_with_keyword?(clause_expr, "rescue") and
-      not starts_with_keyword?(clause_expr, "catch") and
-      not starts_with_keyword?(clause_expr, "else") and
-      (not after? or leading_receive?(acc_expr))
-  end
-
-  defp leading_receive?(expr) do
+  defp stab_clause?(expr) do
     expr
-    |> String.trim_leading()
-    |> starts_with_keyword?("receive")
-  end
-
-  defp starts_with_keyword?(expr, keyword) do
-    expr_size = byte_size(expr)
-    keyword_size = byte_size(keyword)
-
-    expr_size >= keyword_size and
-      :binary.match(expr, keyword, scope: {0, keyword_size}) == {0, keyword_size} and
-      (expr_size == keyword_size or whitespace?(:binary.at(expr, keyword_size)))
-  end
-
-  defp ends_with?(expr, suffix) do
-    expr_size = byte_size(expr)
-    suffix_size = byte_size(suffix)
-
-    expr_size >= suffix_size and
-      :binary.match(expr, suffix, scope: {expr_size - suffix_size, suffix_size}) != :nomatch
-  end
-
-  defp whitespace?(char) do
-    char in [?\s, ?\t, ?\n, ?\r, ?\f, ?\v]
+    |> String.trim_trailing()
+    |> String.ends_with?("->")
   end
 
   # Replace __EEX__(key) placeholders with actual compiled content

--- a/lib/phoenix_live_view/tag_engine/parser.ex
+++ b/lib/phoenix_live_view/tag_engine/parser.ex
@@ -439,7 +439,7 @@ defmodule Phoenix.LiveView.TagEngine.Parser do
          [{:eex_block, expr, meta, upper_buffer, middle_buffer} | stack],
          state
        ) do
-    middle_buffer = [{Enum.reverse(buffer), middle_expr, middle_meta} | middle_buffer]
+    middle_buffer = merge_middle_expr(middle_buffer, buffer, middle_expr, middle_meta)
 
     to_tree(
       tokens,
@@ -499,6 +499,49 @@ defmodule Phoenix.LiveView.TagEngine.Parser do
   defp to_tree([{:eex, _type, expr, meta} | tokens], buffer, stack, state) do
     buffer = process_buffer([{:eex, expr, meta} | buffer], state)
     to_tree(tokens, buffer, stack, state)
+  end
+
+  defp merge_middle_expr(
+         [{prev_buffer, prev_expr, prev_meta} | middle_buffer],
+         buffer,
+         middle_expr,
+         middle_meta
+       ) do
+    if all_spaces?(buffer) and not stab_clause?(prev_expr) do
+      [
+        {prev_buffer, prev_expr <> rendered_spaces(buffer) <> middle_expr, prev_meta}
+        | middle_buffer
+      ]
+    else
+      [
+        {Enum.reverse(buffer), middle_expr, middle_meta},
+        {prev_buffer, prev_expr, prev_meta} | middle_buffer
+      ]
+    end
+  end
+
+  defp merge_middle_expr([], buffer, middle_expr, middle_meta) do
+    [{Enum.reverse(buffer), middle_expr, middle_meta}]
+  end
+
+  defp rendered_spaces(buffer) do
+    buffer
+    |> Enum.reverse()
+    |> Enum.map(fn {:text, text, _meta} -> text end)
+    |> IO.iodata_to_binary()
+  end
+
+  defp all_spaces?(nodes) do
+    Enum.all?(nodes, fn
+      {:text, text, _meta} -> String.trim_leading(text) == ""
+      _ -> false
+    end)
+  end
+
+  defp stab_clause?(expr) do
+    expr
+    |> String.trim_trailing()
+    |> String.ends_with?("->")
   end
 
   @special_attrs ~w(:if :for :key)

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -226,15 +226,6 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
              "\ntimeout\n"
   end
 
-  test "handles case clause patterns that start like special form keywords" do
-    assert render("<%= case @x do %><% catcher -> %>{catcher}<% end %>", %{x: "ok"}) == "ok"
-    assert render("<%= case @x do %><% rescuee -> %>{rescuee}<% end %>", %{x: "ok"}) == "ok"
-    assert render("<%= case @x do %><% elsee -> %>{elsee}<% end %>", %{x: "ok"}) == "ok"
-
-    assert render("<%= case @x do %><% afterwards -> %>{afterwards}<% end %>", %{x: "ok"}) ==
-             "ok"
-  end
-
   test "handles html blocks with regular blocks" do
     assert render("""
            Hello <div>w<%= if true do %>orld<% end %>!</div>

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -173,6 +173,61 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
            """) == "Hello world!"
   end
 
+  test "handles whitespace-only case clauses" do
+    nbsp = <<194, 160>>
+
+    source =
+      IO.iodata_to_binary([
+        "<%= case @x do %>\n",
+        nbsp,
+        nbsp,
+        "<% :foo -> %>\n",
+        nbsp,
+        nbsp,
+        "<% :bar -> %>\n",
+        "<% end %>"
+      ])
+
+    assert render(source, %{x: :foo}) == "\n#{nbsp}#{nbsp}"
+    assert render(source, %{x: :bar}) == "\n"
+  end
+
+  test "handles whitespace-only cond clauses" do
+    source =
+      """
+      <%= cond do %>
+        <% @x == :foo -> %>
+        <% @x == :bar -> %>
+      <% end %>
+      """
+
+    assert render(source, %{x: :foo}) == "\n  "
+    assert render(source, %{x: :bar}) == "\n"
+  end
+
+  test "handles whitespace-only special form bodies" do
+    assert render("<%= try do %>\n<% rescue RuntimeError -> %>\nrescued\n<% end %>") == "\n"
+    assert render("<%= try do %>\n<% catch :throw, _ -> %>\ncaught\n<% end %>") == "\n"
+
+    assert render(
+             "<%= try do %>\n<% else nil -> %>nil<% _ -> %>other<% rescue _ -> %>rescued<% end %>"
+           ) == "other"
+
+    assert render("<%= receive do %>\n<% after 0 -> %>\ntimeout\n<% end %>") == "\ntimeout\n"
+
+    assert render("<%= receive do %>\n<% :msg -> %>\n<% after 0 -> %>\ntimeout\n<% end %>") ==
+             "\ntimeout\n"
+  end
+
+  test "handles case clause patterns that start like special form keywords" do
+    assert render("<%= case @x do %><% catcher -> %>{catcher}<% end %>", %{x: "ok"}) == "ok"
+    assert render("<%= case @x do %><% rescuee -> %>{rescuee}<% end %>", %{x: "ok"}) == "ok"
+    assert render("<%= case @x do %><% elsee -> %>{elsee}<% end %>", %{x: "ok"}) == "ok"
+
+    assert render("<%= case @x do %><% afterwards -> %>{afterwards}<% end %>", %{x: "ok"}) ==
+             "ok"
+  end
+
   test "handles html blocks with regular blocks" do
     assert render("""
            Hello <div>w<%= if true do %>orld<% end %>!</div>

--- a/test/phoenix_live_view/html_engine_test.exs
+++ b/test/phoenix_live_view/html_engine_test.exs
@@ -205,14 +205,21 @@ defmodule Phoenix.LiveView.HTMLEngineTest do
     assert render(source, %{x: :bar}) == "\n"
   end
 
-  test "handles whitespace-only special form bodies" do
-    assert render("<%= try do %>\n<% rescue RuntimeError -> %>\nrescued\n<% end %>") == "\n"
-    assert render("<%= try do %>\n<% catch :throw, _ -> %>\ncaught\n<% end %>") == "\n"
+  test "handles split clause middle expressions" do
+    source =
+      "<%= with {:ok, x} <- @res do %>\n  <p>{x}</p>\n<% else %>\n  <% _ -> %>\n    <p>bad</p>\n<% end %>"
 
-    assert render(
-             "<%= try do %>\n<% else nil -> %>nil<% _ -> %>other<% rescue _ -> %>rescued<% end %>"
-           ) == "other"
+    assert render(source, %{res: {:ok, "ok"}}) == "\n  <p>ok</p>\n"
+    assert render(source, %{res: :error}) == "\n    <p>bad</p>\n"
 
+    assert render("<%= try do %>\n<% rescue %>\n<% RuntimeError -> %>rescued<% end %>") == ""
+
+    assert render("<%= try do %>\n<% catch %>\n<% :throw, :foo -> %>caught<% end %>") == ""
+
+    assert render("<%= receive do %>\n<% after %>\n<% 0 -> %>timeout<% end %>") == "timeout"
+  end
+
+  test "handles receive after clauses" do
     assert render("<%= receive do %>\n<% after 0 -> %>\ntimeout\n<% end %>") == "\ntimeout\n"
 
     assert render("<%= receive do %>\n<% :msg -> %>\n<% after 0 -> %>\ntimeout\n<% end %>") ==

--- a/test/phoenix_live_view/tag_engine/parser_test.exs
+++ b/test/phoenix_live_view/tag_engine/parser_test.exs
@@ -1,0 +1,51 @@
+defmodule Phoenix.LiveView.TagEngine.ParserTest do
+  use ExUnit.Case, async: true
+
+  alias Phoenix.LiveView.TagEngine.Parser
+
+  defp parse(source) do
+    Parser.parse!(source,
+      file: __ENV__.file,
+      caller: __ENV__,
+      source: source,
+      tag_handler: Phoenix.LiveView.HTMLEngine,
+      trim_eex: false
+    )
+  end
+
+  describe "eex blocks" do
+    test "merges split clause middle expressions" do
+      source =
+        "<%= with {:ok, x} <- @res do %>\n  {x}\n<% else %>\n  <% _ -> %>\n    bad\n<% end %>"
+
+      assert %Parser{
+               nodes: [
+                 {:eex_block, " with {:ok, x} <- @res do ",
+                  [
+                    {[
+                       {:text, "\n  ", %{}},
+                       {:body_expr, "x", %{line: 2, column: 3}},
+                       {:text, "\n", %{}}
+                     ], " else \n   _ -> ", %{line: 3, opt: [], column: 1}},
+                    {[{:text, "\n    bad\n", %{}}], " end ", %{line: 6, opt: [], column: 1}}
+                  ], %{line: 1, opt: ~c"=", column: 1}}
+               ]
+             } = parse(source)
+    end
+
+    test "keeps whitespace after stab clauses as body content" do
+      source = "<%= case @x do %>\n  <% :foo -> %>\n  <% :bar -> %>\n<% end %>"
+
+      assert %Parser{
+               nodes: [
+                 {:eex_block, " case @x do ",
+                  [
+                    {[{:text, "\n  ", %{}}], " :foo -> ", %{line: 2, opt: [], column: 3}},
+                    {[{:text, "\n  ", %{}}], " :bar -> ", %{line: 3, opt: [], column: 3}},
+                    {[{:text, "\n", %{}}], " end ", %{line: 4, opt: [], column: 1}}
+                  ], %{line: 1, opt: ~c"=", column: 1}}
+               ]
+             } = parse(source)
+    end
+  end
+end


### PR DESCRIPTION
The following template did not compile on 1.2:

```
<%= case @x do %>
  <% :foo -> %>
  <% :bar -> %>
<% end %>
```

Assisted-by: GPT-5.5