### PR TITLE
Optimize uri_scheme

### DIFF
--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -617,15 +617,15 @@ defmodule Phoenix.LiveView.Utils do
   # Returns the lowercased URI scheme of `to` if it begins with one, that is, a
   # ":" appears before any "/", "?" or "#"; otherwise returns nil. This avoids
   # treating a colon in a path segment, query, or fragment as a scheme.
-  defp uri_scheme(to) do
+  defp uri_scheme(<<char, _::binary>> = to) when char in ?A..?Z or char in ?a..?z do
     case :binary.match(to, [":", "/", "?", "#"]) do
-      {pos, 1} ->
-        if binary_part(to, pos, 1) == ":",
-          do: String.downcase(binary_part(to, 0, pos), :ascii),
-          else: nil
+      {pos, 1} when binary_part(to, pos, 1) == ":" ->
+        String.downcase(binary_part(to, 0, pos), :ascii)
 
-      :nomatch ->
+      _ ->
         nil
     end
   end
+
+  defp uri_scheme(_to), do: nil
 end


### PR DESCRIPTION
Assisted by: Antigravity CLI : Gemini 3.5 Flash (hand rolled in the end)

This provides a ~15x speedup for paths starting with "/" (most common I believe).
For valid inputs this version is equivalent to original.

For invalid input the difference I believe is a correction:
| Input | Original Behavior | New Behavior | Difference / Rationale |
|---|---|---|---|
| `"1http://example.com"` | `"1http"` | `nil` | According to RFC 3986, a scheme cannot start with a digit. The new version correctly treats this as a path (`nil`), whereas the old one extracted an invalid scheme `"1http"`. |
| `":foo"` | `""` | `nil` | An empty scheme is invalid. The new version correctly returns `nil`, whereas the old version extracted an empty string. |

Bench:
```elixir
Mix.install([{:benchee, "~> 1.0"}])

defmodule Original do
  def uri_scheme(to) do
    case :binary.match(to, [":", "/", "?", "#"]) do
      {pos, 1} ->
        if binary_part(to, pos, 1) == ":",
          do: String.downcase(binary_part(to, 0, pos), :ascii),
          else: nil

      :nomatch ->
        nil
    end
  end
end

defmodule Current do
  def uri_scheme(<<char, _::binary>> = to) when char in ?A..?Z or char in ?a..?z do
    case :binary.match(to, [":", "/", "?", "#"]) do
      {pos, 1} when binary_part(to, pos, 1) == ":" ->
        String.downcase(binary_part(to, 0, pos), :ascii)

      _ ->
        nil
    end
  end

  def uri_scheme(_to), do: nil
end

inputs = %{
  "Path starting with slash" => "/foo/bar/baz?query=true#fragment",
  "Path starting with hash" => "#fragment-only",
  "Path starting with question" => "?query=only",
  "Path without starting slash" => "foo/bar",
  "Relative path with dot" => "./foo/bar",
  "Path starting with underscore" => "_foo/bar",
  "HTTP url" => "http://example.com/foo/bar",
  "HTTPS url" => "https://example.com/foo/bar",
  "Mailto link" => "mailto:test@example.com",
  "Javascript link" => "javascript:alert(1)"
}

Benchee.run(
  %{
    "original" => fn input -> Original.uri_scheme(input) end,
    "current" => fn input -> Current.uri_scheme(input) end
  },
  inputs: inputs,
  time: 2,
  memory_time: 2
)
```

Bench results on noisy system:

