### PR TITLE
Run the upload progress callback when an entry ends without completing

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -182,30 +182,7 @@ defmodule Phoenix.LiveView.Channel do
         upload_conf = Upload.get_upload_by_ref!(new_socket, ref)
         entry = UploadConfig.get_entry_by_ref(upload_conf, entry_ref)
 
-        if event = entry && upload_conf.progress_event do
-          case event.(upload_conf.name, entry, new_socket) do
-            {:noreply, %Socket{} = new_socket} ->
-              new_socket =
-                if new_socket.redirected do
-                  flash = Utils.changed_flash(new_socket)
-                  send(new_socket.root_pid, {@prefix, :redirect, new_socket.redirected, flash})
-                  %{new_socket | redirected: nil}
-                else
-                  new_socket
-                end
-
-              {new_socket, {:ok, {msg.ref, %{}}, state}}
-
-            other ->
-              raise ArgumentError, """
-              expected #{inspect(upload_conf.name)} upload progress #{inspect(event)} to return {:noreply, Socket.t()} got:
-
-                  #{inspect(other)}
-              """
-          end
-        else
-          {new_socket, {:ok, {msg.ref, %{}}, state}}
-        end
+        {run_progress_event(upload_conf, entry, new_socket), {:ok, {msg.ref, %{}}, state}}
       end)
 
     {:noreply, new_state}
@@ -734,6 +711,32 @@ defmodule Phoenix.LiveView.Channel do
 
       :error ->
         {:noreply, push_noop(state, ref)}
+    end
+  end
+
+  # Invoked as an entry progresses. Returns the socket unchanged when there is no
+  # callback, or when the entry is already gone.
+  defp run_progress_event(%UploadConfig{} = upload_conf, entry, %Socket{} = socket) do
+    if event = entry && upload_conf.progress_event do
+      case event.(upload_conf.name, entry, socket) do
+        {:noreply, %Socket{} = new_socket} ->
+          if new_socket.redirected do
+            flash = Utils.changed_flash(new_socket)
+            send(new_socket.root_pid, {@prefix, :redirect, new_socket.redirected, flash})
+            %{new_socket | redirected: nil}
+          else
+            new_socket
+          end
+
+        other ->
+          raise ArgumentError, """
+          expected #{inspect(upload_conf.name)} upload progress #{inspect(event)} to return {:noreply, Socket.t()} got:
+
+              #{inspect(other)}
+          """
+      end
+    else
+      socket
     end
   end
 

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -10,6 +10,7 @@ defmodule Phoenix.LiveView.Channel do
     Diff,
     Upload,
     UploadConfig,
+    UploadEntry,
     Route,
     Session,
     Lifecycle,
@@ -714,8 +715,8 @@ defmodule Phoenix.LiveView.Channel do
     end
   end
 
-  # Invoked as an entry progresses. Returns the socket unchanged when there is no
-  # callback, or when the entry is already gone.
+  # Invoked as an entry progresses and when one ends without completing. Returns the
+  # socket unchanged when there is no callback, or when the entry is already gone.
   defp run_progress_event(%UploadConfig{} = upload_conf, entry, %Socket{} = socket) do
     if event = entry && upload_conf.progress_event do
       case event.(upload_conf.name, entry, socket) do
@@ -750,8 +751,38 @@ defmodule Phoenix.LiveView.Channel do
           _ -> state
         end
 
-      {Upload.unregister_completed_entry_upload(socket, conf, entry_ref), {:ok, nil, new_state}}
+      # An entry still in progress here ended without completing: a writer failure,
+      # a chunk timeout, an oversized chunk. Dropping it below first opens the settle
+      # gate. Entries the app cancelled itself are excluded, since re-entering its
+      # callback with a just-removed entry can crash it.
+      ended_entry =
+        case UploadConfig.get_entry_by_ref(conf, entry_ref) do
+          %UploadEntry{done?: false, cancelled?: false} = entry -> entry
+          _ -> nil
+        end
+
+      new_socket = Upload.unregister_completed_entry_upload(socket, conf, entry_ref)
+
+      {report_ended_entry(new_socket, conf, ended_entry), {:ok, nil, new_state}}
     end)
