### PR TITLE
Use locked npm dependencies where relevant

### DIFF
--- a/.github/single-file-samples/main.exs
+++ b/.github/single-file-samples/main.exs
@@ -24,7 +24,7 @@ Mix.install(
 #
 # path = Phoenix.LiveView.__info__(:compile)[:source] |> Path.dirname() |> Path.join("../")
 # System.cmd("mix", ["deps.get"], cd: path, into: IO.binstream())
-# System.cmd("npm", ["install"], cd: Path.join(path, "./assets"), into: IO.binstream())
+# System.cmd("npm", ["ci"], cd: Path.join(path, "./assets"), into: IO.binstream())
 # System.cmd("mix", ["assets.build"], cd: path, into: IO.binstream())
 
 defmodule Example.ErrorView do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,8 +146,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: setup JS
-        run: npm run setup
+      - name: Install locked npm dependencies
+        run: npm ci
 
       - name: typecheck
         run: npm run build && npm run typecheck:tests
@@ -214,8 +214,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: setup
-        run: npm run setup
+      - name: Install locked npm dependencies
+        run: npm ci
 
       - name: Run e2e tests
         run: npm run e2e:test
@@ -306,8 +306,11 @@ jobs:
         with:
           node-version: 20.x
 
+      - name: Install locked npm dependencies
+        run: npm ci
+
       - name: Merge coverage reports
-        run: npm install && npm run cover:merge
+        run: npm run cover:merge
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -193,15 +193,16 @@ $ mix test
 
 Running all JavaScript tests:
 ```bash
-$ npm install
-$ npm run setup
-$ npm run test
+$ mix deps.get
+$ npm ci
+$ npm test
 ```
 
 Running the JavaScript unit tests:
 
 ```bash
-$ npm run setup
+$ mix deps.get
+$ npm ci
 $ npm run js:test
 # to automatically run tests for files that have been changed
 $ npm run js:test.watch
@@ -210,7 +211,8 @@ $ npm run js:test.watch
 Running the JavaScript end-to-end tests:
 
 ```bash
-$ npm run setup
+$ mix deps.get
+$ npm ci
 $ npm run e2e:test
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -204,7 +204,7 @@ defmodule Phoenix.LiveView.MixProject do
 
   defp generate_js_docs(_) do
     Mix.Task.run("app.start")
-    {_, 0} = System.cmd("npm", ["install"], into: IO.stream())
+    {_, 0} = System.cmd("npm", ["ci"], into: IO.stream())
     {_, 0} = System.cmd("npm", ["run", "docs"], into: IO.stream())
   end
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "typescript-eslint": "^8.34.0"
   },
   "scripts": {
-    "setup": "mix deps.get && npm install",
     "build": "tsc",
     "e2e:server": "MIX_ENV=e2e mix test --cover --export-coverage e2e test/e2e/test_helper.exs",
     "e2e:test": "mix assets.build && cd test/e2e && npx playwright install && npx playwright test",
@@ -71,7 +70,7 @@
     "test": "npm run js:test && npm run e2e:test",
     "typecheck:tests": "tsc -p assets/test/tsconfig.json",
     "cover:merge": "node test/e2e/merge-coverage.js",
-    "cover": "npm run test && npm run cover:merge",
+    "cover": "npm test && npm run cover:merge",
     "cover:report": "npx monocart show-report cover/merged-js/index.html",
     "docs": "typedoc assets/js/phoenix_live_view/index.ts --readme assets/js/phoenix_live_view/README.md --html doc/js"
   }

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -7,7 +7,7 @@ with an actual LiveView server.
 
 ## Running the tests
 
-To run the tests, ensure that the npm dependencies are installed by running `npm install`, followed by `npx playwright install` in
+To run the tests, ensure that the npm dependencies are installed by running `npm ci`, followed by `npx playwright install` in
 the root of the repository. Then, run `npm run e2e:test` to run the tests.
 
 This will execute the `npx playwright test` command in the `test/e2e` directory. Playwright


### PR DESCRIPTION
Prefer using `npm ci` to perform a clean install of the dependencies as defined in package-lock.json, instead of `npm install` which may install different versions and silently update package-lock.json.

Replace `npm run setup` script with explicit steps, avoiding duplicate work in a few places, preferring to expose well-known commands instead: `mix deps.get` and `npm ci`.