### PR TITLE
Avoid cloning keyed comprehensions without moves

### DIFF
--- a/assets/js/phoenix_live_view/constants.ts
+++ b/assets/js/phoenix_live_view/constants.ts
@@ -115,6 +115,7 @@ export const ROOT = "r";
 export const COMPONENTS = "c";
 export const KEYED = "k";
 export const KEYED_COUNT = "kc";
+export const KEYED_MOVED = "km";
 export const EVENTS = "e";
 export const REPLY = "r";
 export const TITLE = "t";

--- a/assets/js/phoenix_live_view/rendered.js
+++ b/assets/js/phoenix_live_view/rendered.js
@@ -13,6 +13,7 @@ import {
   ROOT,
   KEYED,
   KEYED_COUNT,
+  KEYED_MOVED,
 } from "./constants";
 
 import { isObject, logError, isCid } from "./utils";
@@ -287,12 +288,12 @@ export default class Rendered {
 
   // keyed comprehensions
   mergeKeyed(target, source) {
-    // we need to clone the target since elements can move and otherwise
-    // it could happen that we modify an element that we'll need to refer to
-    // later
-    const clonedTarget = this.clone(target);
+    // Moves read entries from their old positions. Clone before applying any
+    // entries so an earlier mutation cannot overwrite a position needed later.
+    // Stable-position updates never read from another position.
+    const clonedTarget = source[KEYED][KEYED_MOVED] && this.clone(target);
     Object.entries(source[KEYED]).forEach(([i, entry]) => {
-      if (i === KEYED_COUNT) {
+      if (i === KEYED_COUNT || i === KEYED_MOVED) {
         return;
       }
       if (Array.isArray(entry)) {

--- a/assets/test/rendered_test.ts
+++ b/assets/test/rendered_test.ts
@@ -4,12 +4,13 @@ import {
   COMPONENTS,
   KEYED,
   KEYED_COUNT,
+  KEYED_MOVED,
   TEMPLATES,
 } from "phoenix_live_view/constants";
 
 describe("Rendered", () => {
   describe("mergeDiff", () => {
-    test("recursively merges two diffs", () => {
+    test("merges a diff into the rendered tree", () => {
       const simple = new Rendered("123", simpleDiff1);
       simple.mergeDiff(simpleDiff2);
       expect(simple.get()).toEqual({
@@ -17,10 +18,95 @@ describe("Rendered", () => {
         [COMPONENTS]: {},
         newRender: true,
       });
+    });
 
+    test("merges stable-position keyed updates without cloning", () => {
       const deep = new Rendered("123", deepDiff1);
+      const clone = jest.spyOn(deep, "clone");
       deep.mergeDiff(deepDiff2);
+      expect(clone).not.toHaveBeenCalled();
       expect(deep.get()).toEqual({ ...deepDiffResult, [COMPONENTS]: {} });
+    });
+
+    test("clones before moving entries so later moves use pre-merge positions", () => {
+      const rendered = new Rendered("123", {
+        [KEYED]: {
+          0: { 0: "first", 1: "unchanged" },
+          1: { 0: "second", 1: "old" },
+          [KEYED_COUNT]: 2,
+        },
+        [STATIC]: ["", "", ""],
+      });
+      const before = (rendered.get() as any)[KEYED];
+      const first = before[0];
+      const second = before[1];
+      const clone = jest.spyOn(rendered, "clone");
+
+      rendered.mergeDiff({
+        [KEYED]: {
+          0: [1, { 1: "updated" }],
+          1: 0,
+          [KEYED_COUNT]: 2,
+          [KEYED_MOVED]: true,
+        },
+      });
+
+      expect(clone).toHaveBeenCalledTimes(1);
+      expect((rendered.get() as any)[KEYED]).toEqual({
+        0: { 0: "second", 1: "updated" },
+        1: { 0: "first", 1: "unchanged" },
+        [KEYED_COUNT]: 2,
+      });
+      expect(first).toEqual({ 0: "first", 1: "unchanged" });
+      expect(second).toEqual({ 0: "second", 1: "old" });
+    });
+
+    test("clones only a moved nested keyed subtree", () => {
+      const rendered = new Rendered("123", {
+        [KEYED]: {
+          0: {
+            0: "outer",
+            1: {
+              [KEYED]: {
+                0: { 0: "first" },
+                1: { 0: "second" },
+                [KEYED_COUNT]: 2,
+              },
+              [STATIC]: ["", ""],
+            },
+          },
+          [KEYED_COUNT]: 1,
+        },
+        [STATIC]: ["", "", ""],
+      });
+      const outer = (rendered.get() as any)[KEYED][0];
+      const nested = outer[1];
+      const clone = jest.spyOn(rendered, "clone");
+
+      rendered.mergeDiff({
+        [KEYED]: {
+          0: {
+            1: {
+              [KEYED]: {
+                0: 1,
+                1: 0,
+                [KEYED_COUNT]: 2,
+                [KEYED_MOVED]: true,
+              },
+            },
+          },
+          [KEYED_COUNT]: 1,
+        },
+      });
+
+      expect(clone).toHaveBeenCalledTimes(1);
+      expect(clone.mock.calls[0][0]).toBe(nested);
+      expect((rendered.get() as any)[KEYED][0]).toBe(outer);
+      expect(nested[KEYED]).toEqual({
+        0: { 0: "second" },
+        1: { 0: "first" },
+        [KEYED_COUNT]: 2,
+      });
     });
 
     test("merges the latter diff if it contains a `static` key", () => {

--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -16,6 +16,7 @@ defmodule Phoenix.LiveView.Diff do
   @static :s
   @keyed :k
   @keyed_count :kc
+  @keyed_moved :km
   @events :e
   @reply :r
   @title :t
@@ -793,14 +794,22 @@ defmodule Phoenix.LiveView.Diff do
     # if the diff is empty, we need to check if the item moved
     if child_diff == %{} do
       # check if the entry moved, then annotate it with the previous index
-      diff = if previous_index != index, do: Map.put(diff, index, previous_index), else: diff
+      diff =
+        if previous_index != index do
+          diff
+          |> Map.put(@keyed_moved, true)
+          |> Map.put(index, previous_index)
+        else
+          diff
+        end
+
       {diff, index + 1, new_prints, pending, components, template}
     else
-      child_diff =
+      {diff, child_diff} =
         if previous_index != index do
-          [previous_index, child_diff]
+          {Map.put(diff, @keyed_moved, true), [previous_index, child_diff]}
         else
-          child_diff
+          {diff, child_diff}
         end
 
       {Map.put(diff, index, child_diff), index + 1, new_prints, pending, components, template}

--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -794,9 +794,7 @@ defmodule Phoenix.LiveView.Diff do
     moved? = previous_index != index
     diff = if moved?, do: Map.put(diff, @keyed_moved, true), else: diff
 
-    # if the diff is empty, we need to check if the item moved
     if child_diff == %{} do
-      # check if the entry moved, then annotate it with the previous index
       diff = if moved?, do: Map.put(diff, index, previous_index), else: diff
 
       {diff, index + 1, new_prints, pending, components, template}

--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -791,26 +791,17 @@ defmodule Phoenix.LiveView.Diff do
     new_prints =
       Map.put(new_prints, key, %{index: index, vars: new_vars, child_prints: child_prints})
 
+    moved? = previous_index != index
+    diff = if moved?, do: Map.put(diff, @keyed_moved, true), else: diff
+
     # if the diff is empty, we need to check if the item moved
     if child_diff == %{} do
       # check if the entry moved, then annotate it with the previous index
-      diff =
-        if previous_index != index do
-          diff
-          |> Map.put(@keyed_moved, true)
-          |> Map.put(index, previous_index)
-        else
-          diff
-        end
+      diff = if moved?, do: Map.put(diff, index, previous_index), else: diff
 
       {diff, index + 1, new_prints, pending, components, template}
     else
-      {diff, child_diff} =
-        if previous_index != index do
-          {Map.put(diff, @keyed_moved, true), [previous_index, child_diff]}
-        else
-          {diff, child_diff}
-        end
+      child_diff = if moved?, do: [previous_index, child_diff], else: child_diff
 
       {Map.put(diff, index, child_diff), index + 1, new_prints, pending, components, template}
     end

--- a/test/phoenix_live_view/diff_test.exs
+++ b/test/phoenix_live_view/diff_test.exs
@@ -2019,7 +2019,7 @@ defmodule Phoenix.LiveView.DiffTest do
       {second_render, fingerprints, components} =
         render(keyed_comprehension_with_pattern(assigns), fingerprints, components)
 
-      assert second_render == %{0 => %{k: %{0 => 1, 1 => 0, :kc => 2}}}
+      assert second_render == %{0 => %{k: %{0 => 1, 1 => 0, :kc => 2, :km => true}}}
 
       # update count
       assigns = Phoenix.Component.assign(assigns, :count, 1)
@@ -2041,7 +2041,9 @@ defmodule Phoenix.LiveView.DiffTest do
       {fourth_render, _fingerprints, _components} =
         render(keyed_comprehension_with_pattern(assigns), fingerprints, components)
 
-      assert fourth_render == %{0 => %{k: %{0 => 1, 1 => %{0 => "1", 1 => "Third"}, :kc => 2}}}
+      assert fourth_render == %{
+               0 => %{k: %{0 => 1, 1 => %{0 => "1", 1 => "Third"}, :kc => 2, :km => true}}
+             }
     end
 
     test "change tracking when no key is given" do
@@ -2430,7 +2432,7 @@ defmodule Phoenix.LiveView.DiffTest do
         render(keyed_comprehension_with_component(assigns), fingerprints, components)
 
       # only the order changed
-      assert second_render == %{0 => %{k: %{0 => 1, 1 => 0, :kc => 2}}}
+      assert second_render == %{0 => %{k: %{0 => 1, 1 => 0, :kc => 2, :km => true}}}
 
       # update count
       assigns = Phoenix.Component.assign(%{assigns | __changed__: %{}}, :count, 1)
@@ -2513,7 +2515,7 @@ defmodule Phoenix.LiveView.DiffTest do
         render(keyed_comprehension_with_component_and_slots(assigns), fingerprints, components)
 
       # only the order changed
-      assert second_render == %{0 => %{k: %{0 => 1, 1 => 0, :kc => 2}}}
+      assert second_render == %{0 => %{k: %{0 => 1, 1 => 0, :kc => 2, :km => true}}}
 
       # update count
       assigns = Phoenix.Component.assign(%{assigns | __changed__: %{}}, :count, 1)


### PR DESCRIPTION
@SteffenDE I'm not familiar with the JS side of things but this seems like a small diff for a good gain in performance.

Assisted by: GPT 5.6 Sol - Codex

Clone keyed state only when a diff moves entries. Stable-position
updates never read another old position, so they can merge in place
instead of copying the full cached render tree.

Keyed entries are encoded as:

- `kc`: resulting entry count
- object: new entry or same-position diff
- number: old index for a move without a diff
- `[old_index, diff]`: move with a diff

Only the two move encodings read old positions and need a snapshot
before mutation. Nested keyed diffs apply the same rule, cloning only
the subtree that moves.

Chromium 150 merge-only timings (median of seven calibrated samples;
DOM patching excluded):

- 1,000/10,000 compact two-field rows: 0.435/4.29 ms -> 0.001 ms
- 1,000/10,000 rich rows (eight fields, four children): 3.94/47.5 ms -> 0.001 ms

Stable keyed merges inside LiveComponents dropped from two tree clones
to one, making merge-only benchmarks about 2x faster. Reordering
entries still needs the move-safety clone and showed no material change.
