### PR TITLE
Reconcile stale node_modules symlink for colocated assets

### DIFF
--- a/lib/phoenix_live_view/colocated_assets.ex
+++ b/lib/phoenix_live_view/colocated_assets.ex
@@ -155,9 +155,15 @@ defmodule Phoenix.LiveView.ColocatedAssets do
 
   defp do_symlink(node_modules_path, is_fallback) do
     relative_node_modules_path = relative_to_target(node_modules_path)
+    link_path = Path.join(target_dir(), "node_modules")
 
-    with {:error, reason} when reason != :eexist <-
-           File.ln_s(relative_node_modules_path, Path.join(target_dir(), "node_modules")),
+    result =
+      case File.ln_s(relative_node_modules_path, link_path) do
+        {:error, :eexist} -> maybe_replace_stale_symlink(relative_node_modules_path, link_path)
+        other -> other
+      end
+
+    with {:error, reason} when reason != :eexist <- result,
          false <- Keyword.get(global_settings(), :disable_symlink_warning, false) do
       disable_hint = """
       If you don't use colocated hooks / js / css or you don't need to import files from "assets/node_modules"
@@ -175,6 +181,24 @@ defmodule Phoenix.LiveView.ColocatedAssets do
       On Windows, you can address this issue by starting your Windows terminal at least once
       with "Run as Administrator" and then running your Phoenix application.#{is_fallback && "\n\n" <> disable_hint}
       """)
+    end
+  end
+
+  # An existing link is only replaced when it is a symlink pointing somewhere
+  # else, for example after the node_modules location was reconfigured or a
+  # dependency moved. Anything else (like a real directory) is left untouched.
+  defp maybe_replace_stale_symlink(relative_node_modules_path, link_path) do
+    case File.read_link(link_path) do
+      {:ok, ^relative_node_modules_path} ->
+        :ok
+
+      {:ok, _stale_target} ->
+        with :ok <- File.rm(link_path) do
+          File.ln_s(relative_node_modules_path, link_path)
+        end
+
+      {:error, _} ->
+        {:error, :eexist}
     end
   end
 

--- a/test/phoenix_live_view/colocated_js_test.exs
+++ b/test/phoenix_live_view/colocated_js_test.exs
@@ -244,4 +244,36 @@ defmodule Phoenix.LiveView.ColocatedJSTest do
 
     assert "foo" in File.ls!(symlink)
   end
+
+  test "reconciles stale node_modules symlink pointing to an outdated location" do
+    node_path = Path.expand("../../assets/node_modules", __DIR__)
+
+    if not File.exists?(node_path) do
+      on_exit(fn -> File.rm_rf!(node_path) end)
+    end
+
+    File.mkdir_p!(Path.join(node_path, "foo"))
+
+    symlink =
+      Path.join(
+        Mix.Project.build_path(),
+        "phoenix-colocated/phoenix_live_view/node_modules"
+      )
+
+    # simulate a symlink left behind by a previous compilation, before the
+    # node_modules location changed (e.g. reconfigured :node_modules_path or
+    # a dependency switching between a path dep and a hex dep)
+    File.mkdir_p!(Path.dirname(symlink))
+    File.rm_rf!(symlink)
+    stale_target = "/nonexistent/stale/node_modules"
+    File.ln_s!(stale_target, symlink)
+    on_exit(fn -> File.rm_rf!(symlink) end)
+
+    Phoenix.LiveView.ColocatedAssets.compile()
+
+    # the compiler should replace the stale link with one pointing to the
+    # currently configured node_modules location
+    refute File.read_link!(symlink) == stale_target
+    assert "foo" in File.ls!(symlink)
+  end
 end


### PR DESCRIPTION
### Summary

Fixes #4305

`ColocatedAssets.do_symlink/2` treats `{:error, :eexist}` from `File.ln_s/2` as success without verifying where the existing link points:

```elixir
with {:error, reason} when reason != :eexist <-
       File.ln_s(relative_node_modules_path, Path.join(target_dir(), "node_modules")),
```

As a result, once a `node_modules` symlink exists in `_build/.../phoenix-colocated/<app>/`, it is never updated — even when it points to a location that is no longer the configured one. There is no error or warning; imports from colocated assets just silently fail to resolve.

### Why it was hard to reproduce

Creating the link fresh always works, and a link whose target does not exist *yet* still resolves once `npm install` runs (as shown in the issue thread). The defect only manifests when the node_modules **location changes after** a link was created, e.g.:

* `:node_modules_path` is reconfigured, or
* a dependency switches between a path dep and a hex dep (which the reporter mentioned doing), moving where its assets live.

From that point on the stale link blocks every subsequent compile, silently.

### The fix

On `:eexist`, read the existing link:

* points to the configured location → no-op,
* a symlink pointing elsewhere → replace it,
* not a symlink (e.g. a real directory) → left untouched, same behavior as before.

### Testing

Added a regression test that pre-creates a symlink pointing to an outdated location and asserts `compile/0` reconciles it. The test fails on `main` (the link keeps pointing to the stale location) and passes with this change. Full suite: `mix test` → 6 doctests, 1476 tests, 0 failures.
