### PR TITLE
Ensure async tasks can exit gracefully in LiveViewTest

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -19,6 +19,7 @@ defmodule Phoenix.LiveView.Channel do
   alias Phoenix.Socket.{Broadcast, Message}
 
   @prefix :phoenix
+  @async_shutdown_timeout 5_000
   @not_mounted_at_router :not_mounted_at_router
   @max_host_size 253
 
@@ -48,6 +49,10 @@ defmodule Phoenix.LiveView.Channel do
 
   def async_pids(lv_pid) do
     GenServer.call(lv_pid, {@prefix, :async_pids})
+  end
+
+  def graceful_exit(lv_pid, reason) do
+    GenServer.stop(lv_pid, reason, :infinity)
   end
 
   def ping(pid) do
@@ -476,8 +481,12 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   @impl true
-  def terminate(reason, %{socket: socket}) do
+  def terminate(reason, %{socket: socket} = state) do
     %{view: view} = socket
+
+    if state.live_view_test_await_asyncs and graceful_shutdown?(reason) do
+      await_asyncs(state)
+    end
 
     if exported?(view, :terminate, 2) do
       view.terminate(reason, socket)
@@ -488,6 +497,30 @@ defmodule Phoenix.LiveView.Channel do
 
   def terminate(_reason, _state) do
     :ok
+  end
+
+  defp graceful_shutdown?(:shutdown), do: true
+  defp graceful_shutdown?({:shutdown, _reason}), do: true
+  defp graceful_shutdown?(_reason), do: false
+
+  defp await_asyncs(state) do
+    deadline = System.monotonic_time(:millisecond) + @async_shutdown_timeout
+
+    state
+    |> all_asyncs()
+    |> Map.keys()
+    |> Enum.map(&Process.monitor/1)
+    |> Enum.each(fn ref ->
+      timeout = max(deadline - System.monotonic_time(:millisecond), 0)
+
+      receive do
+        {:DOWN, ^ref, :process, _pid, _reason} ->
+          :ok
+      after
+        timeout ->
+          :ok
+      end
+    end)
   end
 
   @impl true
@@ -1456,7 +1489,8 @@ defmodule Phoenix.LiveView.Channel do
       fingerprints: Diff.new_fingerprints(),
       redirect_count: 0,
       upload_names: %{},
-      upload_pids: %{}
+      upload_pids: %{},
+      live_view_test_await_asyncs: phx_socket.private[:live_view_test_await_asyncs]
     }
   end
 

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -484,7 +484,7 @@ defmodule Phoenix.LiveView.Channel do
   def terminate(reason, %{socket: socket} = state) do
     %{view: view} = socket
 
-    if state.live_view_test_await_asyncs and graceful_shutdown?(reason) do
+    if state.await_asyncs_on_graceful_shutdown and graceful_shutdown?(reason) do
       await_asyncs(state)
     end
 
@@ -1490,7 +1490,7 @@ defmodule Phoenix.LiveView.Channel do
       redirect_count: 0,
       upload_names: %{},
       upload_pids: %{},
-      live_view_test_await_asyncs: phx_socket.private[:live_view_test_await_asyncs]
+      await_asyncs_on_graceful_shutdown: phx_socket.private[:await_asyncs_on_graceful_shutdown]
     }
   end
 

--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -308,16 +308,16 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
         shutdown: @async_shutdown_timeout,
         start:
           {Task, :start_link,
-            [
-              fn ->
-                Process.flag(:trap_exit, true)
+           [
+             fn ->
+               Process.flag(:trap_exit, true)
 
-                receive do
-                  {:EXIT, _from, reason} ->
-                    shutdown_view(pid, reason)
-                end
-              end
-            ]}
+               receive do
+                 {:EXIT, _from, reason} ->
+                   shutdown_view(pid, reason)
+               end
+             end
+           ]}
       })
   end
 

--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -3,6 +3,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
   use GenServer
 
   @data_phx_upload_ref "data-phx-upload-ref"
+  @async_shutdown_timeout 5_000
   @events :e
   @title :t
   @reply :r
@@ -222,6 +223,11 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
       {:ok, pid} ->
         mon_ref = Process.monitor(pid)
 
+        # This helper is started after the channel so that the test supervisor
+        # shuts it down first. It lets the LiveView gracefully shut down async
+        # tasks without requiring the LV to trap exists itself.
+        start_async_shutdown_helper(pid, state)
+
         receive do
           {^ref, {:ok, %{rendered: rendered} = resp}} ->
             Process.demonitor(mon_ref, [:flush])
@@ -256,7 +262,10 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
       serializer: __MODULE__,
       channel: view.module,
       endpoint: view.endpoint,
-      private: %{connect_info: Map.put_new(view.connect_info, :session, state.session)},
+      private: %{
+        connect_info: Map.put_new(view.connect_info, :session, state.session),
+        live_view_test_await_asyncs: true
+      },
       topic: view.topic,
       join_ref: state.join_ref
     }
