### PR TITLE
Handle writer errors like other entry errors

### DIFF
--- a/assets/js/phoenix_live_view/entry_uploader.js
+++ b/assets/js/phoenix_live_view/entry_uploader.js
@@ -20,6 +20,13 @@ export default class EntryUploader {
     this.uploadChannel.leave();
     this.errored = true;
     this.chunkTimer != null && clearTimeout(this.chunkTimer);
+    if (reason === "writer_error") {
+      // The server already recorded the exact writer failure and retained the
+      // entry. Keep the uploader pending until the failed entry is cancelled
+      // and removed from the DOM, without sending a second, generic client
+      // error progress event.
+      return;
+    }
     this.entry.error(reason);
   }
 

--- a/assets/test/entry_uploader_test.ts
+++ b/assets/test/entry_uploader_test.ts
@@ -24,4 +24,36 @@ describe("EntryUploader", () => {
 
     expect(entry.error).toHaveBeenCalledWith("join crashed");
   });
+
+  test("writer errors remain pending without sending a generic entry error", () => {
+    let errorCb;
+    let channelErrorCb;
+    let fakeChannel = {
+      onError: (cb) => (channelErrorCb = cb),
+      leave: jest.fn(),
+      join: () => ({
+        receive(kind, cb) {
+          if (kind === "error") errorCb = cb;
+          return this;
+        },
+      }),
+    };
+    let fakeLiveSocket = { channel: () => fakeChannel };
+    let entry = {
+      ref: "0",
+      metadata: () => ({}),
+      cancel: jest.fn(),
+      error: jest.fn(),
+    };
+    let config = { chunk_size: 1024, chunk_timeout: 5000 };
+
+    new EntryUploader(entry, config, fakeLiveSocket).upload();
+
+    errorCb({ reason: "writer_error" });
+    channelErrorCb("closed");
+
+    expect(fakeChannel.leave).toHaveBeenCalledTimes(1);
+    expect(entry.cancel).not.toHaveBeenCalled();
+    expect(entry.error).not.toHaveBeenCalled();
+  });
 });

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -73,6 +73,11 @@ defmodule Phoenix.LiveView.Channel do
     send(self(), {@prefix, :drop_upload_entries, info})
   end
 
+  def drop_upload_name(%UploadConfig{} = conf) do
+    info = %{name: conf.name, ref: conf.ref, cid: conf.cid}
+    send(self(), {@prefix, :drop_upload_name, info})
+  end
+
   def report_writer_error(pid, reason) do
     channel_pid = self()
     send(pid, {@prefix, :report_writer_error, channel_pid, reason})
@@ -275,6 +280,18 @@ defmodule Phoenix.LiveView.Channel do
         upload_config = Upload.get_upload_by_ref!(socket, ref)
         {Upload.drop_upload_entries(socket, upload_config, entry_refs), {:ok, nil, state}}
       end)
+
+    {:noreply, new_state}
+  end
+
+  def handle_info({@prefix, :drop_upload_name, info}, state) do
+    %{name: name, ref: ref, cid: cid} = info
+
+    new_state =
+      case Map.fetch(state.upload_names, name) do
+        {:ok, {^ref, ^cid}} -> drop_upload_name(state, name)
+        _ -> state
+      end
 
     {:noreply, new_state}
   end
@@ -700,14 +717,21 @@ defmodule Phoenix.LiveView.Channel do
 
   defp unregister_upload(state, ref, entry_ref, cid) do
     write_socket(state, cid, nil, fn socket, _ ->
-      conf = Upload.get_upload_by_ref!(socket, ref)
-      new_socket = Upload.unregister_completed_entry_upload(socket, conf, entry_ref)
-      new_conf = Upload.get_upload_by_ref!(new_socket, ref)
+      case Upload.fetch_upload_by_ref(socket, ref) do
+        {:ok, conf} ->
+          new_socket = Upload.unregister_completed_entry_upload(socket, conf, entry_ref)
+          new_conf = Upload.get_upload_by_ref!(new_socket, ref)
 
-      new_state =
-        if new_conf.entries == [], do: drop_upload_name(state, conf.name), else: state
+          new_state =
+            if new_conf.entries == [], do: drop_upload_name(state, conf.name), else: state
 
-      {new_socket, {:ok, nil, new_state}}
+          {new_socket, {:ok, nil, new_state}}
+
+        :error ->
+          # A progress callback may cancel the failed entry and disallow its config
+          # before the upload channel's ordered :DOWN is handled.
+          {socket, {:ok, nil, state}}
+      end
     end)
   end
 

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -76,6 +76,7 @@ defmodule Phoenix.LiveView.Channel do
   def report_writer_error(pid, reason) do
     channel_pid = self()
     send(pid, {@prefix, :report_writer_error, channel_pid, reason})
+    :ok
   end
 
   @impl true
@@ -111,7 +112,9 @@ defmodule Phoenix.LiveView.Channel do
   def handle_info({:DOWN, _, :process, pid, reason} = msg, %{socket: socket} = state) do
     case Map.fetch(state.upload_pids, pid) do
       {:ok, {ref, entry_ref, cid}} ->
-        if reason in [:normal, {:shutdown, :closed}] do
+        # :shutdown is what Phoenix.Channel.Server exits with when join/3 replies
+        # with an error, which the upload channel does on a writer init/1 failure
+        if reason in [:normal, :shutdown, {:shutdown, :closed}] do
           new_state =
             state
             |> drop_upload_pid(pid)
@@ -182,30 +185,9 @@ defmodule Phoenix.LiveView.Channel do
         upload_conf = Upload.get_upload_by_ref!(new_socket, ref)
         entry = UploadConfig.get_entry_by_ref(upload_conf, entry_ref)
 
-        if event = entry && upload_conf.progress_event do
-          case event.(upload_conf.name, entry, new_socket) do
-            {:noreply, %Socket{} = new_socket} ->
-              new_socket =
-                if new_socket.redirected do
-                  flash = Utils.changed_flash(new_socket)
-                  send(new_socket.root_pid, {@prefix, :redirect, new_socket.redirected, flash})
-                  %{new_socket | redirected: nil}
-                else
-                  new_socket
-                end
+        new_socket = run_progress_event(upload_conf, entry, new_socket)
 
