### PR TITLE
Add Phoenix.Component.quoted to ease creation of components in macros

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -936,6 +936,159 @@ defmodule Phoenix.Component do
   end
 
   @doc ~S'''
+  Turns a `~H` template inside a macro into a quoted template, allowing it
+  to contain `unquote` fragments that are resolved when the macro is invoked.
+
+  Templates are usually compiled where they are written. This makes it
+  impossible to customize them when generating components through macros,
+  as `unquote` inside `~H` has no access to the variables of the macro
+  defining it:
+
+      defmacro build_carousel(opts) do
+        name = Keyword.fetch!(opts, :name)
+        base_class = Keyword.get(opts, :base_class, "carousel")
+
+        quote do
+          def unquote(name)(var!(assigns)) do
+            # unquote(base_class) would fail to compile inside ~H here!
+            ...
+          end
+        end
+      end
+
+  With `quoted/1`, the template is instead written (and parsed) directly in
+  the macro body, where `unquote` works as usual, and spliced into the
+  generated function with a regular `unquote` call:
+
+      defmacro build_carousel(opts) do
+        name = Keyword.fetch!(opts, :name)
+        base_class = Keyword.get(opts, :base_class, "carousel")
+
+        template =
+          Phoenix.Component.quoted(~H"""
+          <div class={unquote(base_class)} id={@id} phx-hook=".Carousel"></div>
+          <script :type={Phoenix.LiveView.ColocatedHook} name=".Carousel">
+            export default {
+              mounted() { ... }
+            }
+          </script>
+          """)
+
+        quote do
+          attr :id, :string, required: true
+
+          def unquote(name)(var!(assigns)) do
+            unquote(template)
+          end
+        end
+      end
+
+  The template is compiled when the macro is invoked, in the context of the
+  caller. Spliced values therefore behave exactly as if they had been written
+  in place: a string becomes a compile-time value that is escaped and tracked
+  as usual, while spliced AST (for example `quote do: @some_assign`) takes
+  part in change tracking like handwritten template code. Macro components,
+  such as `Phoenix.LiveView.ColocatedHook` in the example above, are also
+  only processed at the use site, so their content is extracted into the
+  caller's application.
+
+  Note the generated function must define an `assigns` variable visible to
+  the template, which inside `quote` requires `var!(assigns)`.
+
+  ## Limitations
+
+  `unquote` fragments are supported in `{...}` interpolations, both in
+  attribute values and in tag bodies, as well as in standalone `<% %>`
+  expressions. They are not supported in EEx block expressions, such as
+  `<%= if ... do %>` and their clauses, as those are compiled from their
+  source text.
+
+  The `:type` attribute that identifies macro components must be a
+  compile-time module, it cannot be spliced via `unquote`.
+  '''
+  @doc type: :macro
+  defmacro quoted({:sigil_H, call_meta, [{:<<>>, bin_meta, [template]}, modifiers]})
+           when is_binary(template) and (modifiers == [] or modifiers == ~c"noformat") do
+    file = __CALLER__.file
+    line = (call_meta[:line] || __CALLER__.line) + 1
+    indentation = bin_meta[:indentation] || 0
+
+    %Phoenix.LiveView.TagEngine.Parser{nodes: nodes} =
+      Phoenix.LiveView.TagEngine.Parser.parse!(template,
+        file: file,
+        line: line,
+        indentation: indentation,
+        caller: __CALLER__,
+        source: template,
+        tag_handler: Phoenix.LiveView.HTMLEngine,
+        skip_macro_components: true,
+        quote_exprs: true,
+        trim_eex: false,
+        strip_eex_comments: true
+      )
+
+    quote do
+      Phoenix.Component.__quoted__(
+        unquote(Macro.escape(nodes, unquote: true)),
+        unquote(template),
+        unquote(file),
+        unquote(line),
+        unquote(indentation)
+      )
+    end
+  end
+
+  defmacro quoted(other) do
+    raise ArgumentError,
+          "Phoenix.Component.quoted/1 expects a ~H template without interpolation " <>
+            "as argument, got: #{Macro.to_string(other)}"
+  end
+
+  @doc false
+  def __quoted__(nodes, source, file, line, indentation) do
+    template = %Phoenix.Component.QuotedTemplate{
+      nodes: nodes,
+      source: source,
+      file: file,
+      line: line,
+      indentation: indentation
+    }
+
+    quote do
+      require Phoenix.Component
+      Phoenix.Component.__compile_quoted__(unquote(Macro.escape(template)))
+    end
+  end
+
+  @doc false
+  defmacro __compile_quoted__(quoted_template) do
+    {%Phoenix.Component.QuotedTemplate{} = template, _binding} =
+      Code.eval_quoted(quoted_template)
+
+    if not Macro.Env.has_var?(__CALLER__, {:assigns, nil}) do
+      raise "quoted templates require a variable named \"assigns\" to exist " <>
+              "and be set to a map"
+    end
+
+    {nodes, directives} =
+      Phoenix.LiveView.TagEngine.Parser.process_macro_components!(template.nodes,
+        caller: __CALLER__,
+        source: template.source,
+        file: template.file,
+        indentation: template.indentation
+      )
+
+    Phoenix.LiveView.TagEngine.Compiler.compile(
+      %Phoenix.LiveView.TagEngine.Parser{nodes: nodes, directives: directives},
+      file: template.file,
+      caller: __CALLER__,
+      source: template.source,
+      indentation: template.indentation,
+      tag_handler: Phoenix.LiveView.HTMLEngine
+    )
+  end
+
+  @doc ~S'''
   Filters the assigns as a list of keywords for use in dynamic tag attributes.
 
   One should prefer to use declarative assigns and `:global` attributes

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1089,6 +1089,58 @@ defmodule Phoenix.Component do
   end
 
   @doc ~S'''
