### PR TITLE
Ensure parent navigation succeeds with a blocked child

### DIFF
--- a/assets/js/phoenix_live_view/view.ts
+++ b/assets/js/phoenix_live_view/view.ts
@@ -1126,7 +1126,8 @@ export default class View {
 
   onChannel(event, cb) {
     this.liveSocket.onChannel(this.channel, event, (resp) => {
-      if (this.isJoinPending()) {
+      // We don't need to wait if we know that we'll redirect
+      if (this.isJoinPending() && !["redirect", "live_redirect"].includes(event)) {
         // in case this is a rejoin (joinCount > 1) we store our own join ops
         if (this.joinCount > 1) {
           this.pendingJoinOps.push(() => cb(resp));

--- a/assets/js/phoenix_live_view/view.ts
+++ b/assets/js/phoenix_live_view/view.ts
@@ -1127,7 +1127,10 @@ export default class View {
   onChannel(event, cb) {
     this.liveSocket.onChannel(this.channel, event, (resp) => {
       // We don't need to wait if we know that we'll redirect
-      if (this.isJoinPending() && !["redirect", "live_redirect"].includes(event)) {
+      if (
+        this.isJoinPending() &&
+        !["redirect", "live_redirect"].includes(event)
+      ) {
         // in case this is a rejoin (joinCount > 1) we store our own join ops
         if (this.joinCount > 1) {
           this.pendingJoinOps.push(() => cb(resp));

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -1306,6 +1306,10 @@ defmodule Phoenix.LiveView.Channel do
       {:error, :noproc} ->
         GenServer.reply(from, {:error, %{reason: "stale"}})
         {:stop, :shutdown, :no_state}
+
+      {:error, :parent_redirect} ->
+        GenServer.reply(from, {:error, %{reason: "parent_redirect"}})
+        {:stop, :shutdown, :no_state}
     end
   end
 
@@ -1398,8 +1402,8 @@ defmodule Phoenix.LiveView.Channel do
            live_session_name: live_session_name
          }}
 
-      {:error, :noproc} ->
-        {:error, :noproc}
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -1407,7 +1411,11 @@ defmodule Phoenix.LiveView.Channel do
     try do
       GenServer.call(parent, {@prefix, :child_mount, self(), assign_new})
     catch
-      :exit, {:noproc, _} -> {:error, :noproc}
+      :exit, {:noproc, _} ->
+        {:error, :noproc}
+
+      :exit, {{:shutdown, {kind, _opts}}, _} when kind in [:redirect, :live_redirect] ->
+        {:error, :parent_redirect}
     end
   end
 

--- a/test/e2e/support/issues/issue_4359.ex
+++ b/test/e2e/support/issues/issue_4359.ex
@@ -1,0 +1,33 @@
+defmodule Phoenix.LiveViewTest.E2E.Issue4359Live do
+  # https://github.com/phoenixframework/phoenix_live_view/issues/4359
+
+  defmodule ChildLive do
+    use Phoenix.LiveView
+
+    def mount(_params, _session, socket), do: {:ok, socket}
+
+    def render(assigns) do
+      ~H"child"
+    end
+  end
+
+  use Phoenix.LiveView
+
+  def mount(params, _session, socket) do
+    if connected?(socket) and params["done"] != "1", do: send(self(), :go)
+    {:ok, socket}
+  end
+
+  def handle_info(:go, socket) do
+    # Give the client time to start mounting the child. Its :child_mount call
+    # remains blocked until this parent finishes handling the message.
+    Process.sleep(2_000)
+    {:noreply, push_navigate(socket, to: "/issues/4359?done=1")}
+  end
+
+  def render(assigns) do
+    ~H"""
+    {live_render(@socket, ChildLive, id: "child")}
+    """
+  end
+end

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -224,6 +224,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/4325", Issue4325Live
       live "/4334", Issue4334Live
       live "/4350", Issue4350Live
+      live "/4359", Issue4359Live
     end
   end
 

--- a/test/e2e/tests/issues/4359.spec.js
+++ b/test/e2e/tests/issues/4359.spec.js
@@ -1,0 +1,14 @@
+import { test, expect } from "../../test-fixtures";
+import { syncLV } from "../../utils";
+
+// https://github.com/phoenixframework/phoenix_live_view/issues/4359
+test("parent navigation succeeds while a child LiveView is mounting", async ({
+  page,
+}) => {
+  await page.goto("/issues/4359");
+
+  await expect(page).toHaveURL("/issues/4359?done=1");
+  await syncLV(page);
+  await expect(page.locator("#child")).toContainText("child");
+  await expect(page.locator("#child")).toHaveClass(/phx-connected/);
+});


### PR DESCRIPTION
Closes #4359.
Closes #4360.