### PR TITLE
Fix typo in Inspect.Opts :charlists value :as_list -> :as_lists

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -1029,7 +1029,7 @@ defmodule Phoenix.Component.Declarative do
   end
 
   defp build_literal(literal) do
-    [?`, inspect(literal, charlists: :as_list), ?`]
+    [?`, inspect(literal, charlists: :as_lists), ?`]
   end
 
   defp build_hyphen(%{doc: doc}) when is_binary(doc) do


### PR DESCRIPTION
See: https://github.com/elixir-lang/elixir/pull/15464