+  Converts a quoted template built with `quoted/1` into a string, with all
+  `unquote` fragments replaced by the values that were spliced in.
+
+  The result is formatted with `Phoenix.LiveView.HTMLFormatter`. This is
+  mostly useful to document components generated through macros, showing
+  the final template with all customizations applied:
+
+      defmacro build_carousel(opts) do
+        name = Keyword.fetch!(opts, :name)
+        base_class = Keyword.get(opts, :base_class, "carousel")
+
+        template =
+          Phoenix.Component.quoted(~H"""
+          <div class={unquote(base_class)} id={@id}></div>
+          """)
+
+        quote do
+          @doc """
+          Renders a carousel.
+
+          ```heex
+          #{unquote(Phoenix.Component.quoted_to_string(template))}
+          ```
+          """
+          attr :id, :string, required: true
+
+          def unquote(name)(var!(assigns)) do
+            unquote(template)
+          end
+        end
+      end
+
+  Spliced values are rendered as if they had been written in the template
+  directly, so for `build_carousel(name: :gallery)` the documentation above
+  shows `<div class="carousel" id={@id}></div>`.
+  '''
+  def quoted_to_string(quoted_template)
+
+  def quoted_to_string(
+        {:__block__, _, [_require, {{:., _, [_, :__compile_quoted__]}, _, [escaped]}]}
+      ) do
+    {%Phoenix.Component.QuotedTemplate{} = template, _binding} = Code.eval_quoted(escaped)
+    Phoenix.Component.QuotedTemplate.to_source(template)
+  end
+
+  def quoted_to_string(other) do
+    raise ArgumentError,
+          "quoted_to_string/1 expects a quoted template built by " <>
+            "Phoenix.Component.quoted/1 as argument, got: #{Macro.to_string(other)}"
+  end
+
+  @doc ~S'''
   Filters the assigns as a list of keywords for use in dynamic tag attributes.
 
   One should prefer to use declarative assigns and `:global` attributes

--- a/lib/phoenix_component/macro_component.ex
+++ b/lib/phoenix_component/macro_component.ex
@@ -282,6 +282,11 @@ defmodule Phoenix.Component.MacroComponent do
       {name, {:string, binary, _meta}, _attr_meta} ->
         {name, binary}
 