+  end
+
+  defp report_ended_entry(%Socket{} = socket, _conf, nil), do: socket
+
+  defp report_ended_entry(%Socket{} = socket, conf, %UploadEntry{ref: entry_ref} = entry) do
+    # the drop took the entry's errors with it; restore them so the callback can
+    # learn why it ended, this being the only point where that is possible
+    reasons = for {^entry_ref, reason} <- conf.errors, do: reason
+
+    socket =
+      Enum.reduce(reasons, socket, fn reason, acc ->
+        Upload.put_upload_error(acc, conf.name, entry_ref, reason)
+      end)
+
+    new_socket =
+      run_progress_event(Upload.get_upload_by_ref!(socket, conf.ref), entry, socket)
+
+    Upload.drop_upload_entry_errors(new_socket, conf.name, entry_ref)
   end
 
   defp put_upload_pid(state, pid, ref, entry_ref, cid) when is_pid(pid) do

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -178,6 +178,16 @@ defmodule Phoenix.LiveView.Upload do
   end
 
   @doc """
+  Removes any errors recorded for a given entry.
+  """
+  def drop_upload_entry_errors(%Socket{} = socket, conf_name, entry_ref) do
+    socket.assigns.uploads
+    |> Map.fetch!(conf_name)
+    |> UploadConfig.drop_entry_errors(entry_ref)
+    |> update_uploads(socket)
+  end
+
+  @doc """
   Populates the errors for a given entry.
   """
   def put_upload_error(%Socket{} = socket, conf_name, entry_ref, reason) do

--- a/lib/phoenix_live_view/upload_config.ex
+++ b/lib/phoenix_live_view/upload_config.ex
@@ -705,6 +705,11 @@ defmodule Phoenix.LiveView.UploadConfig do
   end
 
   @doc false
+  def drop_entry_errors(%UploadConfig{} = conf, entry_ref) do
+    %{conf | errors: Enum.reject(conf.errors, fn {ref, _reason} -> ref == entry_ref end)}
+  end
+
+  @doc false
   def drop_entry(%UploadConfig{} = conf, %UploadEntry{ref: ref}) do
     new_entries = for entry <- conf.entries, entry.ref != ref, do: entry
     new_errors = Enum.filter(conf.errors, fn {error_ref, _} -> error_ref != ref end)

--- a/test/phoenix_live_view/upload/channel_test.exs
+++ b/test/phoenix_live_view/upload/channel_test.exs
@@ -71,6 +71,16 @@ defmodule Phoenix.LiveView.UploadChannelTest do
     {CloseErrorWriter, :test_writer}
   end
 
+  def build_writer_failing_for(
+        _name,
+        %Phoenix.LiveView.UploadEntry{} = entry,
+        %Phoenix.LiveView.Socket{}
+      ) do
+    if entry.client_name == "bad.jpeg",
+      do: {CloseErrorWriter, :test_writer},
+      else: {TestWriter, :test_writer}
+  end
+
   def valid_token(lv_pid, ref) do
     LiveView.Static.sign_token(@endpoint, %{pid: lv_pid, ref: ref})
   end
@@ -162,6 +172,49 @@ defmodule Phoenix.LiveView.UploadChannelTest do
       end
 
     {:noreply, socket}
+  end
+
+  # consume_uploaded_entries/3 raises while any entry is in progress, so a callback
+  # using it can only consume once every entry has settled
+  def consume_when_settled(%LiveView.UploadEntry{}, socket) do
+    case Phoenix.LiveView.uploaded_entries(socket, :avatar) do
+      {[_ | _], []} ->
+        names =
+          Phoenix.LiveView.consume_uploaded_entries(socket, :avatar, fn _meta, entry ->
+            {:ok, entry.client_name}
+          end)
+
+        {:noreply,
+         Phoenix.Component.update(socket, :consumed, fn consumed -> names ++ consumed end)}
+
+      _ ->
+        {:noreply, socket}
+    end
+  end
+
+  # an entry no longer in the config is one this callback was invoked for as it
+  # ended, rather than as it progressed
+  def record_end_reason(%LiveView.UploadEntry{} = entry, socket) do
+    conf = socket.assigns.uploads.avatar
+
+    if Enum.any?(conf.entries, &(&1.ref == entry.ref)) do
+      {:noreply, socket}
+    else
+      reasons = Component.upload_errors(conf, entry)
+
+      {:noreply,
+       Phoenix.Component.update(socket, :consumed, fn consumed ->
+         [inspect(reasons) | consumed]
+       end)}
+    end
+  end
+
+  def cancel_while_in_progress(%LiveView.UploadEntry{} = entry, socket) do
+    if entry.done? do
+      {:noreply, socket}
+    else
+      {:noreply, Phoenix.LiveView.cancel_upload(socket, :avatar, entry.ref)}
+    end
   end
 
   setup_all do
@@ -1003,6 +1056,210 @@ defmodule Phoenix.LiveView.UploadChannelTest do
 
         # the failed entry is dropped and the LiveView is still alive
         assert get_uploaded_entries(lv, :avatar) == {[], []}
