### PR TITLE
Use elixirc_options: [no_warn_undefined: ...] instead of deprecated xref: [exclude: ...]

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Phoenix.LiveView.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       test_options: [docs: true],
       test_coverage: [summary: [threshold: 85], ignore_modules: coverage_ignore_modules()],
-      xref: [exclude: [LazyHTML, LazyHTML.Tree]],
+      elixirc_options: [no_warn_undefined: [LazyHTML, LazyHTML.Tree]],
       package: package(),
       deps: deps(),
       aliases: aliases(),


### PR DESCRIPTION
Mix emits the following deprecation warning on Elixir 1.20:

> warning: "xref: [exclude: ...]" in your mix.exs file is deprecated, instead use: "elixirc_options: [no_warn_undefined: ...]"

This was introduced in Elixir 1.20 ([elixir-lang/elixir#…]) to unify compiler-time option handling.

This PR migrates the only `xref: [exclude: ...]` option in `mix.exs` to the new `elixirc_options: [no_warn_undefined: ...]` form, preserving the existing behaviour of suppressing undefined-module warnings for the optional `LazyHTML` / `LazyHTML.Tree` modules.

### Diff

```diff
-      xref: [exclude: [LazyHTML, LazyHTML.Tree]],
+      elixirc_options: [no_warn_undefined: [LazyHTML, LazyHTML.Tree]],
```

After the change, `mix compile --force` produces no xref deprecation warnings on Elixir 1.20.