+      # quoted templates (see Phoenix.Component.quoted/1) carry expressions
+      # in already-quoted form
+      {name, {:expr, {:quoted, ast}, _expr_meta}, _attr_meta} ->
+        {name, ast}
+
       {name, {:expr, code, expr_meta}, _attr_meta} ->
         ast =
           Code.string_to_quoted!(code,

--- a/lib/phoenix_component/quoted_template.ex
+++ b/lib/phoenix_component/quoted_template.ex
@@ -13,4 +13,76 @@ defmodule Phoenix.Component.QuotedTemplate do
   # same LiveView version.
 
   defstruct [:nodes, :source, :file, :line, :indentation]
+
+  @doc """
+  Renders the template back to formatted HEEx source.
+
+  Expressions in already-quoted form are rendered with `Macro.to_string/1`,
+  so unquote fragments appear as the values that were spliced in. The
+  resulting source is then formatted with `Phoenix.LiveView.HTMLFormatter`.
+  """
+  def to_source(%__MODULE__{nodes: nodes}) do
+    nodes
+    |> nodes_to_iodata()
+    |> IO.iodata_to_binary()
+    |> Phoenix.LiveView.HTMLFormatter.format(migrate_eex_to_curly_interpolation: false)
+  end
+
+  defp nodes_to_iodata(nodes), do: Enum.map(nodes, &node_to_iodata/1)
+
+  defp node_to_iodata({:text, text, _meta}), do: text
+
+  defp node_to_iodata({:body_expr, expr, _meta}), do: ["{", expr_to_source(expr), "}"]
+
+  defp node_to_iodata({:eex, expr, %{opt: opt}}),
+    do: ["<%", opt, " ", expr_to_source(expr), " %>"]
+
+  defp node_to_iodata({:eex_comment, text}), do: ["<%!--", text, "--%>"]
+
+  defp node_to_iodata({:eex_block, expr, clauses, %{opt: opt}}) do
+    clauses =
+      Enum.map(clauses, fn {nodes, clause_expr, _clause_meta} ->
+        [nodes_to_iodata(nodes), "<% ", clause_expr, " %>"]
+      end)
+
+    [["<%", opt, " ", expr, " %>"] | clauses]
+  end
+
+  defp node_to_iodata({:self_close, _type, _name, attrs, %{closing: :void} = meta}) do
+    ["<", meta.tag_name, attrs_to_iodata(attrs), ">"]
+  end
+
+  defp node_to_iodata({:self_close, _type, _name, attrs, meta}) do
+    ["<", meta.tag_name, attrs_to_iodata(attrs), " />"]
+  end
+
+  defp node_to_iodata({:block, _type, _name, attrs, children, meta, _close_meta}) do
+    [
+      ["<", meta.tag_name, attrs_to_iodata(attrs), ">"],
+      nodes_to_iodata(children),
+      ["</", meta.tag_name, ">"]
+    ]
+  end
+
+  defp attrs_to_iodata(attrs) do
+    Enum.map(attrs, fn
+      {:root, {:expr, expr, _expr_meta}, _attr_meta} ->
+        [" {", expr_to_source(expr), "}"]
+
+      {name, {:string, value, %{delimiter: ?'}}, _attr_meta} ->
+        [" ", name, "='", value, "'"]
+
+      {name, {:string, value, _str_meta}, _attr_meta} ->
+        [" ", name, "=\"", value, "\""]
+
+      {name, {:expr, expr, _expr_meta}, _attr_meta} ->
+        [" ", name, "={", expr_to_source(expr), "}"]
+
+      {name, nil, _attr_meta} ->
+        [" ", name]
+    end)
+  end
+
+  defp expr_to_source({:quoted, ast}), do: Macro.to_string(ast)
+  defp expr_to_source(source) when is_binary(source), do: source
 end

--- a/lib/phoenix_component/quoted_template.ex
+++ b/lib/phoenix_component/quoted_template.ex
@@ -1,0 +1,16 @@
+defmodule Phoenix.Component.QuotedTemplate do
+  @moduledoc false
+
+  # The value produced by `Phoenix.Component.quoted/1` once its unquote
+  # fragments have been filled in: a parsed HEEx tree plus everything needed
+  # to compile it later, at the use site, via
+  # `Phoenix.Component.__compile_quoted__/1`.
+  #
+  # The node format is private to LiveView. This is fine because the struct
+  # never crosses a LiveView version boundary: it is built when the macro
+  # holding the template is compiled and consumed when the macro's caller is
+  # compiled, both within the same project compilation and therefore with the
+  # same LiveView version.
+
+  defstruct [:nodes, :source, :file, :line, :indentation]
+end

--- a/lib/phoenix_live_view/tag_engine/compiler.ex
+++ b/lib/phoenix_live_view/tag_engine/compiler.ex
@@ -97,14 +97,14 @@ defmodule Phoenix.LiveView.TagEngine.Compiler do
 
   ## HEEx interpolation {...}
   defp handle_node({:body_expr, expr, %{line: line, column: column}}, substate, state) do
-    ast = Code.string_to_quoted!(expr, line: line, column: column, file: state.file)
+    ast = to_quoted!(expr, line, column, state.file)
     substate = state.engine.handle_expr(substate, "=", ast)
     {state, substate}
   end
 
   ## EEx expression (<% ... %> or any modifier like <%= ... %>)
   defp handle_node({:eex, expr, %{opt: opt, line: line, column: column}}, substate, state) do
-    ast = Code.string_to_quoted!(expr, line: line, column: column, file: state.file)
+    ast = to_quoted!(expr, line, column, state.file)
     # opt is a charlist from the tokenizer, convert to string for the engine
     marker = to_string(opt)
     substate = state.engine.handle_expr(substate, marker, ast)
@@ -618,7 +618,16 @@ defmodule Phoenix.LiveView.TagEngine.Compiler do
   end
 
   defp parse_expr!({:expr, value, %{line: line, column: col}}, file) do
-    Code.string_to_quoted!(value, line: line, column: col, file: file)
+    to_quoted!(value, line, col, file)
+  end
+
+  # Quoted templates (see Phoenix.Component.quoted/1) parse expressions
+  # to AST when the template is defined, before unquote fragments are
+  # resolved, so the tree may carry expressions in already-quoted form.
+  defp to_quoted!({:quoted, ast}, _line, _column, _file), do: ast
+
+  defp to_quoted!(source, line, column, file) when is_binary(source) do
+    Code.string_to_quoted!(source, line: line, column: column, file: file)
   end
 
   defp literal_keys?([{key, _value} | rest]) when is_atom(key) or is_binary(key),
@@ -700,7 +709,7 @@ defmodule Phoenix.LiveView.TagEngine.Compiler do
          state,
          _type_component
        ) do
-    quoted_value = Code.string_to_quoted!(value, line: line, column: col, file: state.file)
+    quoted_value = to_quoted!(value, line, col, state.file)
     quoted_value = quote line: line, do: Map.new(unquote(quoted_value))
     {special, [quoted_value | r], a, locs}
   end
@@ -733,7 +742,7 @@ defmodule Phoenix.LiveView.TagEngine.Compiler do
         raise_syntax_error!(message, attr_meta, state)
 
       %{} ->
-        quoted_value = Code.string_to_quoted!(value, line: line, column: col, file: state.file)
+        quoted_value = to_quoted!(value, line, col, state.file)
         validate_quoted_special_attr!(attr, quoted_value, attr_meta, state)
         {Map.put(special, attr, {quoted_value, attr_meta}), r, a, locs}
     end
@@ -756,7 +765,7 @@ defmodule Phoenix.LiveView.TagEngine.Compiler do
          state,
          _type_component
        ) do
-    quoted_value = Code.string_to_quoted!(value, line: line, column: col, file: state.file)
+    quoted_value = to_quoted!(value, line, col, state.file)
     {special, r, [{String.to_atom(name), quoted_value} | a], [line_column(attr_meta) | locs]}
   end
 
@@ -1163,6 +1172,10 @@ defmodule Phoenix.LiveView.TagEngine.Compiler do
       case {key, value, meta} do
         {"phx-hook", {:string, "." <> name, str_meta}, meta} ->
           {key, {:string, "#{inspect(state.caller.module)}.#{name}", str_meta}, meta}
+
+        # allow compile-time strings
+        {"phx-hook", {:expr, {:quoted, "." <> name}, expr_meta}, meta} ->
+          {key, {:expr, {:quoted, "#{inspect(state.caller.module)}.#{name}"}, expr_meta}, meta}
 
         _ ->
           {key, value, meta}

--- a/lib/phoenix_live_view/tag_engine/parser.ex
+++ b/lib/phoenix_live_view/tag_engine/parser.ex
@@ -43,6 +43,7 @@ defmodule Phoenix.LiveView.TagEngine.Parser do
     skip_macro_components = Keyword.get(opts, :skip_macro_components, false)
     prune_text_after_slots = Keyword.get(opts, :prune_text_after_slots, true)
     process_buffer = Keyword.get(opts, :process_buffer)
+    quote_exprs = Keyword.get(opts, :quote_exprs, false)
 
     source
     |> tokenize(opts)
@@ -52,6 +53,8 @@ defmodule Phoenix.LiveView.TagEngine.Parser do
       skip_macro_components: skip_macro_components,
       prune_text_after_slots: prune_text_after_slots,
       process_buffer: process_buffer,
+      quote_exprs: quote_exprs,
+      file: Keyword.get(opts, :file, "nofile"),
       directives: []
     })
   catch
