### PR TITLE
Add an option to link async tasks to the test lifecycle

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -2333,6 +2333,25 @@ defmodule Phoenix.LiveView do
   [error] MyXQL.Connection (#PID<0.308.0>) disconnected: ** (DBConnection.ConnectionError) client #PID<0.794.0>
   ```
 
+  If a LiveView may exit while async operations are still running, you can link those
+  operations to the test lifecycle instead. Configure this for all LiveView tests in
+  `config/test.exs`:
+
+  ```elixir
+  config :phoenix_live_view, :link_asyncs_to_test, true
+  ```
+
+  Or enable it for an individual LiveView when testing:
+
+  ```elixir
+  {:ok, view, _html} = live(conn, "/my_live_view", link_asyncs_to_test: true)
+  ```
+
+  This is useful when the async operation uses the shared database sandbox
+  connection. Otherwise, if you do live navigation to a different LiveView
+  and the async process exits while holding the connection, it will be rolled
+  back and become unavailable for the rest of your test.
+
   """
   defmacro assign_async(socket, key_or_keys, func, opts \\ []) do
     Async.assign_async(socket, key_or_keys, func, opts, __CALLER__)

--- a/lib/phoenix_live_view/async.ex
+++ b/lib/phoenix_live_view/async.ex
@@ -1,7 +1,15 @@
 defmodule Phoenix.LiveView.Async do
   @moduledoc false
 
+  @test_supervisor_key :"$phoenix_live_view_test_async_supervisor"
+
   alias Phoenix.LiveView.{AsyncResult, Socket, Channel}
+
+  def put_test_supervisor(pid) when is_pid(pid) do
+    Process.put(@test_supervisor_key, pid)
+  end
+
+  def put_test_supervisor(_pid), do: :ok
 
   defp warn_socket_access(op, warn) do
     warn.("""
@@ -260,15 +268,30 @@ defmodule Phoenix.LiveView.Async do
     if Phoenix.LiveView.connected?(socket) do
       lv_pid = self()
       cid = cid(socket)
+      test_supervisor = Process.get(@test_supervisor_key)
 
       {:ok, pid} =
-        if supervisor = Keyword.get(opts, :supervisor) do
-          Task.Supervisor.start_child(supervisor, fn ->
-            Process.link(lv_pid)
-            do_async(lv_pid, cid, key, func, kind)
-          end)
-        else
-          Task.start_link(fn -> do_async(lv_pid, cid, key, func, kind) end)
+        case {Keyword.get(opts, :supervisor), test_supervisor} do
+          {nil, nil} ->
+            Task.start_link(fn -> do_async(cid, key, func, kind, lv_pid) end)
+
+          {supervisor, nil} ->
+            Task.Supervisor.start_child(supervisor, fn ->
+              Process.link(lv_pid)
+              do_async(cid, key, func, kind, lv_pid)
+            end)
+
+          {nil, test_supervisor} ->
+            Task.start(fn ->
+              Process.link(test_supervisor)
+              do_async(cid, key, func, kind, test_supervisor)
+            end)
+
+          {supervisor, test_supervisor} ->
+            Task.Supervisor.start_child(supervisor, fn ->
+              Process.link(test_supervisor)
+              do_async(cid, key, func, kind, test_supervisor)
+            end)
         end
 
       ref =
@@ -282,7 +305,7 @@ defmodule Phoenix.LiveView.Async do
     end
   end
 
-  defp do_async(lv_pid, cid, key, func, async_kind) do
+  defp do_async(cid, key, func, async_kind, link_pid) do
     receive do
       {:context, ref} ->
         try do
@@ -294,7 +317,7 @@ defmodule Phoenix.LiveView.Async do
             Channel.report_async_result(ref, async_kind, ref, cid, key, caught_result)
             :erlang.raise(catch_kind, reason, __STACKTRACE__)
         after
-          Process.unlink(lv_pid)
+          Process.unlink(link_pid)
         end
     end
   end

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -1117,6 +1117,7 @@ defmodule Phoenix.LiveView.Channel do
               # TODO: replace with Process.put_label/2 when we require Elixir 1.17
               Process.put(:"$process_label", {Phoenix.LiveView, view, phx_socket.topic})
               Process.put(:"$phx_transport_pid", phx_socket.transport_pid)
+              Async.put_test_supervisor(phx_socket.private[:live_view_test_async_supervisor])
 
               verified_mount(
                 new_verified,

--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -23,7 +23,8 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
             uri: nil,
             connect_params: %{},
             connect_info: %{},
-            on_error: nil
+            on_error: nil,
+            link_asyncs_to_test: false
 
   alias Plug.Conn.Query
   alias Phoenix.LiveViewTest.{ClientProxy, DOM, Diff, Element, TreeDOM, Upload, View}
@@ -86,6 +87,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
       url: url,
       test_supervisor: test_supervisor,
       on_error: on_error,
+      link_asyncs_to_test: link_asyncs_to_test,
       start_location: start_location
     } = opts
 
@@ -130,7 +132,8 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
       topic: "lv:#{id}",
       # we store on_error in the view ClientProxy struct as well
       # to pass it when live_redirecting
-      on_error: on_error
+      on_error: on_error,
+      link_asyncs_to_test: link_asyncs_to_test
     }
 
     # We build an absolute path to any relative
@@ -168,6 +171,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
       url: url,
       page_title: :unset,
       on_error: on_error,
+      link_asyncs_to_test: link_asyncs_to_test,
       start_location: start_location
     }
 
@@ -251,12 +255,16 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
   end
 
   defp start_supervised_channel(state, view, ref, url, redirect_url) do
+    private =
+      %{connect_info: Map.put_new(view.connect_info, :session, state.session)}
+      |> maybe_put_async_test_supervisor(state)
+
     socket = %Phoenix.Socket{
       transport_pid: self(),
       serializer: __MODULE__,
       channel: view.module,
       endpoint: view.endpoint,
-      private: %{connect_info: Map.put_new(view.connect_info, :session, state.session)},
+      private: private,
       topic: view.topic,
       join_ref: state.join_ref
     }
@@ -284,6 +292,15 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
       {:ok, pid}
     end
   end
+
+  defp maybe_put_async_test_supervisor(private, %{
+         link_asyncs_to_test: true,
+         test_supervisor: test_supervisor
+       }) do
+    Map.put(private, :live_view_test_async_supervisor, test_supervisor)
+  end
+
+  defp maybe_put_async_test_supervisor(private, _state), do: private
 
   defp put_non_nil(%{} = map, _key, nil), do: map
   defp put_non_nil(%{} = map, key, val), do: Map.put(map, key, val)

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -250,6 +250,10 @@ defmodule Phoenix.LiveViewTest do
     * `:on_error` - Can be either `:raise` or `:warn` to control whether
        detected errors like duplicate IDs or live components fail the test or just log
        a warning. Defaults to `:raise`.
+    * `:link_asyncs_to_test` - When `true`, async operations are linked to the test
+      lifecycle instead of the LiveView. This allows async operations to finish when
+      their LiveView exits. Defaults to the `:phoenix_live_view`,
+      `:link_asyncs_to_test` application configuration, or `false` when not configured.
 
   ## Examples
 
@@ -289,6 +293,10 @@ defmodule Phoenix.LiveViewTest do
     * `:on_error` - Can be either `:raise` or `:warn` to control whether
        detected errors like duplicate IDs or live components fail the test or just log
        a warning. Defaults to `:raise`.
+    * `:link_asyncs_to_test` - When `true`, async operations are linked to the test
+      lifecycle instead of the LiveView. This allows async operations to finish when
+      their LiveView exits. Defaults to the `:phoenix_live_view`,
+      `:link_asyncs_to_test` application configuration, or `false` when not configured.
 
   All other options are forwarded to the LiveView for rendering. Refer to
   `Phoenix.Component.live_render/3` for a list of supported render
@@ -404,6 +412,7 @@ defmodule Phoenix.LiveViewTest do
       session: maybe_get_session(conn),
       url: Plug.Conn.request_url(conn),
       on_error: opts[:on_error],
+      link_asyncs_to_test: link_asyncs_to_test(opts),
       start_location: start_location
     })
   end
@@ -439,6 +448,7 @@ defmodule Phoenix.LiveViewTest do
 
   defp start_proxy(path, %{} = opts) do
     ref = make_ref()
+    test_supervisor = fetch_test_supervisor!()
 
     opts =
       Map.merge(opts, %{
@@ -450,7 +460,7 @@ defmodule Phoenix.LiveViewTest do
         endpoint: opts.endpoint,
         session: opts.session,
         url: opts.url,
-        test_supervisor: fetch_test_supervisor!(),
+        test_supervisor: test_supervisor,
         on_error: opts.on_error
       })
 
@@ -474,6 +484,21 @@ defmodule Phoenix.LiveViewTest do
     case ExUnit.fetch_test_supervisor() do
       {:ok, sup} -> sup
       :error -> raise ArgumentError, "LiveView helpers can only be invoked from the test process"
+    end
+  end
+
+  defp link_asyncs_to_test(opts) do
+    configured =
+      case Keyword.fetch(opts, :link_asyncs_to_test) do
+        {:ok, value} -> value
+        :error -> Application.get_env(:phoenix_live_view, :link_asyncs_to_test, false)
+      end
+
+    if is_boolean(configured) do
+      configured
+    else
+      raise ArgumentError,
+            "expected :link_asyncs_to_test to be a boolean, got: #{inspect(configured)}"
     end
   end
 
@@ -1046,8 +1071,9 @@ defmodule Phoenix.LiveViewTest do
   end
 
   @doc """
-  Awaits all current `assign_async`, `stream_async` and `start_async` tasks
-  for a given LiveView or element.
+  Awaits `assign_async`, `stream_async` and `start_async` tasks for a given
+  LiveView or element until no tracked async tasks remain. This includes tasks
+  started by an async callback while waiting.
 
   It renders the LiveView or Element once complete and returns the result.
   The default `timeout` is [ExUnit](https://ex-unit.hexdocs.pm/ExUnit.html#configure/1)'s
@@ -1063,36 +1089,51 @@ defmodule Phoenix.LiveViewTest do
         view_or_element,
         timeout \\ Application.fetch_env!(:ex_unit, :assert_receive_timeout)
       ) do
-    pids =
-      case view_or_element do
-        %View{} = view -> call(view, {:async_pids, {proxy_topic(view), nil, nil}})
-        %Element{} = element -> call(element, {:async_pids, element})
-      end
-
-    timeout_ref = make_ref()
-    Process.send_after(self(), {timeout_ref, :timeout}, timeout)
-
-    pids
-    |> Enum.map(&Process.monitor(&1))
-    |> Enum.each(fn ref ->
-      receive do
-        {^timeout_ref, :timeout} ->
-          raise RuntimeError, "expected async processes to finish within #{timeout}ms"
-
-        {:DOWN, ^ref, :process, _pid, _reason} ->
-          :ok
-      end
-    end)
-
-    if !Process.cancel_timer(timeout_ref) do
-      receive do
-        {^timeout_ref, :timeout} -> :noop
-      after
-        0 -> :noop
-      end
-    end
-
+    deadline = System.monotonic_time(:millisecond) + timeout
+    drain_async(view_or_element, deadline, timeout, false)
     render(view_or_element)
+  end
+
+  defp drain_async(view_or_element, deadline, timeout, empty_once?) do
+    case async_pids(view_or_element) do
+      [] when empty_once? ->
+        :ok
+
+      [] ->
+        # try again in case a handle_async starts a new
+        # async tasks by sending a message to self
+        drain_async(view_or_element, deadline, timeout, true)
+
+      pids ->
+        pids
+        |> Enum.map(&Process.monitor/1)
+        |> await_async_refs(deadline, timeout)
+
+        drain_async(view_or_element, deadline, timeout, false)
+    end
+  end
+
+  defp async_pids(%View{} = view) do
+    call(view, {:async_pids, {proxy_topic(view), nil, nil}})
+  end
+
+  defp async_pids(%Element{} = element) do
+    call(element, {:async_pids, element})
+  end
+
+  defp await_async_refs([], _deadline, _timeout), do: :ok
+
+  defp await_async_refs([ref | refs], deadline, timeout) do
+    remaining = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {:DOWN, ^ref, :process, _pid, _reason} ->
+        await_async_refs(refs, deadline, timeout)
+    after
+      remaining ->
+        Enum.each([ref | refs], &Process.demonitor(&1, [:flush]))
+        raise RuntimeError, "expected async processes to finish within #{timeout}ms"
+    end
   end
 
   @doc """
@@ -1973,6 +2014,7 @@ defmodule Phoenix.LiveViewTest do
       session: session,
       url: url,
       on_error: root.on_error,
+      link_asyncs_to_test: root.link_asyncs_to_test,
       start_location: start_location
     })
   end

--- a/test/phoenix_live_view/integrations/assign_async_test.exs
+++ b/test/phoenix_live_view/integrations/assign_async_test.exs
@@ -249,5 +249,24 @@ defmodule Phoenix.LiveView.AssignAsyncTest do
       assert render_async(lv) =~ "{:exit, :boom}"
       assert render(lv)
     end
+
+    test "link_asyncs_to_test works with an explicit task supervisor", %{conn: conn} do
+      Process.register(self(), :assign_async_test_process)
+
+      {:ok, lv, _html} =
+        live(conn, "/assign_async?test=sup_lv_exit", link_asyncs_to_test: true)
+
+      lv_ref = Process.monitor(lv.pid)
+      async_ref = wait_for_async_ready_and_monitor(:lv_exit)
+      async_pid = Process.whereis(:lv_exit)
+      send(lv.pid, :boom)
+
+      assert_receive {:DOWN, ^lv_ref, :process, _pid, :boom}, 1_000
+      assert Process.alive?(async_pid)
+      refute_receive {:DOWN, ^async_ref, :process, _name, _reason}, 50
+
+      Process.exit(async_pid, :kill)
+      assert_receive {:DOWN, ^async_ref, :process, _name, :killed}
+    end
   end
 end

--- a/test/phoenix_live_view/integrations/link_asyncs_to_test_test.exs
+++ b/test/phoenix_live_view/integrations/link_asyncs_to_test_test.exs
@@ -1,0 +1,61 @@
+defmodule Phoenix.LiveView.LinkAsyncsToTestTest do
+  use ExUnit.Case, async: false
+
+  import Phoenix.ConnTest
+  import Phoenix.LiveViewTest
+  import Phoenix.LiveViewTest.Support.AsyncSync
+
+  alias Phoenix.LiveViewTest.Support.Endpoint
+
+  @endpoint Endpoint
+
+  setup do
+    Process.flag(:trap_exit, true)
+    previous = Application.fetch_env(:phoenix_live_view, :link_asyncs_to_test)
+
+    on_exit(fn ->
+      case previous do
+        {:ok, value} ->
+          Application.put_env(:phoenix_live_view, :link_asyncs_to_test, value)
+
+        :error ->
+          Application.delete_env(:phoenix_live_view, :link_asyncs_to_test)
+      end
+    end)
+
+    {:ok, conn: Plug.Test.init_test_session(Phoenix.ConnTest.build_conn(), %{})}
+  end
+
+  test "uses the configured link_asyncs_to_test default", %{conn: conn} do
+    Application.put_env(:phoenix_live_view, :link_asyncs_to_test, true)
+    Process.register(self(), :start_async_test_process)
+
+    {:ok, lv, _html} = live(conn, "/start_async?test=lv_exit")
+    async_ref = wait_for_async_ready_and_monitor(:start_async_exit)
+    async_pid = Process.whereis(:start_async_exit)
+
+    assert {:error, {:live_redirect, %{to: "/start_async?test=ok"}}} =
+             render_click(lv, "navigate_while_async")
+
+    assert Process.alive?(async_pid)
+    refute_receive {:DOWN, ^async_ref, :process, _name, _reason}, 50
+
+    Process.exit(async_pid, :kill)
+    assert_receive {:DOWN, ^async_ref, :process, _name, :killed}
+  end
+
+  test "a live option overrides the configured default", %{conn: conn} do
+    Application.put_env(:phoenix_live_view, :link_asyncs_to_test, true)
+    Process.register(self(), :start_async_test_process)
+
+    {:ok, lv, _html} =
+      live(conn, "/start_async?test=lv_exit", link_asyncs_to_test: false)
+
+    lv_ref = Process.monitor(lv.pid)
+    async_ref = wait_for_async_ready_and_monitor(:start_async_exit)
+    send(lv.pid, :boom)
+
+    assert_receive {:DOWN, ^lv_ref, :process, _pid, :boom}, 1_000
+    assert_receive {:DOWN, ^async_ref, :process, _pid, :boom}, 1_000
+  end
+end

--- a/test/phoenix_live_view/integrations/start_async_test.exs
+++ b/test/phoenix_live_view/integrations/start_async_test.exs
@@ -20,6 +20,23 @@ defmodule Phoenix.LiveView.StartAsyncTest do
       assert render_async(lv) =~ "result: :good"
     end
 
+    test "render_async drains tasks started by async callbacks", %{conn: conn} do
+      test_pid = self()
+
+      coordinator =
+        spawn(fn ->
+          # Ensures the tasks only finish when render_async
+          # starts monitoring them
+          release_when_monitored(:first, test_pid)
+          release_when_monitored(:second, test_pid)
+        end)
+
+      Process.register(coordinator, :start_async_chain_test)
+      {:ok, lv, _html} = live(conn, "/start_async?test=chain")
+
+      assert render_async(lv, 1_000) =~ "result: :second"
+    end
+
     test "raise during execution", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/start_async?test=raise")
 
@@ -46,6 +63,25 @@ defmodule Phoenix.LiveView.StartAsyncTest do
       assert_receive {:DOWN, ^async_ref, :process, _pid, :boom}, 1000
     end
 
+    test "link_asyncs_to_test keeps asyncs alive across navigation", %{conn: conn} do
+      Process.register(self(), :start_async_test_process)
+
+      {:ok, lv, _html} =
+        live(conn, "/start_async?test=lv_exit", link_asyncs_to_test: true)
+
+      async_ref = wait_for_async_ready_and_monitor(:start_async_exit)
+      async_pid = Process.whereis(:start_async_exit)
+
+      assert {:error, {:live_redirect, %{to: "/start_async?test=ok"}}} =
+               render_click(lv, "navigate_while_async")
+
+      assert Process.alive?(async_pid)
+      refute_receive {:DOWN, ^async_ref, :process, _name, _reason}, 50
+
+      Process.exit(async_pid, :kill)
+      assert_receive {:DOWN, ^async_ref, :process, _name, :killed}
+    end
+
     test "cancel_async", %{conn: conn} do
       Process.register(self(), :start_async_test_process)
       {:ok, lv, _html} = live(conn, "/start_async?test=cancel")
@@ -64,6 +100,20 @@ defmodule Phoenix.LiveView.StartAsyncTest do
 
       assert render(lv) =~ "result: :loading"
       assert render_async(lv, 200) =~ "result: :renewed"
+    end
+
+    test "cancel_async remains isolated from the test lifecycle", %{conn: conn} do
+      Process.register(self(), :start_async_test_process)
+
+      {:ok, lv, _html} =
+        live(conn, "/start_async?test=cancel", link_asyncs_to_test: true)
+
+      async_ref = wait_for_async_ready_and_monitor(:start_async_cancel)
+      send(lv.pid, :cancel)
+
+      assert_receive {:DOWN, ^async_ref, :process, _pid, {:shutdown, :cancel}}, 1_000
+      assert Process.alive?(lv.pid)
+      assert render(lv) =~ "result: {:exit, {:shutdown, :cancel}}"
     end
 
     test "trapping exits", %{conn: conn} do
@@ -148,6 +198,25 @@ defmodule Phoenix.LiveView.StartAsyncTest do
       assert_receive {:DOWN, ^async_ref, :process, _pid, :boom}, 1000
     end
 
+    test "link_asyncs_to_test applies to LiveComponent asyncs", %{conn: conn} do
+      Process.register(self(), :start_async_test_process)
+
+      {:ok, lv, _html} =
+        live(conn, "/start_async?test=lc_lv_exit", link_asyncs_to_test: true)
+
+      lv_ref = Process.monitor(lv.pid)
+      async_ref = wait_for_async_ready_and_monitor(:start_async_exit)
+      async_pid = Process.whereis(:start_async_exit)
+      send(lv.pid, :boom)
+
+      assert_receive {:DOWN, ^lv_ref, :process, _pid, :boom}, 1_000
+      assert Process.alive?(async_pid)
+      refute_receive {:DOWN, ^async_ref, :process, _name, _reason}, 50
+
+      Process.exit(async_pid, :kill)
+      assert_receive {:DOWN, ^async_ref, :process, _name, :killed}
+    end
+
     test "cancel_async", %{conn: conn} do
       Process.register(self(), :start_async_test_process)
       {:ok, lv, _html} = live(conn, "/start_async?test=lc_cancel")
@@ -201,6 +270,29 @@ defmodule Phoenix.LiveView.StartAsyncTest do
 
       flash = assert_redirect(lv, "/start_async?test=ok")
       assert %{"info" => "hello"} = flash
+    end
+  end
+
+  defp release_when_monitored(label, test_pid) do
+    receive do
+      {:async_started, ^label, async_pid} ->
+        wait_until_monitored(async_pid, test_pid)
+        send(async_pid, :finish)
+    end
+  end
+
+  defp wait_until_monitored(async_pid, test_pid) do
+    case Process.info(async_pid, :monitored_by) do
+      {:monitored_by, monitored_by} ->
+        if test_pid in monitored_by do
+          :ok
+        else
+          Process.sleep(10)
+          wait_until_monitored(async_pid, test_pid)
+        end
+
+      nil ->
+        :ok
     end
   end
 end

--- a/test/support/live_views/assign_async.ex
+++ b/test/support/live_views/assign_async.ex
@@ -76,6 +76,16 @@ defmodule Phoenix.LiveViewTest.Support.AssignAsyncLive do
      end)}
   end
 
+  def mount(%{"test" => "sup_lv_exit"}, _session, socket) do
+    {:ok,
+     assign_async(
+       socket,
+       :data,
+       fn -> register_and_sleep(:assign_async_test_process, :lv_exit) end,
+       supervisor: TestAsyncSupervisor
+     )}
+  end
+
   def mount(%{"test" => "cancel"}, _session, socket) do
     {:ok,
      assign_async(socket, :data, fn ->

--- a/test/support/live_views/start_async.ex
+++ b/test/support/live_views/start_async.ex
@@ -86,6 +86,19 @@ defmodule Phoenix.LiveViewTest.Support.StartAsyncLive do
      |> start_async({:result_task, :foo}, fn -> :complex_key end)}
   end
 
+  def mount(%{"test" => "chain"}, _session, socket) do
+    {:ok,
+     socket
+     |> assign(result: :loading)
+     |> start_async(:chain_first, fn ->
+       send(:start_async_chain_test, {:async_started, :first, self()})
+
+       receive do
+         :finish -> :first
+       end
+     end)}
+  end
+
   def mount(%{"test" => "navigate"}, _session, socket) do
     {:ok,
      socket
@@ -148,6 +161,23 @@ defmodule Phoenix.LiveViewTest.Support.StartAsyncLive do
     {:noreply, assign(socket, result: result)}
   end
 
+  def handle_async(:chain_first, {:ok, result}, socket) do
+    {:noreply,
+     socket
+     |> assign(result: result)
+     |> start_async(:chain_second, fn ->
+       send(:start_async_chain_test, {:async_started, :second, self()})
+
+       receive do
+         :finish -> :second
+       end
+     end)}
+  end
+
+  def handle_async(:chain_second, {:ok, result}, socket) do
+    {:noreply, assign(socket, result: result)}
+  end
+
   def handle_async(:navigate, {:ok, _result}, socket) do
     {:noreply, push_navigate(socket, to: "/start_async?test=ok")}
   end
@@ -162,6 +192,10 @@ defmodule Phoenix.LiveViewTest.Support.StartAsyncLive do
 
   def handle_async(:flash, {:ok, flash}, socket) do
     {:noreply, put_flash(socket, :info, flash)}
+  end
+
+  def handle_event("navigate_while_async", _params, socket) do
+    {:noreply, push_navigate(socket, to: "/start_async?test=ok")}
   end
 
   def handle_info(:boom, _socket), do: exit(:boom)


### PR DESCRIPTION
Add an option to link async tasks to the test lifecycle instead of to the LiveView. This solves a problem where a live navigation that kills an async task which does a database operaration using Ecto's SQL sandbox leaves the rest of the test without a working sandbox.

Closes #4343.
Relates to #3545.
Relates to #3990.
Relates to #3991.

It also changes render_async to wait for async tasks started during render_async, so tests don't need to call it repeatedly.