### PR TITLE
Align documentation to installer output

### DIFF
--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -327,9 +327,7 @@ config :esbuild,
     args:
       ~w(js/app.js --bundle --target=es2022 --outdir=../priv/static/assets/js --external:/fonts/* --external:/images/* --alias:@=.),
     cd: Path.expand("../assets", __DIR__),
-    env: %{
-      "NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]
-    }
+    env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
   ]
 ```
 

--- a/lib/phoenix_live_view/colocated_css.ex
+++ b/lib/phoenix_live_view/colocated_css.ex
@@ -58,9 +58,7 @@ defmodule Phoenix.LiveView.ColocatedCSS do
           args:
             ~w(js/app.js --bundle --target=es2022 --outdir=../priv/static/assets/js --external:/fonts/* --external:/images/* --alias:@=.),
           cd: Path.expand("../assets", __DIR__),
-          env: %{
-            "NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]
-          }
+          env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
         ]
 
   This is the same setup as for `Phoenix.LiveView.ColocatedJS`. Then, import it like this in your `app.js` file:

--- a/lib/phoenix_live_view/colocated_js.ex
+++ b/lib/phoenix_live_view/colocated_js.ex
@@ -77,9 +77,7 @@ defmodule Phoenix.LiveView.ColocatedJS do
           args:
             ~w(js/app.js --bundle --target=es2022 --outdir=../priv/static/assets/js --external:/fonts/* --external:/images/* --alias:@=.),
           cd: Path.expand("../assets", __DIR__),
-          env: %{
-            "NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]
-          }
+          env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
         ]
 
   The important part here is the `NODE_PATH` environment variable, which tells esbuild to also look


### PR DESCRIPTION
LiveView's counterpart to https://github.com/phoenixframework/phoenix/pull/6730.

While not a particularly important change, matching the lines 1:1 makes them easier to find and mass update when needed.