### PR TITLE
Keep unchanged children in children_cids on a partial render

### DIFF
--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -1031,10 +1031,22 @@ defmodule Phoenix.LiveView.Diff do
         {diff, prints, pending, components, nil} =
           traverse(rendered, prints, %{}, components, nil, changed?)
 
-        children_cids =
+        traversed_cids =
           for {_component, list} <- pending,
               entry <- list,
               do: elem(entry, 0)
+
+        children_cids =
+          case socket.private.children_cids do
+            [] ->
+              traversed_cids
+
+            previous ->
+              # A partial render skips unchanged dynamics, so their children miss pending
+              {cid_to_component, _, _} = components
+              still_alive = Enum.filter(previous, &is_map_key(cid_to_component, &1))
+              Enum.uniq(traversed_cids ++ still_alive)
+          end
 
         diff = if linked_cid, do: Map.put(diff, @static, linked_cid), else: diff
 

--- a/test/phoenix_live_view/diff_test.exs
+++ b/test/phoenix_live_view/diff_test.exs
@@ -427,6 +427,29 @@ defmodule Phoenix.LiveView.DiffTest do
     end
   end
 
+  defmodule NestedLeafComponent do
+    use Phoenix.LiveComponent
+
+    def render(assigns) do
+      ~H"""
+      <div>LEAF</div>
+      """
+    end
+  end
+
+  defmodule NestedRootComponent do
+    use Phoenix.LiveComponent
+
+    def render(assigns) do
+      ~H"""
+      <div>
+        TICK {@tick}
+        <.live_component module={NestedLeafComponent} id="leaf" />
+      </div>
+      """
+    end
+  end
+
   defmodule TempComponent do
     use Phoenix.LiveComponent
 
@@ -1891,6 +1914,34 @@ defmodule Phoenix.LiveView.DiffTest do
                  }
                }
              }
+    end
+
+    test "does not delete a live child when its parent is revived after a partial render" do
+      component = %Component{id: "root", assigns: %{tick: 0}, component: NestedRootComponent}
+
+      {_full_render, fingerprints, components} =
+        render(component_template(%{component: component}))
+
+      {cid_to_component, _, _} = components
+      assert {NestedRootComponent, "root", _, _, _} = cid_to_component[1]
+      assert {NestedLeafComponent, "leaf", _, _, _} = cid_to_component[2]
+
+      # a partial render only traverses the dynamics that changed, leaving the leaf out
+      component = %Component{id: "root", assigns: %{tick: 1}, component: NestedRootComponent}
+
+      {_full_render, fingerprints, components} =
+        render(component_template(%{component: component}), fingerprints, components)
+
+      # the client reports both components as removed from the DOM...
+      components = Diff.mark_for_deletion_component(1, components)
+      components = Diff.mark_for_deletion_component(2, components)
+
+      # ...but they are rendered again before the client confirms the destroy
+      {_full_render, _fingerprints, components} =
+        render(component_template(%{component: component}), fingerprints, components)
+
+      assert {[], components} = Diff.delete_component(1, components)
+      assert {[], _components} = Diff.delete_component(2, components)
     end
   end
 


### PR DESCRIPTION
Fixes #4350

## The problem

A `LiveComponent` that is still on the page can be garbage collected, leaving the client holding a reference to a component the server has dropped. The next render then crashes:

```
** (CaseClauseError) no case clause matching: nil
    (phoenix_live_view) lib/phoenix_live_view/diff.ex:118: Phoenix.LiveView.Diff.resolve_components_xrefs/2
```

## Root cause

Component destruction is a two-step handshake: `cids_will_destroy` marks components, `cids_destroyed` deletes the ones that are still marked. A component that renders in between is unmarked and survives.

Children that are not traversed during that render cannot unmark themselves, so `do_unmark_for_deletion/2` walks `private.children_cids` to unmark them too. But `children_cids` is rebuilt in `render_component/9` from `pending`, which only holds the children that were traversed in that render. A partial render does not evaluate the dynamics that did not change, so live children silently drop out of the list:

```
after first render:   children_cids of cid 1 = [2]
after partial render: children_cids of cid 1 = []
```

Once that has happened, a parent and child that go away and come back during a destroy round-trip end up in an inconsistent state — the parent is revived, the child is not:

```
delete? cid=1 marked=false   # parent revived
delete? cid=2 marked=true    # child left behind
deleted_child=[2]            # a component that is still on the page
```

which is consistent with the trace in #4350, where cid 6 survives while cid 7 is confirmed as destroyed and both are back in the DOM — cids are handed out parent first, so 6 and 7 being a parent and its child fits, though the report does not say so outright.

The same list is handed out by `Phoenix.LiveView.Debug.live_components/1` (`channel.ex:433`), so it reports an incomplete set of children after a partial render as well.

## The fix

Carry the previous children over instead of dropping them, minus the ones that have since been deleted.

The list does not grow without bound: a child that genuinely went away is deleted on the next `cids_destroyed`, and the `cid_to_component` filter drops it from `children_cids` in turn.

One trade-off worth flagging. A child that went away stays in the list until that deletion happens, so a parent revived in the meantime will unmark it and it is not collected at all. That window already exists for children the list tracks correctly, but this widens it a little, because a partial render used to drop them from the list altogether. I kept the merge unconditional rather than restricting it to partial renders — `render_component/9` cannot tell whether `traverse/6` evaluated every dynamic, since that also depends on the fingerprints matching, so branching on `changed?` would only narrow the window rather than close it, at the cost of a second code path. Happy to change that if you would rather trade the simplicity for it.

I first tried making a revived component render in full, which also fixes the crash, but it treats the symptom and leaves `children_cids` wrong for `Debug.live_components/1`. I also tried carrying the cid as the fingerprint of a `%Component{}` position so the print tree would track live children per position; that works, but it breaks the invariant several tests assert, that fingerprints do not change when a component is added or replaced. This version needs no test changes.

## Testing

Added a test in `test/phoenix_live_view/diff_test.exs` that drives the sequence directly through `Diff`: render, partial re-render, mark both components, render again, then confirm the destroy. It fails on main, where `delete_component/2` hands back the live child, and passes with this change.

I kept the test at the `Diff` level rather than writing an integration test, and it is worth saying why. The corruption is server-side bookkeeping and reproduces deterministically there. Driving the crash end to end, on the other hand, requires the LiveView process to receive `cids_will_destroy`, the reviving event and `cids_destroyed` in that exact order, which is a sub-millisecond window I could not make deterministic — and a test that depends on it does not belong in CI. That ordering is also why the issue read as a race for months: whether you hit it depends on the order messages happen to arrive in, while the state corruption underneath is not racy at all.

To be explicit about what this does and does not cover: the test reproduces the server deleting a component that is still on the page. It does not reproduce the `CaseClauseError` from the report, which happens one step later, when the client acts on that confirmation and drops a cid its render tree still points at.

The whole suite passes (1485 tests) and `mix format --check-formatted` is clean.
