### PR TITLE
Namespace diagnostics

### DIFF
--- a/assets/js/phoenix_live_view/diagnostics.ts
+++ b/assets/js/phoenix_live_view/diagnostics.ts
@@ -7,8 +7,15 @@ export type LiveViewDiagnosticLevel = "debug" | "error";
 
 export type LiveViewDiagnosticMetadata = Record<string, unknown>;
 
+export type LiveViewDiagnosticAttribution =
+  | "internal" // errors that signify a bug in LiveView
+  | "network" // errors caused by network problems
+  | "app" // errors that are definitely caused by the user's app
+  | "unknown"; // non-error diagnostics or cases that are not 100% clear
+
 export type LiveViewDiagnosticContext = {
   viewId?: string;
+  attribution: LiveViewDiagnosticAttribution;
 };
 
 export type LiveViewDiagnostic = {
@@ -16,18 +23,22 @@ export type LiveViewDiagnostic = {
   level: LiveViewDiagnosticLevel;
   code: string;
   message: string;
-  viewId?: string;
   metadata?: LiveViewDiagnosticMetadata;
-};
+} & LiveViewDiagnosticContext;
+
+type LiveViewDiagnosticInput = Omit<LiveViewDiagnostic, "version">;
 
 // Debug-level diagnostics are gated on LiveSocket.isDebugEnabled() by the
 // caller; error-level diagnostics are always emitted.
 export const dispatchDiagnostic = (
-  diagnostic: Omit<LiveViewDiagnostic, "version">,
+  diagnostic: LiveViewDiagnosticInput,
 ): void => {
   window.dispatchEvent(
     new CustomEvent<LiveViewDiagnostic>(PHX_LV_DIAGNOSTIC_EVENT, {
-      detail: { version: PHX_LV_DIAGNOSTIC_VERSION, ...diagnostic },
+      detail: {
+        version: PHX_LV_DIAGNOSTIC_VERSION,
+        ...diagnostic,
+      },
     }),
   );
 };