+      end
+
+      # separate file_input/4 calls: entries from one share an UploadClient, whose
+      # death would take the sibling's channel down for a reason no browser produces
+      @tag allow: [
+             max_entries: 2,
+             chunk_size: 5,
+             accept: :any,
+             progress: :consume_when_settled,
+             writer: &__MODULE__.build_writer_failing_for/3
+           ]
+      test "writer failure invokes the progress callback so completed entries are consumed",
+           %{lv: lv} do
+        Process.register(self(), :test_writer)
+
+        good =
+          file_input(lv, "form", :avatar, [
+            %{name: "good.jpeg", content: String.duplicate("0", 100)}
+          ])
+
+        bad =
+          file_input(lv, "form", :avatar, [
+            %{name: "bad.jpeg", content: String.duplicate("0", 100)}
+          ])
+
+        # hold the doomed entry mid-upload so the good one completes while the
+        # batch gate is still closed
+        render_upload(bad, "bad.jpeg", 40)
+        render_upload(good, "good.jpeg")
+        refute render(lv) =~ "consumed:good.jpeg"
+
+        assert %{"bad.jpeg" => bad_pid} = UploadClient.channel_pids(bad)
+        unlink(bad_pid, lv, bad)
+        Process.monitor(bad_pid)
+
+        # finishing the doomed entry fails close(:done), which drops it
+        render_upload(bad, "bad.jpeg", 60)
+        assert_receive {:DOWN, _ref, :process, ^bad_pid, {:shutdown, :closed}}, 1000
+
+        assert render(lv) =~ "consumed:good.jpeg"
+      end
+
+      @tag allow: [
+             max_entries: 2,
+             chunk_size: 5,
+             accept: :any,
+             progress: :consume_when_settled,
+             writer: &__MODULE__.build_writer/3
+           ]
+      test "writer write_chunk/2 error settles completed entries", %{lv: lv} do
+        Process.register(self(), :test_writer)
+
+        good =
+          file_input(lv, "form", :avatar, [
+            %{name: "good.jpeg", content: String.duplicate("0", 100)}
+          ])
+
+        # the second chunk is "error", which TestWriter fails to write
+        bad = file_input(lv, "form", :avatar, [%{name: "bad.jpeg", content: "00000error"}])
+
+        render_upload(bad, "bad.jpeg", 50)
+        render_upload(good, "good.jpeg")
+        refute render(lv) =~ "consumed:good.jpeg"
+
+        assert %{"bad.jpeg" => bad_pid} = UploadClient.channel_pids(bad)
+        unlink(bad_pid, lv, bad)
+        Process.monitor(bad_pid)
+
+        render_upload(bad, "bad.jpeg", 50)
+        assert_receive {:DOWN, _ref, :process, ^bad_pid, {:shutdown, :closed}}, 1000
+
+        assert render(lv) =~ "consumed:good.jpeg"
+      end
+
+      @tag allow: [
+             max_entries: 2,
+             chunk_size: 5,
+             accept: :any,
+             progress: :consume_when_settled,
+             writer: &__MODULE__.build_writer/3
+           ]
+      test "oversized chunk settles completed entries", %{lv: lv} do
+        Process.register(self(), :test_writer)
+
+        good =
+          file_input(lv, "form", :avatar, [
+            %{name: "good.jpeg", content: String.duplicate("0", 100)}
+          ])
+
+        bad =
+          file_input(lv, "form", :avatar, [
+            %{name: "bad.jpeg", content: String.duplicate("0", 100)}
+          ])
+
+        render_upload(bad, "bad.jpeg", 40)
+        render_upload(good, "good.jpeg")
+        refute render(lv) =~ "consumed:good.jpeg"
+
+        assert %{"bad.jpeg" => bad_pid} = UploadClient.channel_pids(bad)
+        unlink(bad_pid, lv, bad)
+        Process.monitor(bad_pid)
+
+        # the channel caps each entry at its declared client_size, not :max_file_size
+        assert UploadClient.simulate_attacker_chunk(
+                 bad,
+                 "bad.jpeg",
+                 String.duplicate("0", 1000)
+               ) == {:error, %{limit: 100, reason: :file_size_limit_exceeded}}
+
+        assert_receive {:DOWN, _ref, :process, ^bad_pid, {:shutdown, :closed}}, 1000
+
+        assert render(lv) =~ "consumed:good.jpeg"
+      end
+
+      # a cancellation is the app's own doing and is not reported back: re-entering
+      # this callback with the just-removed entry would crash on cancel_upload/3
+      @tag allow: [
+             max_entries: 1,
+             chunk_size: 5,
+             accept: :any,
+             progress: :cancel_while_in_progress,
+             writer: &__MODULE__.build_writer/3
+           ]
+      test "progress callback cancelling its own entry does not bring down the LiveView",
+           %{lv: lv} do
+        Process.register(self(), :test_writer)
+
+        avatar =
+          file_input(lv, "form", :avatar, [
+            %{name: "foo.jpeg", content: String.duplicate("0", 100)}
+          ])
+
+        try do
+          render_upload(avatar, "foo.jpeg", 40)
+        catch
+          :exit, _ -> :ok
+        end
+
+        assert Process.alive?(lv.pid)
+        assert get_uploaded_entries(lv, :avatar) == {[], []}
+      end
+
+      @tag allow: [
+             max_entries: 1,
+             chunk_size: 5,
+             accept: :any,
+             progress: :record_end_reason,
+             writer: &__MODULE__.build_close_error_writer/3
+           ]
+      test "progress callback reads why the entry ended, and the error does not linger",
+           %{lv: lv} do
+        Process.register(self(), :test_writer)
+
+        avatar =
+          file_input(lv, "form", :avatar, [
+            %{name: "bad.jpeg", content: String.duplicate("0", 100)}
+          ])
+
+        render_upload(avatar, "bad.jpeg", 40)
+        assert %{"bad.jpeg" => bad_pid} = UploadClient.channel_pids(avatar)
+        unlink(bad_pid, lv, avatar)
+        Process.monitor(bad_pid)
+
+        render_upload(avatar, "bad.jpeg", 60)
+        assert_receive {:DOWN, _ref, :process, ^bad_pid, {:shutdown, :closed}}, 1000
+
+        assert render(lv) =~ "writer_failure"
+
+        assert UploadLive.run(lv, fn socket ->
+                 {:reply, socket.assigns.uploads.avatar.errors, socket}
+               end) == []
+      end
+
+      # control for the tests above: same shape, nothing ends early, pinning their
+      # assertions to the entry ending rather than to upload ordering
+      @tag allow: [
+             max_entries: 2,
+             chunk_size: 5,
+             accept: :any,
+             progress: :consume_when_settled,
+             writer: &__MODULE__.build_writer/3
+           ]
+      test "entries are consumed once settled when no writer fails", %{lv: lv} do
+        Process.register(self(), :test_writer)
+
+        good =
+          file_input(lv, "form", :avatar, [
+            %{name: "good.jpeg", content: String.duplicate("0", 100)}
+          ])
+
+        other =
+          file_input(lv, "form", :avatar, [
+            %{name: "bad.jpeg", content: String.duplicate("0", 100)}
+          ])
+
+        render_upload(other, "bad.jpeg", 40)
+        render_upload(good, "good.jpeg")
+        refute render(lv) =~ "consumed:good.jpeg"
+
+        render_upload(other, "bad.jpeg", 60)
+
+        html = render(lv)
+        assert html =~ "consumed:good.jpeg"
+        assert html =~ "consumed:bad.jpeg"
       end
     end
   end