@@ -290,7 +293,7 @@ defmodule Phoenix.LiveView.TagEngine.Parser do
   end
 
   defp to_tree([{:body_expr, value, meta} | tokens], buffer, stack, state) do
-    buffer = process_buffer([{:body_expr, value, meta} | buffer], state)
+    buffer = process_buffer([{:body_expr, quote_expr(value, meta, state), meta} | buffer], state)
     to_tree(tokens, buffer, stack, state)
   end
 
@@ -302,6 +305,7 @@ defmodule Phoenix.LiveView.TagEngine.Parser do
          state
        )
        when parent_type in [:local_component, :remote_component] do
+    attrs = quote_attrs(attrs, state)
     meta = meta |> Map.put(:special, extract_special_attrs(attrs)) |> maybe_macro_component(attrs)
 
     {tokens, buffer, state} =
@@ -337,6 +341,7 @@ defmodule Phoenix.LiveView.TagEngine.Parser do
          state
        )
        when parent_type in [:local_component, :remote_component] do
+    attrs = quote_attrs(attrs, state)
     meta = meta |> Map.put(:special, extract_special_attrs(attrs)) |> maybe_macro_component(attrs)
     to_tree(tokens, [], [{:slot, name, attrs, meta, buffer} | stack], state)
   end
@@ -364,6 +369,7 @@ defmodule Phoenix.LiveView.TagEngine.Parser do
   # Self-closing tag or component
   defp to_tree([{type, name, attrs, %{closing: _} = meta} | tokens], buffer, stack, state)
        when is_tag_open(type) do
+    attrs = quote_attrs(attrs, state)
     meta = meta |> Map.put(:special, extract_special_attrs(attrs)) |> maybe_macro_component(attrs)
 
     {tokens, buffer, state} =
@@ -375,6 +381,7 @@ defmodule Phoenix.LiveView.TagEngine.Parser do
   # Opening tag or component
   defp to_tree([{type, name, attrs, meta} | tokens], buffer, stack, state)
        when is_tag_open(type) do
+    attrs = quote_attrs(attrs, state)
     meta = meta |> Map.put(:special, extract_special_attrs(attrs)) |> maybe_macro_component(attrs)
     to_tree(tokens, [], [{type, name, attrs, meta, buffer} | stack], state)
   end
@@ -472,7 +479,7 @@ defmodule Phoenix.LiveView.TagEngine.Parser do
          state
        ) do
     block = Enum.reverse([{Enum.reverse(buffer), end_expr, end_meta} | middle_buffer])
-    to_tree(tokens, [{:eex_block, expr, block, meta} | upper_buffer], stack, state)
+    to_tree(tokens, [build_eex_block(expr, block, meta, state) | upper_buffer], stack, state)
   end
 
   defp to_tree(
@@ -482,7 +489,7 @@ defmodule Phoenix.LiveView.TagEngine.Parser do
          state
        ) do
     block = [{Enum.reverse(buffer), end_expr, end_meta}]
-    to_tree(tokens, [{:eex_block, expr, block, meta} | upper_buffer], stack, state)
+    to_tree(tokens, [build_eex_block(expr, block, meta, state) | upper_buffer], stack, state)
   end
 
   # end_expr reached but unclosed tag on stack (inside a do-block)
@@ -497,7 +504,7 @@ defmodule Phoenix.LiveView.TagEngine.Parser do
   end
 
   defp to_tree([{:eex, _type, expr, meta} | tokens], buffer, stack, state) do
-    buffer = process_buffer([{:eex, expr, meta} | buffer], state)
+    buffer = process_buffer([{:eex, quote_expr(expr, meta, state), meta} | buffer], state)
     to_tree(tokens, buffer, stack, state)
   end
 
@@ -547,6 +554,82 @@ defmodule Phoenix.LiveView.TagEngine.Parser do
   @special_attrs ~w(:if :for :key)
   defp extract_special_attrs(attrs) do
     for {name, _, _} <- attrs, name in @special_attrs, do: name