@@ -35,8 +46,8 @@ export const dispatchDiagnostic = (
 export const logError = (
   code: string,
   message: string,
-  metadata?: LiveViewDiagnosticMetadata,
-  context: LiveViewDiagnosticContext = {},
+  metadata: LiveViewDiagnosticMetadata,
+  context: LiveViewDiagnosticContext,
 ): void => {
   console.error && console.error(message, metadata);
   dispatchDiagnostic({

--- a/assets/js/phoenix_live_view/dom.ts
+++ b/assets/js/phoenix_live_view/dom.ts
@@ -366,7 +366,7 @@ const DOM = {
         const currentCycle = this.incCycle(el, DEBOUNCE_TRIGGER, trigger);
         if (isNaN(timeout)) {
           return logError(
-            "binding.invalid-debounce",
+            "dom.invalid-debounce",
             `invalid throttle/debounce value: ${value}`,
             { el, value },
           );

--- a/assets/js/phoenix_live_view/dom.ts
+++ b/assets/js/phoenix_live_view/dom.ts
@@ -41,7 +41,12 @@ const DOM = {
   byId(id) {
     return (
       document.getElementById(id) ||
-      logError("dom.element-not-found", `no id found for ${id}`, { id })
+      logError(
+        "dom.element-not-found",
+        `no id found for ${id}`,
+        { id },
+        { attribution: "internal" },
+      )
     );
   },
 
@@ -369,6 +374,7 @@ const DOM = {
             "dom.invalid-debounce",
             `invalid throttle/debounce value: ${value}`,
             { el, value },
+            { attribution: "app" },
           );
         }
         if (throttle) {
@@ -485,6 +491,7 @@ const DOM = {
         ensure you are calling createHook within your connectedCallback. ${el.outerHTML}
       `,
         { el },
+        { attribution: "app" },
       );
     }
     this.putPrivate(el, "custom-el-hook", hook);
@@ -750,6 +757,7 @@ const DOM = {
               "only HTML element tags with an id are allowed inside containers with phx-update.\n\n" +
                 `removing illegal node: "${(("outerHTML" in childNode && (childNode.outerHTML as string)) || childNode.nodeValue || "").trim()}"\n\n`,
               { container, childNode, phxUpdate },
+              { attribution: "app" },
             );
           }
           toRemove.push(childNode);

--- a/assets/js/phoenix_live_view/dom_patch.ts
+++ b/assets/js/phoenix_live_view/dom_patch.ts
@@ -136,8 +136,8 @@ export default class DOMPatch {
 
   perform(isJoinPatch) {
     const { view, liveSocket, html, container } = this;
-    const reportError = (code, message, metadata?) =>
-      view.logError(code, message, metadata);
+    const reportError = (code, message, metadata, context?) =>
+      view.logError(code, message, metadata, context);
     let targetContainer = this.targetContainer;
 
     if (this.targetCID) {

--- a/assets/js/phoenix_live_view/index.ts
+++ b/assets/js/phoenix_live_view/index.ts
@@ -58,6 +58,7 @@ function createHook(el: HTMLElement, callbacks: Hook): ViewHook {
       "hook.missing-id",
       "Elements passed to createHook need to have a unique id attribute",
       { el },
+      { attribution: "app" },
     );
   }
 

--- a/assets/js/phoenix_live_view/live_socket.ts
+++ b/assets/js/phoenix_live_view/live_socket.ts
@@ -44,6 +44,7 @@ import {
 } from "./utils";
 import {
   dispatchDiagnostic,
+  LiveViewDiagnosticContext,
   logError,
   type LiveViewDiagnosticLevel,
   type LiveViewDiagnosticMetadata,
@@ -619,6 +620,7 @@ export default class LiveSocket {
       code: string;
       level?: LiveViewDiagnosticLevel;
       metadata?: () => LiveViewDiagnosticMetadata;
+      context?: LiveViewDiagnosticContext;
     },
   ) {
     const debugEnabled = this.isDebugEnabled();
@@ -644,6 +646,7 @@ export default class LiveSocket {
         message,
         viewId: view.id,
         metadata: diagnostic.metadata?.(),
+        ...(diagnostic.context || { attribution: "unknown" }),
       });
     }
   }
@@ -766,6 +769,7 @@ export default class LiveSocket {
           runtimeHook,
           name,
         },
+        { attribution: "app" },
       );
       return;
     }
@@ -780,6 +784,7 @@ export default class LiveSocket {
       "hook.runtime-invalid-return",
       "runtime hook must return an object with hook callbacks or an instance of ViewHook",
       { runtimeHook, name },
+      { attribution: "app" },
     );
   }
 
@@ -971,7 +976,7 @@ export default class LiveSocket {
   }
 
   /** @internal */
-  withinOwners(childEl, callback) {
+  withinOwners(childEl, callback: (view: View, targetCtx: Element) => unknown) {
     this.owner(childEl, (view) => callback(view, childEl));
   }
 
@@ -1678,7 +1683,7 @@ export default class LiveSocket {
         externalFormSubmitted = true;
         e.preventDefault();
         this.withinOwners(e.target, (view) => {
-          view.disableForm(e.target);
+          view.disableForm(e.target as HTMLFormElement, phxChange);
           // safari needs next tick
           window.requestAnimationFrame(() => {
             if (DOM.isUnloadableFormSubmit(e)) {

--- a/assets/js/phoenix_live_view/rendered.js
+++ b/assets/js/phoenix_live_view/rendered.js
@@ -575,7 +575,7 @@ export default class Rendered {
       return { buffer: html, streams: streams };
     } else {
       logError(
-        "render.missing-component",
+        "render.internal.missing-component",
         `no component for CID ${cid}`,
         {
           cid,

--- a/assets/js/phoenix_live_view/rendered.js
+++ b/assets/js/phoenix_live_view/rendered.js
@@ -575,13 +575,13 @@ export default class Rendered {
       return { buffer: html, streams: streams };
     } else {
       logError(
-        "render.internal.missing-component",
+        "render.missing-component",
         `no component for CID ${cid}`,
         {
           cid,
           components,
         },
-        { viewId: this.viewId },
+        { viewId: this.viewId, attribution: "internal" },
       );
       throw new Error(
         "Cannot continue render due to missing component: " + cid,

--- a/assets/js/phoenix_live_view/upload_entry.js
+++ b/assets/js/phoenix_live_view/upload_entry.js
@@ -148,7 +148,7 @@ export default class UploadEntry {
     this.meta = resp.entries[this.ref];
     if (!this.meta) {
       this.view.logError(
-        "upload.missing-preflight-response",
+        "upload.internal.missing-preflight-response",
         `no preflight upload response returned with ref ${this.ref}`,
         {
           ref: this.ref,

--- a/assets/js/phoenix_live_view/upload_entry.js
+++ b/assets/js/phoenix_live_view/upload_entry.js
@@ -148,13 +148,14 @@ export default class UploadEntry {
     this.meta = resp.entries[this.ref];
     if (!this.meta) {
       this.view.logError(
-        "upload.internal.missing-preflight-response",
+        "upload.missing-preflight-response",
         `no preflight upload response returned with ref ${this.ref}`,
         {
           ref: this.ref,
           input: this.fileEl,
           response: resp,
         },
+        { attribution: "internal" },
       );
     }
   }

--- a/assets/js/phoenix_live_view/utils.ts
+++ b/assets/js/phoenix_live_view/utils.ts
@@ -43,6 +43,7 @@ export function detectDuplicateIds(reportError: LogError = logError) {
         "dom.duplicate-id",
         `Multiple IDs detected: ${id}. Ensure unique element ids.`,
         { id, elements: [existing, elems[i]] },
+        { attribution: "app" },
       );
     } else {
       ids.set(id, elems[i]);
@@ -71,6 +72,7 @@ export function detectInvalidStreamInserts(
       "dom.invalid-stream-container",
       `The stream container with id "${id}" is missing the phx-update="stream" attribute. Ensure it is set for streams to work properly.`,
       { id, container },
+      { attribution: "app" },
     );
   });
 }

--- a/assets/js/phoenix_live_view/view.ts
+++ b/assets/js/phoenix_live_view/view.ts
@@ -389,7 +389,7 @@ export default class View {
   applyDiff(type: "mount" | "update", rawDiff, callback) {
     const clonedDiff = clone(rawDiff);
     this.log(type, () => ["received diff", clonedDiff], {
-      code: `view.diff.${type}`,
+      code: `view.diff-${type}`,
       metadata: () => ({ diff: clonedDiff }),
     });
     const { diff, reply, events, title } = Rendered.extract(rawDiff);
@@ -1189,7 +1189,7 @@ export default class View {
     this.wrapPush(() => this.channel.join(), {
       ok: (resp) => this.liveSocket.requestDOMUpdate(() => this.onJoin(resp)),
       error: (error) => this.onJoinError(error),
-      timeout: () => this.onJoinError({ reason: "timeout" }),
+      timeout: () => this.onJoinError(new Error("timeout")),
     });
   }
 
@@ -1242,11 +1242,16 @@ export default class View {
     if (resp.live_redirect) {
       return this.onLiveRedirect(resp.live_redirect);
     }
-    this.log("error", () => ["unable to join", resp], {
-      code: "view.join-failed",
-      level: "error",
-      metadata: () => ({ response: resp }),
-    });
+    const timedOut = resp instanceof Error && resp.message === "timeout";
+    this.log(
+      "error",
+      () => [timedOut ? "join timed out" : "unable to join", resp],
+      {
+        code: timedOut ? "view.network.join-timeout" : "view.join-failed",
+        level: "error",
+        metadata: () => (timedOut ? { error: resp } : { response: resp }),
+      },
+    );
     if (this.isMain()) {
       this.displayError(
         [PHX_LOADING_CLASS, PHX_ERROR_CLASS, PHX_SERVER_ERROR_CLASS],
@@ -1269,7 +1274,7 @@ export default class View {
             resp,
           ],
           {
-            code: "view.mount-give-up",
+            code: "view.mount-attempts-exhausted",
             level: "error",
             metadata: () => ({
               attempts: MAX_CHILD_JOIN_ATTEMPTS,
@@ -1444,7 +1449,7 @@ export default class View {
                 () => [
                   "received timeout while communicating with server. Falling back to hard refresh for recovery",
                 ],
-                { code: "view.push-timeout", level: "error" },
+                { code: "view.network.push-timeout", level: "error" },
               );
             });
           }
@@ -1693,7 +1698,7 @@ export default class View {
           { event, payload },
         ],
         {
-          code: "hook.push-disconnected",
+          code: "hook.network.push-disconnected",
           metadata: () => ({ event, payload }),
         },
       );
@@ -1889,7 +1894,7 @@ export default class View {
     )
       .then(({ reply }) => onReply && onReply(reply))
       .catch((error) =>
-        this.logError("event.push-failed", "Failed to push event", {
+        this.logError("event.network.push-failed", "Failed to push event", {
           error,
           type,
           phxEvent,
@@ -1911,7 +1916,7 @@ export default class View {
         .then(() => onReply())
         .catch((error) =>
           view.logError(
-            "upload.progress-push-failed",
+            "upload.network.progress-push-failed",
             "Failed to push file progress",
             { error, fileEl, entryRef, progress },
           ),
@@ -2005,11 +2010,15 @@ export default class View {
         }
       })
       .catch((error) =>
-        this.logError("event.input-push-failed", "Failed to push input event", {
-          error,
-          inputEl,
-          phxEvent,
-        }),
+        this.logError(
+          "event.network.input-push-failed",
+          "Failed to push input event",
+          {
+            error,
+            inputEl,
+            phxEvent,
+          },
+        ),
       );
   }
 
@@ -2146,7 +2155,7 @@ export default class View {
           .then(({ resp }) => onReply(resp))
           .catch((error) =>
             this.logError(
-              "event.submit-push-failed",
+              "event.network.submit-push-failed",
               "Failed to push form submit",
               {
                 error,
@@ -2174,7 +2183,7 @@ export default class View {
         .then(({ resp }) => onReply(resp))
         .catch((error) =>
           this.logError(
-            "event.submit-push-failed",
+            "event.network.submit-push-failed",
             "Failed to push form submit",
             {
               error,
@@ -2257,11 +2266,15 @@ export default class View {
           }
         })
         .catch((error) =>
-          this.logError("upload.push-failed", "Failed to push upload", {
-            error,
-            phxEvent,
-            formEl,
-          }),
+          this.logError(
+            "upload.network.push-failed",
+            "Failed to push upload",
+            {
+              error,
+              phxEvent,
+              formEl,
+            },
+          ),
         );
     });
   }
@@ -2279,7 +2292,7 @@ export default class View {
       uploader.entries().map((entry) => entry.cancel());
     }
     this.log("upload", () => [`error for entry ${uploadRef}`, reason], {
-      code: "upload.entry-error",
+      code: "upload.preflight-rejected",
       metadata: () => ({ uploadRef, reason }),
     });
   }
@@ -2510,7 +2523,7 @@ export default class View {
     const onError = (error, cids) => {
       if (!this.isDestroyed()) {
         this.logError(
-          "component.destroy-push-failed",
+          "component.network.destroy-push-failed",
           "Failed to push components destroyed",
           { error, cids },
         );

--- a/assets/js/phoenix_live_view/view.ts
+++ b/assets/js/phoenix_live_view/view.ts
@@ -2266,15 +2266,11 @@ export default class View {
           }
         })
         .catch((error) =>
-          this.logError(
-            "upload.network.push-failed",
-            "Failed to push upload",
-            {
-              error,
-              phxEvent,
-              formEl,
-            },
-          ),
+          this.logError("upload.network.push-failed", "Failed to push upload", {
+            error,
+            phxEvent,
+            formEl,
+          }),
         );
     });
   }

--- a/assets/js/phoenix_live_view/view.ts
+++ b/assets/js/phoenix_live_view/view.ts
@@ -54,7 +54,12 @@ import {
   maybe,
   isCid,
 } from "./utils";
-import { logError } from "./diagnostics";
+import {
+  LiveViewDiagnosticContext,
+  LiveViewDiagnosticLevel,
+  LiveViewDiagnosticMetadata,
+  logError,
+} from "./diagnostics";
 
 import Browser from "./browser";
 import DOM, { FormInputLike, QueryableNode } from "./dom";
@@ -147,6 +152,7 @@ export default class View {
         Ensure that the template set on the LiveView is different than the root layout.
       `,
         { view: boundView },
+        { attribution: "app" },
       );
       throw new Error("Cannot bind multiple views to the same DOM element.");
     }
@@ -327,13 +333,28 @@ export default class View {
     }
   }
 
-  log(kind, msgCallback, diagnostic?) {
+  log(
+    kind: string,
+    msgCallback: () => [string, unknown] | [string],
+    diagnostic?: {
+      code: string;
+      level?: LiveViewDiagnosticLevel;
+      metadata?: () => LiveViewDiagnosticMetadata;
+      context?: LiveViewDiagnosticContext;
+    },
+  ) {
     this.liveSocket.log(this, kind, msgCallback, diagnostic);
   }
 
-  logError(code, message, metadata?) {
+  logError(
+    code: string,
+    message: string,
+    metadata: Record<string, unknown>,
+    context: LiveViewDiagnosticContext = { attribution: "unknown" },
+  ) {
     logError(code, message, metadata, {
       viewId: this.id ?? this.el.id,
+      ...context,
     });
   }
 
@@ -378,6 +399,7 @@ export default class View {
           "event.missing-selector-target",
           `nothing found matching the phx-target selector "${phxTarget}"`,
           { target: phxTarget },
+          { attribution: "app" },
         );
       }
       targets.forEach((target) =>
@@ -995,6 +1017,7 @@ export default class View {
           "hook.custom-element-missing-hook",
           `no hook found for custom element: ${el.id}`,
           { el },
+          { attribution: "app" },
         );
       this.viewHooks[hookElId] = hook;
       hook.__attachView(this);
@@ -1020,6 +1043,7 @@ export default class View {
             "hook.missing-id",
             `no DOM ID for hook "${hookName}". Hooks require a unique ID on each element.`,
             { el, hookName },
+            { attribution: "app" },
           );
           return;
         }
@@ -1043,6 +1067,7 @@ export default class View {
               "hook.invalid-definition",
               `Invalid hook definition for "${hookName}". Expected a class extending ViewHook or an object definition.`,
               { el, hookName },
+              { attribution: "app" },
             );
             return;
           }
@@ -1052,6 +1077,7 @@ export default class View {
             "hook.creation-failed",
             `Failed to create hook "${hookName}": ${errorMessage}`,
             { el, hookName, error: e },
+            { attribution: "app" },
           );
           return;
         }
@@ -1059,10 +1085,15 @@ export default class View {
         this.viewHooks[ViewHook.elementID(hookInstance.el)] = hookInstance;
         return hookInstance;
       } else if (hookName !== null) {
-        this.logError("hook.unknown", `unknown hook found for "${hookName}"`, {
-          el,
-          hookName,
-        });
+        this.logError(
+          "hook.unknown",
+          `unknown hook found for "${hookName}"`,
+          {
+            el,
+            hookName,
+          },
+          { attribution: "app" },
+        );
       }
     }
   }
@@ -1189,7 +1220,7 @@ export default class View {
     this.wrapPush(() => this.channel.join(), {
       ok: (resp) => this.liveSocket.requestDOMUpdate(() => this.onJoin(resp)),
       error: (error) => this.onJoinError(error),
-      timeout: () => this.onJoinError(new Error("timeout")),
+      timeout: () => this.onJoinError({ reason: "timeout" }),
     });
   }
 
@@ -1209,6 +1240,7 @@ export default class View {
           code: "view.mount-reload",
           level: "error",
           metadata: () => ({ status: resp.status }),
+          context: { attribution: "app" },
         },
       );
       this.onRedirect({
@@ -1227,6 +1259,7 @@ export default class View {
           code: "view.unauthorized-live-redirect",
           level: "error",
           metadata: () => ({ reason: resp.reason }),
+          context: { attribution: "app" },
         },
       );
       this.onRedirect({ to: this.liveSocket.main!.href!, flash: this.flash });
@@ -1242,14 +1275,17 @@ export default class View {
     if (resp.live_redirect) {
       return this.onLiveRedirect(resp.live_redirect);
     }
-    const timedOut = resp instanceof Error && resp.message === "timeout";
+    const timedOut = resp.reason === "timeout";
+    const attribution =
+      timedOut || resp.source === "transport" ? "network" : "app";
     this.log(
       "error",
       () => [timedOut ? "join timed out" : "unable to join", resp],
       {
-        code: timedOut ? "view.network.join-timeout" : "view.join-failed",
+        code: timedOut ? "view.join-timeout" : "view.join-failed",
         level: "error",
         metadata: () => (timedOut ? { error: resp } : { response: resp }),
+        context: { attribution },
       },
     );
     if (this.isMain()) {
@@ -1323,6 +1359,7 @@ export default class View {
         code: "view.crashed",
         level: "error",
         metadata: () => ({ reason }),
+        context: { attribution: "app" },
       });
     }
     if (!this.liveSocket.isUnloaded()) {
@@ -1381,9 +1418,16 @@ export default class View {
     refGenerator,
     event,
     payload,
-  ): Promise<{ resp: any; reply: any; ref: number | null }> {
+  ): Promise<
+    | { type: "ok"; resp: any; reply: any; ref: number | null }
+    | { type: "error"; error: string; context: LiveViewDiagnosticContext }
+  > {
     if (!this.isConnected()) {
-      return Promise.reject(new Error("no connection"));
+      return Promise.resolve({
+        type: "error",
+        error: "no connection",
+        context: { attribution: "network" },
+      });
     }
 
     const [ref, [el], opts] = refGenerator
@@ -1402,7 +1446,7 @@ export default class View {
       delete payload.cid;
     }
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       this.wrapPush(() => this.channel.push(event, payload, PUSH_TIMEOUT), {
         ok: (resp) => {
           if (ref !== null) {
@@ -1419,7 +1463,7 @@ export default class View {
               this.onLiveRedirect(resp.live_redirect);
             }
             onLoadingDone();
-            resolve({ resp: resp, reply: hookReply, ref });
+            resolve({ type: "ok", resp: resp, reply: hookReply, ref });
           };
           if (resp.diff) {
             this.liveSocket.requestDOMUpdate(() => {
@@ -1438,10 +1482,21 @@ export default class View {
             finish(null);
           }
         },
-        error: (reason) =>
-          reject(new Error(`failed with reason: ${JSON.stringify(reason)}`)),
+        error: (reason) => {
+          resolve({
+            type: "error",
+            error: `failed with reason: ${JSON.stringify(reason)}`,
+            context: {
+              attribution: "app",
+            },
+          });
+        },
         timeout: () => {
-          reject(new Error("timeout"));
+          resolve({
+            type: "error",
+            error: "push timeout",
+            context: { attribution: "network" },
+          });
           if (this.joinCount === oldJoinCount) {
             this.liveSocket.reloadWithJitter(this, () => {
               this.log(
@@ -1449,7 +1504,11 @@ export default class View {
                 () => [
                   "received timeout while communicating with server. Falling back to hard refresh for recovery",
                 ],
-                { code: "view.network.push-timeout", level: "error" },
+                {
+                  code: "view.push-timeout-recovery",
+                  level: "error",
+                  context: { attribution: "network" },
+                },
               );
             });
           }
@@ -1698,8 +1757,9 @@ export default class View {
           { event, payload },
         ],
         {
-          code: "hook.network.push-disconnected",
+          code: "hook.push-disconnected",
           metadata: () => ({ event, payload }),
+          context: { attribution: "network" },
         },
       );
       return Promise.reject(
@@ -1718,10 +1778,12 @@ export default class View {
       event: event,
       value: payload,
       cid: this.closestComponentID(targetCtx),
-    }).then(
-      ({ resp: _resp, reply, ref }) =>
-        ({ reply, ref }) as { reply: any; ref: number },
-    );
+    }).then((result) => {
+      if (result.type === "error") {
+        throw new Error("Failed to push hook event: " + result.error);
+      }
+      return { reply: result.reply, ref: result.ref! };
+    });
   }
 
   extractMeta(el, meta, value) {
@@ -1891,16 +1953,23 @@ export default class View {
         value: this.extractMeta(el, meta, opts.value),
         cid: this.targetComponentID(el, targetCtx, opts),
       },
-    )
-      .then(({ reply }) => onReply && onReply(reply))
-      .catch((error) =>
-        this.logError("event.network.push-failed", "Failed to push event", {
-          error,
-          type,
-          phxEvent,
-          el,
-        }),
-      );
+    ).then((result) => {
+      if (result.type === "ok") {
+        onReply && onReply(result.reply);
+      } else {
+        this.logError(
+          "event.push-failed",
+          "Failed to push event",
+          {
+            error: result.error,
+            type,
+            phxEvent,
+            el,
+          },
+          result.context,
+        );
+      }
+    });
   }
 
   pushFileProgress(fileEl, entryRef, progress, onReply = function () {}) {
@@ -1913,14 +1982,18 @@ export default class View {
           progress: progress,
           cid: view.targetComponentID(fileEl.form, targetCtx),
         })
-        .then(() => onReply())
-        .catch((error) =>
-          view.logError(
-            "upload.network.progress-push-failed",
-            "Failed to push file progress",
-            { error, fileEl, entryRef, progress },
-          ),
-        );
+        .then((result) => {
+          if (result.type === "ok") {
+            onReply();
+          } else {
+            view.logError(
+              "upload.progress-push-failed",
+              "Failed to push file progress",
+              { error: result.error, fileEl, entryRef, progress },
+              result.context,
+            );
+          }
+        });
     });
   }
 
@@ -1981,8 +2054,8 @@ export default class View {
       uploads: uploads,
       cid: cid,
     };
-    this.pushWithReply(refGenerator, "event", event)
-      .then(({ resp }) => {
+    this.pushWithReply(refGenerator, "event", event).then((result) => {
+      if (result.type === "ok") {
         if (DOM.isUploadInput(inputEl) && DOM.isAutoUpload(inputEl)) {
           // the element could be inside a locked parent for other unrelated changes;
           // we can only start uploads when the tree is unlocked and the
@@ -1998,7 +2071,7 @@ export default class View {
                 ref,
                 cid,
                 (_uploads) => {
-                  callback && callback(resp);
+                  callback && callback(result.resp);
                   this.triggerAwaitingSubmit(inputEl.form, phxEvent);
                   this.undoRefs(ref, phxEvent);
                 },
@@ -2006,20 +2079,21 @@ export default class View {
             }
           });
         } else {
-          callback && callback(resp);
+          callback && callback(result.resp);
         }
-      })
-      .catch((error) =>
+      } else {
         this.logError(
-          "event.network.input-push-failed",
+          "event.input-push-failed",
           "Failed to push input event",
           {
-            error,
+            error: result.error,
             inputEl,
             phxEvent,
           },
-        ),
-      );
+          result.context,
+        );
+      }
+    });
   }
 
   triggerAwaitingSubmit(formEl, phxEvent) {
@@ -2151,19 +2225,22 @@ export default class View {
           value: formData,
           meta: meta,
           cid: cid,
-        })
-          .then(({ resp }) => onReply(resp))
-          .catch((error) =>
+        }).then((result) => {
+          if (result.type === "ok") {
+            onReply(result.resp);
+          } else {
             this.logError(
-              "event.network.submit-push-failed",
+              "event.submit-push-failed",
               "Failed to push form submit",
               {
-                error,
+                error: result.error,
                 phxEvent,
                 formEl,
               },
-            ),
-          );
+              result.context,
+            );
+          }
+        });
       });
     } else if (
       !(
@@ -2179,19 +2256,22 @@ export default class View {
         value: formData,
         meta: meta,
         cid: cid,
-      })
-        .then(({ resp }) => onReply(resp))
-        .catch((error) =>
+      }).then((result) => {
+        if (result.type === "ok") {
+          onReply(result.resp);
+        } else {
           this.logError(
-            "event.network.submit-push-failed",
+            "event.submit-push-failed",
             "Failed to push form submit",
             {
-              error,
+              error: result.error,
               phxEvent,
               formEl,
             },
-          ),
-        );
+            result.context,
+          );
+        }
+      });
     }
   }
 
