### PR TITLE
Force a full render for components marked for deletion

### DIFF
--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -908,21 +908,29 @@ defmodule Phoenix.LiveView.Diff do
                         "for component #{inspect(component)} when rendering template"
               end
 
-              {socket, components, prints} =
+              {socket, components, prints, revived?} =
                 case cids do
                   %{^cid => {_component, _id, assigns, private, prints}} ->
-                    {private, components} = unmark_for_deletion(private, components)
-                    {configure_socket_for_component(socket, assigns, private), components, prints}
+                    # The client reports the whole destroyed subtree, so a component
+                    # that is used again must render in full. A full render re-traverses
+                    # every dynamic, which reaches (and therefore revives) each child in
+                    # turn.
+                    {revived?, private} = Map.pop(private, @marked_for_deletion, false)
+                    prints = if revived?, do: new_fingerprints(), else: prints
+
+                    {configure_socket_for_component(socket, assigns, private), components, prints,
+                     revived?}
 
                   %{} ->
                     myself_assigns = %{myself: %Phoenix.LiveComponent.CID{cid: cid}}
 
                     {mount_component(socket, component, myself_assigns),
-                     put_cid(components, component, id, cid), new_fingerprints()}
+                     put_cid(components, component, id, cid), new_fingerprints(), false}
                 end
 
               assigns_sockets = [{new_assigns, socket} | assigns_sockets]
-              metadata = [{cid, id, prints, new?} | metadata]
+              # or revived? forces a full render in render_component
+              metadata = [{cid, id, prints, new? or revived?} | metadata]
               seen_ids = Map.put(seen_ids, [component | id], true)
               {assigns_sockets, metadata, components, seen_ids}
           end)
@@ -1063,33 +1071,6 @@ defmodule Phoenix.LiveView.Diff do
     {cid_to_component, id_to_cid, uuids} = components
     cid_to_component = Map.put(cid_to_component, cid, dump)
     {pending, diffs, {cid_to_component, id_to_cid, uuids}}
-  end
-
-  defp unmark_for_deletion(private, {cid_to_component, id_to_cid, uuids}) do
-    {private, cid_to_component} = do_unmark_for_deletion(private, cid_to_component)
-    {private, {cid_to_component, id_to_cid, uuids}}
-  end
-
-  defp do_unmark_for_deletion(private, cids) do
-    {marked?, private} = Map.pop(private, @marked_for_deletion, false)
-
-    cids =
-      if marked? do
-        Enum.reduce(private.children_cids, cids, fn cid, cids ->
-          case cids do
-            %{^cid => {component, id, assigns, private, prints}} ->
-              {private, cids} = do_unmark_for_deletion(private, cids)
-              Map.put(cids, cid, {component, id, assigns, private, prints})
-
-            %{} ->
-              cids
-          end
-        end)
-      else
-        cids
-      end
-
-    {private, cids}
   end
 
   # 32 is one bucket from large maps

