### PR TITLE
Encrypt LiveView upload tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,11 +115,6 @@ by setting `phx-ignore-missing-id` or disable it globally with the `:missing_for
 
 See the module documentation or `Phoenix.LiveViewTest` for more information.
 
-## Unreleased
-
-### Security fixes
-- GHSA-p8fj-694c-pvhc: Encrypt LiveView upload tokens to prevent disclosure of Erlang node metadata (e.g. internal hostnames and pod IPs) via the tokens' embedded PIDs
-
 ## v1.2.7 (2026-07-13)
 
 ### Security fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,11 @@ by setting `phx-ignore-missing-id` or disable it globally with the `:missing_for
 
 See the module documentation or `Phoenix.LiveViewTest` for more information.
 
+## Unreleased
+
+### Security fixes
+- GHSA-p8fj-694c-pvhc: Encrypt LiveView upload tokens to prevent disclosure of Erlang node metadata (e.g. internal hostnames and pod IPs) via the tokens' embedded PIDs
+
 ## v1.2.7 (2026-07-13)
 
 ### Security fixes

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -26,28 +26,27 @@ defmodule Phoenix.LiveView.Static do
   end
 
   @doc """
-  Verifies a LiveView token.
+  Verifies a signed LiveView token.
   """
   def verify_token(endpoint, token) do
-    case Phoenix.Token.verify(endpoint, Utils.salt!(endpoint), token, max_age: @max_session_age) do
-      {:ok, {@token_vsn, term}} -> {:ok, term}
-      {:ok, _} -> {:error, :outdated}
-      {:error, :missing} -> {:error, :invalid}
-      {:error, reason} when reason in [:expired, :invalid] -> {:error, reason}
-    end
+    endpoint
+    |> Phoenix.Token.verify(Utils.salt!(endpoint), token, max_age: @max_session_age)
+    |> token_payload()
   end
 
   @doc """
-  Verifies and decrypts a LiveView token previously produced by `encrypt_token/2`.
+  Verifies an encrytped LiveView token.
   """
   def decrypt_token(endpoint, token) do
-    case Phoenix.Token.decrypt(endpoint, Utils.salt!(endpoint), token, max_age: @max_session_age) do
-      {:ok, {@token_vsn, term}} -> {:ok, term}
-      {:ok, _} -> {:error, :outdated}
-      {:error, :missing} -> {:error, :invalid}
-      {:error, reason} when reason in [:expired, :invalid] -> {:error, reason}
-    end
+    endpoint
+    |> Phoenix.Token.decrypt(Utils.salt!(endpoint), token, max_age: @max_session_age)
+    |> token_payload()
   end
+
+  defp token_payload({:ok, {@token_vsn, term}}), do: {:ok, term}
+  defp token_payload({:ok, _}), do: {:error, :outdated}
+  defp token_payload({:error, :missing}), do: {:error, :invalid}
+  defp token_payload({:error, reason}) when reason in [:expired, :invalid], do: {:error, reason}
 
   defp live_session(%Plug.Conn{} = conn) do
     case conn.private[:phoenix_live_view] do

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -35,7 +35,7 @@ defmodule Phoenix.LiveView.Static do
   end
 
   @doc """
-  Verifies an encrytped LiveView token.
+  Verifies an encrypted LiveView token.
   """
   def decrypt_token(endpoint, token) do
     endpoint

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -37,6 +37,18 @@ defmodule Phoenix.LiveView.Static do
     end
   end
 
+  @doc """
+  Verifies and decrypts a LiveView token previously produced by `encrypt_token/2`.
+  """
+  def decrypt_token(endpoint, token) do
+    case Phoenix.Token.decrypt(endpoint, Utils.salt!(endpoint), token, max_age: @max_session_age) do
+      {:ok, {@token_vsn, term}} -> {:ok, term}
+      {:ok, _} -> {:error, :outdated}
+      {:error, :missing} -> {:error, :invalid}
+      {:error, reason} when reason in [:expired, :invalid] -> {:error, reason}
+    end
+  end
+
   defp live_session(%Plug.Conn{} = conn) do
     case conn.private[:phoenix_live_view] do
       {_view, _opts, %{name: _name, extra: _extra} = lv_session} -> lv_session
