### PR TITLE
Fix root id-change patch corruption

### DIFF
--- a/assets/js/phoenix_live_view/dom_patch.ts
+++ b/assets/js/phoenix_live_view/dom_patch.ts
@@ -369,7 +369,20 @@ export default class DOMPatch {
           ) {
             morphCallbacks.onNodeDiscarded!(fromEl);
             fromEl.replaceWith(toEl);
-            return morphCallbacks.onNodeAdded!(toEl);
+
+            const handleNodeAdded = (node: Node) => {
+              morphCallbacks.onNodeAdded!(node);
+
+              let child = node.firstChild;
+              while (child) {
+                const nextSibling = child.nextSibling;
+                handleNodeAdded(child);
+                child = nextSibling;
+              }
+            };
+
+            handleNodeAdded(toEl);
+            return false;
           }
           DOM.syncPendingAttrs(fromEl, toEl);
           DOM.maintainPrivateHooks(

--- a/assets/test/dom_patch_test.ts
+++ b/assets/test/dom_patch_test.ts
@@ -1,0 +1,40 @@
+import { Socket } from "phoenix";
+import LiveSocket from "phoenix_live_view/live_socket";
+import DOMPatch from "phoenix_live_view/dom_patch";
+
+import { liveViewDOM, simulateJoinedView } from "./test_helpers";
+
+describe("DOMPatch", () => {
+  test("preserves new children when a component root id changes", () => {
+    const root = liveViewDOM(`
+      <div id="old-component" data-phx-component="1" data-phx-view="container">
+        <span id="old-child">old</span>
+      </div>
+    `);
+    const liveSocket = new LiveSocket("/live", Socket);
+    const view = simulateJoinedView(root, liveSocket);
+    const added: Node[] = [];
+
+    const patch = new DOMPatch(
+      view,
+      root,
+      '<div id="new-component" data-phx-component="1" data-phx-view="container"><span id="new-child"><strong>new</strong></span></div>',
+      new Set(),
+      1,
+    );
+    patch.afterAdded((node) => added.push(node));
+
+    patch.perform(false);
+
+    const component = root.querySelector("#new-component")!;
+    expect(component.innerHTML).toContain(
+      '<span id="new-child"><strong>new</strong></span>',
+    );
+    expect(added).toEqual([
+      component,
+      component.querySelector("#new-child"),
+      component.querySelector("strong"),
+      component.querySelector("strong")!.firstChild,
+    ]);
+  });
+});


### PR DESCRIPTION
The previous code returned the result of `onNodeAdded` which is `undefined`. Morphdom aborts an element morph only when `onBeforeElUpdated` returns strictly `false`

https://github.com/patrick-steele-idem/morphdom/blob/8e004ca546b428dbe5a5e34a78b8af6179f85013/src/morphdom.js#L219-L222

It continued with attribute and child morphing using:
- `fromEl` - the detached old root
- `toEl` - the visible replacement root

This PR changes it to recursively apply `onNodeAdded` for the replacement and its children. It also explicitly returns `false` to stop morphdom from processing the detached old root

https://github.com/user-attachments/assets/06762e59-f4ff-452d-b222-06ff823fda06


Fixes #4334