### PR TITLE
Use `to_string` for displaying atoms in generated output for test warnings

### DIFF
--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -535,7 +535,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
         You can change this error by setting
 
             config :phoenix_live_view, :test_warnings,
-              #{inspect(type)}: :warn # can be one of :warn, :raise, or :ignore
+              #{to_string(type)}: :warn # can be one of :warn, :raise, or :ignore
 
         See the `Phoenix.LiveViewTest` documentation for more details.
         """
@@ -548,7 +548,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
           You can change this warning by setting
 
               config :phoenix_live_view, :test_warnings,
-                #{inspect(type)}: :raise # can be one of :warn, :raise, or :ignore
+                #{to_string(type)}: :raise # can be one of :warn, :raise, or :ignore
 
           See the `Phoenix.LiveViewTest` documentation for more details.
           """,


### PR DESCRIPTION
The current test warnings are displayed as:

```
You can change this warning by setting

    config :phoenix_live_view, :test_warnings,
      :missing_form_id: :raise # can be one of :warn, :raise, or :ignore
```

The colons on both sides of `missing_form_id` make the help text invalid for easy copy/pasting.