### PR TITLE
Fix missing parenthesis in Security Model example

### DIFF
--- a/guides/server/security-model.md
+++ b/guides/server/security-model.md
@@ -219,7 +219,7 @@ described, one might implement this:
 
     def handle_event("delete_project", %{"project_id" => project_id}, socket) do
       Project.delete!(socket.assigns.current_user, project_id)
-      {:noreply, update(socket, :projects, &Enum.reject(&1, fn p -> p.id == project_id end)}
+      {:noreply, update(socket, :projects, &Enum.reject(&1, fn p -> p.id == project_id end))}
     end
 
     defp load_projects(socket) do


### PR DESCRIPTION
The code example for `handle_event/3` in the security model guide was missing a closing parenthesis for the `update/3` call.