### PR TITLE
Ls fix handler lost

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.ts
+++ b/assets/js/phoenix_live_view/live_socket.ts
@@ -983,18 +983,21 @@ export default class LiveSocket {
 
   /** @internal */
   bindTopLevelEvents({ dead }: { dead?: boolean } = {}) {
+    if (!this.serverCloseRef) {
+      // enter failsafe reload if server has gone away intentionally, such as "disconnect" broadcast
+      this.serverCloseRef = this.socket.onClose((event) => {
+        // failsafe reload if normal closure and we still have a main LV
+        if (event && event.code === 1000 && this.main) {
+          return this.reloadWithJitter(this.main);
+        }
+      });
+    }
+
     if (this.boundTopLevelEvents) {
       return;
     }
 
     this.boundTopLevelEvents = true;
-    // enter failsafe reload if server has gone away intentionally, such as "disconnect" broadcast
-    this.serverCloseRef = this.socket.onClose((event) => {
-      // failsafe reload if normal closure and we still have a main LV
-      if (event && event.code === 1000 && this.main) {
-        return this.reloadWithJitter(this.main);
-      }
-    });
     document.body.addEventListener("click", function () {}); // ensure all click events bubble for mobile Safari
     window.addEventListener(
       "pageshow",

--- a/assets/js/phoenix_live_view/live_socket.ts
+++ b/assets/js/phoenix_live_view/live_socket.ts
@@ -983,7 +983,7 @@ export default class LiveSocket {
 
   /** @internal */
   bindTopLevelEvents({ dead }: { dead?: boolean } = {}) {
-    if (!this.serverCloseRef) {
+    if (this.serverCloseRef === null) {
       // enter failsafe reload if server has gone away intentionally, such as "disconnect" broadcast
       this.serverCloseRef = this.socket.onClose((event) => {
         // failsafe reload if normal closure and we still have a main LV

--- a/assets/test/live_socket_test.ts
+++ b/assets/test/live_socket_test.ts
@@ -92,7 +92,7 @@ describe("LiveSocket", () => {
 
     liveSocket.disconnect();
     liveSocket.connect();
-    // onClose registers a handler, so reconnecting must replace the registration removed by disconnect()
+    // onClose should be called during each connect(), hence two calls after reconnecting
     expect(onClose).toHaveBeenCalledTimes(2);
 
     const serverCloseHandler = onClose.mock.calls[1][0] as (event: {

--- a/assets/test/live_socket_test.ts
+++ b/assets/test/live_socket_test.ts
@@ -92,6 +92,7 @@ describe("LiveSocket", () => {
 
     liveSocket.disconnect();
     liveSocket.connect();
+    // onClose registers a handler, so reconnecting must replace the registration removed by disconnect()
     expect(onClose).toHaveBeenCalledTimes(2);
 
     const serverCloseHandler = onClose.mock.calls[1][0] as (event: {

--- a/assets/test/live_socket_test.ts
+++ b/assets/test/live_socket_test.ts
@@ -81,6 +81,26 @@ describe("LiveSocket", () => {
     expect(liveSocket.getViewByEl(container(1)).destroy).toBeDefined();
   });
 
+  test("rebinds the server close failsafe after reconnecting", () => {
+    liveSocket = new LiveSocket("/live", Socket);
+    const onClose = jest.spyOn(liveSocket.socket, "onClose");
+    const reloadWithJitter = jest.spyOn(liveSocket, "reloadWithJitter");
+
+    liveSocket.connect();
+    liveSocket.main = liveSocket.getViewByEl(container(1));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    liveSocket.disconnect();
+    liveSocket.connect();
+    expect(onClose).toHaveBeenCalledTimes(2);
+
+    const serverCloseHandler = onClose.mock.calls[1][0] as (event: {
+      code: number;
+    }) => void;
+    serverCloseHandler({ code: 1000 });
+    expect(reloadWithJitter).toHaveBeenCalledWith(liveSocket.main);
+  });
+
   test("channel", async () => {
     liveSocket = new LiveSocket("/live", Socket);
 


### PR DESCRIPTION
Mechanism of the bug in previous code:
`disconnect()` removes the callback referenced by `serverCloseRef` and resets the reference to `null`. On reconnection, `bindTopLevelEvents()` returns immediately because `boundTopLevelEvents` remains `true`, so the socket-close callback is never registered again. Phoenix treats close code 1000 as a clean close and does not reconnect. With failsafe callback missing, the page remains silently disconnected until manually refreshed.

This PR addresses that by registering the server-close callback whenever `serverCloseRef` is absent, before checking `boundTopLevelEvents`

https://github.com/user-attachments/assets/d2d5748b-3faf-4f3c-bf52-b4830ab609da

Fixes #4340