### PR TITLE
Prioritize project-local build path in upgrade igniter script

### DIFF
--- a/lib/phoenix_live_view/igniter/upgrade_to_1_1.ex
+++ b/lib/phoenix_live_view/igniter/upgrade_to_1_1.ex
@@ -120,7 +120,7 @@ if Code.ensure_loaded?(Igniter) do
                   args:
                     ~w(js/app.js --bundle --target=es2022 --outdir=../priv/static/assets/js --external:/fonts/* --external:/images/* --alias:@=.),
                   cd: "...",
-                  env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
+                  env: %{"NODE_PATH" => [Mix.Project.build_path(), Path.expand("../deps", __DIR__)]}
                 ]
           """
 
@@ -144,7 +144,7 @@ if Code.ensure_loaded?(Igniter) do
                 if Igniter.Code.Keyword.keyword_has_path?(zipper, [:args]) and
                      Igniter.Code.Keyword.keyword_has_path?(zipper, [:env]) do
                   with {:ok, zipper} <- update_esbuild_args(zipper, warning),
-                       {:ok, zipper} <- update_esbuild_env(zipper) do
+                       {:ok, zipper} <- update_esbuild_env(zipper, warning) do
                     {:ok, zipper}
                   end
                 else
@@ -209,7 +209,7 @@ if Code.ensure_loaded?(Igniter) do
       end)
     end
 
-    defp update_esbuild_env(zipper) do
+    defp update_esbuild_env(zipper, warning) do
       Igniter.Code.Keyword.put_in_keyword(
         zipper,
         [:env],
@@ -219,7 +219,9 @@ if Code.ensure_loaded?(Igniter) do
           Igniter.Code.Map.put_in_map(
             zipper,
             ["NODE_PATH"],
-            ~s<"[Path.expand("../deps", __DIR__), Mix.Project.build_path()])>,
+            Sourceror.parse_string!(
+              "[Mix.Project.build_path(), Path.expand(\"../deps\", __DIR__)]"
+            ),
             fn zipper ->
               if Igniter.Code.List.list?(zipper) do
                 index =
@@ -233,16 +235,32 @@ if Code.ensure_loaded?(Igniter) do
                     end
                   end)
 
-                if index do
-                  {:ok, zipper}
-                else
-                  Igniter.Code.List.append_to_list(zipper, {:code, "Mix.Project.build_path()"})
+                cond do
+                  index == 0 ->
+                    {:ok, zipper}
+
+                  index > 0 ->
+                    zipper
+                    |> Igniter.Code.List.remove_index(index)
+                    |> case do
+                      {:ok, zipper} ->
+                        Igniter.Code.List.prepend_to_list(
+                          zipper,
+                          {:code, "Mix.Project.build_path()"}
+                        )
+
+                      :error ->
+                        {:warning, warning}
+                    end
+
+                  true ->
+                    Igniter.Code.List.prepend_to_list(zipper, {:code, "Mix.Project.build_path()"})
                 end
               else
-                # If NODE_PATH is not a list, convert it to a list with the original value and Mix.Project.build_path()
+                # If NODE_PATH is not a list, convert it to a list with Mix.Project.build_path() and the original value
                 zipper
                 |> Igniter.Code.Common.replace_code("[Mix.Project.build_path()]")
-                |> Igniter.Code.List.prepend_to_list(zipper.node)
+                |> Igniter.Code.List.append_to_list(zipper.node)
               end
             end
           )

--- a/test/phoenix_live_view/igniter/upgrade_to_1_1_test.exs
+++ b/test/phoenix_live_view/igniter/upgrade_to_1_1_test.exs
@@ -288,7 +288,7 @@ defmodule Phoenix.LiveView.Igniter.UpgradeTo1_1Test do
       + |    args: ~w(js/app.js --bundle --outdir=../priv/static/assets --alias:@=.),
         |    cd: Path.expand("../assets", __DIR__),
       - |    env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
-      + |    env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
+      + |    env: %{"NODE_PATH" => [Mix.Project.build_path(), Path.expand("../deps", __DIR__)]}
       """)
       |> assert_has_notice(fn notice -> notice =~ "Final step for colocated hooks" end)
     end
@@ -347,7 +347,7 @@ defmodule Phoenix.LiveView.Igniter.UpgradeTo1_1Test do
       + |    args: ~w(js/app.js --bundle --outdir=../priv/static/assets --alias:@=.),
         |    cd: Path.expand("../assets", __DIR__),
       - |    env: %{"NODE_PATH" => "something_custom"}
-      + |    env: %{"NODE_PATH" => ["something_custom", Mix.Project.build_path()]}
+      + |    env: %{"NODE_PATH" => [Mix.Project.build_path(), "something_custom"]}
       """)
       |> assert_has_notice(fn notice -> notice =~ "Final step for colocated hooks" end)
     end
@@ -405,6 +405,37 @@ defmodule Phoenix.LiveView.Igniter.UpgradeTo1_1Test do
       # yes to esbuild but no config exists (no deps prompt since no existing deps)
       |> run_upgrade(input: "y\n")
       |> refute_has_notice()
+    end
+
+    test "updates esbuild env when NODE_PATH is not configured initially" do
+      test_project(
+        app_name: :my_app,
+        files: %{
+          "config/config.exs" => """
+          import Config
+
+          config :esbuild,
+            my_app: [
+              args: ~w(js/app.js --bundle --outdir=../priv/static/assets),
+              cd: Path.expand("../assets", __DIR__),
+              env: %{}
+            ]
+          """
+        }
+      )
+      # yes to esbuild
+      |> run_upgrade(input: "y\n")
+      |> assert_has_patch("mix.exs", """
+      + |      {:esbuild, "~> 0.10", runtime: Mix.env() == :dev},
+      """)
+      |> assert_has_patch("config/config.exs", """
+      - |    args: ~w(js/app.js --bundle --outdir=../priv/static/assets),
+      + |    args: ~w(js/app.js --bundle --outdir=../priv/static/assets --alias:@=.),
+        |    cd: Path.expand("../assets", __DIR__),
+      - |    env: %{}
+      + |    env: %{"NODE_PATH" => [Mix.Project.build_path(), Path.expand("../deps", __DIR__)]}
+      """)
+      |> assert_has_notice(fn notice -> notice =~ "Final step for colocated hooks" end)
     end
   end
 
@@ -477,7 +508,7 @@ defmodule Phoenix.LiveView.Igniter.UpgradeTo1_1Test do
       + |    args: ~w(js/app.js --bundle --outdir=../priv/static/assets --alias:@=.),
         |    cd: Path.expand("../assets", __DIR__),
       - |    env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
-      + |    env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
+      + |    env: %{"NODE_PATH" => [Mix.Project.build_path(), Path.expand("../deps", __DIR__)]}
       """)
     end
   end


### PR DESCRIPTION
Update the 1.1 upgrade Igniter script to prioritize `Mix.Project.build_path()` over dependency directories in NODE_PATH.

Specifically, this change:
- Replaces a buggy/malformed default string value in `update_esbuild_env/2` with a correctly parsed AST representation via Sourceror.
- Prepends `Mix.Project.build_path()` to the list (and handles removing/re-prepending if already present in another position) instead of appending it.
- Updates the upgrade warning/instruction text to show the secure order.
- Adds test coverage and updates existing unit tests to verify the new order.

---

See also #4313.

Disclosure: I'm not deeply familiar with Igniter and the changes were AI-assisted, verified through the unit tests.

<details>

In the  `upgrade_to_1_1.ex`  Igniter script, the default fallback value for  NODE_PATH  (used if  NODE_PATH  was not configured initially) was defined as:

    ~s<"[Path.expand("../deps", __DIR__), Mix.Project.build_path()])>

  This had two issues:

  1. Malformed Syntax: It had an unbalanced trailing parenthesis  )  instead of a bracket  ] , causing a parsing failure.
  2. String Literal Insertion: Because it was passed as a raw string sigil, Igniter would insert this as a string literal in the generated Elixir file rather than executable code.

  We resolved this by using  `Sourceror.parse_string!/1`  to build a valid AST with all formatting metadata:

    Sourceror.parse_string!("[Mix.Project.build_path(), Path.expand(\"../deps\", __DIR__)]")

  We also refactored the list-modification logic in  `update_esbuild_env/2`:

  • We now check if `Mix.Project.build_path()` is already present in the list.
  • If it is present but not in the first position, we remove it and prepend it to the beginning.
  • If it is not present at all, we prepend it.
  • If `NODE_PATH` is not a list, we wrap it and append the original value to the end, keeping the build path first.

  ### Verification

  • Added a new unit test in  `upgrade_to_1_1_test.exs`  to explicitly verify that the esbuild environment updates correctly when  NODE_PATH  is not configured initially.

</details>