### PR TITLE
Skip unknown upload refs in form events so the LiveView channel survives

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -1518,8 +1518,9 @@ defmodule Phoenix.LiveView.Channel do
             {:error, _error_resp, %Socket{} = new_socket} -> new_socket
           end
 
-        # The ref is client supplied, so it may name an upload this socket
-        # never allowed. Skipping keeps the rest of the event alive.
+        # The client may include stale refs in case an input keeps
+        # being rendered after disallow_upload, or when an input
+        # event races with it.
         :error ->
           acc
       end

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -1511,11 +1511,17 @@ defmodule Phoenix.LiveView.Channel do
     cid = payload["cid"]
 
     Enum.reduce(uploads, socket, fn {ref, entries}, acc ->
-      upload_conf = Upload.get_upload_by_ref!(acc, ref)
+      case Upload.fetch_upload_by_ref(acc, ref) do
+        {:ok, upload_conf} ->
+          case Upload.put_entries(acc, upload_conf, entries, cid) do
+            {:ok, new_socket} -> new_socket
+            {:error, _error_resp, %Socket{} = new_socket} -> new_socket
+          end
 
-      case Upload.put_entries(acc, upload_conf, entries, cid) do
-        {:ok, new_socket} -> new_socket
-        {:error, _error_resp, %Socket{} = new_socket} -> new_socket
+        # The ref is client supplied, so it may name an upload this socket
+        # never allowed. Skipping keeps the rest of the event alive.
+        :error ->
+          acc
       end
     end)
   end

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -193,6 +193,24 @@ defmodule Phoenix.LiveView.Upload do
   end
 
   @doc """
+  Retrieves the `%UploadConfig{}` from the socket for the provided ref.
+
+  Returns `:error` when the socket has no upload allowed for the ref.
+  """
+  def fetch_upload_by_ref(%Socket{} = socket, config_ref) do
+    case socket.assigns[:uploads] do
+      nil ->
+        :error
+
+      uploads ->
+        case Map.fetch(Map.fetch!(uploads, @refs_to_names), config_ref) do
+          {:ok, name} -> {:ok, Map.fetch!(uploads, name)}
+          :error -> :error
+        end
+    end
+  end
+
+  @doc """
   Retrieves the `%UploadConfig{}` from the socket for the provided ref or raises.
   """
   def get_upload_by_ref!(%Socket{} = socket, config_ref) do

--- a/test/phoenix_live_view/upload/channel_test.exs
+++ b/test/phoenix_live_view/upload/channel_test.exs
@@ -176,6 +176,61 @@ defmodule Phoenix.LiveView.UploadChannelTest do
              Phoenix.ChannelTest.subscribe_and_join(socket, "lvu:123", %{"token" => "bad"})
   end
 
+  test "ignores upload entries for a ref that is no longer allowed" do
+    # :other keeps the ref lookup non-empty, as it was in the reported crash
+    {:ok, lv} =
+      mount_lv(fn socket ->
+        socket
+        |> Phoenix.LiveView.allow_upload(:avatar, accept: :any)
+        |> Phoenix.LiveView.allow_upload(:other, accept: :any)
+      end)
+
+    avatar = file_input(lv, "form", :avatar, build_entries(1))
+
+    # disallow_upload/2 drops the ref but keeps the config that renders it
+    :ok = GenServer.call(lv.pid, {:setup, &Phoenix.LiveView.disallow_upload(&1, :avatar)})
+
+    html = lv |> form("form") |> render_change(avatar)
+    assert html =~ "save"
+    refute html =~ "myfile1.jpeg"
+  end
+
+  test "ignores upload entries when no uploads are allowed" do
+    {:ok, lv} = mount_lv(& &1)
+
+    # without allow_upload/3 there is no input to select, so only a raw
+    # message can carry uploads here
+    send_form_event_with_uploads(lv, "phx-stale-ref")
+
+    assert render(lv) =~ "loading..."
+  end
+
+  defp send_form_event_with_uploads(lv, config_ref) do
+    %{proxy: {_ref, topic, _pid}} = lv
+
+    send(lv.pid, %Phoenix.Socket.Message{
+      topic: topic,
+      event: "event",
+      ref: "1",
+      payload: %{
+        "type" => "form",
+        "event" => "validate",
+        "value" => "",
+        "uploads" => %{
+          config_ref => [
+            %{
+              "name" => "foo.jpeg",
+              "size" => 1,
+              "type" => "image/jpeg",
+              "ref" => "0",
+              "last_modified" => 1_594_171_879_000
+            }
+          ]
+        }
+      }
+    })
+  end
+
   defp setup_lv(%{allow: opts}) do
     opts = opts_for_allow_upload(opts)
     {:ok, lv} = mount_lv(fn socket -> Phoenix.LiveView.allow_upload(socket, :avatar, opts) end)