-              {new_socket, {:ok, {msg.ref, %{}}, state}}
-
-            other ->
-              raise ArgumentError, """
-              expected #{inspect(upload_conf.name)} upload progress #{inspect(event)} to return {:noreply, Socket.t()} got:
-
-                  #{inspect(other)}
-              """
-          end
-        else
-          {new_socket, {:ok, {msg.ref, %{}}, state}}
-        end
+        {new_socket, {:ok, {msg.ref, %{}}, state}}
       end)
 
     {:noreply, new_state}
@@ -298,28 +280,7 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   def handle_info({@prefix, :report_writer_error, channel_pid, reason}, state) do
-    case state.upload_pids do
-      %{^channel_pid => {ref, entry_ref, cid}} ->
-        new_state =
-          write_socket(state, cid, nil, fn socket, _ ->
-            upload_config = Upload.get_upload_by_ref!(socket, ref)
-
-            new_socket =
-              Upload.put_upload_error(
-                socket,
-                upload_config.name,
-                entry_ref,
-                {:writer_failure, reason}
-              )
-
-            {new_socket, {:ok, nil, state}}
-          end)
-
-        {:noreply, new_state}
-
-      _ ->
-        {:noreply, state}
-    end
+    {:noreply, fail_writer_entry(state, channel_pid, reason)}
   end
 
   def handle_info({@prefix, :send_update, update}, state) do
@@ -740,15 +701,64 @@ defmodule Phoenix.LiveView.Channel do
   defp unregister_upload(state, ref, entry_ref, cid) do
     write_socket(state, cid, nil, fn socket, _ ->
       conf = Upload.get_upload_by_ref!(socket, ref)
+      new_socket = Upload.unregister_completed_entry_upload(socket, conf, entry_ref)
+      new_conf = Upload.get_upload_by_ref!(new_socket, ref)
 
       new_state =
-        case conf.entries do
-          [_] -> drop_upload_name(state, conf.name)
-          _ -> state
-        end
+        if new_conf.entries == [], do: drop_upload_name(state, conf.name), else: state
 
-      {Upload.unregister_completed_entry_upload(socket, conf, entry_ref), {:ok, nil, new_state}}
+      {new_socket, {:ok, nil, new_state}}
     end)
+  end
+
+  defp fail_writer_entry(state, channel_pid, reason) do
+    case state.upload_pids do
+      %{^channel_pid => {ref, entry_ref, cid}} ->
+        write_socket(state, cid, nil, fn socket, _ ->
+          upload_conf = Upload.get_upload_by_ref!(socket, ref)
+
+          new_socket =
+            Upload.fail_entry_upload(
+              socket,
+              upload_conf,
+              entry_ref,
+              {:writer_failure, reason}
+            )
+
+          failed_conf = Upload.get_upload_by_ref!(new_socket, ref)
+          failed_entry = UploadConfig.get_entry_by_ref(failed_conf, entry_ref)
+          new_socket = run_progress_event(failed_conf, failed_entry, new_socket)
+
+          {new_socket, {:ok, nil, state}}
+        end)
+
+      _ ->
+        state
+    end
+  end
+
+  defp run_progress_event(%UploadConfig{} = upload_conf, entry, %Socket{} = socket) do
+    if event = entry && upload_conf.progress_event do
+      case event.(upload_conf.name, entry, socket) do
+        {:noreply, %Socket{} = new_socket} ->
+          if new_socket.redirected do
+            flash = Utils.changed_flash(new_socket)
+            send(new_socket.root_pid, {@prefix, :redirect, new_socket.redirected, flash})
+            %{new_socket | redirected: nil}
+          else
+            new_socket
+          end
+
+        other ->
+          raise ArgumentError, """
+          expected #{inspect(upload_conf.name)} upload progress #{inspect(event)} to return {:noreply, Socket.t()} got:
+
+              #{inspect(other)}
+          """
+      end
+    else
+      socket
+    end
   end
 
   defp put_upload_pid(state, pid, ref, entry_ref, cid) when is_pid(pid) do
@@ -1551,8 +1561,10 @@ defmodule Phoenix.LiveView.Channel do
             writer: writer!(socket, conf.name, entry, conf.writer)
           }
 
-          GenServer.reply(from, {:ok, reply})
+          # monitor before replying, otherwise a channel that exits as soon as it is
+          # acknowledged (writer init/1 failure) can be dead by the time we monitor it
           new_state = put_upload_pid(state, pid, ref, entry_ref, cid)
+          GenServer.reply(from, {:ok, reply})
           {new_socket, {:ok, nil, new_state}}
 
         {:error, reason} ->

--- a/lib/phoenix_live_view/test/upload_client.ex
+++ b/lib/phoenix_live_view/test/upload_client.ex
@@ -134,20 +134,23 @@ defmodule Phoenix.LiveViewTest.UploadClient do
       "ref" => ref
     } = client_entry
 
-    {:ok, _resp, entry_socket} =
-      Phoenix.ChannelTest.subscribe_and_join(state.socket, "lvu:123", %{"token" => token})
+    case Phoenix.ChannelTest.subscribe_and_join(state.socket, "lvu:123", %{"token" => token}) do
+      {:ok, _resp, entry_socket} ->
+        %{
+          name: name,
+          content: content,
+          size: byte_size(content),
+          type: type,
+          socket: entry_socket,
+          ref: ref,
+          token: token,
+          chunk_percent: 0
+        }
+        |> with_chunk_boundaries()
 
-    %{
-      name: name,
-      content: content,
-      size: byte_size(content),
-      type: type,
-      socket: entry_socket,
-      ref: ref,
-      token: token,
-      chunk_percent: 0
-    }
-    |> with_chunk_boundaries()
+      {:error, %{reason: reason}} ->
+        {:error, reason}
+    end
   end
 
   def with_chunk_boundaries(entry) do
@@ -250,6 +253,9 @@ defmodule Phoenix.LiveViewTest.UploadClient do
             state.cid
           )
 
