### PR TITLE
fix: don't drop directives with multiple macro components

### DIFF
--- a/lib/phoenix_live_view/tag_engine/parser.ex
+++ b/lib/phoenix_live_view/tag_engine/parser.ex
@@ -645,10 +645,11 @@ defmodule Phoenix.LiveView.TagEngine.Parser do
         )
 
       {{:text, "", _}, directives} ->
-        {strip_text(tokens), buffer, %{state | directives: directives}}
+        {strip_text(tokens), buffer, %{state | directives: state.directives ++ directives}}
 
       {new_node, directives} ->
-        {strip_text(tokens), [new_node | buffer], %{state | directives: directives}}
+        {strip_text(tokens), [new_node | buffer],
+         %{state | directives: state.directives ++ directives}}
     end
   end
 

--- a/test/phoenix_component/macro_component_integration_test.exs
+++ b/test/phoenix_component/macro_component_integration_test.exs
@@ -53,6 +53,15 @@ defmodule Phoenix.Component.MacroComponentIntegrationTest do
     end
   end
 
+  defmodule NoDirectiveMacroComponent do
+    @behaviour Phoenix.Component.MacroComponent
+
+    @impl true
+    def transform(_ast, _meta) do
+      {:ok, ""}
+    end
+  end
+
   test "receives ast" do
     defmodule TestComponentAst do
       use Phoenix.Component
@@ -468,6 +477,27 @@ defmodule Phoenix.Component.MacroComponentIntegrationTest do
 
                  <p phx-r>Part of the component</p>
                </div>
+               """
+    end
+
+    test "are not dropped by a later macro component that emits no directives" do
+      defmodule TestComponentDirectivesPreserved do
+        use Phoenix.Component
+
+        def render(assigns) do
+          ~H"""
+          <div :type={DirectiveMacroComponent}></div>
+          <div id="hello">
+            <script :type={NoDirectiveMacroComponent}></script>
+          </div>
+          """
+        end
+      end
+
+      assert render_component(&TestComponentDirectivesPreserved.render/1)
+             |> TreeDOM.normalize_to_tree(sort_attributes: true) ==
+               ~X"""
+               <div id="hello" phx-sample-one="test" phx-sample-two="test" phx-r></div>
                """
     end
 

--- a/test/phoenix_component/macro_component_integration_test.exs
+++ b/test/phoenix_component/macro_component_integration_test.exs
@@ -488,7 +488,8 @@ defmodule Phoenix.Component.MacroComponentIntegrationTest do
           ~H"""
           <div :type={DirectiveMacroComponent}></div>
           <div id="hello">
-            <script :type={NoDirectiveMacroComponent}></script>
+            <script :type={NoDirectiveMacroComponent}>
+            </script>
           </div>
           """
         end


### PR DESCRIPTION
I ran into a bug when using both ColocatedCSS (scoped) and ColocatedHook in the same component. The directive that added the `phx-css-*` attribute was getting dropped by the ColocatedHook. I'm not entirely sure if this is the correct way to go about fixing the issue, but it did preserve the attributes. Happy to do it differently if this is not the correct approach.