### PR TITLE
Wrap renders caused by component updates in a telemetry span

### DIFF
--- a/guides/server/telemetry.md
+++ b/guides/server/telemetry.md
@@ -145,7 +145,9 @@ LiveView currently exposes the following [`telemetry`](https://telemetry.hexdocs
           }
 
   * `[:phoenix, :live_view, :render, :start]` - Dispatched by a `Phoenix.LiveView`
-    immediately before [`render/1`](`c:Phoenix.LiveComponent.render/1`) is invoked.
+    immediately before a render starts. A render may invoke
+    [`Phoenix.LiveView.render/1`](`c:Phoenix.LiveView.render/1`) or
+    [`Phoenix.LiveComponent.render/1`](`c:Phoenix.LiveComponent.render/1`) callbacks.
 
     * Measurement:
 
@@ -159,8 +161,16 @@ LiveView currently exposes the following [`telemetry`](https://telemetry.hexdocs
             changed?: boolean
           }
 
+      For component renders, the metadata also includes:
+
+          %{
+            component: module,
+            id: term,
+            cid: integer
+          }
+
   * `[:phoenix, :live_view, :render, :stop]` - Dispatched by a `Phoenix.LiveView`
-    when the [`render/1`](`c:Phoenix.LiveView.render/1`) callback completes successfully.
+    when a render completes successfully.
 
     * Measurement:
 
@@ -174,8 +184,16 @@ LiveView currently exposes the following [`telemetry`](https://telemetry.hexdocs
             changed?: boolean
           }
 
+      For component renders, the metadata also includes:
+
+          %{
+            component: module,
+            id: term,
+            cid: integer
+          }
+
   * `[:phoenix, :live_view, :render, :exception]` - Dispatched by a `Phoenix.LiveView`
-    when an exception is raised in the [`render/1`](`c:Phoenix.LiveView.render/1`) callback.
+    when an exception is raised during a render.
 
     * Measurement:
 
@@ -189,6 +207,14 @@ LiveView currently exposes the following [`telemetry`](https://telemetry.hexdocs
             reason: term,
             force?: boolean,
             changed?: boolean
+          }
+
+      For component renders, the metadata also includes:
+
+          %{
+            component: module,
+            id: term,
+            cid: integer
           }
 
   * `[:phoenix, :live_component, :update, :start]` - Dispatched by a `Phoenix.LiveComponent`

--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -237,16 +237,37 @@ defmodule Phoenix.LiveView.Diff do
           |> configure_socket_for_component(assigns, private)
           |> fun.(component)
 
-        diff = render_private(csocket, %{})
+        changed? = Utils.changed?(csocket)
 
-        {pending, cdiffs, components} =
-          render_component(csocket, component, id, prints, cid, false, cids, %{}, components)
+        render = fn ->
+          diff = render_private(csocket, %{})
 
-        {cdiffs, components} =
-          render_pending_components(socket, pending, cids, cdiffs, components)
+          {pending, cdiffs, components} =
+            render_component(csocket, component, id, prints, cid, false, cids, %{}, components)
 
-        {diff, cdiffs} = extract_events({diff, cdiffs})
-        {maybe_put_cdiffs(diff, cdiffs), components, extra}
+          {cdiffs, components} =
+            render_pending_components(socket, pending, cids, cdiffs, components)
+
+          {diff, cdiffs} = extract_events({diff, cdiffs})
+          {maybe_put_cdiffs(diff, cdiffs), components, extra}
+        end
+
+        if changed? do
+          metadata = %{
+            socket: socket,
+            component: component,
+            id: id,
+            cid: cid,
+            force?: false,
+            changed?: changed?
+          }
+
+          :telemetry.span([:phoenix, :live_view, :render], metadata, fn ->
+            {render.(), metadata}
+          end)
+        else
+          render.()
+        end
 
       %{} ->
         :error

--- a/test/phoenix_live_view/integrations/telemetry_test.exs
+++ b/test/phoenix_live_view/integrations/telemetry_test.exs
@@ -276,6 +276,39 @@ defmodule Phoenix.LiveView.TelemetryTest do
       assert metadata.params == %{"op" => "boom"}
     end
 
+    test "emits live view render telemetry when component render fails after callback", %{
+      conn: conn
+    } do
+      Process.flag(:trap_exit, true)
+
+      {:ok, view, _html} = live(conn, "/components")
+      attach_telemetry([:phoenix, :live_view, :render])
+
+      assert view |> element("#chris") |> render_click(%{"op" => "crash-render"}) |> catch_exit
+
+      assert_receive {:event, [:phoenix, :live_view, :render, :start], %{system_time: _},
+                      metadata}
+
+      assert metadata.socket.transport_pid
+      assert metadata.component == Phoenix.LiveViewTest.Support.StatefulComponent
+      assert metadata.id == "chris"
+      assert is_integer(metadata.cid)
+      refute metadata.force?
+      assert metadata.changed?
+
+      assert_receive {:event, [:phoenix, :live_view, :render, :exception], %{duration: _},
+                      metadata}
+
+      assert metadata.socket.transport_pid
+      assert metadata.component == Phoenix.LiveViewTest.Support.StatefulComponent
+      assert metadata.id == "chris"
+      assert is_integer(metadata.cid)
+      refute metadata.force?
+      assert metadata.changed?
+      assert metadata.kind == :error
+      assert metadata.reason == :badarith
+    end
+
     test "emits telemetry events for update calls", %{conn: conn} do
       attach_telemetry([:phoenix, :live_component, :update])
 

--- a/test/support/live_views/components.ex
+++ b/test/support/live_views/components.ex
@@ -209,6 +209,14 @@ defmodule Phoenix.LiveViewTest.Support.StatefulComponent do
     """
   end
 
+  def render(%{crash_render?: true} = assigns) do
+    ~H"""
+    <div id={@id}>
+      {1 / 0}
+    </div>
+    """
+  end
+
   def render(%{socket: _} = assigns) do
     ~H"""
     <div phx-click="transform" id={@id} phx-target={"#" <> @id <> include_parent_id(@parent_id)}>
@@ -234,6 +242,9 @@ defmodule Phoenix.LiveViewTest.Support.StatefulComponent do
 
       "dup" ->
         {:noreply, assign(socket, :dup_name, socket.assigns.name <> "-dup")}
+
+      "crash-render" ->
+        {:noreply, assign(socket, :crash_render?, true)}
 
       "push_navigate" ->
         {:noreply, push_navigate(socket, to: "/components?redirect=push")}


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix_live_view/issues/4258.