### PR TITLE
Optimize URI scheme detection for paths

### DIFF
--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -617,14 +617,14 @@ defmodule Phoenix.LiveView.Utils do
   # Returns the lowercased URI scheme of `to` if it begins with one, that is, a
   # ":" appears before any "/", "?" or "#"; otherwise returns nil. This avoids
   # treating a colon in a path segment, query, or fragment as a scheme.
+  defp uri_scheme("/" <> _to), do: nil
+
   defp uri_scheme(to) do
     case :binary.match(to, [":", "/", "?", "#"]) do
-      {pos, 1} ->
-        if binary_part(to, pos, 1) == ":",
-          do: String.downcase(binary_part(to, 0, pos), :ascii),
-          else: nil
+      {pos, 1} when binary_part(to, pos, 1) == ":" ->
+        String.downcase(binary_part(to, 0, pos), :ascii)
 
-      :nomatch ->
+      _ ->
         nil
     end
   end


### PR DESCRIPTION
Fast path for paths starting with "/".

Also merges the condition into the guard again. 