@@ -287,6 +296,27 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
 
   defp put_non_nil(%{} = map, _key, nil), do: map
   defp put_non_nil(%{} = map, key, val), do: Map.put(map, key, val)
+
+  defp start_async_shutdown_helper(pid, state) do
+    {:ok, _helper} =
+      Supervisor.start_child(state.test_supervisor, %{
+        id: {__MODULE__, :async_shutdown, pid},
+        restart: :temporary,
+        shutdown: @async_shutdown_timeout,
+        start:
+          {Task, :start_link,
+            [
+              fn ->
+                Process.flag(:trap_exit, true)
+
+                receive do
+                  {:EXIT, _from, reason} ->
+                    shutdown_view(pid, reason)
+                end
+              end
+            ]}
+      })
+  end
 
   def handle_info({:sync_children, topic, from}, state) do
     view = fetch_view_by_topic!(state, topic)
@@ -707,6 +737,24 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
   def handle_call({:get_lazy, id}, _from, state) do
     {state, root} = root(state, id)
     {:reply, {:ok, root}, state}
+  end
+
+  defp shutdown_view(pid, reason) do
+    ref = Process.monitor(pid)
+
+    try do
+      Phoenix.LiveView.Channel.graceful_exit(pid, reason)
+    catch
+      # The channel may already be stopping because its transport exited.
+      # Its DOWN still synchronizes us with terminate/2 and therefore with any
+      # async work that terminate/2 is awaiting.
+      :exit, _reason -> :ok
+    after
+      receive do
+        {:DOWN, ^ref, :process, ^pid, _reason} ->
+          :ok
+      end
+    end
   end
 
   defp ping!(pid, state, fun) do

--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -264,7 +264,7 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
       endpoint: view.endpoint,
       private: %{
         connect_info: Map.put_new(view.connect_info, :session, state.session),
-        live_view_test_await_asyncs: true
+        await_asyncs_on_graceful_shutdown: true
       },
       topic: view.topic,
       join_ref: state.join_ref
@@ -298,6 +298,9 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
   defp put_non_nil(%{} = map, key, val), do: Map.put(map, key, val)
 
   defp start_async_shutdown_helper(pid, state) do
+    # We need to use a separate process because we need to trap exits
+    # and we don't want to change the LiveView channel itself to trap exits,
+    # which changes user visible behavior.
     {:ok, _helper} =
       Supervisor.start_child(state.test_supervisor, %{
         id: {__MODULE__, :async_shutdown, pid},
@@ -740,20 +743,11 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
   end
 
   defp shutdown_view(pid, reason) do
-    ref = Process.monitor(pid)
-
     try do
       Phoenix.LiveView.Channel.graceful_exit(pid, reason)
     catch
       # The channel may already be stopping because its transport exited.
-      # Its DOWN still synchronizes us with terminate/2 and therefore with any
-      # async work that terminate/2 is awaiting.
       :exit, _reason -> :ok
-    after
-      receive do
-        {:DOWN, ^ref, :process, ^pid, _reason} ->
-          :ok
-      end
     end
   end
 

--- a/test/phoenix_live_view/integrations/start_async_test.exs
+++ b/test/phoenix_live_view/integrations/start_async_test.exs
@@ -96,6 +96,41 @@ defmodule Phoenix.LiveView.StartAsyncTest do
       assert_redirect(lv, "/start_async?test=ok")
     end
 
+    test "navigation awaits async tasks", %{conn: conn} do
+      Process.register(self(), :start_async_test_process)
+
+      assert {:error, {:live_redirect, %{kind: :push, to: "/start_async?test=ok"}}} =
+               live(conn, "/start_async?test=await_navigate")
+
+      assert_receive :async_finished
+    end
+
+    test "test supervisor shutdown awaits async tasks", %{conn: conn} do
+      Process.register(self(), :start_async_test_process)
+      test_pid = self()
+
+      {:ok, observer} =
+        Agent.start(
+          fn -> %{async_finished?: false, live_view_pid: nil} end,
+          name: :start_async_test_observer
+        )
+
+      on_exit(fn ->
+        try do
+          state = Agent.get(observer, & &1)
+          assert state.async_finished?
+          refute Process.alive?(test_pid)
+          assert is_pid(state.live_view_pid)
+          refute Process.alive?(state.live_view_pid)
+        after
+          Agent.stop(observer)
+        end
+      end)
+
+      assert {:ok, lv, _html} = live(conn, "/start_async?test=await_shutdown")
+      Agent.update(observer, &Map.put(&1, :live_view_pid, lv.pid))
+    end
+
     test "patch", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/start_async?test=patch")
 

--- a/test/phoenix_live_view/integrations/start_async_test.exs
+++ b/test/phoenix_live_view/integrations/start_async_test.exs
@@ -96,6 +96,29 @@ defmodule Phoenix.LiveView.StartAsyncTest do
       assert_redirect(lv, "/start_async?test=ok")
     end
 
+    test "navigation awaits async tasks", %{conn: conn} do
+      Process.register(self(), :start_async_test_process)
+
+      assert {:error, {:live_redirect, %{kind: :push, to: "/start_async?test=ok"}}} =
+               live(conn, "/start_async?test=await_navigate")
+
+      assert_receive :async_finished, 1_500
+    end
+
+    test "test supervisor shutdown awaits async tasks", %{conn: conn} do
+      {:ok, observer} = Agent.start(fn -> false end, name: :start_async_test_observer)
+
+      on_exit(fn ->
+        try do
+          assert Agent.get(observer, & &1)
+        after
+          Agent.stop(observer)
+        end
+      end)
+
+      assert {:ok, _lv, _html} = live(conn, "/start_async?test=await_shutdown")
+    end
+
     test "patch", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/start_async?test=patch")
 

--- a/test/phoenix_live_view/integrations/start_async_test.exs
+++ b/test/phoenix_live_view/integrations/start_async_test.exs
@@ -96,29 +96,6 @@ defmodule Phoenix.LiveView.StartAsyncTest do
       assert_redirect(lv, "/start_async?test=ok")
     end
 
-    test "navigation awaits async tasks", %{conn: conn} do
-      Process.register(self(), :start_async_test_process)
-
-      assert {:error, {:live_redirect, %{kind: :push, to: "/start_async?test=ok"}}} =
-               live(conn, "/start_async?test=await_navigate")
-
-      assert_receive :async_finished, 1_500
-    end
-
-    test "test supervisor shutdown awaits async tasks", %{conn: conn} do
-      {:ok, observer} = Agent.start(fn -> false end, name: :start_async_test_observer)
-
-      on_exit(fn ->
-        try do
-          assert Agent.get(observer, & &1)
-        after
-          Agent.stop(observer)
-        end
-      end)
-
-      assert {:ok, _lv, _html} = live(conn, "/start_async?test=await_shutdown")
-    end
-
     test "patch", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/start_async?test=patch")
 

--- a/test/support/live_views/start_async.ex
+++ b/test/support/live_views/start_async.ex
@@ -66,6 +66,34 @@ defmodule Phoenix.LiveViewTest.Support.StartAsyncLive do
      end)}
   end
 
