### PR TITLE
Allow cancelling client-side live navigation

### DIFF
--- a/assets/js/phoenix_live_view/dom.ts
+++ b/assets/js/phoenix_live_view/dom.ts
@@ -551,7 +551,7 @@ const DOM = {
       name === "click"
         ? new MouseEvent("click", eventOpts)
         : new CustomEvent(name, eventOpts);
-    target.dispatchEvent(event);
+    return target.dispatchEvent(event);
   },
 
   cloneNode(node, html) {

--- a/assets/js/phoenix_live_view/live_socket.ts
+++ b/assets/js/phoenix_live_view/live_socket.ts
@@ -1355,7 +1355,7 @@ export default class LiveSocket {
     window.addEventListener(
       "popstate",
       (event) => {
-        if (!this.registerNewLocation(window.location)) {
+        if (!this.isNewLocation(window.location)) {
           return;
         }
         const { type, backType, id, scroll, position } = event.state || {};
@@ -1364,6 +1364,26 @@ export default class LiveSocket {
         // Compare positions to determine direction
         const isForward = position > this.currentHistoryPosition;
         const navType = isForward ? type : backType || type;
+        const direction = isForward ? "forward" : "backward";
+        const detail = {
+          href,
+          patch: navType === "patch",
+          pop: true,
+          direction,
+        };
+
+        if (!this.dispatchBeforeNavigate(detail)) {
+          // Because we only register the new location afterwards,
+          // the back / forward popstate event exits early in the isNewLocation check.
+          if (isForward) {
+            history.back();
+          } else {
+            history.forward();
+          }
+          return;
+        }
+
+        this.registerNewLocation(window.location);
 
         // Update current position
         this.currentHistoryPosition = position || 0;
@@ -1372,14 +1392,7 @@ export default class LiveSocket {
           this.currentHistoryPosition.toString(),
         );
 
-        DOM.dispatchEvent(window, "phx:navigate", {
-          detail: {
-            href,
-            patch: navType === "patch",
-            pop: true,
-            direction: isForward ? "forward" : "backward",
-          },
-        });
+        DOM.dispatchEvent(window, "phx:navigate", { detail });
         this.requestDOMUpdate(() => {
           const callback = () => {
             this.maybeScroll(scroll);
@@ -1426,26 +1439,42 @@ export default class LiveSocket {
             `expected ${PHX_LINK_STATE} to be "replace" or "push", got: ${linkState}`,
           );
         }
+        if (type !== "patch" && type !== "redirect") {
+          throw new Error(
+            `expected ${PHX_LIVE_LINK} to be "patch" or "redirect", got: ${type}`,
+          );
+        }
         e.preventDefault();
         e.stopImmediatePropagation(); // do not bubble click to regular phx-click bindings
         if (this.pendingLink === href) {
           return;
         }
 
-        this.requestDOMUpdate(() => {
-          if (type === "patch") {
-            this.pushHistoryPatch(e, href, linkState, target);
-          } else if (type === "redirect") {
-            this.historyRedirect(e, href, linkState, null, target);
-          } else {
-            throw new Error(
-              `expected ${PHX_LIVE_LINK} to be "patch" or "redirect", got: ${type}`,
-            );
-          }
-          const phxClick = target.getAttribute(this.binding("click"));
+        const detail = {
+          href,
+          patch: type === "patch",
+          pop: false,
+          direction: "forward",
+        };
+        const phxClick = target.getAttribute(this.binding("click"));
+        const execPhxClick = () => {
           if (phxClick) {
             this.requestDOMUpdate(() => this.execJS(target, phxClick, "click"));
           }
+        };
+
+        if (!this.dispatchBeforeNavigate(detail)) {
+          execPhxClick();
+          return;
+        }
+
+        this.requestDOMUpdate(() => {
+          if (type === "patch") {
+            this.pushHistoryPatch(e, href, linkState, target);
+          } else {
+            this.historyRedirect(e, href, linkState, null, target);
+          }
+          execPhxClick();
         });
       },
       false,
@@ -1477,6 +1506,11 @@ export default class LiveSocket {
     const done = () =>
       DOM.dispatchEvent(window, "phx:page-loading-stop", { detail: info });
     return callback ? callback(done) : done;
+  }
+
+  /** @internal */
+  dispatchBeforeNavigate(detail) {
+    return DOM.dispatchEvent(window, "phx:before-navigate", { detail });
   }
 
   /** @internal */
@@ -1591,11 +1625,20 @@ export default class LiveSocket {
 
   /** @internal */
   registerNewLocation(newLocation) {
+    if (!this.isNewLocation(newLocation)) {
+      return false;
+    } else {
+      this.currentLocation = clone(newLocation);
+      return true;
+    }
+  }
+
+  /** @internal */
+  isNewLocation(newLocation) {
     const { pathname, search } = this.currentLocation;
     if (pathname + search === newLocation.pathname + newLocation.search) {
       return false;
     } else {
-      this.currentLocation = clone(newLocation);
       return true;
     }
   }

--- a/guides/client/syncing-changes.md
+++ b/guides/client/syncing-changes.md
@@ -221,6 +221,27 @@ A lower level `phx:navigate` event is also triggered any time the browser's URL 
   - `"patch"` - the boolean flag indicating this was a patch navigation.
   - `"pop"` - the boolean flag indication this was a navigation via `popstate`
     from a user navigation forward or back in history.
+  - `"direction"` - the direction of the navigation, either `"forward"` or
+    `"backward"`.
 
 For navigation-aware logic, prefer `phx:navigate` over hook callbacks like `updated()`,
 as hooks may fire before `window.location` is updated.
+
+A cancelable `phx:before-navigate` event is also triggered before LiveView
+performs client-side live navigation from `<.link navigate={...}>`,
+`<.link patch={...}>`, or browser forward/back navigation. It receives the same
+detail shape as `phx:navigate`. Calling `event.preventDefault()` prevents the
+client-side navigation synchronously:
+
+```javascript
+window.addEventListener("phx:before-navigate", event => {
+  if (hasUnsavedChanges() && !confirm("Discard changes?")) {
+    event.preventDefault()
+  }
+})
+```
+
+This event only guards navigation initiated in the browser. It is not invoked
+for server-side `push_navigate`, `push_patch`, redirects, regular links, form
+submits, or page unloads. Use the browser's `beforeunload` event for page
+unloads.

--- a/test/e2e/support/form_unsaved_live.ex
+++ b/test/e2e/support/form_unsaved_live.ex
@@ -1,0 +1,90 @@
+defmodule Phoenix.LiveViewTest.E2E.FormUnsavedLive do
+  use Phoenix.LiveView
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    assigns = %{}
+
+    pre_script =
+      ~H"""
+      <script>
+        (() => {
+          if (window.unsavedFormListenersInstalled) {
+            return;
+          }
+
+          window.unsavedFormListenersInstalled = true;
+          window.unsavedEvents = window.unsavedEvents || [];
+
+          const hasUnsavedChanges = () =>
+            document.querySelector("#unsaved-form[data-dirty='true']") !== null;
+
+          window.addEventListener("phx:before-navigate", (event) => {
+            if (hasUnsavedChanges()) {
+              window.unsavedEvents.push({ type: "phx", detail: event.detail });
+
+              if (!window.confirm("You have unsaved changes. Leave without saving?")) {
+                event.preventDefault();
+              }
+            }
+          });
+
+          window.addEventListener("beforeunload", (event) => {
+            if (hasUnsavedChanges()) {
+              window.unsavedEvents.push({ type: "beforeunload" });
+              event.preventDefault();
+              event.returnValue = "";
+            }
+          });
+        })();
+      </script>
+      """
+
+    socket
+    |> assign(:note, "")
+    |> assign(:dirty, false)
+    |> assign(:pre_script, pre_script)
+    |> then(&{:ok, &1})
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("validate", %{"note" => note}, socket) do
+    {:noreply, assign(socket, note: note, dirty: note != "")}
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <h1>Unsaved form</h1>
+
+    <.link navigate="/form-unsaved/target">Leave form</.link>
+
+    <form
+      id="unsaved-form"
+      phx-change="validate"
+      data-dirty={if @dirty, do: "true", else: "false"}
+      style="margin-top: 1rem; display: flex; flex-direction: column; gap: 0.5rem; max-width: 20rem;"
+    >
+      <label for="unsaved-note">Unsaved note</label>
+      <input
+        id="unsaved-note"
+        name="note"
+        value={@note}
+        style="height: 2rem; border: 1px solid #cbd5e1; padding: 0 0.5rem;"
+      />
+      <p id="unsaved-value">Unsaved value: {@note}</p>
+    </form>
+    """
+  end
+end
+
+defmodule Phoenix.LiveViewTest.E2E.FormUnsavedLive.Target do
+  use Phoenix.LiveView
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <h1>Unsaved form target</h1>
+    """
+  end
+end

--- a/test/e2e/support/navigation.ex
+++ b/test/e2e/support/navigation.ex
@@ -18,9 +18,23 @@ defmodule Phoenix.LiveViewTest.E2E.Navigation.Layout do
       });
       liveSocket.connect();
       window.liveSocket = liveSocket;
+      window.liveNavigationPreventEnabled = false;
+
+      window.addEventListener("phx:before-navigate", (e) => {
+        console.log("before navigate event", JSON.stringify(e.detail));
+        if (window.liveNavigationPreventEnabled) {
+          e.preventDefault();
+        }
+      });
 
       window.addEventListener("phx:navigate", (e) => {
         console.log("navigate event", JSON.stringify(e.detail));
+      });
+
+      window.addEventListener("change", (e) => {
+        if (e.target && e.target.id === "prevent-navigation-toggle") {
+          window.liveNavigationPreventEnabled = e.target.checked;
+        }
       });
     </script>
 
@@ -37,6 +51,11 @@ defmodule Phoenix.LiveViewTest.E2E.Navigation.Layout do
     <div style="display: flex; width: 100%; height: 100vh;">
       <div style="position: fixed; height: 100vh; background-color: #f8fafc; border-right: 1px solid; width: 20rem; display: flex; flex-direction: column; padding: 1rem; gap: 0.5rem;">
         <h1 style="margin-bottom: 1rem; font-size: 1.125rem; line-height: 1.75rem;">Navigation</h1>
+
+        <label style="display: flex; align-items: center; gap: 0.5rem; background-color: #e2e8f0; padding: 0.5rem; cursor: pointer;">
+          <input id="prevent-navigation-toggle" type="checkbox" />
+          <span>Prevent navigation</span>
+        </label>
 
         <.link navigate="/navigation/a" style="background-color: #f1f5f9; padding: 0.5rem;">
           LiveView A
@@ -84,6 +103,11 @@ defmodule Phoenix.LiveViewTest.E2E.Navigation.ALive do
   end
 
   @impl Phoenix.LiveView
+  def handle_event("server_navigate", _params, socket) do
+    {:noreply, push_navigate(socket, to: "/navigation/b")}
+  end
+
+  @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
     <h1>This is page A</h1>
@@ -93,6 +117,13 @@ defmodule Phoenix.LiveViewTest.E2E.Navigation.ALive do
     <.styled_link patch={"/navigation/a?param=#{@param_next}"}>Patch this LiveView</.styled_link>
     <.styled_link patch={"/navigation/a?param=#{@param_next}"} replace>Patch (Replace)</.styled_link>
     <.styled_link navigate="/navigation/b#items-item-42">Navigate to 42</.styled_link>
+    <button
+      type="button"
+      phx-click="server_navigate"
+      style="padding-left: 1rem; padding-right: 1rem; padding-top: 0.5rem; padding-bottom: 0.5rem; background-color: #e2e8f0; display: inline-flex; align-items: center; border-radius: 0.375rem; cursor: pointer;"
+    >
+      Server Navigate
+    </button>
     """
   end
 

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -154,6 +154,8 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
 
       live "/upload", E2E.UploadLive
       live "/form", E2E.FormLive
+      live "/form-unsaved", E2E.FormUnsavedLive
+      live "/form-unsaved/target", E2E.FormUnsavedLive.Target
       live "/form/dynamic-inputs", E2E.FormDynamicInputsLive
       live "/form/nested", E2E.NestedFormLive
       live "/form/stream", E2E.FormStreamLive

--- a/test/e2e/tests/form-unsaved.spec.js
+++ b/test/e2e/tests/form-unsaved.spec.js
@@ -1,0 +1,109 @@
+import { test, expect } from "../test-fixtures";
+import { syncLV } from "../utils";
+
+let webSocketEvents = [];
+let networkEvents = [];
+
+test.beforeEach(async ({ page }) => {
+  networkEvents = [];
+  webSocketEvents = [];
+
+  page.on("request", (request) =>
+    networkEvents.push({ method: request.method(), url: request.url() }),
+  );
+
+  page.on("websocket", (ws) => {
+    ws.on("framesent", (event) =>
+      webSocketEvents.push({ type: "sent", payload: event.payload }),
+    );
+    ws.on("framereceived", (event) =>
+      webSocketEvents.push({ type: "received", payload: event.payload }),
+    );
+    ws.on("close", () => webSocketEvents.push({ type: "close" }));
+  });
+});
+
+test("can prevent live navigation and beforeunload", async ({ page }) => {
+  await page.goto("/form-unsaved");
+  await syncLV(page);
+
+  expect(await page.evaluate(() => window.unsavedEvents)).toEqual([]);
+
+  await page.locator("#unsaved-note").fill("draft");
+  await syncLV(page);
+  await expect(page.locator("#unsaved-value")).toHaveText(
+    "Unsaved value: draft",
+  );
+
+  networkEvents = [];
+  webSocketEvents = [];
+
+  const confirmPromise = page.waitForEvent("dialog");
+  const clickPromise = page.getByRole("link", { name: "Leave form" }).click();
+  const confirmDialog = await confirmPromise;
+  expect(confirmDialog.type()).toBe("confirm");
+  expect(confirmDialog.message()).toBe(
+    "You have unsaved changes. Leave without saving?",
+  );
+  await confirmDialog.dismiss();
+  await clickPromise;
+
+  await expect(page).toHaveURL("/form-unsaved");
+  expect(networkEvents).toEqual([]);
+  expect(webSocketEvents).toEqual([]);
+  expect(await page.evaluate(() => window.unsavedEvents)).toEqual([
+    {
+      type: "phx",
+      detail: {
+        href: "http://localhost:4004/form-unsaved/target",
+        patch: false,
+        pop: false,
+        direction: "forward",
+      },
+    },
+  ]);
+
+  await page.locator("#unsaved-note").fill("draft after live nav cancel");
+  await syncLV(page);
+  await expect(page.locator("#unsaved-value")).toHaveText(
+    "Unsaved value: draft after live nav cancel",
+  );
+
+  const dialogPromise = page.waitForEvent("dialog");
+  const reloadPromise = page
+    .reload({ waitUntil: "domcontentloaded", timeout: 1000 })
+    .catch(() => null);
+  const dialog = await dialogPromise;
+  expect(dialog.type()).toBe("beforeunload");
+  await dialog.dismiss();
+  await reloadPromise;
+
+  await expect(page).toHaveURL("/form-unsaved");
+  await expect(page.locator("#unsaved-note")).toHaveValue(
+    "draft after live nav cancel",
+  );
+  expect(await page.evaluate(() => window.unsavedEvents)).toEqual([
+    {
+      type: "phx",
+      detail: {
+        href: "http://localhost:4004/form-unsaved/target",
+        patch: false,
+        pop: false,
+        direction: "forward",
+      },
+    },
+    { type: "beforeunload" },
+  ]);
+  expect(
+    await page.evaluate(() => ({
+      connected: window.liveSocket.isConnected(),
+      unloaded: window.liveSocket.isUnloaded(),
+    })),
+  ).toEqual({ connected: true, unloaded: false });
+
+  await page.locator("#unsaved-note").fill("draft after beforeunload cancel");
+  await syncLV(page);
+  await expect(page.locator("#unsaved-value")).toHaveText(
+    "Unsaved value: draft after beforeunload cancel",
+  );
+});

--- a/test/e2e/tests/form-unsaved.spec.js
+++ b/test/e2e/tests/form-unsaved.spec.js
@@ -70,14 +70,13 @@ test("can prevent live navigation and beforeunload", async ({ page }) => {
   );
 
   const dialogPromise = page.waitForEvent("dialog");
-  const reloadPromise = page
-    .reload({ waitUntil: "domcontentloaded", timeout: 1000 })
-    .catch(() => null);
+  const closePromise = page.close({ runBeforeUnload: true });
   const dialog = await dialogPromise;
   expect(dialog.type()).toBe("beforeunload");
   await dialog.dismiss();
-  await reloadPromise;
+  await closePromise;
 
+  expect(page.isClosed()).toBe(false);
   await expect(page).toHaveURL("/form-unsaved");
   await expect(page.locator("#unsaved-note")).toHaveValue(
     "draft after live nav cancel",

--- a/test/e2e/tests/navigation.spec.js
+++ b/test/e2e/tests/navigation.spec.js
@@ -146,6 +146,129 @@ test("popstate", async ({ page }) => {
   expect(networkEvents).toEqual([]);
 });
 
+test("can prevent live link navigation with before navigate", async ({
+  page,
+}) => {
+  await page.goto("/navigation/a");
+  await syncLV(page);
+
+  await page.evaluate(() => {
+    window.beforeNavigateEvents = [];
+    window.navigateEvents = [];
+    window.preventNavigation = true;
+    window.addEventListener("phx:before-navigate", (event) => {
+      window.beforeNavigateEvents.push(event.detail);
+      if (window.preventNavigation) {
+        event.preventDefault();
+      }
+    });
+    window.addEventListener("phx:navigate", (event) => {
+      window.navigateEvents.push(event.detail);
+    });
+  });
+
+  networkEvents = [];
+  webSocketEvents = [];
+
+  await page.getByRole("link", { name: "LiveView B" }).click();
+
+  await expect(page).toHaveURL("/navigation/a");
+  expect(networkEvents).toEqual([]);
+  expect(webSocketEvents).toEqual([]);
+  expect(await page.evaluate(() => window.beforeNavigateEvents)).toEqual([
+    {
+      href: "http://localhost:4004/navigation/b",
+      patch: false,
+      pop: false,
+      direction: "forward",
+    },
+  ]);
+  expect(await page.evaluate(() => window.navigateEvents)).toEqual([]);
+
+  await page.evaluate(() => {
+    window.preventNavigation = false;
+  });
+  await page.getByRole("link", { name: "LiveView B" }).click();
+  await syncLV(page);
+
+  await expect(page).toHaveURL("/navigation/b");
+  expect(networkEvents).toEqual([]);
+});
+
+test("can prevent popstate navigation with before navigate", async ({
+  page,
+}) => {
+  await page.goto("/navigation/a");
+  await syncLV(page);
+
+  await page.getByRole("link", { name: "LiveView B" }).click();
+  await syncLV(page);
+  await expect(page).toHaveURL("/navigation/b");
+
+  await page.evaluate(() => {
+    window.beforeNavigateEvents = [];
+    window.navigateEvents = [];
+    window.preventNavigation = true;
+    window.addEventListener("phx:before-navigate", (event) => {
+      window.beforeNavigateEvents.push(event.detail);
+      if (window.preventNavigation) {
+        event.preventDefault();
+      }
+    });
+    window.addEventListener("phx:navigate", (event) => {
+      window.navigateEvents.push(event.detail);
+    });
+  });
+
+  networkEvents = [];
+  webSocketEvents = [];
+
+  await page.goBack();
+
+  await expect(page).toHaveURL("/navigation/b");
+  expect(networkEvents).toEqual([]);
+  expect(webSocketEvents).toEqual([]);
+  expect(await page.evaluate(() => window.beforeNavigateEvents)).toEqual([
+    {
+      href: "http://localhost:4004/navigation/a",
+      patch: false,
+      pop: true,
+      direction: "backward",
+    },
+  ]);
+  expect(await page.evaluate(() => window.navigateEvents)).toEqual([]);
+
+  await page.evaluate(() => {
+    window.preventNavigation = false;
+  });
+  await page.goBack();
+  await syncLV(page);
+
+  await expect(page).toHaveURL("/navigation/a");
+  expect(networkEvents).toEqual([]);
+});
+
+test("before navigate does not prevent server-side navigation", async ({
+  page,
+}) => {
+  await page.goto("/navigation/a");
+  await syncLV(page);
+
+  await page.evaluate(() => {
+    window.beforeNavigateEvents = [];
+    window.addEventListener("phx:before-navigate", (event) => {
+      window.beforeNavigateEvents.push(event.detail);
+      event.preventDefault();
+    });
+  });
+
+  await page.getByRole("button", { name: "Server Navigate" }).click();
+  await syncLV(page);
+
+  await expect(page).toHaveURL("/navigation/b");
+  expect(await page.evaluate(() => window.beforeNavigateEvents)).toEqual([]);
+});
+
 test("patch with replace replaces history", async ({ page }) => {
   await page.goto("/navigation/a");
   await syncLV(page);


### PR DESCRIPTION
Adds a `phx:before-navigate` event that can be prevented.

Relates to: https://github.com/phoenixframework/phoenix_live_view/issues/2926.
Relates to: https://github.com/phoenixframework/phoenix_live_view/pull/3051.