### PR TITLE
Handle keyed root when patching live components

### DIFF
--- a/assets/js/phoenix_live_view/dom_patch.ts
+++ b/assets/js/phoenix_live_view/dom_patch.ts
@@ -191,6 +191,7 @@ export default class DOMPatch {
         // another case is the recursive patch of a stream item that was kept on reset (-> onBeforeNodeAdded)
         childrenOnly:
           targetContainer.getAttribute(PHX_COMPONENT) === null && !withChildren,
+        keyedRoot: targetContainer.getAttribute(PHX_COMPONENT) != null,
         getNodeKey: (node) => {
           if (!(node instanceof Element)) return null;
           if (DOM.isPhxDestroyed(node)) {
@@ -360,17 +361,6 @@ export default class DOMPatch {
           this.maybeReOrderStream(el, false);
         },
         onBeforeElUpdated: (fromEl, toEl) => {
-          // if we are patching the root target container and the id has changed, treat it as a new node
-          // by replacing the fromEl with the toEl, which ensures hooks are torn down and re-created
-          if (
-            fromEl.id &&
-            fromEl.isSameNode(targetContainer) &&
-            fromEl.id !== toEl.id
-          ) {
-            morphCallbacks.onNodeDiscarded!(fromEl);
-            fromEl.replaceWith(toEl);
-            return morphCallbacks.onNodeAdded!(toEl);
-          }
           DOM.syncPendingAttrs(fromEl, toEl);
           DOM.maintainPrivateHooks(
             fromEl,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.7",
       "license": "MIT",
       "dependencies": {
-        "morphdom": "2.7.8"
+        "morphdom": "github:SteffenDE/morphdom#sd-keyed-root"
       },
       "devDependencies": {
         "@babel/cli": "7.27.2",
@@ -6976,8 +6976,7 @@
     },
     "node_modules/morphdom": {
       "version": "2.7.8",
-      "resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.7.8.tgz",
-      "integrity": "sha512-D/fR4xgGUyVRbdMGU6Nejea1RFzYxYtyurG4Fbv2Fi/daKlWKuXGLOdXtl+3eIwL110cI2hz1ZojGICjjFLgTg==",
+      "resolved": "git+ssh://git@github.com/SteffenDE/morphdom.git#92f9125ed8c1a52861719544c83314cd062d65aa",
       "license": "MIT"
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "types": "./assets/js/types/index.d.ts",
   "dependencies": {
-    "morphdom": "2.7.8"
+    "morphdom": "github:SteffenDE/morphdom#sd-keyed-root"
   },
   "devDependencies": {
     "@babel/cli": "7.27.2",

--- a/test/e2e/support/issues/issue_4334.ex
+++ b/test/e2e/support/issues/issue_4334.ex
@@ -1,0 +1,78 @@
+defmodule Phoenix.LiveViewTest.E2E.Issue4334Live do
+  # https://github.com/phoenixframework/phoenix_live_view/issues/4334
+  use Phoenix.LiveView
+
+  defmodule RootChangingComponent do
+    use Phoenix.LiveComponent
+
+    @impl true
+    def mount(socket), do: {:ok, assign(socket, changed: false)}
+
+    @impl true
+    def handle_event("change-root-id", _params, socket) do
+      {:noreply, assign(socket, changed: true)}
+    end
+
+    @impl true
+    def render(assigns) do
+      ~H"""
+      <section
+        id={if @changed, do: "new-root", else: "old-root"}
+        data-testid="component-root"
+        phx-hook="RootChange"
+        style="min-height: 10rem; margin-top: 2rem; padding: 1.5rem; border: 4px solid #dc2626;"
+      >
+        <button
+          id="change-root"
+          phx-click="change-root-id"
+          phx-target={@myself}
+          style="padding: 0.75rem 1rem; background: #111827; color: white;"
+        >
+          Change component root ID
+        </button>
+
+        <p id={if @changed, do: "new-child", else: "old-child"} style="font-size: 1.25rem;">
+          {if @changed, do: "NEW CHILD SHOULD REMAIN VISIBLE", else: "Old child is visible"}
+        </p>
+      </section>
+      """
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    assigns = %{}
+
+    pre_script =
+      ~H"""
+      <script>
+        window.hooks.RootChange = {
+          mounted() {
+            console.log("MyHook mounted");
+          },
+          updated() {
+            console.log("MyHook updated");
+          },
+        };
+      </script>
+      """
+
+    {:ok, assign(socket, count: 0, pre_script: pre_script)}
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <main style="max-width: 48rem; margin: 4rem auto; font-family: system-ui;">
+      <h1>LiveComponent root ID corruption repro</h1>
+      <p id="instructions">
+        Click the button. The component root changes from <code>old-root</code>
+        to <code>new-root</code>. On affected LiveView versions, the replacement root remains
+        but all of its new children disappear.
+      </p>
+
+      <.live_component module={RootChangingComponent} id="demo-component" />
+    </main>
+    """
+  end
+end

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -219,6 +219,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/4290/a", Issue4290.ALive
       live "/4290/b", Issue4290.BLive
       live "/4325", Issue4325Live
+      live "/4334", Issue4334Live
     end
   end
 

--- a/test/e2e/tests/issues/4334.spec.js
+++ b/test/e2e/tests/issues/4334.spec.js
@@ -1,0 +1,28 @@
+import { test, expect } from "../../test-fixtures";
+import { syncLV } from "../../utils";
+
+// https://github.com/phoenixframework/phoenix_live_view/issues/4334
+test("hook is remounted when changing LC root id and content is properly patched", async ({
+  page,
+}) => {
+  const logs = [];
+  page.on("console", (e) => logs.push(e.text()));
+
+  await page.goto("/issues/4334");
+  await syncLV(page);
+
+  expect(logs.filter((msg) => msg.indexOf("MyHook") !== -1)).toEqual([
+    "MyHook mounted",
+  ]);
+
+  await page.getByRole("button", { name: "Change component root id" }).click();
+  await syncLV(page);
+
+  // Hook remounts
+  expect(logs.filter((msg) => msg.indexOf("MyHook") !== -1)).toEqual([
+    "MyHook mounted",
+    "MyHook mounted",
+  ]);
+
+  await expect(page.getByText("NEW CHILD SHOULD REMAIN VISIBLE")).toBeVisible();
+});


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix_live_view/pull/4335.
Closes https://github.com/phoenixframework/phoenix_live_view/issues/4334.
Relates to #3423.