+  def mount(%{"test" => "await_shutdown"}, _session, socket) do
+    {:ok,
+     socket
+     |> assign(result: :loading)
+     |> start_async(:result_task, fn ->
+       Process.sleep(1_000)
+       Agent.update(:start_async_test_observer, fn _completed? -> true end)
+       :finished
+     end)}
+  end
+
+  def mount(%{"test" => "await_navigate"}, _session, socket) do
+    socket = assign(socket, result: :loading)
+
+    if connected?(socket) do
+      {:ok,
+       socket
+       |> start_async(:result_task, fn ->
+         Process.sleep(1_000)
+         send(:start_async_test_process, :async_finished)
+         :finished
+       end)
+       |> push_navigate(to: "/start_async?test=ok")}
+    else
+      {:ok, socket}
+    end
+  end
+
   def mount(%{"test" => "trap_exit"}, _session, socket) do
     Process.flag(:trap_exit, true)
 

--- a/test/support/live_views/start_async.ex
+++ b/test/support/live_views/start_async.ex
@@ -67,12 +67,15 @@ defmodule Phoenix.LiveViewTest.Support.StartAsyncLive do
   end
 
   def mount(%{"test" => "await_shutdown"}, _session, socket) do
+    test_pid = Process.whereis(:start_async_test_process)
+
     {:ok,
      socket
      |> assign(result: :loading)
      |> start_async(:result_task, fn ->
-       Process.sleep(1_000)
-       Agent.update(:start_async_test_observer, fn _completed? -> true end)
+       ref = Process.monitor(test_pid)
+       receive do: ({:DOWN, ^ref, :process, ^test_pid, _reason} -> :ok)
+       Agent.update(:start_async_test_observer, &Map.put(&1, :async_finished?, true))
        :finished
      end)}
   end
@@ -81,10 +84,13 @@ defmodule Phoenix.LiveViewTest.Support.StartAsyncLive do
     socket = assign(socket, result: :loading)
 
     if connected?(socket) do
+      transport_pid = socket.transport_pid
+
       {:ok,
        socket
        |> start_async(:result_task, fn ->
-         Process.sleep(1_000)
+         ref = Process.monitor(transport_pid)
+         receive do: ({:DOWN, ^ref, :process, ^transport_pid, _reason} -> :ok)
          send(:start_async_test_process, :async_finished)
          :finished
        end)


### PR DESCRIPTION
Closes #4345.
Closes #4343.
Relates to #3545.
Relates to #3990.
Relates to #3991.