@@ -404,6 +416,20 @@ defmodule Phoenix.LiveView.Static do
   """
   def sign_token(endpoint, data) do
     Phoenix.Token.sign(endpoint, Utils.salt!(endpoint), {@token_vsn, data})
+  end
+
+  @doc """
+  Encrypts a LiveView token.
+
+  Unlike `sign_token/2`, the payload is encrypted rather than merely signed,
+  so its contents cannot be inspected by the client. Use this whenever the
+  payload embeds Erlang terms whose external binary format may reveal internal
+  infrastructure details — e.g. PIDs, whose ETF representation encodes the
+  originating node name and can leak internal hostnames or IPs when the
+  release node follows patterns like `app@<pod-ip>.<ns>.pod.cluster.local`.
+  """
+  def encrypt_token(endpoint, data) do
+    Phoenix.Token.encrypt(endpoint, Utils.salt!(endpoint), {@token_vsn, data})
   end
 
   defp container(%{container: {tag, attrs}}, opts) do

--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -420,13 +420,6 @@ defmodule Phoenix.LiveView.Static do
 
   @doc """
   Encrypts a LiveView token.
-
-  Unlike `sign_token/2`, the payload is encrypted rather than merely signed,
-  so its contents cannot be inspected by the client. Use this whenever the
-  payload embeds Erlang terms whose external binary format may reveal internal
-  infrastructure details — e.g. PIDs, whose ETF representation encodes the
-  originating node name and can leak internal hostnames or IPs when the
-  release node follows patterns like `app@<pod-ip>.<ns>.pod.cluster.local`.
   """
   def encrypt_token(endpoint, data) do
     Phoenix.Token.encrypt(endpoint, Utils.salt!(endpoint), {@token_vsn, data})

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -383,7 +383,7 @@ defmodule Phoenix.LiveView.Upload do
     reply_entries =
       for entry <- entries, entry.valid?, into: %{} do
         token =
-          Phoenix.LiveView.Static.sign_token(socket.endpoint, %{
+          Phoenix.LiveView.Static.encrypt_token(socket.endpoint, %{
             pid: self(),
             ref: {conf.ref, entry.ref},
             cid: cid

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -382,6 +382,10 @@ defmodule Phoenix.LiveView.Upload do
        ) do
     reply_entries =
       for entry <- entries, entry.valid?, into: %{} do
+        # We encrypt the upload token because it contains the pid,
+        # which when serialized includes the node's address.
+        # Since uploads are not on a hot-path, always encrypting
+        # here is acceptable.
         token =
           Phoenix.LiveView.Static.encrypt_token(socket.endpoint, %{
             pid: self(),

--- a/lib/phoenix_live_view/upload_channel.ex
+++ b/lib/phoenix_live_view/upload_channel.ex
@@ -56,7 +56,7 @@ defmodule Phoenix.LiveView.UploadChannel do
   def join(_topic, auth_payload, socket) do
     %{"token" => token} = auth_payload
 
-    with {:ok, %{pid: pid, ref: ref, cid: cid}} <- Static.verify_token(socket.endpoint, token),
+    with {:ok, %{pid: pid, ref: ref, cid: cid}} <- Static.decrypt_token(socket.endpoint, token),
          {:ok, config} <- Channel.register_upload(pid, ref, cid),
          %{max_file_size: max_file_size, chunk_timeout: chunk_timeout} = config,
          {writer, writer_opts} <- config.writer,

--- a/test/phoenix_live_view/upload/channel_test.exs
+++ b/test/phoenix_live_view/upload/channel_test.exs
@@ -182,7 +182,7 @@ defmodule Phoenix.LiveView.UploadChannelTest do
     # and the Erlang external term format encodes the source node name into the
     # PID's binary representation, tokens leaked the BEAM node — which in
     # container releases (e.g. `app@<pod-ip>.<ns>.pod.cluster.local`) exposes
-    # internal hostnames and pod IPs. Tokens must now be encrypted.
+    # internal hostnames and pod IPs.
     token = LiveView.Static.encrypt_token(@endpoint, %{pid: self(), ref: {"foo", "bar"}})
 
     salt = Phoenix.LiveView.Utils.salt!(@endpoint)

--- a/test/phoenix_live_view/upload/channel_test.exs
+++ b/test/phoenix_live_view/upload/channel_test.exs
@@ -72,7 +72,7 @@ defmodule Phoenix.LiveView.UploadChannelTest do
   end
 
   def valid_token(lv_pid, ref) do
-    LiveView.Static.sign_token(@endpoint, %{pid: lv_pid, ref: ref})
+    LiveView.Static.encrypt_token(@endpoint, %{pid: lv_pid, ref: ref})
   end
 
   def mount_lv(setup) when is_function(setup, 1) do
@@ -174,6 +174,25 @@ defmodule Phoenix.LiveView.UploadChannelTest do
 
     assert {:error, %{reason: :invalid_token}} =
              Phoenix.ChannelTest.subscribe_and_join(socket, "lvu:123", %{"token" => "bad"})
+  end
+
+  test "upload token is encrypted, not merely signed (GHSA-p8fj-694c-pvhc)" do
+    # Regression: upload tokens used to be produced by Phoenix.Token.sign, so the
+    # base64 payload was readable client-side. Because the payload embeds a PID
+    # and the Erlang external term format encodes the source node name into the
+    # PID's binary representation, tokens leaked the BEAM node — which in
+    # container releases (e.g. `app@<pod-ip>.<ns>.pod.cluster.local`) exposes
+    # internal hostnames and pod IPs. Tokens must now be encrypted.
+    token = LiveView.Static.encrypt_token(@endpoint, %{pid: self(), ref: {"foo", "bar"}})
+
+    salt = Phoenix.LiveView.Utils.salt!(@endpoint)
+
+    # An encrypted token must NOT verify as a signed token.
+    assert {:error, :invalid} =
+             Phoenix.Token.verify(@endpoint, salt, token, max_age: :infinity)
+
+    # And the raw token body must not contain the local node name in the clear.
+    refute String.contains?(token, Atom.to_string(node()))
   end
 
   defp setup_lv(%{allow: opts}) do


### PR DESCRIPTION
## Summary

Upload tokens generated by `allow_upload/3` were signed but not encrypted. The payload embeds a PID via `pid: self()` (`lib/phoenix_live_view/upload.ex:387`), and the Erlang external term format encodes the source node name literally into a PID's binary representation. As a result, the base64-wrapped payload is trivially decodable by any client and leaks the BEAM node name, which in container releases typically exposes internal hostnames and pod IPs — e.g. `app@<pod-ip>.<ns>.pod.cluster.local`.

This is tracked as GHSA-p8fj-694c-pvhc — currently a private draft filed under `phoenixframework/phoenix`. Note that the affected code path actually lives here in `phoenix_live_view`; ideally the advisory would be moved or refiled against this repository.

## Fix

Adds `Phoenix.LiveView.Static.encrypt_token/2` and `decrypt_token/2` alongside the existing signed variants, and switches the upload preflight (`upload.ex`) and channel-join (`upload_channel.ex`) paths to use them. The PID stays in the payload — the server needs it for `Process.monitor/1` and `Channel.register_upload/3` — but the payload is now opaque to the client.

No configuration changes required: `Phoenix.Token.encrypt/4` derives its key from the existing `:secret_key_base` plus the existing `:signing_salt` under `:live_view`.

## Rolling-deploy compatibility

- Old (signed) token → new server: `Phoenix.Token.decrypt` returns `{:error, :invalid}` → the channel returns `{:error, %{reason: :invalid_token}}` → the JS client re-runs preflight and gets a fresh (encrypted) token. One retry, no stuck state.
- New (encrypted) token → old server during rollout: `Phoenix.Token.verify` returns `{:error, :invalid}` → same benign flow.
- `@token_vsn` is deliberately **not** bumped, because that constant is shared across session/static/upload tokens; bumping it would invalidate every LiveView session, not just upload preflights. The natural incompatibility between signed and encrypted binary shapes is enough to invalidate just the upload path.

## Test plan

- [x] `mix test test/phoenix_live_view/upload/channel_test.exs` — 117/117 pass, including the new regression test that asserts the token cannot be verified as a signed token and does not contain the local node name in the clear.
- [x] `mix test` full suite — 6 doctests, 1475 tests, 0 failures.