@@ -2229,16 +2309,16 @@ export default class View {
         metadata: () => ({ payload }),
       });
 
-      this.pushWithReply(null, "allow_upload", payload)
-        .then(({ resp }) => {
-          this.log("upload", () => ["got preflight response", resp], {
+      this.pushWithReply(null, "allow_upload", payload).then((result) => {
+        if (result.type === "ok") {
+          this.log("upload", () => ["got preflight response", result.resp], {
             code: "upload.preflight-response",
-            metadata: () => ({ response: resp }),
+            metadata: () => ({ response: result.resp }),
           });
           // the preflight will reject entries beyond the max entries
           // so we error and cancel entries on the client that are missing from the response
           uploader.entries().forEach((entry) => {
-            if (resp.entries && !resp.entries[entry.ref]) {
+            if (result.resp.entries && !result.resp.entries[entry.ref]) {
               this.handleFailedEntryPreflight(
                 entry.ref,
                 "failed preflight",
@@ -2248,9 +2328,12 @@ export default class View {
           });
           // for auto uploads, we may have an empty entries response from the server
           // for form submits that contain invalid entries
-          if (resp.error || Object.keys(resp.entries).length === 0) {
+          if (
+            result.resp.error ||
+            Object.keys(result.resp.entries).length === 0
+          ) {
             this.undoRefs(ref, phxEvent);
-            const errors = resp.error || [];
+            const errors = result.resp.error || [];
             errors.map(([entry_ref, reason]) => {
               this.handleFailedEntryPreflight(entry_ref, reason, uploader);
             });
@@ -2262,16 +2345,21 @@ export default class View {
                 }
               });
             };
-            uploader.initAdapterUpload(resp, onError, this.liveSocket);
+            uploader.initAdapterUpload(result.resp, onError, this.liveSocket);
           }
-        })
-        .catch((error) =>
-          this.logError("upload.network.push-failed", "Failed to push upload", {
-            error,
-            phxEvent,
-            formEl,
-          }),
-        );
+        } else {
+          this.logError(
+            "upload.push-failed",
+            "Failed to push upload",
+            {
+              error: result.error,
+              phxEvent,
+              formEl,
+            },
+            result.context,
+          );
+        }
+      });
     });
   }
 
@@ -2303,12 +2391,14 @@ export default class View {
         "upload.input-not-found",
         `no live file inputs found matching the name "${name}"`,
         { name },
+        { attribution: "app" },
       );
     } else if (inputs.length > 1) {
       this.logError(
         "upload.duplicate-input",
         `duplicate live file inputs found matching the name "${name}"`,
         { name, inputs },
+        { attribution: "app" },
       );
     } else {
       DOM.dispatchEvent(inputs[0], PHX_TRACK_UPLOADS, {
@@ -2410,12 +2500,12 @@ export default class View {
       ? `${location.protocol}//${location.host}${href}`
       : href;
 
-    this.pushWithReply(refGen, "live_patch", { url }).then(
-      ({ resp }) => {
+    this.pushWithReply(refGen, "live_patch", { url }).then((result) => {
+      if (result.type === "ok") {
         this.liveSocket.requestDOMUpdate(() => {
-          if (resp.link_redirect) {
+          if (result.resp.link_redirect) {
             this.liveSocket.replaceMain(href, null, callback, linkRef);
-          } else if (resp.redirect) {
+          } else if (result.resp.redirect) {
             // handled by bindChannel
             return;
           } else {
@@ -2426,9 +2516,10 @@ export default class View {
             callback && callback(linkRef);
           }
         });
-      },
-      ({ error: _error, timeout: _timeout }) => fallback(),
-    );
+      } else {
+        fallback();
+      }
+    });
   }
 
   getFormsForRecovery() {
@@ -2516,12 +2607,13 @@ export default class View {
       return DOM.findComponent(this.id, cid) === null;
     });
 
-    const onError = (error, cids) => {
+    const onError = (result, cids) => {
       if (!this.isDestroyed()) {
         this.logError(
-          "component.network.destroy-push-failed",
+          "component.destroy-push-failed",
           "Failed to push components destroyed",
-          { error, cids },
+          { error: result.error, cids },
+          result.context,
         );
       }
     };
@@ -2531,8 +2623,10 @@ export default class View {
       // could be added back from the server so we don't skip them
       willDestroyCIDs.forEach((cid) => this.rendered!.resetRender(cid));
 
-      this.pushWithReply(null, "cids_will_destroy", { cids: willDestroyCIDs })
-        .then(() => {
+      this.pushWithReply(null, "cids_will_destroy", {
+        cids: willDestroyCIDs,
+      }).then((result) => {
+        if (result.type === "ok") {
           // we must wait for pending transitions to complete before determining
           // if the cids were added back to the DOM in the meantime (#3139)
           this.liveSocket.requestDOMUpdate(() => {
@@ -2545,15 +2639,19 @@ export default class View {
             if (completelyDestroyCIDs.length > 0) {
               this.pushWithReply(null, "cids_destroyed", {
                 cids: completelyDestroyCIDs,
-              })
-                .then(({ resp }) => {
-                  this.rendered!.pruneCIDs(resp.cids);
-                })
-                .catch((err) => onError(err, completelyDestroyCIDs));
+              }).then((result) => {
+                if (result.type === "ok") {
+                  this.rendered!.pruneCIDs(result.resp.cids);
+                } else {
+                  onError(result, completelyDestroyCIDs);
+                }
+              });
             }
           });
-        })
-        .catch((err) => onError(err, willDestroyCIDs));
+        } else {
+          onError(result, willDestroyCIDs);
+        }
+      });
     }
   }
 

--- a/assets/test/diagnostics_test.ts
+++ b/assets/test/diagnostics_test.ts
@@ -18,6 +18,7 @@ describe("diagnostics", () => {
         level: "debug",
         code: "test.code",
         message: "message",
+        attribution: "app",
       });
     } finally {
       window.removeEventListener("phx:live-view:diagnostic", listener);
@@ -25,7 +26,13 @@ describe("diagnostics", () => {
     }
 
     expect(received).toEqual([
-      { version: 1, level: "debug", code: "test.code", message: "message" },
+      {
+        version: 1,
+        level: "debug",
+        code: "test.code",
+        message: "message",
+        attribution: "app",
+      },
     ]);
   });
 
@@ -36,18 +43,20 @@ describe("diagnostics", () => {
     const { diagnostics, stop } = captureDiagnostics();
 
     try {
-      logError("hook.missing-id", "no id");
+      logError("hook.missing-id", "no id", {}, { attribution: "app" });
     } finally {
       stop();
     }
 
-    expect(consoleError).toHaveBeenCalledWith("no id", undefined);
+    expect(consoleError).toHaveBeenCalledWith("no id", {});
     expect(diagnostics).toEqual([
       {
         version: 1,
         level: "error",
         code: "hook.missing-id",
         message: "no id",
+        attribution: "app",
+        metadata: {},
       },
     ]);
   });
@@ -62,6 +71,7 @@ describe("diagnostics", () => {
     try {
       logError("dom.duplicate-id", "duplicate", metadata, {
         viewId: "users-view",
+        attribution: "app",
       });
     } finally {
       stop();
@@ -76,6 +86,7 @@ describe("diagnostics", () => {
         message: "duplicate",
         metadata,
         viewId: "users-view",
+        attribution: "app",
       },
     ]);
   });

--- a/assets/test/js_test.ts
+++ b/assets/test/js_test.ts
@@ -749,7 +749,12 @@ describe("JS", () => {
           },
           uploads: {},
         });
-        return Promise.resolve({ resp: done(), reply: null, ref: null });
+        return Promise.resolve({
+          type: "ok",
+          resp: done(),
+          reply: null,
+          ref: null,
+        });
       };
       const args = ["push", { _target: input.name, dispatcher: input }];
       JS.exec(
@@ -782,7 +787,12 @@ describe("JS", () => {
           },
           uploads: {},
         });
-        return Promise.resolve({ resp: done(), reply: null, ref: null });
+        return Promise.resolve({
+          type: "ok",
+          resp: done(),
+          reply: null,
+          ref: null,
+        });
       };
       const args = ["push", { _target: input.name, dispatcher: input }];
       JS.exec(
@@ -815,7 +825,12 @@ describe("JS", () => {
           },
           uploads: {},
         });
