### PR TITLE
docs: rewrite of binding explanation and connection to handle_event callbacks

### DIFF
--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -1,19 +1,24 @@
 # Bindings
 
-Phoenix supports DOM element bindings for client-server interaction. For
+Phoenix LiveView supports DOM element bindings for client-server interaction. For
 example, to react to a click on a button, you would render the element:
 
 ```heex
 <button phx-click="inc_temperature">+</button>
 ```
 
-Then on the server, all LiveView bindings are handled with the `handle_event`
-callback, for example:
+Under the hood, in LiveView, when a client makes use of any binding, it will 
+form a socket message and send it through the socket to the server.
+In the example above, by clicking the element with a `phx-click` binding, 
+this message, alongside all other LiveView bindings, are dealt with by the server 
+by a `handle_event` callback declared on the LiveView:
 
     def handle_event("inc_temperature", _value, socket) do
       {:ok, new_temp} = Thermostat.inc_temperature(socket.assigns.id)
       {:noreply, assign(socket, :temperature, new_temp)}
     end
+
+Note: If a callback is not explicitly defined and therefore a message goes unhandled, the server will raise a FunctionClauseError exception and reload the page.
 
 | Binding                | Attributes |
 |------------------------|------------|
@@ -33,8 +38,8 @@ If you need to trigger commands actions via JavaScript, see [JavaScript interope
 
 ## Click Events
 
-The `phx-click` binding is used to send click events to the server.
-When any client event, such as a `phx-click` click is pushed, the value
+As previously stated, the `phx-click` binding is used to send click events to the server.
+When any client event, such as a `phx-click` click is pushed, the value sent via params
 sent to the server will be chosen with the following priority:
 
   * The `:value` specified in `Phoenix.LiveView.JS.push/3`, such as:

--- a/guides/client/bindings.md
+++ b/guides/client/bindings.md
@@ -7,16 +7,17 @@ example, to react to a click on a button, you would render the element:
 <button phx-click="inc_temperature">+</button>
 ```
 
-Under the hood, in LiveView, when a client makes use of any binding, it will 
-form a socket message and send it through the socket to the server.
-In the example above, by clicking the element with a `phx-click` binding, 
-this message, alongside all other LiveView bindings, are dealt with by the server 
-by a `handle_event` callback declared on the LiveView:
+When a client makes use of any binding, it will form a socket message 
+and send it to the server. By clicking an element with a `phx-click` binding, 
+a message is dealt with by a `handle_event` callback declared on the LiveView:
 
     def handle_event("inc_temperature", _value, socket) do
       {:ok, new_temp} = Thermostat.inc_temperature(socket.assigns.id)
       {:noreply, assign(socket, :temperature, new_temp)}
     end
+
+The behavior of using a DOM element binding to enable the client 
+to send a message to the server is a hallmark of client-server interaction in LiveView.
 
 Note: If a callback is not explicitly defined and therefore a message goes unhandled, the server will raise a FunctionClauseError exception and reload the page.
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -2209,7 +2209,9 @@ defmodule Phoenix.LiveView do
         reset? = Keyword.get(opts, :reset, false)
 
         stream = if reset?, do: LiveStream.reset(original_stream), else: original_stream
-        new_stream = Enum.reduce(items, stream, &LiveStream.insert_item(&2, &1, at, limit, update_only))
+
+        new_stream =
+          Enum.reduce(items, stream, &LiveStream.insert_item(&2, &1, at, limit, update_only))
 
         if new_stream === original_stream and not reset? do
           socket


### PR DESCRIPTION
Sometimes, developers may feel like this is a secondary part of interactions.
This is an attempt to make a bit clearer that is it primary to make requests and features in the system.