### PR TITLE
Prioritize project-local build path in NODE_PATH documentation examples

### DIFF
--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -327,7 +327,7 @@ config :esbuild,
     args:
       ~w(js/app.js --bundle --target=es2022 --outdir=../priv/static/assets/js --external:/fonts/* --external:/images/* --alias:@=.),
     cd: Path.expand("../assets", __DIR__),
-    env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
+    env: %{"NODE_PATH" => [Mix.Project.build_path(), Path.expand("../deps", __DIR__)]}
   ]
 ```
 

--- a/lib/phoenix_live_view/colocated_css.ex
+++ b/lib/phoenix_live_view/colocated_css.ex
@@ -33,7 +33,7 @@ defmodule Phoenix.LiveView.ColocatedCSS do
             --output=priv/static/assets/css/app.css
           ),
           cd: Path.expand("..", __DIR__),
-          env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
+          env: %{"NODE_PATH" => [Mix.Project.build_path(), Path.expand("../deps", __DIR__)]}
         ]
 
   Then, import the `colocated.css` file in your `app.css` file:
@@ -58,7 +58,7 @@ defmodule Phoenix.LiveView.ColocatedCSS do
           args:
             ~w(js/app.js --bundle --target=es2022 --outdir=../priv/static/assets/js --external:/fonts/* --external:/images/* --alias:@=.),
           cd: Path.expand("../assets", __DIR__),
-          env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
+          env: %{"NODE_PATH" => [Mix.Project.build_path(), Path.expand("../deps", __DIR__)]}
         ]
 
   This is the same setup as for `Phoenix.LiveView.ColocatedJS`. Then, import it like this in your `app.js` file:

--- a/lib/phoenix_live_view/colocated_js.ex
+++ b/lib/phoenix_live_view/colocated_js.ex
@@ -77,7 +77,7 @@ defmodule Phoenix.LiveView.ColocatedJS do
           args:
             ~w(js/app.js --bundle --target=es2022 --outdir=../priv/static/assets/js --external:/fonts/* --external:/images/* --alias:@=.),
           cd: Path.expand("../assets", __DIR__),
-          env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
+          env: %{"NODE_PATH" => [Mix.Project.build_path(), Path.expand("../deps", __DIR__)]}
         ]
 
   The important part here is the `NODE_PATH` environment variable, which tells esbuild to also look


### PR DESCRIPTION
Update guides and module documentation examples for colocated assets (CSS and JS) to list `Mix.Project.build_path()` before the deps folder in `NODE_PATH`. This ensures documentation reflects the secure path-resolution order, giving priority to project-local files over paths controlled by dependencies.