--- a/test/e2e/support/issues/issue_4350.ex
+++ b/test/e2e/support/issues/issue_4350.ex
@@ -1,0 +1,63 @@
+defmodule Phoenix.LiveViewTest.E2E.Issue4350Live do
+  # https://github.com/phoenixframework/phoenix_live_view/issues/4350
+  #
+  # A LiveComponent that is destroyed and then used again before the client's
+  # cids_destroyed arrives must revive its whole subtree, including children that
+  # change tracking would otherwise skip.
+
+  defmodule Leaf do
+    use Phoenix.LiveComponent
+
+    def mount(socket), do: {:ok, assign(socket, count: 0)}
+
+    def handle_event("bump", _params, socket) do
+      {:noreply, update(socket, :count, &(&1 + 1))}
+    end
+
+    def render(assigns) do
+      ~H"""
+      <div id="leaf">
+        count: <span id="leaf-count">{@count}</span>
+        <button id="bump" phx-click="bump" phx-target={@myself}>bump</button>
+      </div>
+      """
+    end
+  end
+
+  defmodule Branch do
+    use Phoenix.LiveComponent
+
+    # @tick changes, the live_component below does not, so change tracking skips
+    # the dynamic holding the leaf on every re-render after the first.
+    def render(assigns) do
+      ~H"""
+      <div id="branch">
+        tick: {@tick}
+        <.live_component module={Leaf} id="leaf" />
+      </div>
+      """
+    end
+  end
+
+  use Phoenix.LiveView
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, show: true, tick: 0)}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <button id="tick" phx-click="tick">tick</button>
+    <button id="hide" phx-click="hide">hide</button>
+    <button id="show" phx-click="show">show</button>
+
+    <div :if={@show} id="wrapper">
+      <.live_component module={Branch} id="branch" tick={@tick} />
+    </div>
+    """
+  end
+
+  def handle_event("tick", _params, socket), do: {:noreply, update(socket, :tick, &(&1 + 1))}
+  def handle_event("hide", _params, socket), do: {:noreply, assign(socket, show: false)}
+  def handle_event("show", _params, socket), do: {:noreply, assign(socket, show: true)}
+end

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -223,6 +223,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/4323", Issue4323Live
       live "/4325", Issue4325Live
       live "/4334", Issue4334Live
+      live "/4350", Issue4350Live
     end
   end
 

--- a/test/e2e/tests/issues/4350.spec.js
+++ b/test/e2e/tests/issues/4350.spec.js
@@ -1,0 +1,92 @@
+import { test, expect } from "../../test-fixtures";
+import { syncLV } from "../../utils";
+
+// https://github.com/phoenixframework/phoenix_live_view/issues/4350
+//
+// A component that is used again between cids_will_destroy and cids_destroyed must
+// revive its whole subtree. Children that change tracking skips are the interesting
+// case: the parent comes back, but nothing re-renders the child, so it stays marked
+// and is deleted while its DOM is still on the page.
+//
+// The window between the two messages is a single round trip, so we hold
+// cids_destroyed in flight and bring the component back while it is delayed.
+test("reviving a component also revives children skipped by change tracking", async ({
+  page,
+}) => {
+  // cids_destroyed is held until the test releases it, so the ordering is
+  // explicit rather than timing dependent
+  let onDestroyedSent, releaseDestroyed, onDestroyedHandled;
+  const destroyedSent = new Promise((resolve) => (onDestroyedSent = resolve));
+  const destroyedReleased = new Promise(
+    (resolve) => (releaseDestroyed = resolve),
+  );
+  const destroyedHandled = new Promise(
+    (resolve) => (onDestroyedHandled = resolve),
+  );
+
+  await page.routeWebSocket(/.*live.*/, (ws) => {
+    const server = ws.connectToServer();
+    // [join_ref, ref, topic, event, payload]
+    let destroyedRef = null;
+
+    ws.onMessage(async (message) => {
+      if (typeof message === "string" && message.includes("cids_destroyed")) {
+        destroyedRef = JSON.parse(message)[1];
+        onDestroyedSent();
+        await destroyedReleased;
+      }
+
+      server.send(message);
+    });
+
+    server.onMessage((message) => {
+      if (destroyedRef !== null && typeof message === "string") {
+        const [, ref] = JSON.parse(message);
+        if (ref === destroyedRef) {
+          onDestroyedHandled();
+        }
+      }
+
+      ws.send(message);
+    });
+  });
+
+  await page.goto("/issues/4350");
+  await syncLV(page);
+
+  await page.locator("#bump").click();
+  await expect(page.locator("#leaf-count")).toHaveText("1");
+
+  // re-render the branch so the dynamic holding the leaf is change-tracked away
+  await page.locator("#tick").click();
+  await syncLV(page);
+  await expect(page.locator("#branch")).toContainText("tick: 1");
+
+  const leafCid = await page
+    .locator("#leaf")
+    .getAttribute("data-phx-component");
+
+  // remove the subtree; the client reports both cids as destroyed
+  await page.locator("#hide").click();
+  await expect(page.locator("#wrapper")).toHaveCount(0);
+
+  // cids_destroyed is held in flight - bring the component back before it lands.
+  // The subtree being back means the server has already re-rendered it.
+  await destroyedSent;
+  await page.locator("#show").click();
+  await expect(page.locator("#wrapper")).toHaveCount(1);
+  await syncLV(page);
+
+  // only now let the destroy through, and wait for the server to answer it
+  releaseDestroyed();
+  await destroyedHandled;
+
+  // the leaf is the same component and is still wired to the server
+  await expect(page.locator("#leaf")).toHaveAttribute(
+    "data-phx-component",
+    leafCid,
+  );
+
+  await page.locator("#bump").click();
+  await expect(page.locator("#leaf-count")).toHaveText("2");
+});

--- a/test/phoenix_live_view/diff_test.exs
+++ b/test/phoenix_live_view/diff_test.exs
@@ -427,6 +427,61 @@ defmodule Phoenix.LiveView.DiffTest do
     end
   end
 
+  defmodule NestedLeafComponent do
+    use Phoenix.LiveComponent
+
+    def render(assigns) do
+      ~H"""
+      <div id={@id}>LEAF</div>
+      """
+    end
+  end
+
+  defmodule NestedRootComponent do
+    use Phoenix.LiveComponent
+
+    defmodule Branch do
+      use Phoenix.LiveComponent
+
+      def render(assigns) do
+        ~H"""
+        <div>
+          <.live_component module={NestedLeafComponent} id="leaf" />
+        </div>
+        """
+      end
+    end
+
+    def render(assigns) do
+      ~H"""
+      <div>
+        TICK {@tick}
+        <%= if @show_child do %>
+          <.live_component module={Branch} id="branch" />
+        <% end %>
+      </div>
+      """
+    end
+  end
+
+  defmodule KeyedRootComponent do
+    use Phoenix.LiveComponent
+
+    def render(assigns) do
+      ~H"""
+      <div>
+        TICK {@tick}
+        <.live_component
+          :for={id <- @child_ids}
+          :key={id}
+          module={NestedLeafComponent}
+          id={id}
+        />
+      </div>
+      """
+    end
+  end
+
   defmodule TempComponent do
     use Phoenix.LiveComponent
 
@@ -1047,6 +1102,106 @@ defmodule Phoenix.LiveView.DiffTest do
   end
 
   describe "live components" do
+    test "revives a subtree that change tracking skipped" do
+      root = %Component{
+        id: "root",
+        assigns: %{tick: 0, show_child: true},
+        component: NestedRootComponent
+      }
+
+      {_, fingerprints, components} = render(component_template(%{component: root}))
+
+      root = %{root | assigns: %{tick: 1, show_child: true}}
+
+      {_, fingerprints, components} =
+        render(component_template(%{component: root}), fingerprints, components)
+
+      # The branch dynamic was skipped, so the root render never reached it.
+
+      # The client removes the component subtree and reports both CIDs.
+      {_, fingerprints, components} =
+        render(component_template(%{component: ""}), fingerprints, components)
+
+      components = Diff.mark_for_deletion_component(1, components)
+      components = Diff.mark_for_deletion_component(2, components)
+      components = Diff.mark_for_deletion_component(3, components)
+
+      # The same component identity is rendered before cids_destroyed arrives.
+      {_, _fingerprints, components} =
+        render(component_template(%{component: root}), fingerprints, components)
+
+      assert {[], components} = Diff.delete_component(1, components)
+      assert {[], components} = Diff.delete_component(2, components)
+      assert {[], _components} = Diff.delete_component(3, components)
+    end
+
+    test "does not revive children that are no longer rendered" do
+      root = %Component{
+        id: "root",
+        assigns: %{tick: 0, show_child: true},
+        component: NestedRootComponent
+      }
+
+      {_, fingerprints, components} = render(component_template(%{component: root}))
+
+      root = %{root | assigns: %{tick: 1, show_child: false}}
+
+      {_, fingerprints, components} =
+        render(component_template(%{component: root}), fingerprints, components)
+
+      # The removed branch is awaiting cids_destroyed when the parent is also removed.
+      components = Diff.mark_for_deletion_component(2, components)
+      components = Diff.mark_for_deletion_component(3, components)
+
+      {_, fingerprints, components} =
+        render(component_template(%{component: ""}), fingerprints, components)
+
+      components = Diff.mark_for_deletion_component(1, components)
+
+      # Reviving the parent must not revive the leaf that is no longer in its subtree.
+      {_, _fingerprints, components} =
+        render(component_template(%{component: root}), fingerprints, components)
+
+      assert {[], components} = Diff.delete_component(1, components)
+      assert {[2], components} = Diff.delete_component(2, components)
+      assert {[3], _components} = Diff.delete_component(3, components)
+    end
+
+    test "revives keyed comprehension children" do
+      root = %Component{
+        id: "root",
+        assigns: %{tick: 0, child_ids: ["a", "b"]},
+        component: KeyedRootComponent
+      }
+
+      {_, fingerprints, components} = render(component_template(%{component: root}))
+
+      root = %{root | assigns: %{tick: 1, child_ids: ["b", "a"]}}
+
+      {_, fingerprints, components} =
+        render(component_template(%{component: root}), fingerprints, components)
+
+      root = %{root | assigns: %{tick: 2, child_ids: ["b"]}}
+
+      {_, fingerprints, components} =
+        render(component_template(%{component: root}), fingerprints, components)
+
+      components = Diff.mark_for_deletion_component(2, components)
+
+      {_, fingerprints, components} =
+        render(component_template(%{component: ""}), fingerprints, components)
+
+      components = Diff.mark_for_deletion_component(1, components)
+      components = Diff.mark_for_deletion_component(3, components)
+
+      {_, _fingerprints, components} =
+        render(component_template(%{component: root}), fingerprints, components)
+
+      assert {[], components} = Diff.delete_component(1, components)
+      assert {[2], components} = Diff.delete_component(2, components)
+      assert {[], _components} = Diff.delete_component(3, components)
+    end
+
     test "on mount" do
       component = %Component{id: "hello", assigns: %{from: :component}, component: MyComponent}
       rendered = component_template(%{component: component})


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix_live_view/pull/4356.
Closes https://github.com/phoenixframework/phoenix_live_view/issues/4350.

Issue https://github.com/phoenixframework/phoenix_live_view/pull/4356 diagnosed the problem correctly, but going with https://github.com/phoenixframework/phoenix_live_view/pull/4356 would
mean we just move the problem in the opposite direction:
A re-render could end up unmarking components that were actually removed.

This change goes a different route: a component that was marked for deletion forces a full render. Since the LV JS always sends the full list of all removed CIDs, a removed parent also marks its children as destroyed. Now, when the parent is re-rendered, it also renders all children, which means they are only not destroyed if they really are still rendered.