### PR DESCRIPTION
## Problem

`maybe_update_uploads/2` resolves client-supplied refs with
`get_upload_by_ref!/2`. A ref naming no registered config raises
`KeyError` inside `handle_info`, which takes down the channel and every
in-flight upload in the session.

Production, 1.2.7, four events in a 26 second burst from one user on
iPad Safari:

```
KeyError: key "phx-GMUR0Vofn-xJ6azB" not found in:
    %{"phx-GMUR6e_wR1rbuF8i" => "e56210c1-c284-4177-a3da-8ea4a155ad3e"}

  :erlang.map_get/2
  Phoenix.LiveView.Upload.get_upload_by_ref!/2 (upload.ex:197)
  anonymous fn/3 in Phoenix.LiveView.Channel.maybe_update_uploads/2 (channel.ex:1479)
  :maps.fold_1/4
  Phoenix.LiveView.Channel.handle_info/2 (channel.ex:257)
```

## Reaching it

`disallow_upload/2` gets there without a reconnect. It drops the ref
from `@refs_to_names` and keeps the config; `live_file_input/1` never
looks at `allowed?`, which nothing under `lib/`, `assets/`, or `priv/`
reads. The page keeps rendering an enabled input whose ref the socket
will not resolve:

```elixir
avatar = file_input(lv, "form", :avatar, build_entries(1))

# the input keeps rendering the ref this drops from the socket
:ok = GenServer.call(lv.pid, {:setup, &disallow_upload(&1, :avatar)})

lv |> form("form") |> render_change(avatar)
#=> ** (KeyError) key "phx-GMYFmRZEPUtLhHeB" not found in:
#=>        %{"phx-GMYFmRZEXRNLhHfB" => :other}
```

That is the reported stack, on a socket that still has another upload
allowed. Whether `disallow_upload/2` should stop the input rendering is
a separate question. The channel should not die on an unresolvable
client ref regardless.

A reconnect produces the same payload. #2807 fixed form recovery itself,
and this trace comes from a release that has it, but the mount patch is
still deferred until recovery replies; for that round trip the channel
is joined while the live input holds the previous mount's ref. The
report does not tell me which route that session took.

## Fix

`maybe_update_uploads/2` already swallows `put_entries/4` errors on this
payload. An unresolvable ref now gets skipped the same way. Its entries
go with it, since there is no config to attach them or an error to.
Uploads already in flight keep their channels and progress.

The new lookup stays soft only on the client supplied value. A violated
server invariant still raises.

## Open questions

The absent-`:uploads` case raised `ArgumentError` before and now skips
like any other unknown ref. The whole `"uploads"` map is client authored
at this call site, and a reconnect can deliver a stale ref to a mount
with no configs at all. Every other `get_upload_by_ref!/2` call site
keeps the diagnostic. I can put the raise back.

`"progress"` and `"allow_upload"` bang on client refs too, so the crash
class is not gone. I left them because the ref is what those messages
are about, and skipping there would leave nothing to act on. Both are
easy to fold in.