+        update_entry_percent(state, entry, stats.new_percent)
+
+      %Phoenix.Socket.Reply{ref: ^ref, status: :error, payload: %{reason: :writer_error}} ->
         update_entry_percent(state, entry, stats.new_percent)
 
       %Phoenix.Socket.Reply{ref: ^ref, status: :error} ->

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -74,9 +74,13 @@ defmodule Phoenix.LiveView.Upload do
 
     case UploadConfig.get_entry_by_ref(upload_config, entry_ref) do
       %UploadEntry{} = entry ->
-        upload_config
-        |> UploadConfig.cancel_entry(entry)
-        |> update_uploads(socket)
+        new_upload_config = UploadConfig.cancel_entry(upload_config, entry)
+
+        if new_upload_config.entries == [] do
+          Phoenix.LiveView.Channel.drop_upload_name(new_upload_config)
+        end
+
+        update_uploads(new_upload_config, socket)
 
       _ ->
         raise ArgumentError, "no entry in upload \"#{inspect(name)}\" with ref \"#{entry_ref}\""

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -162,6 +162,13 @@ defmodule Phoenix.LiveView.Upload do
     |> update_uploads(socket)
   end
 
+  @doc false
+  def fail_entry_upload(%Socket{} = socket, %UploadConfig{} = conf, entry_ref, reason) do
+    conf
+    |> UploadConfig.fail_entry(entry_ref, reason)
+    |> update_uploads(socket)
+  end
+
   @doc """
   Registers a new entry upload for a `Phoenix.LiveView.UploadChannel` process.
   """

--- a/lib/phoenix_live_view/upload_channel.ex
+++ b/lib/phoenix_live_view/upload_channel.ex
@@ -57,37 +57,44 @@ defmodule Phoenix.LiveView.UploadChannel do
     %{"token" => token} = auth_payload
 
     with {:ok, %{pid: pid, ref: ref, cid: cid}} <- Static.verify_token(socket.endpoint, token),
-         {:ok, config} <- Channel.register_upload(pid, ref, cid),
-         %{max_file_size: max_file_size, chunk_timeout: chunk_timeout} = config,
-         {writer, writer_opts} <- config.writer,
-         {:ok, writer_state} <- writer.init(writer_opts) do
-      Process.monitor(pid)
-      Process.flag(:trap_exit, true)
+         {:ok, config} <- Channel.register_upload(pid, ref, cid) do
+      %{max_file_size: max_file_size, chunk_timeout: chunk_timeout, writer: {writer, writer_opts}} =
+        config
 
-      socket =
-        assign(socket, %{
-          writer: writer,
-          writer_state: writer_state,
-          live_view_pid: pid,
-          max_file_size: max_file_size,
-          chunk_timeout: chunk_timeout,
-          chunk_timer: nil,
-          writer_closed?: false,
-          done?: false,
-          uploaded_size: 0
-        })
+      case writer.init(writer_opts) do
+        {:ok, writer_state} ->
+          Process.monitor(pid)
+          Process.flag(:trap_exit, true)
 
-      {:ok, socket}
+          socket =
+            assign(socket, %{
+              writer: writer,
+              writer_state: writer_state,
+              live_view_pid: pid,
+              max_file_size: max_file_size,
+              chunk_timeout: chunk_timeout,
+              chunk_timer: nil,
+              writer_closed?: false,
+              done?: false,
+              uploaded_size: 0
+            })
+
+          {:ok, socket}
+
+        {:error, reason} ->
+          # the entry is already registered with the LiveView at this point, so the
+          # failure must be reported just like a write_chunk/2 or close/2 failure,
+          # which retains the entry with a {:writer_failure, reason} error
+          Channel.report_writer_error(pid, reason)
+
+          {:error, %{reason: :writer_error}}
+      end
     else
-      {:error, reason} when reason in [:expired, :invalid] ->
+      {:error, reason} when reason in [:expired, :invalid, :outdated] ->
         {:error, %{reason: :invalid_token}}
 
       {:error, reason} when reason in [:already_registered, :disallowed] ->
         {:error, %{reason: reason}}
-
-      # writer init error
-      {:error, _reason} ->
-        {:error, %{reason: :writer_error}}
     end
   end
 
@@ -113,7 +120,7 @@ defmodule Phoenix.LiveView.UploadChannel do
               end
             end
 
-          Channel.report_writer_error(socket.assigns.live_view_pid, reason)
+          :ok = Channel.report_writer_error(socket.assigns.live_view_pid, reason)
 
           {:stop, {:shutdown, :closed}, {:error, %{reason: :writer_error}}, new_socket}
       end

--- a/lib/phoenix_live_view/upload_config.ex
+++ b/lib/phoenix_live_view/upload_config.ex
@@ -378,11 +378,17 @@ defmodule Phoenix.LiveView.UploadConfig do
 
   @doc false
   def fail_entry(%UploadConfig{} = conf, entry_ref, reason) do
-    %UploadEntry{} = get_entry_by_ref(conf, entry_ref)
+    # the entry may already have been dropped, for example by a progress callback
+    # that cancelled it, in which case the failure report is stale
+    case get_entry_by_ref(conf, entry_ref) do
+      %UploadEntry{} ->
+        conf
+        |> put_error(entry_ref, reason)
+        |> Map.update!(:entry_refs_to_pids, &Map.put(&1, entry_ref, @failed))
 
-    conf
-    |> put_error(entry_ref, reason)
-    |> Map.update!(:entry_refs_to_pids, &Map.put(&1, entry_ref, @failed))
+      nil ->
+        conf
+    end
   end
 
   @doc false
@@ -414,6 +420,10 @@ defmodule Phoenix.LiveView.UploadConfig do
 
       {:ok, existing_pid} when is_pid(existing_pid) ->
         {:error, :already_registered}
+
+      # the entry is retained, but it may no longer be uploaded to
+      {:ok, status} when status in [@invalid, @failed] ->
+        {:error, :disallowed}
 
       :error ->
         {:error, :disallowed}
