### PR TITLE
LiveViewTest: only warn about missing form id when recovery applies

### DIFF
--- a/lib/phoenix_live_view/test/dom.ex
+++ b/lib/phoenix_live_view/test/dom.ex
@@ -71,7 +71,9 @@ defmodule Phoenix.LiveViewTest.DOM do
 
   defp detect_forms_without_id(lazydoc, error_reporter) do
     lazydoc
-    |> LazyHTML.query("form:not([id])")
+    |> LazyHTML.query(
+      ~s|form:not([id])[phx-change]:not([phx-ignore-missing-id]):not([phx-auto-recover="ignore"])|
+    )
     |> Enum.each(fn el ->
       error_reporter.(:missing_form_id, """
       Detected a form with phx-change but missing id:

--- a/lib/phoenix_live_view/test/tree_dom.ex
+++ b/lib/phoenix_live_view/test/tree_dom.ex
@@ -357,8 +357,9 @@ defmodule Phoenix.LiveViewTest.TreeDOM do
 
   defp detect_forms_without_id({"form", attrs, _children} = node, error_reporter) do
     case {attribute(node, "id"), attribute(node, "phx-change"),
-          attribute(node, "phx-ignore-missing-id")} do
-      {nil, phx_change, nil} when is_binary(phx_change) ->
+          attribute(node, "phx-ignore-missing-id"), attribute(node, "phx-auto-recover")} do
+      {nil, phx_change, nil, auto_recover}
+      when is_binary(phx_change) and auto_recover != "ignore" ->
         error_reporter.(:missing_form_id, """
         Detected a form with phx-change but missing id:
 

--- a/test/phoenix_live_view/integrations/live_view_test_warnings_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test_warnings_test.exs
@@ -112,6 +112,30 @@ defmodule Phoenix.LiveView.LiveViewTestWarningsTest do
         end)
 
       assert warning =~ "Detected a form with phx-change but missing id"
+      assert warning =~ "should-warn"
+    end
+
+    test "does not warn for forms that are not eligible for recovery" do
+      orig = Application.get_env(:phoenix_live_view, :test_warnings)
+
+      Application.put_env(:phoenix_live_view, :test_warnings, missing_form_id: :warn)
+
+      on_exit(fn ->
+        Application.put_env(:phoenix_live_view, :test_warnings, orig)
+      end)
+
+      warning =
+        capture_io(:stderr, fn ->
+          {:ok, view, _html} = live(Phoenix.ConnTest.build_conn(), "/form-missing-id")
+          render(view)
+        end)
+
+      # a form without phx-change is never recovered
+      refute warning =~ "no-change"
+      # a form that opted out with phx-auto-recover="ignore" is never recovered
+      refute warning =~ "opted-out"
+      # a form that explicitly opted out of the check with phx-ignore-missing-id
+      refute warning =~ "ignored"
     end
   end
 end

--- a/test/support/live_views/test_warnings.ex
+++ b/test/support/live_views/test_warnings.ex
@@ -111,7 +111,10 @@ defmodule Phoenix.LiveViewTest.Support.FormMissingIdLive do
 
   def render(assigns) do
     ~H"""
-    <form phx-change="foo" phx-submit="bar"></form>
+    <form phx-change="should-warn"></form>
+    <form phx-change="opted-out" phx-auto-recover="ignore"></form>
+    <form phx-change="ignored" phx-ignore-missing-id></form>
+    <form phx-submit="no-change"></form>
     """
   end
 end


### PR DESCRIPTION
The missing form id check matched every form without an id, including forms that are never eligible for recovery. This produced false warnings in applications that have id-less forms which LiveView would never attempt to recover.

An example:

```heex
          <form method="dialog" class="sticky ml-auto top-2 -mb-10 z-101">
            <button class="w-8 h-8 cursor-pointer">
              <.icon name="close_small" />
            </button>
          </form>
```

I'm happy to close this out in favor of opening an "issue." if you'd prefer that.