-        return Promise.resolve({ resp: done(), reply: null, ref: null });
+        return Promise.resolve({
+          type: "ok",
+          resp: done(),
+          reply: null,
+          ref: null,
+        });
       };
       const args = ["push", { _target: input.name, dispatcher: input }];
       JS.exec(
@@ -862,7 +877,12 @@ describe("JS", () => {
           value: "_unused_username=&username=&_unused_other=&other=",
           meta: { _target: "username" },
         });
-        return Promise.resolve({ resp: done(), reply: null, ref: null });
+        return Promise.resolve({
+          type: "ok",
+          resp: done(),
+          reply: null,
+          ref: null,
+        });
       };
       const args = ["push", { _target: input.name, dispatcher: input }];
       JS.exec(
@@ -908,7 +928,12 @@ describe("JS", () => {
           value: "_unused_username=&username=",
           meta: { _target: "username" },
         });
-        return Promise.resolve({ resp: done(), reply: null, ref: null });
+        return Promise.resolve({
+          type: "ok",
+          resp: done(),
+          reply: null,
+          ref: null,
+        });
       };
       const args = ["push", { _target: input.name, dispatcher: input }];
       JS.exec(
@@ -954,7 +979,12 @@ describe("JS", () => {
           value: "_unused_username=&username=",
           meta: { _target: "username" },
         });
-        return Promise.resolve({ resp: done(), reply: null, ref: null });
+        return Promise.resolve({
+          type: "ok",
+          resp: done(),
+          reply: null,
+          ref: null,
+        });
       };
       const args = ["push", { _target: input.name, dispatcher: input }];
       JS.exec(
@@ -985,7 +1015,12 @@ describe("JS", () => {
           value: "username=&desc=",
           meta: {},
         });
-        return Promise.resolve({ resp: done(), reply: null, ref: null });
+        return Promise.resolve({
+          type: "ok",
+          resp: done(),
+          reply: null,
+          ref: null,
+        });
       };
       JS.exec(event, "submit", form.getAttribute("phx-submit"), view, form, [
         "push",
@@ -1021,7 +1056,12 @@ describe("JS", () => {
             attribute_value: "attribute",
           },
         });
-        return Promise.resolve({ resp: done(), reply: null, ref: null });
+        return Promise.resolve({
+          type: "ok",
+          resp: done(),
+          reply: null,
+          ref: null,
+        });
       };
       JS.exec(event, "submit", form.getAttribute("phx-submit"), view, form, [
         "push",
@@ -1066,7 +1106,12 @@ describe("JS", () => {
 
       view.pushWithReply = (refGenerator, event, payload) => {
         expect(payload.value).toEqual({ one: 1, two: 2, three: "3" });
-        return Promise.resolve({ resp: done(), reply: null, ref: null });
+        return Promise.resolve({
+          type: "ok",
+          resp: done(),
+          reply: null,
+          ref: null,
+        });
       };
       JS.exec(event, "click", click.getAttribute("phx-click"), view, click);
     });

--- a/assets/test/live_socket_test.ts
+++ b/assets/test/live_socket_test.ts
@@ -70,7 +70,7 @@ describe("LiveSocket", () => {
         "update",
         () => ["received diff", JSON.stringify("<div>")],
         {
-          code: "view.diff.update",
+          code: "view.diff-update",
           metadata: () => ({ diff: "<div>" }),
         },
       );
@@ -87,7 +87,7 @@ describe("LiveSocket", () => {
       {
         version: 1,
         level: "debug",
-        code: "view.diff.update",
+        code: "view.diff-update",
         message: "received diff",
         viewId: view.id,
         metadata: { diff: "<div>" },
@@ -142,7 +142,7 @@ describe("LiveSocket", () => {
 
     try {
       liveSocket.log(view, "update", () => ["message", { value: 1 }], {
-        code: "view.diff.update",
+        code: "view.diff-update",
         metadata,
       });
     } finally {
@@ -201,7 +201,7 @@ describe("LiveSocket", () => {
 
     try {
       liveSocket.log(view, "update", msgCallback, {
-        code: "view.diff.update",
+        code: "view.diff-update",
       });
     } finally {
       window.removeEventListener(PHX_LV_DIAGNOSTIC_EVENT, listener);
@@ -225,7 +225,7 @@ describe("LiveSocket", () => {
 
     try {
       liveSocket.log(view, "update", () => ["received diff", metadata], {
-        code: "view.diff.update",
+        code: "view.diff-update",
         metadata: () => metadata,
       });
 
@@ -237,7 +237,7 @@ describe("LiveSocket", () => {
         {
           version: 1,
           level: "debug",
-          code: "view.diff.update",
+          code: "view.diff-update",
           message: "received diff",
           viewId: "view-id",
           metadata,

--- a/assets/test/live_socket_test.ts
+++ b/assets/test/live_socket_test.ts
@@ -91,6 +91,7 @@ describe("LiveSocket", () => {
         message: "received diff",
         viewId: view.id,
         metadata: { diff: "<div>" },
+        attribution: "unknown",
       },
     ]);
   });
@@ -123,6 +124,7 @@ describe("LiveSocket", () => {
           message: "test error",
           viewId: view.id,
           metadata: { reason: "test" },
+          attribution: "unknown",
         },
       ]);
     } finally {
@@ -172,6 +174,7 @@ describe("LiveSocket", () => {
         code: "view.join-failed",
         level: "error",
         metadata: () => ({ response: { reason: 1 } }),
+        context: { attribution: "network" },
       });
     } finally {
       window.removeEventListener(PHX_LV_DIAGNOSTIC_EVENT, listener);
@@ -187,6 +190,7 @@ describe("LiveSocket", () => {
         message: "unable to join",
         viewId: "view-id",
         metadata: { response: { reason: 1 } },
+        attribution: "network",
       },
     ]);
   });
@@ -227,6 +231,7 @@ describe("LiveSocket", () => {
       liveSocket.log(view, "update", () => ["received diff", metadata], {
         code: "view.diff-update",
         metadata: () => metadata,
+        context: { attribution: "unknown" },
       });
 
       expect(consoleLog).toHaveBeenCalledWith(
@@ -241,6 +246,7 @@ describe("LiveSocket", () => {
           message: "received diff",
           viewId: "view-id",
           metadata,
+          attribution: "unknown",
         },
       ]);
     } finally {

--- a/assets/test/utils_test.ts
+++ b/assets/test/utils_test.ts
@@ -98,6 +98,7 @@ describe("utils", () => {
           code: "dom.invalid-stream-container",
           message: `The stream container with id "${containerId}" is missing the phx-update="stream" attribute. Ensure it is set for streams to work properly.`,
           metadata: { id: containerId, container },
+          attribution: "app",
         },
       ]);
     });

--- a/assets/test/view_test.ts
+++ b/assets/test/view_test.ts
@@ -22,6 +22,7 @@ import {
   liveViewDOM,
   simulateVisibility,
   appendTitle,
+  captureDiagnostics,
 } from "./test_helpers";
 
 const simulateUsedInput = (input) => {
@@ -1288,6 +1289,34 @@ describe("View", function () {
 
     expect(payloads).toEqual([{ from: "mount" }]);
     expect(redirectSpy).toHaveBeenCalledWith({ to: "/redirected" });
+  });
+
+  test("onJoinError reports join timeouts separately", () => {
+    liveSocket = new LiveSocket("/live", Socket);
+    const el = liveViewDOM();
+    const view = new View(el, liveSocket, null, null, null);
+    stubChannel(view);
+    const error = new Error("timeout");
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { diagnostics, stop } = captureDiagnostics();
+
+    try {
+      view.onJoinError(error);
+    } finally {
+      stop();
+      consoleError.mockRestore();
+    }
+
+    expect(diagnostics).toContainEqual({
+      version: 1,
+      level: "error",
+      code: "view.network.join-timeout",
+      message: "join timed out",
+      viewId: view.id,
+      metadata: { error },
+    });
   });
 
   test("sends _track_static and _mounts on params", () => {

--- a/assets/test/view_test.ts
+++ b/assets/test/view_test.ts
@@ -1296,7 +1296,7 @@ describe("View", function () {
     const el = liveViewDOM();
     const view = new View(el, liveSocket, null, null, null);
     stubChannel(view);
-    const error = new Error("timeout");
+    const error = { reason: "timeout" };
     const consoleError = jest
       .spyOn(console, "error")
       .mockImplementation(() => {});
@@ -1312,10 +1312,11 @@ describe("View", function () {
     expect(diagnostics).toContainEqual({
       version: 1,
       level: "error",
-      code: "view.network.join-timeout",
+      code: "view.join-timeout",
       message: "join timed out",
       viewId: view.id,
       metadata: { error },
+      attribution: "network",
     });
   });
 


### PR DESCRIPTION
* Use .network for network events
* Use .internal for invariants
* Break view.join-failed into view.join-failed and view.network.join-timeout

Also rename some events:

* Rename `view.diff.` into `view.diff-`
* Remove binding namespace (it is dom validation)
* upload.entry-error is upload.preflight-rejected
* view.mount-give-up is view.mount-attempts-exhausted