@@ -702,7 +712,10 @@ defmodule Phoenix.LiveView.UploadConfig do
   end
 
   def put_error(%UploadConfig{} = conf, entry_ref, reason) do
-    %{conf | errors: conf.errors ++ [{entry_ref, reason}]}
+    # entries with errors are retained, so the same error can be reported more than
+    # once for the same entry, for example by repeated external client failures
+    pair = {entry_ref, reason}
+    %{conf | errors: List.delete(conf.errors, pair) ++ [pair]}
   end
 
   @doc false

--- a/lib/phoenix_live_view/upload_config.ex
+++ b/lib/phoenix_live_view/upload_config.ex
@@ -63,6 +63,8 @@ defmodule Phoenix.LiveView.UploadConfig do
 
   @unregistered :unregistered
   @invalid :invalid
+  # Writer failures retain their entry until it is explicitly cancelled or replaced.
+  @failed :failed
 
   @too_many_files :too_many_files
 
@@ -111,7 +113,7 @@ defmodule Phoenix.LiveView.UploadConfig do
           max_entries: pos_integer(),
           max_file_size: pos_integer(),
           entries: list(),
-          entry_refs_to_pids: %{String.t() => pid() | :unregistered | :done},
+          entry_refs_to_pids: %{String.t() => pid() | :unregistered | :invalid | :failed},
           entry_refs_to_metas: %{String.t() => map()},
           accept: list() | :any,
           acceptable_types: MapSet.t(),
@@ -340,7 +342,7 @@ defmodule Phoenix.LiveView.UploadConfig do
   def entry_pid(%UploadConfig{} = conf, %UploadEntry{} = entry) do
     case Map.fetch(conf.entry_refs_to_pids, entry.ref) do
       {:ok, pid} when is_pid(pid) -> pid
-      {:ok, status} when status in [@unregistered, @invalid] -> nil
+      {:ok, status} when status in [@unregistered, @invalid, @failed] -> nil
     end
   end
 
@@ -367,9 +369,20 @@ defmodule Phoenix.LiveView.UploadConfig do
 
   @doc false
   def unregister_completed_entry(%UploadConfig{} = conf, entry_ref) do
-    %UploadEntry{} = entry = get_entry_by_ref(conf, entry_ref)
+    case {get_entry_by_ref(conf, entry_ref), Map.get(conf.entry_refs_to_pids, entry_ref)} do
+      {%UploadEntry{}, @failed} -> conf
+      {%UploadEntry{} = entry, _status} -> drop_entry(conf, entry)
+      {nil, _status} -> conf
+    end
+  end
 
-    drop_entry(conf, entry)
+  @doc false
+  def fail_entry(%UploadConfig{} = conf, entry_ref, reason) do
+    %UploadEntry{} = get_entry_by_ref(conf, entry_ref)
+
+    conf
+    |> put_error(entry_ref, reason)
+    |> Map.update!(:entry_refs_to_pids, &Map.put(&1, entry_ref, @failed))
   end
 
   @doc false