### PR DESCRIPTION
A `:progress` callback that consumes with `consume_uploaded_entries/3` has to wait until nothing is
in progress, because that function raises otherwise. If an entry ends without completing it is never
told the upload settled, so the files that did upload are left unconsumed.

`{:writer_failure, reason}` is documented at `phoenix_component.ex:1227`. #2750 added it together
with a test asserting that it renders. #4320 made the failed entry drop, and `drop_entry/2` takes an
entry's errors with it, so the value now only exists briefly and that test was replaced.

Apps using the per-entry recipe from the `allow_upload/3` docs are unaffected. It consumes on
`entry.done?`, so it cannot strand anything.

The callback runs after the entry is dropped, not where the writer error is recorded. Firing at the
error would leave the entry in progress, and would only cover writer failures, not timeouts or
oversized chunks.

## Costs

Application code now runs on a path that previously only did bookkeeping, so a callback that raises
will crash the LiveView. The entry it receives is no longer in the socket, so per-entry calls on that
entry raise; the second commit message has the detail.

Timeouts and oversized chunks record no error, so absence from `conf.entries` is the only signal
available in every case.

A progress message carrying `%{"error" => _}` and the channel's `:DOWN` come from different
processes, and nothing orders them.

## Open questions

1. Should the failed entry stay instead of being dropped, so the documented `upload_errors/2`
   template loop works without a callback? That needs a client change as well. A retained entry stays
   in `data-phx-preflighted-refs` and never reaches `data-phx-done-refs`, and
   `hasUploadsInProgress` compares those two, so form submits defer indefinitely. `upload_entry.js`
   and its `error()` also never call `_onDone`, which `live_uploader.js` waits for. I tried this and
   backed it out. The Elixir suite passed while the form was stuck, so server tests alone will not
   cover it.
2. Should `:chunk_timeout` and `:file_size_limit_exceeded` be recorded as entry errors? It would make
   the reason available in every case, but it adds values to a documented list.
3. Should `drop_entry/2` get a variant that keeps errors? The restore and remove in
   `report_ended_entry/3` is only there because it does not.
4. Validation-rejected entries strand the same way and are not covered here. They never get a
   channel, so there is no `:DOWN`, and `uploaded_entries/2` counts them as in progress.
5. External failures record `:external_client_failure` and invoke the callback, but leave the entry
   in progress.
