### PR TITLE
Fix HTMLFormatter inserting extra characters in templates with multi-codepoint emojis

### DIFF
--- a/lib/phoenix_live_view/html_formatter.ex
+++ b/lib/phoenix_live_view/html_formatter.ex
@@ -299,7 +299,7 @@ defmodule Phoenix.LiveView.HTMLFormatter do
       source
     else
       line_length = opts[:heex_line_length] || opts[:line_length] || @default_line_length
-      newlines = newlines(source)
+      newlines = :binary.matches(source, ["\r\n", "\n"])
 
       opts =
         Enum.reduce([:attribute_formatters, :tag_formatters], opts, fn type, opts ->
@@ -345,28 +345,6 @@ defmodule Phoenix.LiveView.HTMLFormatter do
 
       IO.iodata_to_binary([formatted, newline])
     end
-  end
-
-  defp newlines(source) do
-    source
-    |> String.codepoints()
-    |> do_newlines(0, [])
-  end
-
-  defp do_newlines(["\r", "\n" | rest], idx, newlines) do
-    do_newlines(rest, idx + 2, [{idx, 2} | newlines])
-  end
-
-  defp do_newlines(["\n" | rest], idx, newlines) do
-    do_newlines(rest, idx + 1, [{idx, 1} | newlines])
-  end
-
-  defp do_newlines([_codepoint | rest], idx, newlines) do
-    do_newlines(rest, idx + 1, newlines)
-  end
-
-  defp do_newlines([], _idx, newlines) do
-    Enum.reverse(newlines)
   end
 
   # Buffer processing callback for Parser - handles preserve mode propagation and text metadata
@@ -621,26 +599,31 @@ defmodule Phoenix.LiveView.HTMLFormatter do
     [first_line | _] = lines
     [last_line | _] = Enum.reverse(lines)
 
-    codepoints = String.codepoints(source)
+    offset_start = line_byte_offset(source, first_line, column_start)
+    offset_end = line_byte_offset(source, last_line, column_end)
 
-    offset_start = line_codepoint_offset(codepoints, first_line, column_start)
-    offset_end = line_codepoint_offset(codepoints, last_line, column_end)
-
-    codepoints
-    |> Enum.slice(offset_start, offset_end - offset_start)
-    |> Enum.join()
+    binary_part(source, offset_start, offset_end - offset_start)
   end
 
-  defp line_codepoint_offset(codepoints, {line_before, line_size}, column) do
+  defp line_byte_offset(source, {line_before, line_size}, column) do
     line_offset = line_before + line_size
 
     line_extra =
-      codepoints
-      |> Enum.drop(line_offset)
-      |> Enum.take(column - 1)
-      |> length()
+      source
+      |> binary_part(line_offset, byte_size(source) - line_offset)
+      |> codepoint_byte_size(column - 1)
 
     line_offset + line_extra
+  end
+
+  defp codepoint_byte_size(binary, count),
+    do: codepoint_byte_size(binary, count, byte_size(binary))
+
+  defp codepoint_byte_size(binary, 0, original_size), do: original_size - byte_size(binary)
+  defp codepoint_byte_size(<<>>, _count, original_size), do: original_size
+
+  defp codepoint_byte_size(<<_codepoint::utf8, rest::binary>>, count, original_size) do
+    codepoint_byte_size(rest, count - 1, original_size)
   end
 
   defp maybe_format_tag(

--- a/lib/phoenix_live_view/html_formatter.ex
+++ b/lib/phoenix_live_view/html_formatter.ex
@@ -299,7 +299,7 @@ defmodule Phoenix.LiveView.HTMLFormatter do
       source
     else
       line_length = opts[:heex_line_length] || opts[:line_length] || @default_line_length
-      newlines = :binary.matches(source, ["\r\n", "\n"])
+      newlines = newlines(source)
 
       opts =
         Enum.reduce([:attribute_formatters, :tag_formatters], opts, fn type, opts ->
@@ -345,6 +345,28 @@ defmodule Phoenix.LiveView.HTMLFormatter do
 
       IO.iodata_to_binary([formatted, newline])
     end
+  end
+
+  defp newlines(source) do
+    source
+    |> String.codepoints()
+    |> do_newlines(0, [])
+  end
+
+  defp do_newlines(["\r", "\n" | rest], idx, newlines) do
+    do_newlines(rest, idx + 2, [{idx, 2} | newlines])
+  end
+
+  defp do_newlines(["\n" | rest], idx, newlines) do
+    do_newlines(rest, idx + 1, [{idx, 1} | newlines])
+  end
+
+  defp do_newlines([_codepoint | rest], idx, newlines) do
+    do_newlines(rest, idx + 1, newlines)
+  end
+
+  defp do_newlines([], _idx, newlines) do
+    Enum.reverse(newlines)
   end
 
   # Buffer processing callback for Parser - handles preserve mode propagation and text metadata
@@ -599,20 +621,24 @@ defmodule Phoenix.LiveView.HTMLFormatter do
     [first_line | _] = lines
     [last_line | _] = Enum.reverse(lines)
 
-    offset_start = line_byte_offset(source, first_line, column_start)
-    offset_end = line_byte_offset(source, last_line, column_end)
+    codepoints = String.codepoints(source)
 
-    binary_part(source, offset_start, offset_end - offset_start)
+    offset_start = line_codepoint_offset(codepoints, first_line, column_start)
+    offset_end = line_codepoint_offset(codepoints, last_line, column_end)
+
+    codepoints
+    |> Enum.slice(offset_start, offset_end - offset_start)
+    |> Enum.join()
   end
 
-  defp line_byte_offset(source, {line_before, line_size}, column) do
+  defp line_codepoint_offset(codepoints, {line_before, line_size}, column) do
     line_offset = line_before + line_size
 
     line_extra =
-      source
-      |> binary_part(line_offset, byte_size(source) - line_offset)
-      |> String.slice(0, column - 1)
-      |> byte_size()
+      codepoints
+      |> Enum.drop(line_offset)
+      |> Enum.take(column - 1)
+      |> length()
 
     line_offset + line_extra
   end

--- a/test/phoenix_live_view/html_formatter_test.exs
+++ b/test/phoenix_live_view/html_formatter_test.exs
@@ -2457,4 +2457,12 @@ defmodule Phoenix.LiveView.HTMLFormatterTest do
       attribute_formatters: %{upcased: UpcaseFormatter, unloaded: Unloaded}
     )
   end
+
+  test "handles multi-codepoint emoji characters in :preserve mode" do
+    assert_formatter_doesnt_change("""
+    <.component>
+      <:icon>⚠️</:icon>{@test}
+    </.component>
+    """)
+  end
 end


### PR DESCRIPTION
I'm not 100% confident this is the exactly correct fix, but it seems to work and figured id throw it up at least as reference.

The HTMLFormatter had changes introduced in #2112 to handle formatting content in tags where the content should be preserved. These changes involved doing byte-level arithmetic to extract and preserve the inner content during formatting. This works fine for simple text, but in the scenario in #4321 the emoji ⚠️ is two codepoints and 6 bytes.

The logic to extract the content relies on `meta.inner_location` and `close_meta.inner_location` which comes from the tokenizer, which _appears_ to count in codepoints (from what I can see, anyways), so this desync between bytes and codepoints causes the logic for preserving content to overrun its bounds and errantly insert additional characters from the surrounding tags into the content itself.

This PR replaces the aforementioned byte-oriented algorithm with a codepoint-oriented one to address these issues.

Closes #4321