### PR TITLE
Refactor JS.put_op/3 and fix internal opaque typespec

### DIFF
--- a/lib/phoenix_live_view/js.ex
+++ b/lib/phoenix_live_view/js.ex
@@ -211,7 +211,7 @@ defmodule Phoenix.LiveView.JS do
 
   defstruct ops: []
 
-  @opaque internal :: []
+  @opaque internal :: list()
   @type t :: %__MODULE__{ops: internal}
 
   @default_transition_time 200
@@ -1278,13 +1278,8 @@ defmodule Phoenix.LiveView.JS do
   def concat(%JS{ops: first}, %JS{ops: second}), do: %JS{ops: first ++ second}
 
   defp put_op(%JS{ops: ops} = js, kind, args) do
-    args = drop_nil_values(args)
-    struct!(js, ops: ops ++ [[kind, args]])
-  end
-
-  defp drop_nil_values(args) when is_list(args) do
-    Enum.reject(args, fn {_k, v} -> is_nil(v) end)
-    |> Map.new()
+    args = for {k, v} <- args, v != nil, into: %{}, do: {k, v}
+    %{js | ops: ops ++ [[kind, args]]}
   end
 
   defp class_names(names) do


### PR DESCRIPTION
It's less code and it's marginally faster.


As I understand from Elixir docs the `[]` type is only for empty lists.
https://elixir.hexdocs.pm/typespecs.html#built-in-types

<img width="438" height="36" alt="image" src="https://github.com/user-attachments/assets/b0e523b8-0dea-4813-97a0-799c6486d120" />