### PR TITLE
Remove dead vars_changed_vars(:all) clause

### DIFF
--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -862,8 +862,6 @@ defmodule Phoenix.LiveView.Engine do
   defp to_component_keys(:all), do: :all
   defp to_component_keys(map), do: Map.keys(map)
 
-  defp vars_changed_vars(:all), do: []
-
   defp vars_changed_vars(keys) do
     # when we calculate the changed map for components, we need to
     # also pass the variables for vars_changed;


### PR DESCRIPTION
Since dynamic assigns no longer perform change tracking (removed in ae8aa81e), the vars_changed_vars function is now only ever called with a List. Thus, the :all clause is unreachable dead code.