+  end
+
+  # Quoted templates (see Phoenix.Component.quoted/1) parse all expressions
+  # when the template is defined, replacing the source string with
+  # {:quoted, ast}, so that escaping the tree with
+  # `Macro.escape(nodes, unquote: true)` resolves unquote fragments just
+  # like `quote do ... end` does.
+  defp quote_expr(source, _meta, %{quote_exprs: false}), do: source
+
+  defp quote_expr(source, %{line: line, column: column}, state) do
+    {:quoted, Code.string_to_quoted!(source, line: line, column: column, file: state.file)}
+  end
+
+  defp quote_attrs(attrs, %{quote_exprs: false}), do: attrs
+
+  defp quote_attrs(attrs, state) do
+    Enum.map(attrs, fn
+      # :type identifies macro components and must be resolvable
+      # from the template source alone
+      {":type", _value, _attr_meta} = attr ->
+        attr
+
+      {name, {:expr, source, expr_meta}, attr_meta} ->
+        {name, {:expr, quote_expr(source, expr_meta, state), expr_meta}, attr_meta}
+
+      attr ->
+        attr
+    end)
+  end
+
+  # EEx block expressions are reassembled textually by the compiler,
+  # so they cannot carry expressions in already-quoted form
+  defp build_eex_block(expr, block, meta, %{quote_exprs: true}) do
+    assert_no_unquote!(expr, meta)
+
+    for {_nodes, clause_expr, clause_meta} <- block do
+      assert_no_unquote!(clause_expr, clause_meta)
+    end
+
+    {:eex_block, expr, block, meta}
+  end
+
+  defp build_eex_block(expr, block, meta, _state) do
+    {:eex_block, expr, block, meta}
+  end
+
+  defp assert_no_unquote!(expr, meta) do
+    # block expressions are incomplete ("if foo do"), so we can only
+    # detect unquote fragments in them on a best-effort basis
+    case Code.string_to_quoted(expr <> " end") do
+      {:ok, ast} ->
+        if has_unquote?(ast) do
+          throw_syntax_error!(
+            "unquote is not supported inside <% %> expressions of quoted templates. " <>
+              "Use {...} interpolation instead",
+            meta
+          )
+        end
+
+      {:error, _} ->
+        :ok
+    end
+  end
+
+  defp has_unquote?(ast) do
+    {_ast, found?} =
+      Macro.prewalk(ast, false, fn
+        {unquote_call, _, [_]} = node, _acc
+        when unquote_call in [:unquote, :unquote_splicing] ->
+          {node, true}
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    found?
   end
 
   # Prune leading whitespace from the next text token (used after slots)
@@ -600,6 +683,23 @@ defmodule Phoenix.LiveView.TagEngine.Parser do
 
   defp maybe_process_macro_component(tree_node, tokens, buffer, state)
        when is_macro_component(tree_node) and not skip_macro_components(state) do
+    case run_macro_component(tree_node, state) do
+      {_new_node, _module, directives} when directives != [] and buffer != [] ->
+        throw_directive_position_error!(tree_node, state)
+
+      {{:text, "", _}, _module, directives} ->
+        {strip_text(tokens), buffer, %{state | directives: directives}}
+
+      {new_node, _module, directives} ->
+        {strip_text(tokens), [new_node | buffer], %{state | directives: directives}}
+    end
+  end
+
+  defp maybe_process_macro_component(tree_node, tokens, buffer, state) do
+    {tokens, [tree_node | buffer], state}
+  end
+
+  defp run_macro_component(tree_node, state) do
     caller = state.caller
 
     if is_nil(caller) do
@@ -637,24 +737,105 @@ defmodule Phoenix.LiveView.TagEngine.Parser do
     module_string = meta.macro_component
     module = validate_module!(module_string, meta, state)
 
-    case process_macro_component(tree_node, module, state) do
-      {_new_node, directives} when directives != [] and buffer != [] ->
-        throw_syntax_error!(
-          "macro component #{inspect(module)} specified directives and therefore must appear at the very beginning of the template",
-          get_meta(tree_node)
-        )
+    {new_node, directives} = process_macro_component(tree_node, module, state)
+    {new_node, module, directives}
+  end
 
-      {{:text, "", _}, directives} ->
-        {strip_text(tokens), buffer, %{state | directives: directives}}
+  defp throw_directive_position_error!(tree_node, state) do
+    meta = get_meta(tree_node)
+    module = validate_module!(meta.macro_component, meta, state)
 
-      {new_node, directives} ->
-        {strip_text(tokens), [new_node | buffer], %{state | directives: directives}}
+    throw_syntax_error!(
+      "macro component #{inspect(module)} specified directives and therefore must appear at the very beginning of the template",
+      meta
+    )
+  end
+
+  @doc false
+  # Processes macro components in a tree that was parsed with
+  # `skip_macro_components: true`. Used by quoted templates (see
+  # `Phoenix.Component.quoted/1`), which parse the template when the macro
+  # holding it is defined, but process macro components only when the
+  # template is compiled at the use site, so that macro components (such as
+  # colocated hooks) extract into the caller's application.
+  def process_macro_components!(nodes, opts) do
+    caller = Keyword.fetch!(opts, :caller)
+    source = Keyword.fetch!(opts, :source)
+    file = Keyword.get(opts, :file, "nofile")
+    indentation = Keyword.get(opts, :indentation, 0)
+
+    state = %{caller: caller, directives: []}
+
+    try do
+      walk_macro_components(nodes, [], [], true, state)
+    catch
+      {:syntax_error, line, column, message} ->
+        raise Tokenizer.ParseError,
+          line: line,
+          column: column,
+          file: file,
+          description:
+            message <>
+              Tokenizer.ParseError.code_snippet(
+                source,
+                %{line: line, column: column},
+                indentation
+              )
     end
   end
 
-  defp maybe_process_macro_component(tree_node, tokens, buffer, state) do
-    {tokens, [tree_node | buffer], state}
+  defp walk_macro_components([node | rest], acc, directives, beginning?, state)
+       when is_macro_component(node) do
+    case run_macro_component(node, state) do
+      {_new_node, _module, node_directives} when node_directives != [] and not beginning? ->
+        throw_directive_position_error!(node, state)
+
+      {{:text, "", _}, _module, node_directives} ->
+        walk_macro_components(strip_text(rest), acc, directives ++ node_directives, false, state)
+
+      {new_node, _module, node_directives} ->
+        walk_macro_components(
+          strip_text(rest),
+          [new_node | acc],
+          directives ++ node_directives,
+          false,
+          state
+        )
+    end
   end
+
+  defp walk_macro_components([node | rest], acc, directives, beginning?, state) do
+    {node, child_directives} = walk_macro_component_children(node, state)
+    beginning? = beginning? and whitespace_text?(node)
+    walk_macro_components(rest, [node | acc], directives ++ child_directives, beginning?, state)
+  end
+
+  defp walk_macro_components([], acc, directives, _beginning?, _state) do
+    {Enum.reverse(acc), directives}
+  end
+
+  defp walk_macro_component_children(
+         {:block, type, name, attrs, children, meta, close_meta},
+         state
+       ) do
+    {children, directives} = walk_macro_components(children, [], [], false, state)
+    {{:block, type, name, attrs, children, meta, close_meta}, directives}
+  end
+
+  defp walk_macro_component_children({:eex_block, expr, clauses, meta}, state) do
+    {clauses, directives} =
+      Enum.map_reduce(clauses, [], fn {nodes, clause_expr, clause_meta}, acc ->
+        {nodes, directives} = walk_macro_components(nodes, [], [], false, state)
+        {{nodes, clause_expr, clause_meta}, acc ++ directives}
+      end)
+
+    {{:eex_block, expr, clauses, meta}, directives}
+  end
+
+  defp walk_macro_component_children(node, _state), do: {node, []}
+
+  defp whitespace_text?({:text, text, _meta}), do: String.trim(text) == ""
+  defp whitespace_text?(_node), do: false
 
   # Process a macro component: call transform and convert result back to tree nodes
   defp process_macro_component(tree_node, module, state) do

--- a/test/phoenix_component/quoted_template_test.exs
+++ b/test/phoenix_component/quoted_template_test.exs
@@ -88,6 +88,42 @@ defmodule Phoenix.Component.QuotedTemplateTest do
         def unquote(name)(var!(assigns)), do: unquote(template)
       end
     end
+
+    defmacro tag_source(class) do
+      template =
+        Phoenix.Component.quoted(~H"""
+        <div class={unquote(class)} id={@id}>{@inner}</div>
+        """)
+
+      Phoenix.Component.quoted_to_string(template)
+    end
+
+    defmacro block_source(value) do
+      template =
+        Phoenix.Component.quoted(~H"""
+        <%= if @show do %>
+          <div data-value={unquote(value)}><.inner /></div>
+        <% else %>
+          <img src={@src} />
+        <% end %>
+        """)
+
+      Phoenix.Component.quoted_to_string(template)
+    end
+
+    defmacro hook_source(hook_name) do
+      template =
+        Phoenix.Component.quoted(~H"""
+        <div id={@id} phx-hook={unquote(hook_name)}></div>
+        <script :type={Phoenix.LiveView.ColocatedHook} name={unquote(hook_name)}>
+          export default {
+            mounted() {},
+          };
+        </script>
+        """)
+
+      Phoenix.Component.quoted_to_string(template)
+    end
   end
 
   defmodule Tags do
@@ -96,6 +132,14 @@ defmodule Phoenix.Component.QuotedTemplateTest do
 
     Builder.build_tag(name: :card, class: "card")
     Builder.build_tag(name: :badge, class: "badge")
+  end
+
+  defmodule Sources do
+    require Builder
+
+    def tag, do: Builder.tag_source("card")
+    def block, do: Builder.block_source("a > b")
+    def hook, do: Builder.hook_source(".Widget")
   end
 
   defmodule Tracked do
@@ -205,6 +249,38 @@ defmodule Phoenix.Component.QuotedTemplateTest do
     after
       :code.delete(__MODULE__.WithHook)
       :code.purge(__MODULE__.WithHook)
+    end
+  end
+
+  describe "quoted_to_string" do
+    test "renders the template with spliced values in place" do
+      assert Sources.tag() == """
+             <div class="card" id={@id}>{@inner}</div>
+             """
+    end
+
+    test "renders EEx blocks, components and void tags" do
+      assert Sources.block() == """
+             <%= if @show do %>
+               <div data-value="a > b"><.inner /></div>
+             <% else %>
+               <img src={@src} />
+             <% end %>
+             """
+    end
+
+    test "renders macro components with their content" do
+      source = Sources.hook()
+
+      assert source =~ ~s(phx-hook=".Widget")
+      assert source =~ ~s(<script :type={Phoenix.LiveView.ColocatedHook} name=".Widget">)
+      assert source =~ "mounted() {},"
+    end
+
+    test "raises when the argument is not a quoted template" do
+      assert_raise ArgumentError,
+                   ~r/expects a quoted template built by Phoenix\.Component\.quoted\/1/,
+                   fn -> Phoenix.Component.quoted_to_string({:foo, [], []}) end
     end
   end
 

--- a/test/phoenix_component/quoted_template_test.exs
+++ b/test/phoenix_component/quoted_template_test.exs
@@ -1,0 +1,282 @@
+defmodule Phoenix.Component.QuotedTemplateTest do
+  # async: false because the colocated hook tests read/write a shared folder
+  use ExUnit.Case, async: false
+
+  import Phoenix.LiveViewTest
+
+  defmodule Builder do
+    use Phoenix.Component
+
+    defmacro build_tag(opts) do
+      name = Keyword.fetch!(opts, :name)
+      class = Keyword.get(opts, :class, "default")
+
+      template =
+        Phoenix.Component.quoted(~H"""
+        <div class={unquote(class)} id={@id}>{@inner}</div>
+        """)
+
+      quote do
+        def unquote(name)(var!(assigns)), do: unquote(template)
+      end
+    end
+
+    defmacro build_with_assign_splice(name, assign_name) do
+      # splice AST referencing an assign, as if it was written in the template
+      hole = {:@, [], [{assign_name, [], nil}]}
+
+      template =
+        Phoenix.Component.quoted(~H"""
+        <div id={@id} class={unquote(hole)}></div>
+        """)
+
+      quote do
+        def unquote(name)(var!(assigns)), do: unquote(template)
+      end
+    end
+
+    defmacro build_with_root_attrs(name, attrs) do
+      template =
+        Phoenix.Component.quoted(~H"""
+        <div {unquote(attrs)}></div>
+        """)
+
+      quote do
+        def unquote(name)(var!(assigns)), do: unquote(template)
+      end
+    end
+
+    defmacro build_with_component_call(name) do
+      template =
+        Phoenix.Component.quoted(~H"""
+        <.inner label={unquote("from macro")} />
+        """)
+
+      quote do
+        def unquote(name)(var!(assigns)), do: unquote(template)
+      end
+    end
+
+    defmacro build_with_hook(opts) do
+      name = Keyword.fetch!(opts, :name)
+      hook_name = Keyword.fetch!(opts, :hook_name)
+
+      template =
+        Phoenix.Component.quoted(~H"""
+        <div id={@id} phx-hook={unquote(hook_name)}></div>
+        <script :type={Phoenix.LiveView.ColocatedHook} name={unquote(hook_name)}>
+          export default {
+            mounted() {
+              this.el.textContent = "from quoted";
+            },
+          };
+        </script>
+        """)
+
+      quote do
+        def unquote(name)(var!(assigns)), do: unquote(template)
+      end
+    end
+
+    defmacro build_static_attr(name, value) do
+      template =
+        Phoenix.Component.quoted(~H"""
+        <div title={unquote(value)} id={@id}></div>
+        """)
+
+      quote do
+        def unquote(name)(var!(assigns)), do: unquote(template)
+      end
+    end
+  end
+
+  defmodule Tags do
+    use Phoenix.Component
+    require Builder
+
+    Builder.build_tag(name: :card, class: "card")
+    Builder.build_tag(name: :badge, class: "badge")
+  end
+
+  defmodule Tracked do
+    use Phoenix.Component
+    require Builder
+
+    Builder.build_with_assign_splice(:dyn, :extra)
+  end
+
+  describe "value splicing" do
+    test "splices compile-time values into attributes" do
+      assert rendered_to_string(Tags.card(%{id: "a", inner: "hi"})) ==
+               ~s(<div class="card" id="a">hi</div>)
+
+      assert rendered_to_string(Tags.badge(%{id: "b", inner: "ho"})) ==
+               ~s(<div class="badge" id="b">ho</div>)
+    end
+
+    test "spliced values are HTML escaped" do
+      defmodule Evil do
+        use Phoenix.Component
+        require Builder
+
+        Builder.build_tag(name: :evil, class: "\"><script>alert(1)</script>")
+      end
+
+      assert rendered_to_string(Evil.evil(%{id: "x", inner: "hi"})) ==
+               "<div class=\"&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;\" id=\"x\">hi</div>"
+    end
+
+    test "splices keyword lists into root attributes" do
+      defmodule RootAttrs do
+        use Phoenix.Component
+        require Builder
+
+        Builder.build_with_root_attrs(:static_root, class: "fixed", id: "root")
+      end
+
+      assert rendered_to_string(RootAttrs.static_root(%{})) =~ ~s(class="fixed")
+      assert rendered_to_string(RootAttrs.static_root(%{})) =~ ~s(id="root")
+    end
+
+    test "calls components resolved in the caller context" do
+      defmodule WithComponentCall do
+        use Phoenix.Component
+        require Builder
+
+        def inner(assigns), do: ~H"<span>{@label}</span>"
+
+        Builder.build_with_component_call(:outer)
+      end
+
+      assert rendered_to_string(WithComponentCall.outer(%{})) == "<span>from macro</span>"
+    end
+  end
+
+  describe "change tracking" do
+    test "spliced AST takes part in change tracking" do
+      rendered = Tracked.dyn(%{id: "a", extra: "one", __changed__: nil})
+      assert Enum.to_list(rendered.dynamic.(true)) == [[" id=\"", "a", 34], "one"]
+
+      rendered = Tracked.dyn(%{id: "a", extra: "two", __changed__: %{extra: true}})
+      assert Enum.to_list(rendered.dynamic.(true)) == [nil, "two"]
+
+      rendered = Tracked.dyn(%{id: "b", extra: "two", __changed__: %{id: true}})
+      assert Enum.to_list(rendered.dynamic.(true)) == [[" id=\"", "b", 34], nil]
+    end
+
+    test "spliced literals are inlined as escaped static parts" do
+      defmodule StaticAttr do
+        use Phoenix.Component
+        require Builder
+
+        Builder.build_static_attr(:titled, "say \"hi\"")
+      end
+
+      rendered = StaticAttr.titled(%{id: "a", __changed__: nil})
+      # the title attribute is inlined, so only @id is dynamic,
+      # exactly as for a handwritten title={"..."}
+      assert length(Enum.to_list(rendered.dynamic.(true))) == 1
+      assert hd(rendered.static) == "<div title=\"say &quot;hi&quot;\""
+    end
+  end
+
+  describe "colocated hooks" do
+    test "are extracted into the caller's application" do
+      defmodule WithHook do
+        use Phoenix.Component
+        require Builder
+
+        Builder.build_with_hook(name: :widget, hook_name: ".QuotedWidget")
+      end
+
+      # the relative hook name resolves against the caller module
+      assert rendered_to_string(WithHook.widget(%{id: "w"})) =~
+               ~s(phx-hook="Phoenix.Component.QuotedTemplateTest.WithHook.QuotedWidget")
+
+      base = Path.join(Mix.Project.build_path(), "phoenix-colocated/phoenix_live_view")
+
+      assert folder =
+               base
+               |> File.ls!()
+               |> Enum.find(&(&1 =~ "Phoenix.Component.QuotedTemplateTest.WithHook"))
+
+      assert [script] = Path.wildcard(Path.join(base, "#{folder}/*.js"))
+      assert File.read!(script) =~ "from quoted"
+    after
+      :code.delete(__MODULE__.WithHook)
+      :code.purge(__MODULE__.WithHook)
+    end
+  end
+
+  describe "errors" do
+    test "raises on unquote inside EEx block expressions" do
+      assert_raise Phoenix.LiveView.TagEngine.Tokenizer.ParseError,
+                   ~r/unquote is not supported inside <% %> expressions/,
+                   fn ->
+                     defmodule EExBlockHole do
+                       use Phoenix.Component
+
+                       defmacro bad(cond_ast) do
+                         Phoenix.Component.quoted(~H"""
+                         <%= if unquote(cond_ast) do %>
+                           <div>hi</div>
+                         <% end %>
+                         """)
+                       end
+                     end
+                   end
+    end
+
+    test "raises when the argument is not a ~H sigil" do
+      assert_raise ArgumentError,
+                   ~r/expects a ~H template without interpolation/,
+                   fn ->
+                     defmodule NotASigil do
+                       use Phoenix.Component
+
+                       defmacro bad do
+                         Phoenix.Component.quoted("<div></div>")
+                       end
+                     end
+                   end
+    end
+
+    test "raises when no assigns variable is in scope at the use site" do
+      assert_raise RuntimeError,
+                   ~r/quoted templates require a variable named "assigns"/,
+                   fn ->
+                     defmodule NoAssigns do
+                       use Phoenix.Component
+
+                       defmacro bad_def(name) do
+                         template = Phoenix.Component.quoted(~H"<div></div>")
+
+                         quote do
+                           def unquote(name)(_other_name), do: unquote(template)
+                         end
+                       end
+                     end
+
+                     defmodule NoAssignsUser do
+                       use Phoenix.Component
+                       require NoAssigns
+                       NoAssigns.bad_def(:broken)
+                     end
+                   end
+    end
+
+    test "raises on invalid HTML when the macro is defined" do
+      assert_raise Phoenix.LiveView.TagEngine.Tokenizer.ParseError,
+                   ~r/unmatched closing tag/,
+                   fn ->
+                     defmodule BadHtml do
+                       use Phoenix.Component
+
+                       defmacro bad do
+                         Phoenix.Component.quoted(~H"<div></span>"noformat)
+                       end
+                     end
+                   end
+    end
+  end
+end


### PR DESCRIPTION
This commit introduces a Phoenix.Component.quoted macro. It can be used when defining components in a macro where values should be unquoted into the component.

Templates are normally compiled where they are written, so `unquote` inside `~H` has no access to the variables of a macro generating a component:

```elixir
defmacro build_button(opts) do
  name = Keyword.fetch!(opts, :name)

  quote do
    def unquote(name)(var!(assigns)) do
      ~H"""
      # cannot use unquote here
      """
    end
  end
end
```

With Phoenix.Component.quoted, the template is written directly in the macro body, where unquote works as in any quite block, and the result is spliced into the generated function with a regular unquote call:

```elixir
template =
  Phoenix.Component.quoted(~H"""
  <div class={unquote(base_class)} id={@id} phx-hook={unquote(hook)}></div>
  <script :type={Phoenix.LiveView.ColocatedHook} name={unquote(hook)}>
    ...
  </script>
  """)

quote do
  def unquote(name)(var!(assigns)), do: unquote(template)
end
```

This works in three stages:

1. When the module defining the macro is compiled, the template is parsed into the HEEx tree with all expressions converted to AST. Then, we escape it with unquote: true.

2. When the macro is invoked, the resolved tree is packaged into a Phoenix.Component.QuotedTemplate struct and returned as quoted code.

3. Finally, when the caller module is compiled, we actually call the regular HEEx compiler to compile the nodes as usual. This means that strings injected by a macro are treated as compile-time macros by the HEEx compiler and can be inlined into the static parts.

We deliberately don't handle EEx blocks.