--- a/test/e2e/support/issues/issue_4368.ex
+++ b/test/e2e/support/issues/issue_4368.ex
@@ -1,0 +1,82 @@
+defmodule Phoenix.LiveViewTest.E2E.Issue4368Live do
+  use Phoenix.LiveView
+
+  defmodule Writer do
+    @behaviour Phoenix.LiveView.UploadWriter
+
+    @impl true
+    def init(name), do: {:ok, name}
+
+    @impl true
+    def meta(name), do: %{name: name}
+
+    @impl true
+    def write_chunk("error", name), do: {:error, :invalid_pdf, name}
+    def write_chunk(_chunk, name), do: {:ok, name}
+
+    @impl true
+    def close(name, _reason), do: {:ok, name}
+  end
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(consumed: [], submitted?: false)
+     |> allow_upload(:documents,
+       accept: :any,
+       auto_upload: true,
+       chunk_size: 5,
+       max_entries: 2,
+       progress: &__MODULE__.handle_progress/3,
+       writer: &__MODULE__.writer/3
+     )}
+  end
+
+  def writer(_name, entry, _socket), do: {Writer, entry.client_name}
+
+  def handle_progress(:documents, %{done?: true} = entry, socket) do
+    name = consume_uploaded_entry(socket, entry, fn _meta -> {:ok, entry.client_name} end)
+    {:noreply, update(socket, :consumed, &[name | &1])}
+  end
+
+  def handle_progress(:documents, _entry, socket), do: {:noreply, socket}
+
+  @impl true
+  def handle_event("validate", _params, socket), do: {:noreply, socket}
+
+  def handle_event("cancel", %{"ref" => ref}, socket) do
+    {:noreply, cancel_upload(socket, :documents, ref)}
+  end
+
+  def handle_event("submit", _params, socket) do
+    {:noreply, assign(socket, submitted?: true)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id="issue-4368">
+      <form id="upload-form" phx-change="validate" phx-submit="submit">
+        <.live_file_input upload={@uploads.documents} />
+        <button type="submit">Submit</button>
+      </form>
+
+      <p id="submitted">submitted: {@submitted?}</p>
+      <p id="consumed">consumed: {Enum.join(@consumed, ",")}</p>
+
+      <article
+        :for={entry <- @uploads.documents.entries}
+        class="upload-entry"
+        data-name={entry.client_name}
+      >
+        <span>{entry.client_name}: {entry.progress}%</span>
+        <button type="button" phx-click="cancel" phx-value-ref={entry.ref}>Cancel</button>
+        <p :for={error <- upload_errors(@uploads.documents, entry)} class="upload-error">
+          {inspect(error)}
+        </p>
+      </article>
+    </div>
+    """
+  end
+end

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -225,6 +225,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/4334", Issue4334Live
       live "/4350", Issue4350Live
       live "/4359", Issue4359Live
+      live "/4368", Issue4368Live
     end
   end
 

--- a/test/e2e/tests/issues/4368.spec.js
+++ b/test/e2e/tests/issues/4368.spec.js
@@ -1,0 +1,46 @@
+import { test, expect } from "../../test-fixtures";
+import { syncLV } from "../../utils";
+
+// https://github.com/phoenixframework/phoenix_live_view/pull/4368
+test("a custom writer failure remains visible until it is cancelled", async ({
+  page,
+}) => {
+  await page.goto("/issues/4368");
+  await syncLV(page);
+
+  const input = page.locator("#upload-form input[type='file']");
+
+  await input.setInputFiles([
+    {
+      name: "good.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("0000000000"),
+    },
+    {
+      name: "bad.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("00000error"),
+    },
+  ]);
+
+  const failedEntry = page.locator('.upload-entry[data-name="bad.pdf"]');
+  await expect(failedEntry.locator(".upload-error")).toHaveText(
+    "{:writer_failure, :invalid_pdf}",
+  );
+  await expect(page.locator("#consumed")).toHaveText("consumed: good.pdf");
+  await expect(page.locator("#submitted")).toHaveText("submitted: false");
+  await expect(page.locator("[data-phx-main]")).toHaveClass(/phx-connected/);
+
+  const failedRef = await input.getAttribute("data-phx-active-refs");
+  expect(failedRef).not.toBe("");
+  expect(await input.getAttribute("data-phx-preflighted-refs")).toBe(failedRef);
+  await expect(input).toHaveAttribute("data-phx-done-refs", "");
+
+  await failedEntry.getByRole("button", { name: "Cancel" }).click();
+  await expect(failedEntry).toHaveCount(0);
+  await syncLV(page);
+
+  await page.getByRole("button", { name: "Submit" }).click();
+  await syncLV(page);
+  await expect(page.locator("#submitted")).toHaveText("submitted: true");
+});

--- a/test/e2e/tests/issues/4368.spec.js
+++ b/test/e2e/tests/issues/4368.spec.js
@@ -32,8 +32,9 @@ test("a custom writer failure remains visible until it is cancelled", async ({
   await expect(page.locator("[data-phx-main]")).toHaveClass(/phx-connected/);
 
   const failedRef = await input.getAttribute("data-phx-active-refs");
+  // eslint-disable-next-line playwright/prefer-web-first-assertions
   expect(failedRef).not.toBe("");
-  expect(await input.getAttribute("data-phx-preflighted-refs")).toBe(failedRef);
+  await expect(input).toHaveAttribute("data-phx-preflighted-refs", failedRef);
   await expect(input).toHaveAttribute("data-phx-done-refs", "");
 
   await failedEntry.getByRole("button", { name: "Cancel" }).click();

--- a/test/phoenix_live_view/upload/channel_test.exs
+++ b/test/phoenix_live_view/upload/channel_test.exs
@@ -63,8 +63,31 @@ defmodule Phoenix.LiveView.UploadChannelTest do
     def close(test_name, reason), do: TestWriter.close(test_name, reason)
   end
 
+  defmodule InitErrorWriter do
+    @behaviour Phoenix.LiveView.UploadWriter
+
+    @impl true
+    def init(test_name) do
+      send(test_name, :init)
+      {:error, :init_failed}
+    end
+
+    @impl true
+    defdelegate meta(test_name), to: TestWriter
+
+    @impl true
+    defdelegate write_chunk(data, test_name), to: TestWriter
+
+    @impl true
+    defdelegate close(test_name, reason), to: TestWriter
+  end
+
   def build_writer(_name, %Phoenix.LiveView.UploadEntry{}, %Phoenix.LiveView.Socket{}) do
     {TestWriter, :test_writer}
+  end
+
+  def build_init_error_writer(_name, %Phoenix.LiveView.UploadEntry{}, %Phoenix.LiveView.Socket{}) do
+    {InitErrorWriter, :test_writer}
   end
 
   def build_close_error_writer(_name, %Phoenix.LiveView.UploadEntry{}, %Phoenix.LiveView.Socket{}) do
@@ -101,6 +124,21 @@ defmodule Phoenix.LiveView.UploadChannelTest do
     UploadLive.run(lv, fn socket ->
       {:reply, Phoenix.LiveView.uploaded_entries(socket, name), socket}
     end)
+  end
+
+  # TODO: Replace this helper with ExUnit's trace/3 once it is available in our
+  # supported Elixir versions.
+  defp eventually(fun, attempts \\ 100)
+
+  defp eventually(fun, 0), do: fun.()
+
+  defp eventually(fun, attempts) do
+    if fun.() do
+      true
+    else
+      Process.sleep(10)
+      eventually(fun, attempts - 1)
+    end
   end
 
   def build_entries(count, opts \\ []) do
@@ -162,6 +200,19 @@ defmodule Phoenix.LiveView.UploadChannelTest do
       end
 
     {:noreply, socket}
+  end
+
+  def record_writer_failure(%LiveView.UploadEntry{} = entry, socket) do
+    errors = Component.upload_errors(socket.assigns.uploads.avatar, entry)
+
+    if errors == [] do
+      {:noreply, socket}
+    else
+      {_completed, in_progress} = LiveView.uploaded_entries(socket, :avatar)
+      in_progress? = Enum.any?(in_progress, &(&1.ref == entry.ref))
+      send(:test_writer, {:writer_failure_progress, entry, in_progress?, errors})
+      {:noreply, socket}
+    end
   end
 
   setup_all do
@@ -940,6 +991,7 @@ defmodule Phoenix.LiveView.UploadChannelTest do
              max_entries: 1,
              chunk_size: 5,
              accept: :any,
+             progress: :record_writer_failure,
              writer: &__MODULE__.build_writer/3
            ]
       test "writer write_chunk/2 error self-closes the upload channel without bringing down the LiveView",
@@ -964,7 +1016,77 @@ defmodule Phoenix.LiveView.UploadChannelTest do
         # the upload channel self-closes instead of being left {:shutdown, :left}
         assert_receive {:DOWN, _ref, :process, ^channel_pid, {:shutdown, :closed}}, 1000
 
-        # the failed entry is dropped and the LiveView is still alive
+        assert {[],
+                [
+                  %LiveView.UploadEntry{
+                    client_name: "foo.jpeg",
+                    done?: false,
+                    ref: failed_ref
+                  }
+                ]} =
+                 get_uploaded_entries(lv, :avatar)
+
+        html = render(lv)
+        assert html =~ "#{@context}:foo.jpeg:50%"
+        assert html =~ "entry_error:{:writer_failure, :custom_error}"
+        assert html =~ ~s(data-phx-active-refs="#{failed_ref}")
+        assert html =~ ~s(data-phx-preflighted-refs="#{failed_ref}")
+        assert html =~ ~s(data-phx-done-refs="")
+
+        assert_receive {:writer_failure_progress,
+                        %LiveView.UploadEntry{client_name: "foo.jpeg", done?: false}, true,
+                        [writer_failure: :custom_error]}
+
+        refute_receive {:writer_failure_progress, _, _, _}
+        assert Process.alive?(lv.pid)
+
+        UploadLive.run(lv, fn socket ->
+          {[], [%{ref: ref}]} = LiveView.uploaded_entries(socket, :avatar)
+          {:reply, :ok, LiveView.cancel_upload(socket, :avatar, ref)}
+        end)
+
+        assert get_uploaded_entries(lv, :avatar) == {[], []}
+        html = render(lv)
+        refute html =~ "#{@context}:foo.jpeg"
+        assert html =~ ~s(data-phx-active-refs="")
+        assert html =~ ~s(data-phx-preflighted-refs="")
+        assert html =~ ~s(data-phx-done-refs="")
+      end
+
+      @tag allow: [
+             max_entries: 1,
+             chunk_size: 50,
+             accept: :any,
+             progress: :record_writer_failure,
+             writer: &__MODULE__.build_init_error_writer/3
+           ]
+      test "writer init/1 error fails the entry without bringing down the LiveView", %{lv: lv} do
+        Process.register(self(), :test_writer)
+
+        avatar =
+          file_input(lv, "form", :avatar, [
+            %{name: "foo.jpeg", content: String.duplicate("0", 100)}
+          ])
+
+        assert {:error, :writer_error} = render_upload(avatar, "foo.jpeg", 50)
+        assert_receive :init
+
+        # the entry is retained with the writer failure, exactly like a write_chunk/2 error
+        assert {[], [%LiveView.UploadEntry{client_name: "foo.jpeg", done?: false, ref: ref}]} =
+                 get_uploaded_entries(lv, :avatar)
+
+        assert render(lv) =~ "entry_error:{:writer_failure, :init_failed}"
+
+        assert_receive {:writer_failure_progress,
+                        %LiveView.UploadEntry{client_name: "foo.jpeg", done?: false}, true,
+                        [writer_failure: :init_failed]}
+
+        assert Process.alive?(lv.pid)
+
+        UploadLive.run(lv, fn socket ->
+          {:reply, :ok, LiveView.cancel_upload(socket, :avatar, ref)}
+        end)
+
         assert get_uploaded_entries(lv, :avatar) == {[], []}
       end
 
@@ -972,6 +1094,7 @@ defmodule Phoenix.LiveView.UploadChannelTest do
              max_entries: 1,
              chunk_size: 50,
              accept: :any,
+             progress: :record_writer_failure,
              writer: &__MODULE__.build_close_error_writer/3
            ]
       test "writer close error self-closes the upload channel without bringing down the LiveView",
@@ -1001,8 +1124,85 @@ defmodule Phoenix.LiveView.UploadChannelTest do
         # the upload channel self-closes instead of being left {:shutdown, :left}
         assert_receive {:DOWN, _ref, :process, ^channel_pid, {:shutdown, :closed}}, 1000
 
-        # the failed entry is dropped and the LiveView is still alive
-        assert get_uploaded_entries(lv, :avatar) == {[], []}
+        assert {[], [%LiveView.UploadEntry{client_name: "foo.jpeg", done?: false}]} =
+                 get_uploaded_entries(lv, :avatar)
+
+        assert render(lv) =~ "entry_error:{:writer_failure, :close_failed}"
+
+        assert_receive {:writer_failure_progress,
+                        %LiveView.UploadEntry{client_name: "foo.jpeg", done?: false}, true,
+                        [writer_failure: :close_failed]}
+
+        refute_receive {:writer_failure_progress, _, _, _}
+        assert Process.alive?(lv.pid)
+      end
+
+      @tag allow: [
+             max_entries: 2,
+             chunk_size: 5,
+             accept: :any,
+             writer: &__MODULE__.build_writer/3
+           ]
+      test "a successful sibling can be consumed individually after a writer failure", %{lv: lv} do
+        Process.register(self(), :test_writer)
+
+        good =
+          file_input(lv, "form", :avatar, [
+            %{name: "good.jpeg", content: String.duplicate("0", 100)}
+          ])
+
+        bad = file_input(lv, "form", :avatar, [%{name: "bad.jpeg", content: "00000error"}])
+
+        assert render_upload(bad, "bad.jpeg", 50) =~ "bad.jpeg:50%"
+        assert render_upload(good, "good.jpeg") =~ "good.jpeg:100%"
+        assert %{"bad.jpeg" => bad_pid} = UploadClient.channel_pids(bad)
+
+        unlink(bad_pid, lv, bad)
+        Process.monitor(bad_pid)
+
+        render_upload(bad, "bad.jpeg", 50)
+        assert_receive {:DOWN, _ref, :process, ^bad_pid, {:shutdown, :closed}}, 1000
+
+        assert {[%LiveView.UploadEntry{client_name: "good.jpeg"}],
+                [%LiveView.UploadEntry{client_name: "bad.jpeg"}]} =
+                 get_uploaded_entries(lv, :avatar)
+
+        assert {:error, "cannot consume uploaded files when entries are still in progress"} =
+                 UploadLive.run(lv, fn socket ->
+                   result =
+                     try do
+                       LiveView.consume_uploaded_entries(socket, :avatar, fn _meta, _entry ->
+                         {:ok, :consumed}
+                       end)
+                     rescue
+                       error in ArgumentError -> {:error, Exception.message(error)}
+                     end
+
+                   {:reply, result, socket}
+                 end)
+
+        assert "good.jpeg" =
+                 UploadLive.run(lv, fn socket ->
+                   {[good_entry], [_failed_entry]} = LiveView.uploaded_entries(socket, :avatar)
+
+                   result =
+                     LiveView.consume_uploaded_entry(socket, good_entry, fn _meta ->
+                       {:ok, good_entry.client_name}
+                     end)
+
+                   {:reply, result, socket}
+                 end)
+
+        assert eventually(fn ->
+                 match?(
+                   {[], [%LiveView.UploadEntry{client_name: "bad.jpeg"}]},
+                   get_uploaded_entries(lv, :avatar)
+                 )
+               end)
+
+        html = render(lv)
+        assert html =~ "entry_error:{:writer_failure, :custom_error}"
+        refute html =~ "good.jpeg"
       end
     end
   end

--- a/test/phoenix_live_view/upload/channel_test.exs
+++ b/test/phoenix_live_view/upload/channel_test.exs
@@ -1006,6 +1006,7 @@ defmodule Phoenix.LiveView.UploadChannelTest do
 
         assert render_upload(avatar, "foo.jpeg", 50) =~ "#{@context}:foo.jpeg:50%"
         assert %{"foo.jpeg" => channel_pid} = UploadClient.channel_pids(avatar)
+        assert {:ok, %{token: token}} = UploadClient.fetch_allow_acknowledged(avatar, "foo.jpeg")
 
         unlink(channel_pid, lv, avatar)
         Process.monitor(channel_pid)
@@ -1038,6 +1039,14 @@ defmodule Phoenix.LiveView.UploadChannelTest do
                         [writer_failure: :custom_error]}
 
         refute_receive {:writer_failure_progress, _, _, _}
+        assert Process.alive?(lv.pid)
+
+        # the entry is retained, but its still valid token may no longer be joined with
+        {:ok, socket} = Phoenix.ChannelTest.connect(Phoenix.LiveView.Socket, %{})
+
+        assert {:error, %{reason: :disallowed}} =
+                 Phoenix.ChannelTest.subscribe_and_join(socket, "lvu:123", %{"token" => token})
+
         assert Process.alive?(lv.pid)
 
         UploadLive.run(lv, fn socket ->

--- a/test/phoenix_live_view/upload/channel_test.exs
+++ b/test/phoenix_live_view/upload/channel_test.exs
@@ -126,6 +126,18 @@ defmodule Phoenix.LiveView.UploadChannelTest do
     end)
   end
 
+  defp cancel_last_entry_and_reallow(lv) do
+    UploadLive.run(lv, fn socket ->
+      {completed, in_progress} = LiveView.uploaded_entries(socket, :avatar)
+      [%{ref: ref}] = completed ++ in_progress
+      {:reply, :ok, LiveView.cancel_upload(socket, :avatar, ref)}
+    end)
+
+    UploadLive.run(lv, fn socket ->
+      {:reply, :ok, LiveView.allow_upload(socket, :avatar, accept: :any)}
+    end)
+  end
+
   # TODO: Replace this helper with ExUnit's trace/3 once it is available in our
   # supported Elixir versions.
   defp eventually(fun, attempts \\ 100)
@@ -211,6 +223,20 @@ defmodule Phoenix.LiveView.UploadChannelTest do
       {_completed, in_progress} = LiveView.uploaded_entries(socket, :avatar)
       in_progress? = Enum.any?(in_progress, &(&1.ref == entry.ref))
       send(:test_writer, {:writer_failure_progress, entry, in_progress?, errors})
+      {:noreply, socket}
+    end
+  end
+
+  def cancel_and_disallow_writer_failure(%LiveView.UploadEntry{} = entry, socket) do
+    if Component.upload_errors(socket.assigns.uploads.avatar, entry) == [] do
+      {:noreply, socket}
+    else
+      socket =
+        socket
+        |> LiveView.cancel_upload(:avatar, entry.ref)
+        |> LiveView.disallow_upload(:avatar)
+
+      send(:test_writer, :writer_failure_cancelled_and_disallowed)
       {:noreply, socket}
     end
   end
@@ -533,7 +559,7 @@ defmodule Phoenix.LiveView.UploadChannelTest do
       end
 
       @tag allow: [max_entries: 1, chunk_size: 20, accept: :any, max_file_size: 1]
-      test "render_change error with upload", %{lv: lv} do
+      test "too_large entry is retained without starting an upload channel", %{lv: lv} do
         avatar = file_input(lv, "form", :avatar, [%{name: "foo.jpeg", content: "overmax"}])
 
         assert lv
@@ -541,6 +567,12 @@ defmodule Phoenix.LiveView.UploadChannelTest do
                |> render_change(avatar) =~ "entry_error::too_large"
 
         assert {:error, [[_ref, :too_large]]} = render_upload(avatar, "foo.jpeg")
+        assert UploadClient.channel_pids(avatar) == %{}
+
+        cancel_last_entry_and_reallow(lv)
+
+        retry = file_input(lv, "form", :avatar, [%{name: "retry.jpeg", content: "retry"}])
+        assert render_upload(retry, "retry.jpeg") =~ "#{@context}:retry.jpeg:100%"
       end
 
       @tag allow: [
@@ -590,7 +622,7 @@ defmodule Phoenix.LiveView.UploadChannelTest do
              max_file_size: 1,
              auto_upload: true
            ]
-      test "render_upload invalid with auto_upload", %{lv: lv} do
+      test "auto-upload too_large entry releases its upload name when cancelled", %{lv: lv} do
         avatar = file_input(lv, "form", :avatar, [%{name: "foo.jpeg", content: "overmax"}])
 
         html =
@@ -602,6 +634,14 @@ defmodule Phoenix.LiveView.UploadChannelTest do
         assert html =~ "foo.jpeg:0%"
 
         assert {:error, [[_ref, :too_large]]} = render_upload(avatar, "foo.jpeg")
+
+        assert {:error, [:too_large]} =
+                 UploadClient.fetch_allow_acknowledged(avatar, "foo.jpeg")
+
+        cancel_last_entry_and_reallow(lv)
+
+        retry = file_input(lv, "form", :avatar, [%{name: "retry.jpeg", content: "retry"}])
+        assert render_upload(retry, "retry.jpeg") =~ "#{@context}:retry.jpeg:100%"
       end
 
       @tag allow: [max_entries: 1, chunk_size: 20, accept: :any]
@@ -901,6 +941,13 @@ defmodule Phoenix.LiveView.UploadChannelTest do
         end)
 
         refute render(lv) =~ file_name
+
+        UploadLive.run(lv, fn socket ->
+          {:reply, :ok, LiveView.allow_upload(socket, :avatar, accept: :any)}
+        end)
+
+        retry = file_input(lv, "form", :avatar, [%{name: "retry.jpeg", content: "retry"}])
+        assert render_upload(retry, "retry.jpeg") =~ "#{@context}:retry.jpeg:100%"
       end
 
       @tag allow: [max_entries: 1, chunk_size: 20, accept: :any]
@@ -1060,6 +1107,39 @@ defmodule Phoenix.LiveView.UploadChannelTest do
         assert html =~ ~s(data-phx-active-refs="")
         assert html =~ ~s(data-phx-preflighted-refs="")
         assert html =~ ~s(data-phx-done-refs="")
+
+        UploadLive.run(lv, fn socket ->
+          {:reply, :ok, LiveView.allow_upload(socket, :avatar, accept: :any)}
+        end)
+
+        retry = file_input(lv, "form", :avatar, [%{name: "retry.jpeg", content: "retry"}])
+        assert render_upload(retry, "retry.jpeg") =~ "#{@context}:retry.jpeg:100%"
+      end
+
+      @tag allow: [
+             max_entries: 1,
+             chunk_size: 5,
+             accept: :any,
+             progress: :cancel_and_disallow_writer_failure,
+             writer: &__MODULE__.build_writer/3
+           ]
+      test "writer failure callback may cancel and disallow before channel cleanup", %{lv: lv} do
+        Process.register(self(), :test_writer)
+
+        avatar = file_input(lv, "form", :avatar, [%{name: "foo.jpeg", content: "00000error"}])
+
+        assert render_upload(avatar, "foo.jpeg", 50) =~ "#{@context}:foo.jpeg:50%"
+        assert %{"foo.jpeg" => channel_pid} = UploadClient.channel_pids(avatar)
+
+        unlink(channel_pid, lv, avatar)
+        Process.monitor(channel_pid)
+
+        render_upload(avatar, "foo.jpeg", 50)
+
+        assert_receive :writer_failure_cancelled_and_disallowed
+        assert_receive {:DOWN, _ref, :process, ^channel_pid, {:shutdown, :closed}}, 1000
+        assert render(lv) =~ "save"
+        assert Process.alive?(lv.pid)
       end
 
       @tag allow: [

--- a/test/phoenix_live_view/upload/config_test.exs
+++ b/test/phoenix_live_view/upload/config_test.exs
@@ -208,6 +208,57 @@ defmodule Phoenix.LiveView.UploadConfigTest do
     end
   end
 
+  describe "fail_entry/3" do
+    test "retains the entry with its error and rejects further registration" do
+      socket = LiveView.allow_upload(build_socket(), :avatar, accept: :any)
+      %{"ref" => ref} = entry = build_client_entry(:avatar)
+      assert {:ok, avatar} = UploadConfig.put_entries(socket.assigns.uploads.avatar, [entry])
+
+      avatar = UploadConfig.fail_entry(avatar, ref, {:writer_failure, :custom_error})
+
+      assert [%UploadEntry{ref: ^ref}] = avatar.entries
+      assert avatar.errors == [{ref, {:writer_failure, :custom_error}}]
+
+      assert UploadConfig.entry_pid(avatar, UploadConfig.get_entry_by_ref(avatar, ref)) == nil
+
+      assert UploadConfig.register_entry_upload(avatar, self(), ref) == {:error, :disallowed}
+
+      # the failed entry is kept when its upload channel goes down
+      assert UploadConfig.unregister_completed_entry(avatar, ref) == avatar
+    end
+
+    test "ignores a failure reported for an entry that is already gone" do
+      socket = LiveView.allow_upload(build_socket(), :avatar, accept: :any)
+      %{"ref" => ref} = entry = build_client_entry(:avatar)
+      assert {:ok, avatar} = UploadConfig.put_entries(socket.assigns.uploads.avatar, [entry])
+
+      avatar = drop_entry(avatar, ref)
+
+      assert UploadConfig.fail_entry(avatar, ref, {:writer_failure, :custom_error}) == avatar
+    end
+
+    test "does not accumulate the same error for a retained entry" do
+      socket = LiveView.allow_upload(build_socket(), :avatar, accept: :any)
+      %{"ref" => ref} = entry = build_client_entry(:avatar)
+      assert {:ok, avatar} = UploadConfig.put_entries(socket.assigns.uploads.avatar, [entry])
+
+      avatar =
+        avatar
+        |> UploadConfig.fail_entry(ref, {:writer_failure, :custom_error})
+        |> UploadConfig.fail_entry(ref, {:writer_failure, :custom_error})
+
+      assert avatar.errors == [{ref, {:writer_failure, :custom_error}}]
+
+      # distinct errors for the same entry are still kept
+      avatar = UploadConfig.put_error(avatar, ref, :external_client_failure)
+
+      assert avatar.errors == [
+               {ref, {:writer_failure, :custom_error}},
+               {ref, :external_client_failure}
+             ]
+    end
+  end
+
   describe "put_entries/2" do
     test "does not overwrite existing refs" do
       socket = LiveView.allow_upload(build_socket(), :avatar, accept: :any, max_entries: 1)


### PR DESCRIPTION
Ensures errors from a custom upload writer are not silently dropped.

Closes https://github.com/phoenixframework/phoenix_live_view/issues/3743.
Closes https://github.com/phoenixframework/phoenix_live_view/pull/4368.

@aptinio please review! I'd say the previous behavior (crashing the LiveView, but also dropping the entry) was definitely a bug. This means that the entry will be kept and `consume_uploaded_entries` will only work once a client removes the failed ones. `upload_errors` should work as documented now.