```txt
##### With input HTTP url #####
Name               ips        average  deviation         median         99th %
original        1.44 M      692.82 ns  ±1010.36%         651 ns         932 ns
current         1.40 M      712.71 ns   ±642.98%         671 ns         992 ns

Comparison:
original        1.44 M
current         1.40 M - 1.03x slower +19.89 ns

Memory usage statistics:

Name        Memory usage
original           152 B
current            240 B - 1.58x memory usage +88 B

**All measurements for memory usage were the same**

##### With input HTTPS url #####
Name               ips        average  deviation         median         99th %
original        1.43 M      698.67 ns   ±991.16%         651 ns        1132 ns
current         1.43 M      700.79 ns  ±1041.04%         651 ns        1012 ns

Comparison:
original        1.43 M
current         1.43 M - 1.00x slower +2.12 ns

Memory usage statistics:

Name        Memory usage
original           168 B
current            256 B - 1.52x memory usage +88 B

**All measurements for memory usage were the same**

##### With input Javascript link #####
Name               ips        average  deviation         median         99th %
current         1.37 M      727.84 ns   ±996.96%         681 ns        1002 ns
original        1.32 M      757.72 ns   ±929.64%         701 ns        1303 ns

Comparison:
current         1.37 M
original        1.32 M - 1.04x slower +29.88 ns

Memory usage statistics:

Name        Memory usage
current            336 B
original           256 B - 0.76x memory usage -80 B

**All measurements for memory usage were the same**

##### With input Mailto link #####
Name               ips        average  deviation         median         99th %
current         1.41 M      707.87 ns   ±975.13%         661 ns        1012 ns
original        1.41 M      709.91 ns   ±974.76%         661 ns         982 ns

Comparison:
current         1.41 M
original        1.41 M - 1.00x slower +2.04 ns

Memory usage statistics:

Name        Memory usage
current            264 B
original           184 B - 0.70x memory usage -80 B

**All measurements for memory usage were the same**

##### With input Path starting with hash #####
Name               ips        average  deviation         median         99th %
current        26.59 M       37.61 ns ±10783.46%          30 ns          40 ns
original        1.71 M      583.73 ns    ±87.43%         571 ns         851 ns

Comparison:
current        26.59 M
original        1.71 M - 15.52x slower +546.11 ns

Memory usage statistics:

Name        Memory usage
current             40 B
original            24 B - 0.60x memory usage -16 B

**All measurements for memory usage were the same**

##### With input Path starting with question #####
Name               ips        average  deviation         median         99th %
current        27.35 M       36.56 ns ±10100.43%          30 ns          40 ns
original        1.72 M      582.69 ns    ±81.19%         571 ns         841 ns

Comparison:
current        27.35 M
original        1.72 M - 15.94x slower +546.13 ns

Memory usage statistics:

Name        Memory usage
current             40 B
original            24 B - 0.60x memory usage -16 B

**All measurements for memory usage were the same**

##### With input Path starting with slash #####
Name               ips        average  deviation         median         99th %
current        28.45 M       35.15 ns ±10165.31%          30 ns          40 ns
original        1.71 M      583.76 ns    ±86.54%         571 ns         792 ns

Comparison:
current        28.45 M
original        1.71 M - 16.61x slower +548.61 ns

Memory usage statistics:

Name        Memory usage
current             40 B
original            24 B - 0.60x memory usage -16 B

**All measurements for memory usage were the same**

##### With input Path starting with underscore #####
Name               ips        average  deviation         median         99th %
current        27.39 M       36.50 ns ±10150.89%          30 ns          40 ns
original        1.64 M      611.52 ns    ±83.08%         591 ns         991 ns

Comparison:
current        27.39 M
original        1.64 M - 16.75x slower +575.01 ns

Memory usage statistics:

Name        Memory usage
current             40 B
original            24 B - 0.60x memory usage -16 B

**All measurements for memory usage were the same**

##### With input Path without starting slash #####
Name               ips        average  deviation         median         99th %
current         1.66 M      602.12 ns   ±521.79%         571 ns         842 ns
original        1.65 M      605.05 ns    ±84.02%         591 ns         871 ns

Comparison:
current         1.66 M
original        1.65 M - 1.00x slower +2.92 ns

Memory usage statistics:

Name        Memory usage
current             88 B
original            24 B - 0.27x memory usage -64 B

**All measurements for memory usage were the same**

##### With input Relative path with dot #####
Name               ips        average  deviation         median         99th %
current        27.22 M       36.74 ns ±10714.84%          30 ns          40 ns
original        1.67 M      599.36 ns    ±85.75%         581 ns         852 ns

Comparison:
current        27.22 M
original        1.67 M - 16.32x slower +562.62 ns

Memory usage statistics:

Name        Memory usage
current             40 B
original            24 B - 0.60x memory usage -16 B

**All measurements for memory usage were the same**
```
