### PR TITLE
Fix testing file uploads with multiple entries

### DIFF
--- a/assets/js/phoenix_live_view/constants.ts
+++ b/assets/js/phoenix_live_view/constants.ts
@@ -27,6 +27,7 @@ export const PHX_TRACK_UPLOADS = "track-uploads";
 export const PHX_UPLOAD_REF = "data-phx-upload-ref";
 export const PHX_PREFLIGHTED_REFS = "data-phx-preflighted-refs";
 export const PHX_DONE_REFS = "data-phx-done-refs";
+export const PHX_ERROR_REFS = "data-phx-error-refs";
 export const PHX_DROP_TARGET = "drop-target";
 export const PHX_ACTIVE_ENTRY_REFS = "data-phx-active-refs";
 export const PHX_LIVE_FILE_UPDATED = "phx:live-file:updated";

--- a/assets/js/phoenix_live_view/entry_uploader.js
+++ b/assets/js/phoenix_live_view/entry_uploader.js
@@ -20,6 +20,13 @@ export default class EntryUploader {
     this.uploadChannel.leave();
     this.errored = true;
     this.chunkTimer != null && clearTimeout(this.chunkTimer);
+    if (reason === "writer_error") {
+      // The server already recorded the exact writer failure and retained the
+      // entry. Keep the uploader pending until the failed entry is cancelled
+      // and removed from the DOM, without sending a second, generic client
+      // error progress event.
+      return;
+    }
     this.entry.error(reason);
   }
 

--- a/assets/js/phoenix_live_view/hooks.ts
+++ b/assets/js/phoenix_live_view/hooks.ts
@@ -1,5 +1,6 @@
 import {
   PHX_ACTIVE_ENTRY_REFS,
+  PHX_ERROR_REFS,
   PHX_LIVE_FILE_UPDATED,
   PHX_PREFLIGHTED_REFS,
   PHX_UPLOAD_REF,
@@ -262,13 +263,27 @@ const LiveFileUpload: Hook<object, HTMLInputElement> = {
     return this.el.getAttribute(PHX_PREFLIGHTED_REFS);
   },
 
+  errorRefs() {
+    return this.el.getAttribute(PHX_ERROR_REFS) || "";
+  },
+
   mounted() {
     this.js().ignoreAttributes(this.el, ["value"]);
     this.preflightedWas = this.preflightedRefs();
+    this.errorRefsWas = this.errorRefs();
   },
 
   updated() {
     const newPreflights = this.preflightedRefs();
+    const newErrorRefs = this.errorRefs();
+
+    if (this.errorRefsWas !== newErrorRefs) {
+      this.errorRefsWas = newErrorRefs;
+      if (newErrorRefs !== "") {
+        this.__view().cancelSubmit(this.el.form);
+      }
+    }
+
     if (this.preflightedWas !== newPreflights) {
       this.preflightedWas = newPreflights;
       if (newPreflights === "") {

--- a/assets/js/phoenix_live_view/live_uploader.js
+++ b/assets/js/phoenix_live_view/live_uploader.js
@@ -1,5 +1,6 @@
 import {
   PHX_DONE_REFS,
+  PHX_ERROR_REFS,
   PHX_PREFLIGHTED_REFS,
   PHX_UPLOAD_REF,
 } from "./constants";
@@ -41,6 +42,12 @@ export default class LiveUploader {
       }
     });
     return active > 0;
+  }
+
+  static hasUploadErrors(formEl) {
+    return DOM.findUploadInputs(formEl).some(
+      (input) => (input.getAttribute(PHX_ERROR_REFS) || "") !== "",
+    );
   }
 
   static serializeUploads(inputEl) {

--- a/assets/js/phoenix_live_view/view.ts
+++ b/assets/js/phoenix_live_view/view.ts
@@ -2204,7 +2204,9 @@ export default class View {
     // for phx-trigger-action
     DOM.putPrivate(formEl, "submitter", submitter);
     const cid = this.targetComponentID(formEl, targetCtx);
-    if (LiveUploader.hasUploadsInProgress(formEl)) {
+    if (LiveUploader.hasUploadErrors(formEl)) {
+      return this.cancelSubmit(formEl, phxEvent);
+    } else if (LiveUploader.hasUploadsInProgress(formEl)) {
       const [ref, _els] = refGenerator();
       const push = () =>
         this.pushFormSubmit(

--- a/assets/test/entry_uploader_test.ts
+++ b/assets/test/entry_uploader_test.ts
@@ -24,4 +24,36 @@ describe("EntryUploader", () => {
 
     expect(entry.error).toHaveBeenCalledWith("join crashed");
   });
+
+  test("writer errors remain pending without sending a generic entry error", () => {
+    let errorCb;
+    let channelErrorCb;
+    let fakeChannel = {
+      onError: (cb) => (channelErrorCb = cb),
+      leave: jest.fn(),
+      join: () => ({
+        receive(kind, cb) {
+          if (kind === "error") errorCb = cb;
+          return this;
+        },
+      }),
+    };
+    let fakeLiveSocket = { channel: () => fakeChannel };
+    let entry = {
+      ref: "0",
+      metadata: () => ({}),
+      cancel: jest.fn(),
+      error: jest.fn(),
+    };
+    let config = { chunk_size: 1024, chunk_timeout: 5000 };
+
+    new EntryUploader(entry, config, fakeLiveSocket).upload();
+
+    errorCb({ reason: "writer_error" });
+    channelErrorCb("closed");
+
+    expect(fakeChannel.leave).toHaveBeenCalledTimes(1);
+    expect(entry.cancel).not.toHaveBeenCalled();
+    expect(entry.error).not.toHaveBeenCalled();
+  });
 });

--- a/assets/test/hooks_test.ts
+++ b/assets/test/hooks_test.ts
@@ -1,5 +1,38 @@
 import Hooks from "phoenix_live_view/hooks";
 
+describe("LiveFileUpload", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("cancels a scheduled submit when the upload becomes errored", () => {
+    document.body.innerHTML = `
+      <form>
+        <input
+          type="file"
+          data-phx-active-refs="0"
+          data-phx-preflighted-refs=""
+        >
+      </form>
+    `;
+
+    const input = document.querySelector("input")!;
+    const cancelSubmit = jest.fn();
+    const ctx = {
+      ...Hooks.LiveFileUpload,
+      el: input,
+      js: () => ({ ignoreAttributes: jest.fn() }),
+      __view: () => ({ cancelSubmit }),
+    };
+
+    Hooks.LiveFileUpload.mounted!.call(ctx as any);
+    input.setAttribute("data-phx-error-refs", "0");
+    Hooks.LiveFileUpload.updated!.call(ctx as any);
+
+    expect(cancelSubmit).toHaveBeenCalledWith(input.form);
+  });
+});
+
 describe("InfiniteScroll", () => {
   describe("updated", () => {
     afterEach(() => {

--- a/guides/server/uploads.md
+++ b/guides/server/uploads.md
@@ -70,10 +70,10 @@ be set automatically based on the [`allow_upload/3`] spec.
 Reactive updates to the template will occur as the end-user
 interacts with the file input.
 
-The `:max_entries` option applies for the lifetime of an upload configuration,
-including files that have already been consumed. Once all entries have been
-consumed or cancelled, call `allow_upload/3` again to start a new batch and
-reset the limit.
+By default, consumed entries free capacity under the `:max_entries` limit. Pass
+`max_entries_mode: :total` to count consumed entries for the lifetime of an
+upload configuration instead. Once all entries have been consumed or cancelled,
+call `allow_upload/3` again to start a new batch and reset a `:total` limit.
 
 ### Upload entries
 

--- a/guides/server/uploads.md
+++ b/guides/server/uploads.md
@@ -70,6 +70,11 @@ be set automatically based on the [`allow_upload/3`] spec.
 Reactive updates to the template will occur as the end-user
 interacts with the file input.
 
+The `:max_entries` option applies for the lifetime of an upload configuration,
+including files that have already been consumed. Once all entries have been
+consumed or cancelled, call `allow_upload/3` again to start a new batch and
+reset the limit.
+
 ### Upload entries
 
 Uploads are populated in an `@uploads` assign in the socket.

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1198,7 +1198,8 @@ defmodule Phoenix.Component do
 
   The output is a list. The following error may be returned:
 
-  * `:too_many_files` - The number of selected files exceeds the `:max_entries` constraint
+  * `:too_many_files` - The number of selected and already consumed files exceeds the
+    `:max_entries` constraint
 
   ## Examples
 

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -3364,6 +3364,9 @@ defmodule Phoenix.Component do
       data-phx-preflighted-refs={
         join_refs(for(entry <- @upload.entries, entry.preflighted?, do: entry.ref))
       }
+      data-phx-error-refs={
+        @upload.errors != [] && join_refs(for {ref, _reason} <- @upload.errors, uniq: true, do: ref)
+      }
       data-phx-auto-upload={@upload.auto_upload?}
       {if @upload.max_entries > 1, do: Map.put(@rest, :multiple, true), else: @rest}
     />

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1198,8 +1198,7 @@ defmodule Phoenix.Component do
 
   The output is a list. The following error may be returned:
 
-  * `:too_many_files` - The number of selected and already consumed files exceeds the
-    `:max_entries` constraint
+  * `:too_many_files` - The number of files exceeds the `:max_entries` constraint
 
   ## Examples
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -883,8 +883,10 @@ defmodule Phoenix.LiveView do
       `:any` instead of a list to support to allow any kind of file.
       For example, `[".jpeg"]`, `:any`, etc.
 
-    * `:max_entries` - The maximum number of selected files to allow per
-      file input. Defaults to 1.
+    * `:max_entries` - The maximum number of files to allow for the lifetime
+      of the upload configuration, including entries that have already been
+      consumed. Defaults to 1. Once all entries have been consumed or cancelled,
+      call `allow_upload/3` again to allow a new batch.
 
     * `:max_file_size` - The maximum file size in bytes to allow to be uploaded.
       Defaults 8MB. For example, `12_000_000`.

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -883,10 +883,14 @@ defmodule Phoenix.LiveView do
       `:any` instead of a list to support to allow any kind of file.
       For example, `[".jpeg"]`, `:any`, etc.
 
-    * `:max_entries` - The maximum number of files to allow for the lifetime
-      of the upload configuration, including entries that have already been
-      consumed. Defaults to 1. Once all entries have been consumed or cancelled,
-      call `allow_upload/3` again to allow a new batch.
+    * `:max_entries` - The maximum number of files to allow. Defaults to 1.
+
+    * `:max_entries_mode` - Controls how `:max_entries` is counted. `:selected`
+      limits the entries currently selected by the file input, so consuming an
+      entry frees capacity for another. `:total` also counts entries that have
+      already been consumed for the lifetime of the upload configuration. Once
+      all entries have been consumed or cancelled, call `allow_upload/3` again
+      to reset a `:total` limit. Defaults to `:selected`.
 
     * `:max_file_size` - The maximum file size in bytes to allow to be uploaded.
       Defaults 8MB. For example, `12_000_000`.

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -73,6 +73,11 @@ defmodule Phoenix.LiveView.Channel do
     send(self(), {@prefix, :drop_upload_entries, info})
   end
 
+  def drop_upload_name(%UploadConfig{} = conf) do
+    info = %{name: conf.name, ref: conf.ref, cid: conf.cid}
+    send(self(), {@prefix, :drop_upload_name, info})
+  end
+
   def report_writer_error(pid, reason) do
     channel_pid = self()
     send(pid, {@prefix, :report_writer_error, channel_pid, reason})
@@ -275,6 +280,18 @@ defmodule Phoenix.LiveView.Channel do
         upload_config = Upload.get_upload_by_ref!(socket, ref)
         {Upload.drop_upload_entries(socket, upload_config, entry_refs), {:ok, nil, state}}
       end)
+
+    {:noreply, new_state}
+  end
+
+  def handle_info({@prefix, :drop_upload_name, info}, state) do
+    %{name: name, ref: ref, cid: cid} = info
+
+    new_state =
+      case Map.fetch(state.upload_names, name) do
+        {:ok, {^ref, ^cid}} -> drop_upload_name(state, name)
+        _ -> state
+      end
 
     {:noreply, new_state}
   end
@@ -700,14 +717,21 @@ defmodule Phoenix.LiveView.Channel do
 
   defp unregister_upload(state, ref, entry_ref, cid) do
     write_socket(state, cid, nil, fn socket, _ ->
-      conf = Upload.get_upload_by_ref!(socket, ref)
-      new_socket = Upload.unregister_completed_entry_upload(socket, conf, entry_ref)
-      new_conf = Upload.get_upload_by_ref!(new_socket, ref)
+      case Upload.fetch_upload_by_ref(socket, ref) do
+        {:ok, conf} ->
+          new_socket = Upload.unregister_completed_entry_upload(socket, conf, entry_ref)
+          new_conf = Upload.get_upload_by_ref!(new_socket, ref)
 
-      new_state =
-        if new_conf.entries == [], do: drop_upload_name(state, conf.name), else: state
+          new_state =
+            if new_conf.entries == [], do: drop_upload_name(state, conf.name), else: state
 
-      {new_socket, {:ok, nil, new_state}}
+          {new_socket, {:ok, nil, new_state}}
+
+        :error ->
+          # A progress callback may cancel the failed entry and disallow its config
+          # before the upload channel's ordered :DOWN is handled.
+          {socket, {:ok, nil, state}}
+      end
     end)
   end
 

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -76,6 +76,7 @@ defmodule Phoenix.LiveView.Channel do
   def report_writer_error(pid, reason) do
     channel_pid = self()
     send(pid, {@prefix, :report_writer_error, channel_pid, reason})
+    :ok
   end
 
   @impl true
@@ -111,7 +112,9 @@ defmodule Phoenix.LiveView.Channel do
   def handle_info({:DOWN, _, :process, pid, reason} = msg, %{socket: socket} = state) do
     case Map.fetch(state.upload_pids, pid) do
       {:ok, {ref, entry_ref, cid}} ->
-        if reason in [:normal, {:shutdown, :closed}] do
+        # :shutdown is what Phoenix.Channel.Server exits with when join/3 replies
+        # with an error, which the upload channel does on a writer init/1 failure
+        if reason in [:normal, :shutdown, {:shutdown, :closed}] do
           new_state =
             state
             |> drop_upload_pid(pid)
@@ -182,30 +185,9 @@ defmodule Phoenix.LiveView.Channel do
         upload_conf = Upload.get_upload_by_ref!(new_socket, ref)
         entry = UploadConfig.get_entry_by_ref(upload_conf, entry_ref)
 
-        if event = entry && upload_conf.progress_event do
-          case event.(upload_conf.name, entry, new_socket) do
-            {:noreply, %Socket{} = new_socket} ->
-              new_socket =
-                if new_socket.redirected do
-                  flash = Utils.changed_flash(new_socket)
-                  send(new_socket.root_pid, {@prefix, :redirect, new_socket.redirected, flash})
-                  %{new_socket | redirected: nil}
-                else
-                  new_socket
-                end
+        new_socket = run_progress_event(upload_conf, entry, new_socket)
 
-              {new_socket, {:ok, {msg.ref, %{}}, state}}
-
-            other ->
-              raise ArgumentError, """
-              expected #{inspect(upload_conf.name)} upload progress #{inspect(event)} to return {:noreply, Socket.t()} got:
-
-                  #{inspect(other)}
-              """
-          end
-        else
-          {new_socket, {:ok, {msg.ref, %{}}, state}}
-        end
+        {new_socket, {:ok, {msg.ref, %{}}, state}}
       end)
 
     {:noreply, new_state}
@@ -298,28 +280,7 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   def handle_info({@prefix, :report_writer_error, channel_pid, reason}, state) do
-    case state.upload_pids do
-      %{^channel_pid => {ref, entry_ref, cid}} ->
-        new_state =
-          write_socket(state, cid, nil, fn socket, _ ->
-            upload_config = Upload.get_upload_by_ref!(socket, ref)
-
-            new_socket =
-              Upload.put_upload_error(
-                socket,
-                upload_config.name,
-                entry_ref,
-                {:writer_failure, reason}
-              )
-
-            {new_socket, {:ok, nil, state}}
-          end)
-
-        {:noreply, new_state}
-
-      _ ->
-        {:noreply, state}
-    end
+    {:noreply, fail_writer_entry(state, channel_pid, reason)}
   end
 
   def handle_info({@prefix, :send_update, update}, state) do
@@ -740,15 +701,64 @@ defmodule Phoenix.LiveView.Channel do
   defp unregister_upload(state, ref, entry_ref, cid) do
     write_socket(state, cid, nil, fn socket, _ ->
       conf = Upload.get_upload_by_ref!(socket, ref)
+      new_socket = Upload.unregister_completed_entry_upload(socket, conf, entry_ref)
+      new_conf = Upload.get_upload_by_ref!(new_socket, ref)
 
       new_state =
-        case conf.entries do
-          [_] -> drop_upload_name(state, conf.name)
-          _ -> state
-        end
+        if new_conf.entries == [], do: drop_upload_name(state, conf.name), else: state
 
-      {Upload.unregister_completed_entry_upload(socket, conf, entry_ref), {:ok, nil, new_state}}
+      {new_socket, {:ok, nil, new_state}}
     end)
+  end
+
+  defp fail_writer_entry(state, channel_pid, reason) do
+    case state.upload_pids do
+      %{^channel_pid => {ref, entry_ref, cid}} ->
+        write_socket(state, cid, nil, fn socket, _ ->
+          upload_conf = Upload.get_upload_by_ref!(socket, ref)
+
+          new_socket =
+            Upload.fail_entry_upload(
+              socket,
+              upload_conf,
+              entry_ref,
+              {:writer_failure, reason}
+            )
+
+          failed_conf = Upload.get_upload_by_ref!(new_socket, ref)
+          failed_entry = UploadConfig.get_entry_by_ref(failed_conf, entry_ref)
+          new_socket = run_progress_event(failed_conf, failed_entry, new_socket)
+
+          {new_socket, {:ok, nil, state}}
+        end)
+
+      _ ->
+        state
+    end
+  end
+
+  defp run_progress_event(%UploadConfig{} = upload_conf, entry, %Socket{} = socket) do
+    if event = entry && upload_conf.progress_event do
+      case event.(upload_conf.name, entry, socket) do
+        {:noreply, %Socket{} = new_socket} ->
+          if new_socket.redirected do
+            flash = Utils.changed_flash(new_socket)
+            send(new_socket.root_pid, {@prefix, :redirect, new_socket.redirected, flash})
+            %{new_socket | redirected: nil}
+          else
+            new_socket
+          end
+
+        other ->
+          raise ArgumentError, """
+          expected #{inspect(upload_conf.name)} upload progress #{inspect(event)} to return {:noreply, Socket.t()} got:
+
+              #{inspect(other)}
+          """
+      end
+    else
+      socket
+    end
   end
 
   defp put_upload_pid(state, pid, ref, entry_ref, cid) when is_pid(pid) do
@@ -1551,8 +1561,10 @@ defmodule Phoenix.LiveView.Channel do
             writer: writer!(socket, conf.name, entry, conf.writer)
           }
 
-          GenServer.reply(from, {:ok, reply})
+          # monitor before replying, otherwise a channel that exits as soon as it is
+          # acknowledged (writer init/1 failure) can be dead by the time we monitor it
           new_state = put_upload_pid(state, pid, ref, entry_ref, cid)
+          GenServer.reply(from, {:ok, reply})
           {new_socket, {:ok, nil, new_state}}
 
         {:error, reason} ->

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -68,9 +68,9 @@ defmodule Phoenix.LiveView.Channel do
     GenServer.call(pid, {@prefix, :fetch_upload_config, name, cid})
   end
 
-  def drop_upload_entries(%UploadConfig{} = conf, entry_refs) do
+  def drop_consumed_upload_entries(%UploadConfig{} = conf, entry_refs) do
     info = %{ref: conf.ref, entry_refs: entry_refs, cid: conf.cid}
-    send(self(), {@prefix, :drop_upload_entries, info})
+    send(self(), {@prefix, :drop_consumed_upload_entries, info})
   end
 
   def drop_upload_name(%UploadConfig{} = conf) do
@@ -81,6 +81,12 @@ defmodule Phoenix.LiveView.Channel do
   def report_writer_error(pid, reason) do
     channel_pid = self()
     send(pid, {@prefix, :report_writer_error, channel_pid, reason})
+    :ok
+  end
+
+  def report_upload_consumed(pid) do
+    channel_pid = self()
+    send(pid, {@prefix, :report_upload_consumed, channel_pid})
     :ok
   end
 
@@ -272,13 +278,21 @@ defmodule Phoenix.LiveView.Channel do
     end
   end
 
-  def handle_info({@prefix, :drop_upload_entries, info}, state) do
+  def handle_info({@prefix, :drop_consumed_upload_entries, info}, state) do
     %{ref: ref, cid: cid, entry_refs: entry_refs} = info
 
     new_state =
       write_socket(state, cid, nil, fn socket, _ ->
         upload_config = Upload.get_upload_by_ref!(socket, ref)
-        {Upload.drop_upload_entries(socket, upload_config, entry_refs), {:ok, nil, state}}
+        new_socket = Upload.drop_consumed_upload_entries(socket, upload_config, entry_refs)
+        new_upload_config = Upload.get_upload_by_ref!(new_socket, ref)
+
+        new_state =
+          if new_upload_config.entries == [],
+            do: drop_upload_name(state, upload_config.name),
+            else: state
+
+        {new_socket, {:ok, nil, new_state}}
       end)
 
     {:noreply, new_state}
@@ -298,6 +312,30 @@ defmodule Phoenix.LiveView.Channel do
 
   def handle_info({@prefix, :report_writer_error, channel_pid, reason}, state) do
     {:noreply, fail_writer_entry(state, channel_pid, reason)}
+  end
+
+  def handle_info({@prefix, :report_upload_consumed, channel_pid}, state) do
+    new_state =
+      case state.upload_pids do
+        %{^channel_pid => {ref, entry_ref, cid}} ->
+          write_socket(state, cid, nil, fn socket, _ ->
+            upload_config = Upload.get_upload_by_ref!(socket, ref)
+            new_socket = Upload.consume_entry_upload(socket, upload_config, entry_ref)
+            new_upload_config = Upload.get_upload_by_ref!(new_socket, ref)
+
+            new_state =
+              if new_upload_config.entries == [],
+                do: drop_upload_name(state, upload_config.name),
+                else: state
+
+            {new_socket, {:ok, nil, new_state}}
+          end)
+
+        _ ->
+          state
+      end
+
+    {:noreply, new_state}
   end
 
   def handle_info({@prefix, :send_update, update}, state) do

--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -1620,6 +1620,7 @@ defmodule Phoenix.LiveView.Channel do
           reply = %{
             max_file_size: entry.client_size,
             chunk_timeout: conf.chunk_timeout,
+            max_entries_mode: conf.max_entries_mode,
             writer: writer!(socket, conf.name, entry, conf.writer)
           }
 

--- a/lib/phoenix_live_view/test/upload_client.ex
+++ b/lib/phoenix_live_view/test/upload_client.ex
@@ -83,7 +83,11 @@ defmodule Phoenix.LiveViewTest.UploadClient do
   end
 
   def handle_call(:channel_pids, _from, state) do
-    pids = Enum.into(state.entries, %{}, fn {name, entry} -> {name, entry.socket.channel_pid} end)
+    pids =
+      for {name, %{socket: %{channel_pid: pid}}} <- state.entries,
+          into: %{},
+          do: {name, pid}
+
     {:reply, pids, state}
   end
 
@@ -136,6 +140,10 @@ defmodule Phoenix.LiveViewTest.UploadClient do
 
     case Phoenix.ChannelTest.subscribe_and_join(state.socket, "lvu:123", %{"token" => token}) do
       {:ok, _resp, entry_socket} ->
+        channel_pid = entry_socket.channel_pid
+        Process.unlink(channel_pid)
+        Process.monitor(channel_pid)
+
         %{
           name: name,
           content: content,
@@ -301,7 +309,42 @@ defmodule Phoenix.LiveViewTest.UploadClient do
     {:noreply, state}
   end
 
-  def handle_info({:socket_close, _pid, reason}, state) do
-    {:stop, reason, state}
+  def handle_info({:socket_close, pid, reason}, state) do
+    drop_closed_channel(state, pid, reason)
+  end
+
+  def handle_info({:DOWN, _ref, :process, pid, reason}, state) do
+    drop_closed_channel(state, pid, reason)
+  end
+
+  defp drop_closed_channel(state, pid, reason) do
+    case entry_for_channel_pid(state.entries, pid) do
+      {name, _entry} ->
+        new_state = %{state | entries: Map.delete(state.entries, name)}
+
+        if has_channel_entries?(new_state.entries) do
+          {:noreply, new_state}
+        else
+          {:stop, reason, new_state}
+        end
+
+      nil ->
+        {:noreply, state}
+    end
+  end
+
+  # Entries rejected during preflight remain as {:error, reason} and have no channel pid.
+  defp entry_for_channel_pid(entries, pid) do
+    Enum.find(entries, fn
+      {_name, %{socket: %{channel_pid: channel_pid}}} -> channel_pid == pid
+      {_name, _entry} -> false
+    end)
+  end
+
+  defp has_channel_entries?(entries) do
+    Enum.any?(entries, fn
+      {_name, %{socket: %{channel_pid: _pid}}} -> true
+      {_name, _entry} -> false
+    end)
   end
 end

--- a/lib/phoenix_live_view/test/upload_client.ex
+++ b/lib/phoenix_live_view/test/upload_client.ex
@@ -134,20 +134,23 @@ defmodule Phoenix.LiveViewTest.UploadClient do
       "ref" => ref
     } = client_entry
 
-    {:ok, _resp, entry_socket} =
-      Phoenix.ChannelTest.subscribe_and_join(state.socket, "lvu:123", %{"token" => token})
+    case Phoenix.ChannelTest.subscribe_and_join(state.socket, "lvu:123", %{"token" => token}) do
+      {:ok, _resp, entry_socket} ->
+        %{
+          name: name,
+          content: content,
+          size: byte_size(content),
+          type: type,
+          socket: entry_socket,
+          ref: ref,
+          token: token,
+          chunk_percent: 0
+        }
+        |> with_chunk_boundaries()
 
-    %{
-      name: name,
-      content: content,
-      size: byte_size(content),
-      type: type,
-      socket: entry_socket,
-      ref: ref,
-      token: token,
-      chunk_percent: 0
-    }
-    |> with_chunk_boundaries()
+      {:error, %{reason: reason}} ->
+        {:error, reason}
+    end
   end
 
   def with_chunk_boundaries(entry) do
@@ -250,6 +253,9 @@ defmodule Phoenix.LiveViewTest.UploadClient do
             state.cid
           )
 
+        update_entry_percent(state, entry, stats.new_percent)
+
+      %Phoenix.Socket.Reply{ref: ^ref, status: :error, payload: %{reason: :writer_error}} ->
         update_entry_percent(state, entry, stats.new_percent)
 
       %Phoenix.Socket.Reply{ref: ^ref, status: :error} ->

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -74,9 +74,13 @@ defmodule Phoenix.LiveView.Upload do
 
     case UploadConfig.get_entry_by_ref(upload_config, entry_ref) do
       %UploadEntry{} = entry ->
-        upload_config
-        |> UploadConfig.cancel_entry(entry)
-        |> update_uploads(socket)
+        new_upload_config = UploadConfig.cancel_entry(upload_config, entry)
+
+        if new_upload_config.entries == [] do
+          Phoenix.LiveView.Channel.drop_upload_name(new_upload_config)
+        end
+
+        update_uploads(new_upload_config, socket)
 
       _ ->
         raise ArgumentError, "no entry in upload \"#{inspect(name)}\" with ref \"#{entry_ref}\""

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -384,7 +384,11 @@ defmodule Phoenix.LiveView.Upload do
     %UploadConfig{} = conf = Map.fetch!(socket.assigns.uploads, name)
 
     # don't send more than the remaining max_entries preflight responses
-    remaining_entries = max(conf.max_entries - conf.consumed_entries, 0)
+    remaining_entries =
+      case conf.max_entries_mode do
+        :selected -> conf.max_entries
+        :total -> max(conf.max_entries - conf.consumed_entries, 0)
+      end
 
     refs =
       for {entry, i} <- Enum.with_index(conf.entries),

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -167,6 +167,19 @@ defmodule Phoenix.LiveView.Upload do
   end
 
   @doc false
+  def consume_entry_upload(%Socket{} = socket, %UploadConfig{} = conf, entry_ref) do
+    case UploadConfig.get_entry_by_ref(conf, entry_ref) do
+      %UploadEntry{} = entry ->
+        conf
+        |> UploadConfig.consume_entry(entry)
+        |> update_uploads(socket)
+
+      nil ->
+        socket
+    end
+  end
+
+  @doc false
   def fail_entry_upload(%Socket{} = socket, %UploadConfig{} = conf, entry_ref, reason) do
     conf
     |> UploadConfig.fail_entry(entry_ref, reason)
@@ -298,10 +311,10 @@ defmodule Phoenix.LiveView.Upload do
   @doc """
   Drops all entries from the upload.
   """
-  def drop_upload_entries(%Socket{} = socket, %UploadConfig{} = conf, entry_refs) do
+  def drop_consumed_upload_entries(%Socket{} = socket, %UploadConfig{} = conf, entry_refs) do
     conf.entries
     |> Enum.filter(fn entry -> entry.ref in entry_refs end)
-    |> Enum.reduce(conf, fn entry, acc -> UploadConfig.drop_entry(acc, entry) end)
+    |> Enum.reduce(conf, fn entry, acc -> UploadConfig.consume_entry(acc, entry) end)
     |> update_uploads(socket)
   end
 
@@ -352,7 +365,7 @@ defmodule Phoenix.LiveView.Upload do
           {ref, _result} -> [ref]
         end)
 
-      Phoenix.LiveView.Channel.drop_upload_entries(conf, consumed_refs)
+      Phoenix.LiveView.Channel.drop_consumed_upload_entries(conf, consumed_refs)
 
       Enum.map(results, fn {_ref, result} -> result end)
     else
@@ -370,11 +383,13 @@ defmodule Phoenix.LiveView.Upload do
   def generate_preflight_response(%Socket{} = socket, name, cid, refs) do
     %UploadConfig{} = conf = Map.fetch!(socket.assigns.uploads, name)
 
-    # don't send more than max_entries preflight responses
+    # don't send more than the remaining max_entries preflight responses
+    remaining_entries = max(conf.max_entries - conf.consumed_entries, 0)
+
     refs =
       for {entry, i} <- Enum.with_index(conf.entries),
           entry.ref in refs,
-          i < conf.max_entries && not entry.preflighted?,
+          i < remaining_entries && not entry.preflighted?,
           do: entry.ref
 
     client_meta = %{

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -162,6 +162,13 @@ defmodule Phoenix.LiveView.Upload do
     |> update_uploads(socket)
   end
 
+  @doc false
+  def fail_entry_upload(%Socket{} = socket, %UploadConfig{} = conf, entry_ref, reason) do
+    conf
+    |> UploadConfig.fail_entry(entry_ref, reason)
+    |> update_uploads(socket)
+  end
+
   @doc """
   Registers a new entry upload for a `Phoenix.LiveView.UploadChannel` process.
   """

--- a/lib/phoenix_live_view/upload_channel.ex
+++ b/lib/phoenix_live_view/upload_channel.ex
@@ -158,6 +158,7 @@ defmodule Phoenix.LiveView.UploadChannel do
 
   @impl true
   def handle_call(:consume_done, from, socket) do
+    :ok = Channel.report_upload_consumed(socket.assigns.live_view_pid)
     GenServer.reply(from, :ok)
     {:stop, {:shutdown, :closed}, socket}
   end

--- a/lib/phoenix_live_view/upload_channel.ex
+++ b/lib/phoenix_live_view/upload_channel.ex
@@ -58,8 +58,12 @@ defmodule Phoenix.LiveView.UploadChannel do
 
     with {:ok, %{pid: pid, ref: ref, cid: cid}} <- Static.verify_token(socket.endpoint, token),
          {:ok, config} <- Channel.register_upload(pid, ref, cid) do
-      %{max_file_size: max_file_size, chunk_timeout: chunk_timeout, writer: {writer, writer_opts}} =
-        config
+      %{
+        max_file_size: max_file_size,
+        chunk_timeout: chunk_timeout,
+        max_entries_mode: max_entries_mode,
+        writer: {writer, writer_opts}
+      } = config
 
       case writer.init(writer_opts) do
         {:ok, writer_state} ->
@@ -72,6 +76,7 @@ defmodule Phoenix.LiveView.UploadChannel do
               writer_state: writer_state,
               live_view_pid: pid,
               max_file_size: max_file_size,
+              max_entries_mode: max_entries_mode,
               chunk_timeout: chunk_timeout,
               chunk_timer: nil,
               writer_closed?: false,
@@ -158,7 +163,10 @@ defmodule Phoenix.LiveView.UploadChannel do
 
   @impl true
   def handle_call(:consume_done, from, socket) do
-    :ok = Channel.report_upload_consumed(socket.assigns.live_view_pid)
+    if socket.assigns.max_entries_mode == :total do
+      :ok = Channel.report_upload_consumed(socket.assigns.live_view_pid)
+    end
+
     GenServer.reply(from, :ok)
     {:stop, {:shutdown, :closed}, socket}
   end

--- a/lib/phoenix_live_view/upload_channel.ex
+++ b/lib/phoenix_live_view/upload_channel.ex
@@ -57,37 +57,44 @@ defmodule Phoenix.LiveView.UploadChannel do
     %{"token" => token} = auth_payload
 
     with {:ok, %{pid: pid, ref: ref, cid: cid}} <- Static.verify_token(socket.endpoint, token),
-         {:ok, config} <- Channel.register_upload(pid, ref, cid),
-         %{max_file_size: max_file_size, chunk_timeout: chunk_timeout} = config,
-         {writer, writer_opts} <- config.writer,
-         {:ok, writer_state} <- writer.init(writer_opts) do
-      Process.monitor(pid)
-      Process.flag(:trap_exit, true)
+         {:ok, config} <- Channel.register_upload(pid, ref, cid) do
+      %{max_file_size: max_file_size, chunk_timeout: chunk_timeout, writer: {writer, writer_opts}} =
+        config
 
-      socket =
-        assign(socket, %{
-          writer: writer,
-          writer_state: writer_state,
-          live_view_pid: pid,
-          max_file_size: max_file_size,
-          chunk_timeout: chunk_timeout,
-          chunk_timer: nil,
-          writer_closed?: false,
-          done?: false,
-          uploaded_size: 0
-        })
+      case writer.init(writer_opts) do
+        {:ok, writer_state} ->
+          Process.monitor(pid)
+          Process.flag(:trap_exit, true)
 
-      {:ok, socket}
+          socket =
+            assign(socket, %{
+              writer: writer,
+              writer_state: writer_state,
+              live_view_pid: pid,
+              max_file_size: max_file_size,
+              chunk_timeout: chunk_timeout,
+              chunk_timer: nil,
+              writer_closed?: false,
+              done?: false,
+              uploaded_size: 0
+            })
+
+          {:ok, socket}
+
+        {:error, reason} ->
+          # the entry is already registered with the LiveView at this point, so the
+          # failure must be reported just like a write_chunk/2 or close/2 failure,
+          # which retains the entry with a {:writer_failure, reason} error
+          Channel.report_writer_error(pid, reason)
+
+          {:error, %{reason: :writer_error}}
+      end
     else
-      {:error, reason} when reason in [:expired, :invalid] ->
+      {:error, reason} when reason in [:expired, :invalid, :outdated] ->
         {:error, %{reason: :invalid_token}}
 
       {:error, reason} when reason in [:already_registered, :disallowed] ->
         {:error, %{reason: reason}}
-
-      # writer init error
-      {:error, _reason} ->
-        {:error, %{reason: :writer_error}}
     end
   end
 
@@ -113,7 +120,7 @@ defmodule Phoenix.LiveView.UploadChannel do
               end
             end
 
-          Channel.report_writer_error(socket.assigns.live_view_pid, reason)
+          :ok = Channel.report_writer_error(socket.assigns.live_view_pid, reason)
 
           {:stop, {:shutdown, :closed}, {:error, %{reason: :writer_error}}, new_socket}
       end

--- a/lib/phoenix_live_view/upload_config.ex
+++ b/lib/phoenix_live_view/upload_config.ex
@@ -378,11 +378,17 @@ defmodule Phoenix.LiveView.UploadConfig do
 
   @doc false
   def fail_entry(%UploadConfig{} = conf, entry_ref, reason) do
-    %UploadEntry{} = get_entry_by_ref(conf, entry_ref)
+    # the entry may already have been dropped, for example by a progress callback
+    # that cancelled it, in which case the failure report is stale
+    case get_entry_by_ref(conf, entry_ref) do
+      %UploadEntry{} ->
+        conf
+        |> put_error(entry_ref, reason)
+        |> Map.update!(:entry_refs_to_pids, &Map.put(&1, entry_ref, @failed))
 
-    conf
-    |> put_error(entry_ref, reason)
-    |> Map.update!(:entry_refs_to_pids, &Map.put(&1, entry_ref, @failed))
+      nil ->
+        conf
+    end
   end
 
   @doc false
@@ -414,6 +420,10 @@ defmodule Phoenix.LiveView.UploadConfig do
 
       {:ok, existing_pid} when is_pid(existing_pid) ->
         {:error, :already_registered}
+
+      # the entry is retained, but it may no longer be uploaded to
+      {:ok, status} when status in [@invalid, @failed] ->
+        {:error, :disallowed}
 
       :error ->
         {:error, :disallowed}
@@ -702,7 +712,10 @@ defmodule Phoenix.LiveView.UploadConfig do
   end
 
   def put_error(%UploadConfig{} = conf, entry_ref, reason) do
-    %{conf | errors: conf.errors ++ [{entry_ref, reason}]}
+    # entries with errors are retained, so the same error can be reported more than
+    # once for the same entry, for example by repeated external client failures
+    pair = {entry_ref, reason}
+    %{conf | errors: List.delete(conf.errors, pair) ++ [pair]}
   end
 
   @doc false

--- a/lib/phoenix_live_view/upload_config.ex
+++ b/lib/phoenix_live_view/upload_config.ex
@@ -57,6 +57,7 @@ defmodule Phoenix.LiveView.UploadConfig do
   alias Phoenix.LiveView.UploadEntry
 
   @default_max_entries 1
+  @default_max_entries_mode :selected
   @default_max_file_size 8_000_000
   @default_chunk_size 64_000
   @default_chunk_timeout 10_000
@@ -75,6 +76,7 @@ defmodule Phoenix.LiveView.UploadConfig do
              :entries,
              :consumed_entries,
              :max_entries,
+             :max_entries_mode,
              :max_file_size,
              :accept,
              :errors,
@@ -88,6 +90,7 @@ defmodule Phoenix.LiveView.UploadConfig do
             cid: :unregistered,
             client_key: nil,
             max_entries: @default_max_entries,
+            max_entries_mode: @default_max_entries_mode,
             max_file_size: @default_max_file_size,
             chunk_size: @default_chunk_size,
             chunk_timeout: @default_chunk_timeout,
@@ -113,6 +116,7 @@ defmodule Phoenix.LiveView.UploadConfig do
           cid: :unregistered | nil | integer(),
           client_key: String.t(),
           max_entries: pos_integer(),
+          max_entries_mode: :selected | :total,
           max_file_size: pos_integer(),
           entries: list(),
           consumed_entries: non_neg_integer(),
@@ -210,6 +214,24 @@ defmodule Phoenix.LiveView.UploadConfig do
 
         :error ->
           @default_max_entries
+      end
+
+    max_entries_mode =
+      case Keyword.fetch(opts, :max_entries_mode) do
+        {:ok, mode} when mode in [:selected, :total] ->
+          mode
+
+        {:ok, other} ->
+          raise ArgumentError, """
+          invalid :max_entries_mode value provided to allow_upload.
+
+          Only :selected and :total are supported (Defaults to :selected). Got:
+
+          #{inspect(other)}
+          """
+
+        :error ->
+          @default_max_entries_mode
       end
 
     max_file_size =
@@ -324,6 +346,7 @@ defmodule Phoenix.LiveView.UploadConfig do
       ref: random_ref,
       name: name,
       max_entries: max_entries,
+      max_entries_mode: max_entries_mode,
       max_file_size: max_file_size,
       entry_refs_to_pids: %{},
       entry_refs_to_metas: %{},
@@ -584,11 +607,8 @@ defmodule Phoenix.LiveView.UploadConfig do
     conf
   end
 
-  defp too_many_files?(%UploadConfig{
-         entries: entries,
-         consumed_entries: consumed_entries,
-         max_entries: max
-       }) do
+  defp too_many_files?(%UploadConfig{entries: entries, max_entries: max} = conf) do
+    consumed_entries = if conf.max_entries_mode == :total, do: conf.consumed_entries, else: 0
     consumed_entries + length(entries) > max
   end
 
@@ -738,6 +758,10 @@ defmodule Phoenix.LiveView.UploadConfig do
   end
 
   @doc false
+  def consume_entry(%UploadConfig{max_entries_mode: :selected} = conf, %UploadEntry{} = entry) do
+    drop_entry(conf, entry)
+  end
+
   def consume_entry(%UploadConfig{} = conf, %UploadEntry{} = entry) do
     conf
     |> Map.update!(:consumed_entries, &(&1 + 1))

--- a/lib/phoenix_live_view/upload_config.ex
+++ b/lib/phoenix_live_view/upload_config.ex
@@ -73,6 +73,7 @@ defmodule Phoenix.LiveView.UploadConfig do
              :name,
              :ref,
              :entries,
+             :consumed_entries,
              :max_entries,
              :max_file_size,
              :accept,
@@ -91,6 +92,7 @@ defmodule Phoenix.LiveView.UploadConfig do
             chunk_size: @default_chunk_size,
             chunk_timeout: @default_chunk_timeout,
             entries: [],
+            consumed_entries: 0,
             entry_refs_to_pids: %{},
             entry_refs_to_metas: %{},
             accept: [],
@@ -113,6 +115,7 @@ defmodule Phoenix.LiveView.UploadConfig do
           max_entries: pos_integer(),
           max_file_size: pos_integer(),
           entries: list(),
+          consumed_entries: non_neg_integer(),
           entry_refs_to_pids: %{String.t() => pid() | :unregistered | :invalid | :failed},
           entry_refs_to_metas: %{String.t() => map()},
           accept: list() | :any,
@@ -364,7 +367,7 @@ defmodule Phoenix.LiveView.UploadConfig do
   def unregister_completed_external_entry(%UploadConfig{} = conf, entry_ref) do
     %UploadEntry{} = entry = get_entry_by_ref(conf, entry_ref)
 
-    drop_entry(conf, entry)
+    consume_entry(conf, entry)
   end
 
   @doc false
@@ -581,8 +584,12 @@ defmodule Phoenix.LiveView.UploadConfig do
     conf
   end
 
-  defp too_many_files?(%UploadConfig{entries: entries, max_entries: max}) do
-    length(entries) > max
+  defp too_many_files?(%UploadConfig{
+         entries: entries,
+         consumed_entries: consumed_entries,
+         max_entries: max
+       }) do
+    consumed_entries + length(entries) > max
   end
 
   defp cast_and_validate_entry(%UploadConfig{} = conf, %{"ref" => ref} = client_entry) do
@@ -728,6 +735,13 @@ defmodule Phoenix.LiveView.UploadConfig do
       _ ->
         drop_entry(conf, entry)
     end
+  end
+
+  @doc false
+  def consume_entry(%UploadConfig{} = conf, %UploadEntry{} = entry) do
+    conf
+    |> Map.update!(:consumed_entries, &(&1 + 1))
+    |> drop_entry(entry)
   end
 
   @doc false

--- a/lib/phoenix_live_view/upload_config.ex
+++ b/lib/phoenix_live_view/upload_config.ex
@@ -63,6 +63,8 @@ defmodule Phoenix.LiveView.UploadConfig do
 
   @unregistered :unregistered
   @invalid :invalid
+  # Writer failures retain their entry until it is explicitly cancelled or replaced.
+  @failed :failed
 
   @too_many_files :too_many_files
 
@@ -111,7 +113,7 @@ defmodule Phoenix.LiveView.UploadConfig do
           max_entries: pos_integer(),
           max_file_size: pos_integer(),
           entries: list(),
-          entry_refs_to_pids: %{String.t() => pid() | :unregistered | :done},
+          entry_refs_to_pids: %{String.t() => pid() | :unregistered | :invalid | :failed},
           entry_refs_to_metas: %{String.t() => map()},
           accept: list() | :any,
           acceptable_types: MapSet.t(),
@@ -340,7 +342,7 @@ defmodule Phoenix.LiveView.UploadConfig do
   def entry_pid(%UploadConfig{} = conf, %UploadEntry{} = entry) do
     case Map.fetch(conf.entry_refs_to_pids, entry.ref) do
       {:ok, pid} when is_pid(pid) -> pid
-      {:ok, status} when status in [@unregistered, @invalid] -> nil
+      {:ok, status} when status in [@unregistered, @invalid, @failed] -> nil
     end
   end
 
@@ -367,9 +369,20 @@ defmodule Phoenix.LiveView.UploadConfig do
 
   @doc false
   def unregister_completed_entry(%UploadConfig{} = conf, entry_ref) do
-    %UploadEntry{} = entry = get_entry_by_ref(conf, entry_ref)
+    case {get_entry_by_ref(conf, entry_ref), Map.get(conf.entry_refs_to_pids, entry_ref)} do
+      {%UploadEntry{}, @failed} -> conf
+      {%UploadEntry{} = entry, _status} -> drop_entry(conf, entry)
+      {nil, _status} -> conf
+    end
+  end
 
-    drop_entry(conf, entry)
+  @doc false
+  def fail_entry(%UploadConfig{} = conf, entry_ref, reason) do
+    %UploadEntry{} = get_entry_by_ref(conf, entry_ref)
+
+    conf
+    |> put_error(entry_ref, reason)
+    |> Map.update!(:entry_refs_to_pids, &Map.put(&1, entry_ref, @failed))
   end
 
   @doc false

--- a/test/e2e/support/issues/issue_2835.ex
+++ b/test/e2e/support/issues/issue_2835.ex
@@ -1,0 +1,51 @@
+defmodule Phoenix.LiveViewTest.E2E.Issue2835Live do
+  use Phoenix.LiveView
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:uploaded_files, [])
+     |> allow_upload(:documents,
+       accept: :any,
+       auto_upload: true,
+       max_entries: 2,
+       progress: &__MODULE__.handle_progress/3
+     )}
+  end
+
+  def handle_progress(:documents, %{done?: true} = entry, socket) do
+    name = consume_uploaded_entry(socket, entry, fn _meta -> {:ok, entry.client_name} end)
+    {:noreply, update(socket, :uploaded_files, &(&1 ++ [name]))}
+  end
+
+  def handle_progress(:documents, _entry, socket), do: {:noreply, socket}
+
+  @impl true
+  def handle_event("validate", _params, socket), do: {:noreply, socket}
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <form id="upload-form" phx-change="validate">
+      <.live_file_input upload={@uploads.documents} />
+
+      <article
+        :for={entry <- @uploads.documents.entries}
+        class="upload-entry"
+        data-name={entry.client_name}
+      >
+        {entry.client_name}: {entry.progress}%
+      </article>
+
+      <p :for={error <- upload_errors(@uploads.documents)} class="upload-error">
+        {inspect(error)}
+      </p>
+    </form>
+
+    <ul id="uploaded-files">
+      <li :for={name <- @uploaded_files}>{name}</li>
+    </ul>
+    """
+  end
+end

--- a/test/e2e/support/issues/issue_2835.ex
+++ b/test/e2e/support/issues/issue_2835.ex
@@ -10,6 +10,7 @@ defmodule Phoenix.LiveViewTest.E2E.Issue2835Live do
        accept: :any,
        auto_upload: true,
        max_entries: 2,
+       max_entries_mode: :total,
        progress: &__MODULE__.handle_progress/3
      )}
   end

--- a/test/e2e/support/issues/issue_3391.ex
+++ b/test/e2e/support/issues/issue_3391.ex
@@ -1,0 +1,55 @@
+defmodule Phoenix.LiveViewTest.E2E.Issue3391Live do
+  use Phoenix.LiveView
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(submitted?: false, uploaded?: false)
+     |> allow_upload(:document,
+       accept: ~w(.txt),
+       auto_upload: true,
+       max_entries: 1,
+       progress: &__MODULE__.handle_progress/3
+     )}
+  end
+
+  def handle_progress(:document, %{done?: true} = entry, socket) do
+    :ok = consume_uploaded_entry(socket, entry, fn _meta -> {:ok, :ok} end)
+    {:noreply, assign(socket, :uploaded?, true)}
+  end
+
+  def handle_progress(:document, _entry, socket), do: {:noreply, socket}
+
+  @impl true
+  def handle_event("validate", _params, socket), do: {:noreply, socket}
+
+  def handle_event("cancel", %{"ref" => ref}, socket) do
+    {:noreply, cancel_upload(socket, :document, ref)}
+  end
+
+  def handle_event("submit", _params, socket) do
+    {:noreply, assign(socket, :submitted?, true)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <form id="upload-form" phx-change="validate" phx-submit="submit">
+      <.live_file_input upload={@uploads.document} />
+      <button type="submit">Submit</button>
+
+      <article :for={entry <- @uploads.document.entries} class="upload-entry">
+        <span>{entry.client_name}: {entry.progress}%</span>
+        <button type="button" phx-click="cancel" phx-value-ref={entry.ref}>Cancel</button>
+        <p :for={error <- upload_errors(@uploads.document, entry)} class="upload-error">
+          {inspect(error)}
+        </p>
+      </article>
+    </form>
+
+    <p id="uploaded">uploaded: {@uploaded?}</p>
+    <p id="submitted">submitted: {@submitted?}</p>
+    """
+  end
+end

--- a/test/e2e/support/issues/issue_4368.ex
+++ b/test/e2e/support/issues/issue_4368.ex
@@ -1,0 +1,82 @@
+defmodule Phoenix.LiveViewTest.E2E.Issue4368Live do
+  use Phoenix.LiveView
+
+  defmodule Writer do
+    @behaviour Phoenix.LiveView.UploadWriter
+
+    @impl true
+    def init(name), do: {:ok, name}
+
+    @impl true
+    def meta(name), do: %{name: name}
+
+    @impl true
+    def write_chunk("error", name), do: {:error, :invalid_pdf, name}
+    def write_chunk(_chunk, name), do: {:ok, name}
+
+    @impl true
+    def close(name, _reason), do: {:ok, name}
+  end
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(consumed: [], submitted?: false)
+     |> allow_upload(:documents,
+       accept: :any,
+       auto_upload: true,
+       chunk_size: 5,
+       max_entries: 2,
+       progress: &__MODULE__.handle_progress/3,
+       writer: &__MODULE__.writer/3
+     )}
+  end
+
+  def writer(_name, entry, _socket), do: {Writer, entry.client_name}
+
+  def handle_progress(:documents, %{done?: true} = entry, socket) do
+    name = consume_uploaded_entry(socket, entry, fn _meta -> {:ok, entry.client_name} end)
+    {:noreply, update(socket, :consumed, &[name | &1])}
+  end
+
+  def handle_progress(:documents, _entry, socket), do: {:noreply, socket}
+
+  @impl true
+  def handle_event("validate", _params, socket), do: {:noreply, socket}
+
+  def handle_event("cancel", %{"ref" => ref}, socket) do
+    {:noreply, cancel_upload(socket, :documents, ref)}
+  end
+
+  def handle_event("submit", _params, socket) do
+    {:noreply, assign(socket, submitted?: true)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id="issue-4368">
+      <form id="upload-form" phx-change="validate" phx-submit="submit">
+        <.live_file_input upload={@uploads.documents} />
+        <button type="submit">Submit</button>
+      </form>
+
+      <p id="submitted">submitted: {@submitted?}</p>
+      <p id="consumed">consumed: {Enum.join(@consumed, ",")}</p>
+
+      <article
+        :for={entry <- @uploads.documents.entries}
+        class="upload-entry"
+        data-name={entry.client_name}
+      >
+        <span>{entry.client_name}: {entry.progress}%</span>
+        <button type="button" phx-click="cancel" phx-value-ref={entry.ref}>Cancel</button>
+        <p :for={error <- upload_errors(@uploads.documents, entry)} class="upload-error">
+          {inspect(error)}
+        </p>
+      </article>
+    </div>
+    """
+  end
+end

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -225,6 +225,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/4334", Issue4334Live
       live "/4350", Issue4350Live
       live "/4359", Issue4359Live
+      live "/4368", Issue4368Live
     end
   end
 

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -185,6 +185,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       live "/3194", Issue3194Live
       live "/3194/other", Issue3194Live.OtherLive
       live "/3378", Issue3378.HomeLive
+      live "/3391", Issue3391Live
       live "/3448", Issue3448Live
       live "/3496/a", Issue3496.ALive
       live "/3496/b", Issue3496.BLive

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -175,6 +175,7 @@ defmodule Phoenix.LiveViewTest.E2E.Router do
       pipe_through(:browser)
 
       live "/2787", Issue2787Live
+      live "/2835", Issue2835Live
       live "/3026", Issue3026Live
       live "/3040", Issue3040Live
       live "/3083", Issue3083Live

--- a/test/e2e/tests/issues/2835.spec.js
+++ b/test/e2e/tests/issues/2835.spec.js
@@ -18,7 +18,7 @@ const uploadState = async (page) => ({
 });
 
 // https://github.com/phoenixframework/phoenix_live_view/issues/2835
-test("max_entries includes files consumed by an auto upload", async ({
+test("max_entries total mode includes files consumed by an auto upload", async ({
   page,
 }) => {
   await page.goto("/issues/2835");

--- a/test/e2e/tests/issues/2835.spec.js
+++ b/test/e2e/tests/issues/2835.spec.js
@@ -1,0 +1,53 @@
+import { test, expect } from "../../test-fixtures";
+import { syncLV } from "../../utils";
+
+const file = (name) => ({
+  name,
+  mimeType: "text/plain",
+  buffer: Buffer.from(name),
+});
+
+const uploadState = async (page) => ({
+  uploaded: (await page.locator("#uploaded-files li").allTextContents()).sort(),
+  pending: (await page.locator(".upload-entry").allTextContents())
+    .map((text) => text.split(":")[0].trim())
+    .sort(),
+  errors: (await page.locator(".upload-error").allTextContents()).map((text) =>
+    text.trim(),
+  ),
+});
+
+// https://github.com/phoenixframework/phoenix_live_view/issues/2835
+test("max_entries includes files consumed by an auto upload", async ({
+  page,
+}) => {
+  await page.goto("/issues/2835");
+  await syncLV(page);
+
+  const input = page.locator("#upload-form input[type='file']");
+
+  await input.setInputFiles([
+    file("first.txt"),
+    file("second.txt"),
+    file("third.txt"),
+  ]);
+  await syncLV(page);
+  const afterInitialSelection = await uploadState(page);
+
+  await input.setInputFiles(file("fourth.txt"));
+  await syncLV(page);
+  const afterAdditionalSelection = await uploadState(page);
+
+  expect({ afterInitialSelection, afterAdditionalSelection }).toEqual({
+    afterInitialSelection: {
+      uploaded: ["first.txt", "second.txt"],
+      pending: ["third.txt"],
+      errors: [":too_many_files"],
+    },
+    afterAdditionalSelection: {
+      uploaded: ["first.txt", "second.txt"],
+      pending: ["fourth.txt", "third.txt"],
+      errors: [":too_many_files"],
+    },
+  });
+});

--- a/test/e2e/tests/issues/3391.spec.js
+++ b/test/e2e/tests/issues/3391.spec.js
@@ -1,0 +1,51 @@
+import { test, expect } from "../../test-fixtures";
+import { syncLV } from "../../utils";
+
+// https://github.com/phoenixframework/phoenix_live_view/issues/3391
+test("an invalid auto-upload cancels submit without locking the form", async ({
+  page,
+}) => {
+  await page.goto("/issues/3391");
+  await syncLV(page);
+
+  const form = page.locator("#upload-form");
+  const input = form.locator("input[type='file']");
+  const submit = form.getByRole("button", { name: "Submit" });
+
+  await input.setInputFiles({
+    name: "invalid.html",
+    mimeType: "text/html",
+    buffer: Buffer.from("<h1>invalid</h1>"),
+  });
+  await syncLV(page);
+
+  const failedEntry = form.locator(".upload-entry");
+  await expect(failedEntry.locator(".upload-error")).toHaveText(
+    ":not_accepted",
+  );
+
+  await submit.click();
+
+  await expect(form).not.toHaveClass(/phx-submit-loading/);
+  await expect(submit).toBeEnabled();
+  await expect(
+    failedEntry.getByRole("button", { name: "Cancel" }),
+  ).toBeEnabled();
+  await expect(failedEntry.locator(".upload-error")).toHaveText(
+    ":not_accepted",
+  );
+  await expect(page.locator("#submitted")).toHaveText("submitted: false");
+
+  await failedEntry.getByRole("button", { name: "Cancel" }).click();
+  await expect(failedEntry).toHaveCount(0);
+
+  await input.setInputFiles({
+    name: "valid.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("valid"),
+  });
+  await expect(page.locator("#uploaded")).toHaveText("uploaded: true");
+
+  await submit.click();
+  await expect(page.locator("#submitted")).toHaveText("submitted: true");
+});

--- a/test/e2e/tests/issues/4368.spec.js
+++ b/test/e2e/tests/issues/4368.spec.js
@@ -1,0 +1,46 @@
+import { test, expect } from "../../test-fixtures";
+import { syncLV } from "../../utils";
+
+// https://github.com/phoenixframework/phoenix_live_view/pull/4368
+test("a custom writer failure remains visible until it is cancelled", async ({
+  page,
+}) => {
+  await page.goto("/issues/4368");
+  await syncLV(page);
+
+  const input = page.locator("#upload-form input[type='file']");
+
+  await input.setInputFiles([
+    {
+      name: "good.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("0000000000"),
+    },
+    {
+      name: "bad.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("00000error"),
+    },
+  ]);
+
+  const failedEntry = page.locator('.upload-entry[data-name="bad.pdf"]');
+  await expect(failedEntry.locator(".upload-error")).toHaveText(
+    "{:writer_failure, :invalid_pdf}",
+  );
+  await expect(page.locator("#consumed")).toHaveText("consumed: good.pdf");
+  await expect(page.locator("#submitted")).toHaveText("submitted: false");
+  await expect(page.locator("[data-phx-main]")).toHaveClass(/phx-connected/);
+
+  const failedRef = await input.getAttribute("data-phx-active-refs");
+  expect(failedRef).not.toBe("");
+  expect(await input.getAttribute("data-phx-preflighted-refs")).toBe(failedRef);
+  await expect(input).toHaveAttribute("data-phx-done-refs", "");
+
+  await failedEntry.getByRole("button", { name: "Cancel" }).click();
+  await expect(failedEntry).toHaveCount(0);
+  await syncLV(page);
+
+  await page.getByRole("button", { name: "Submit" }).click();
+  await syncLV(page);
+  await expect(page.locator("#submitted")).toHaveText("submitted: true");
+});

--- a/test/e2e/tests/issues/4368.spec.js
+++ b/test/e2e/tests/issues/4368.spec.js
@@ -32,8 +32,9 @@ test("a custom writer failure remains visible until it is cancelled", async ({
   await expect(page.locator("[data-phx-main]")).toHaveClass(/phx-connected/);
 
   const failedRef = await input.getAttribute("data-phx-active-refs");
+  // eslint-disable-next-line playwright/prefer-web-first-assertions
   expect(failedRef).not.toBe("");
-  expect(await input.getAttribute("data-phx-preflighted-refs")).toBe(failedRef);
+  await expect(input).toHaveAttribute("data-phx-preflighted-refs", failedRef);
   await expect(input).toHaveAttribute("data-phx-done-refs", "");
 
   await failedEntry.getByRole("button", { name: "Cancel" }).click();

--- a/test/phoenix_component/components_test.exs
+++ b/test/phoenix_component/components_test.exs
@@ -708,6 +708,18 @@ defmodule Phoenix.LiveView.ComponentsTest do
                ~X|<input type="file" accept="" data-phx-hook="Phoenix.LiveFileUpload" data-phx-active-refs="foo" data-phx-done-refs="" data-phx-preflighted-refs="" data-phx-auto-upload class="&lt;script&gt;alert(&#39;nice try&#39;);&lt;/script&gt;">|
     end
 
+    test "renders upload error refs" do
+      assigns = %{
+        conf: %Phoenix.LiveView.UploadConfig{
+          entries: [%{preflighted?: true, done?: false, ref: "foo"}],
+          errors: [{"foo", :too_large}, {"foo", :not_accepted}]
+        }
+      }
+
+      assert t2h(~H|<.live_file_input upload={@conf} />|) ==
+               ~X|<input type="file" accept="" data-phx-hook="Phoenix.LiveFileUpload" data-phx-active-refs="foo" data-phx-done-refs="" data-phx-preflighted-refs="foo" data-phx-error-refs="foo">|
+    end
+
     test "renders optional webkitdirectory attribute" do
       assigns = %{
         conf: %Phoenix.LiveView.UploadConfig{

--- a/test/phoenix_live_view/upload/channel_test.exs
+++ b/test/phoenix_live_view/upload/channel_test.exs
@@ -63,8 +63,31 @@ defmodule Phoenix.LiveView.UploadChannelTest do
     def close(test_name, reason), do: TestWriter.close(test_name, reason)
   end
 
+  defmodule InitErrorWriter do
+    @behaviour Phoenix.LiveView.UploadWriter
+
+    @impl true
+    def init(test_name) do
+      send(test_name, :init)
+      {:error, :init_failed}
+    end
+
+    @impl true
+    defdelegate meta(test_name), to: TestWriter
+
+    @impl true
+    defdelegate write_chunk(data, test_name), to: TestWriter
+
+    @impl true
+    defdelegate close(test_name, reason), to: TestWriter
+  end
+
   def build_writer(_name, %Phoenix.LiveView.UploadEntry{}, %Phoenix.LiveView.Socket{}) do
     {TestWriter, :test_writer}
+  end
+
+  def build_init_error_writer(_name, %Phoenix.LiveView.UploadEntry{}, %Phoenix.LiveView.Socket{}) do
+    {InitErrorWriter, :test_writer}
   end
 
   def build_close_error_writer(_name, %Phoenix.LiveView.UploadEntry{}, %Phoenix.LiveView.Socket{}) do
@@ -101,6 +124,21 @@ defmodule Phoenix.LiveView.UploadChannelTest do
     UploadLive.run(lv, fn socket ->
       {:reply, Phoenix.LiveView.uploaded_entries(socket, name), socket}
     end)
+  end
+
+  # TODO: Replace this helper with ExUnit's trace/3 once it is available in our
+  # supported Elixir versions.
+  defp eventually(fun, attempts \\ 100)
+
+  defp eventually(fun, 0), do: fun.()
+
+  defp eventually(fun, attempts) do
+    if fun.() do
+      true
+    else
+      Process.sleep(10)
+      eventually(fun, attempts - 1)
+    end
   end
 
   def build_entries(count, opts \\ []) do
@@ -162,6 +200,19 @@ defmodule Phoenix.LiveView.UploadChannelTest do
       end
 
     {:noreply, socket}
+  end
+
+  def record_writer_failure(%LiveView.UploadEntry{} = entry, socket) do
+    errors = Component.upload_errors(socket.assigns.uploads.avatar, entry)
+
+    if errors == [] do
+      {:noreply, socket}
+    else
+      {_completed, in_progress} = LiveView.uploaded_entries(socket, :avatar)
+      in_progress? = Enum.any?(in_progress, &(&1.ref == entry.ref))
+      send(:test_writer, {:writer_failure_progress, entry, in_progress?, errors})
+      {:noreply, socket}
+    end
   end
 
   setup_all do
@@ -940,6 +991,7 @@ defmodule Phoenix.LiveView.UploadChannelTest do
              max_entries: 1,
              chunk_size: 5,
              accept: :any,
+             progress: :record_writer_failure,
              writer: &__MODULE__.build_writer/3
            ]
       test "writer write_chunk/2 error self-closes the upload channel without bringing down the LiveView",
@@ -964,7 +1016,77 @@ defmodule Phoenix.LiveView.UploadChannelTest do
         # the upload channel self-closes instead of being left {:shutdown, :left}
         assert_receive {:DOWN, _ref, :process, ^channel_pid, {:shutdown, :closed}}, 1000
 
-        # the failed entry is dropped and the LiveView is still alive
+        assert {[],
+                [
+                  %LiveView.UploadEntry{
+                    client_name: "foo.jpeg",
+                    done?: false,
+                    ref: failed_ref
+                  }
+                ]} =
+                 get_uploaded_entries(lv, :avatar)
+
+        html = render(lv)
+        assert html =~ "#{@context}:foo.jpeg:50%"
+        assert html =~ "entry_error:{:writer_failure, :custom_error}"
+        assert html =~ ~s(data-phx-active-refs="#{failed_ref}")
+        assert html =~ ~s(data-phx-preflighted-refs="#{failed_ref}")
+        assert html =~ ~s(data-phx-done-refs="")
+
+        assert_receive {:writer_failure_progress,
+                        %LiveView.UploadEntry{client_name: "foo.jpeg", done?: false}, true,
+                        [writer_failure: :custom_error]}
+
+        refute_receive {:writer_failure_progress, _, _, _}
+        assert Process.alive?(lv.pid)
+
+        UploadLive.run(lv, fn socket ->
+          {[], [%{ref: ref}]} = LiveView.uploaded_entries(socket, :avatar)
+          {:reply, :ok, LiveView.cancel_upload(socket, :avatar, ref)}
+        end)
+
+        assert get_uploaded_entries(lv, :avatar) == {[], []}
+        html = render(lv)
+        refute html =~ "#{@context}:foo.jpeg"
+        assert html =~ ~s(data-phx-active-refs="")
+        assert html =~ ~s(data-phx-preflighted-refs="")
+        assert html =~ ~s(data-phx-done-refs="")
+      end
+
+      @tag allow: [
+             max_entries: 1,
+             chunk_size: 50,
+             accept: :any,
+             progress: :record_writer_failure,
+             writer: &__MODULE__.build_init_error_writer/3
+           ]
+      test "writer init/1 error fails the entry without bringing down the LiveView", %{lv: lv} do
+        Process.register(self(), :test_writer)
+
+        avatar =
+          file_input(lv, "form", :avatar, [
+            %{name: "foo.jpeg", content: String.duplicate("0", 100)}
+          ])
+
+        assert {:error, :writer_error} = render_upload(avatar, "foo.jpeg", 50)
+        assert_receive :init
+
+        # the entry is retained with the writer failure, exactly like a write_chunk/2 error
+        assert {[], [%LiveView.UploadEntry{client_name: "foo.jpeg", done?: false, ref: ref}]} =
+                 get_uploaded_entries(lv, :avatar)
+
+        assert render(lv) =~ "entry_error:{:writer_failure, :init_failed}"
+
+        assert_receive {:writer_failure_progress,
+                        %LiveView.UploadEntry{client_name: "foo.jpeg", done?: false}, true,
+                        [writer_failure: :init_failed]}
+
+        assert Process.alive?(lv.pid)
+
+        UploadLive.run(lv, fn socket ->
+          {:reply, :ok, LiveView.cancel_upload(socket, :avatar, ref)}
+        end)
+
         assert get_uploaded_entries(lv, :avatar) == {[], []}
       end
 
@@ -972,6 +1094,7 @@ defmodule Phoenix.LiveView.UploadChannelTest do
              max_entries: 1,
              chunk_size: 50,
              accept: :any,
+             progress: :record_writer_failure,
              writer: &__MODULE__.build_close_error_writer/3
            ]
       test "writer close error self-closes the upload channel without bringing down the LiveView",
@@ -1001,8 +1124,85 @@ defmodule Phoenix.LiveView.UploadChannelTest do
         # the upload channel self-closes instead of being left {:shutdown, :left}
         assert_receive {:DOWN, _ref, :process, ^channel_pid, {:shutdown, :closed}}, 1000
 
-        # the failed entry is dropped and the LiveView is still alive
-        assert get_uploaded_entries(lv, :avatar) == {[], []}
+        assert {[], [%LiveView.UploadEntry{client_name: "foo.jpeg", done?: false}]} =
+                 get_uploaded_entries(lv, :avatar)
+
+        assert render(lv) =~ "entry_error:{:writer_failure, :close_failed}"
+
+        assert_receive {:writer_failure_progress,
+                        %LiveView.UploadEntry{client_name: "foo.jpeg", done?: false}, true,
+                        [writer_failure: :close_failed]}
+
+        refute_receive {:writer_failure_progress, _, _, _}
+        assert Process.alive?(lv.pid)
+      end
+
+      @tag allow: [
+             max_entries: 2,
+             chunk_size: 5,
+             accept: :any,
+             writer: &__MODULE__.build_writer/3
+           ]
+      test "a successful sibling can be consumed individually after a writer failure", %{lv: lv} do
+        Process.register(self(), :test_writer)
+
+        good =
+          file_input(lv, "form", :avatar, [
+            %{name: "good.jpeg", content: String.duplicate("0", 100)}
+          ])
+
+        bad = file_input(lv, "form", :avatar, [%{name: "bad.jpeg", content: "00000error"}])
+
+        assert render_upload(bad, "bad.jpeg", 50) =~ "bad.jpeg:50%"
+        assert render_upload(good, "good.jpeg") =~ "good.jpeg:100%"
+        assert %{"bad.jpeg" => bad_pid} = UploadClient.channel_pids(bad)
+
+        unlink(bad_pid, lv, bad)
+        Process.monitor(bad_pid)
+
+        render_upload(bad, "bad.jpeg", 50)
+        assert_receive {:DOWN, _ref, :process, ^bad_pid, {:shutdown, :closed}}, 1000
+
+        assert {[%LiveView.UploadEntry{client_name: "good.jpeg"}],
+                [%LiveView.UploadEntry{client_name: "bad.jpeg"}]} =
+                 get_uploaded_entries(lv, :avatar)
+
+        assert {:error, "cannot consume uploaded files when entries are still in progress"} =
+                 UploadLive.run(lv, fn socket ->
+                   result =
+                     try do
+                       LiveView.consume_uploaded_entries(socket, :avatar, fn _meta, _entry ->
+                         {:ok, :consumed}
+                       end)
+                     rescue
+                       error in ArgumentError -> {:error, Exception.message(error)}
+                     end
+
+                   {:reply, result, socket}
+                 end)
+
+        assert "good.jpeg" =
+                 UploadLive.run(lv, fn socket ->
+                   {[good_entry], [_failed_entry]} = LiveView.uploaded_entries(socket, :avatar)
+
+                   result =
+                     LiveView.consume_uploaded_entry(socket, good_entry, fn _meta ->
+                       {:ok, good_entry.client_name}
+                     end)
+
+                   {:reply, result, socket}
+                 end)
+
+        assert eventually(fn ->
+                 match?(
+                   {[], [%LiveView.UploadEntry{client_name: "bad.jpeg"}]},
+                   get_uploaded_entries(lv, :avatar)
+                 )
+               end)
+
+        html = render(lv)
+        assert html =~ "entry_error:{:writer_failure, :custom_error}"
+        refute html =~ "good.jpeg"
       end
     end
   end

--- a/test/phoenix_live_view/upload/channel_test.exs
+++ b/test/phoenix_live_view/upload/channel_test.exs
@@ -619,6 +619,68 @@ defmodule Phoenix.LiveView.UploadChannelTest do
              max_entries: 1,
              chunk_size: 20,
              accept: :any,
+             auto_upload: true,
+             progress: :consume
+           ]
+      test "consumed auto uploads count towards max_entries", %{lv: lv} do
+        first = file_input(lv, "form", :avatar, [%{name: "first.jpeg", content: "first"}])
+        assert render_upload(first, "first.jpeg") =~ "consumed:first.jpeg"
+
+        assert eventually(fn ->
+                 UploadLive.run(lv, fn socket ->
+                   conf = socket.assigns.uploads.avatar
+                   {:reply, conf.consumed_entries == 1 && conf.entries == [], socket}
+                 end)
+               end)
+
+        second = file_input(lv, "form", :avatar, [%{name: "second.jpeg", content: "second"}])
+
+        assert lv
+               |> form("form", user: %{})
+               |> render_change(second) =~ "config_error::too_many_files"
+
+        assert {:error, :not_allowed} = render_upload(second, "second.jpeg")
+      end
+
+      @tag allow: [
+             max_entries: 1,
+             chunk_size: 20,
+             accept: :any,
+             auto_upload: true,
+             progress: :consume
+           ]
+      test "allow_upload starts a new max_entries budget after consumption", %{lv: lv} do
+        first = file_input(lv, "form", :avatar, [%{name: "first.jpeg", content: "first"}])
+        assert render_upload(first, "first.jpeg") =~ "consumed:first.jpeg"
+
+        assert eventually(fn ->
+                 UploadLive.run(lv, fn socket ->
+                   conf = socket.assigns.uploads.avatar
+                   {:reply, conf.consumed_entries == 1 && conf.entries == [], socket}
+                 end)
+               end)
+
+        UploadLive.run(lv, fn socket ->
+          socket =
+            LiveView.allow_upload(socket, :avatar,
+              max_entries: 1,
+              chunk_size: 20,
+              accept: :any,
+              auto_upload: true,
+              progress: fn :avatar, entry, socket -> __MODULE__.consume(entry, socket) end
+            )
+
+          {:reply, :ok, socket}
+        end)
+
+        second = file_input(lv, "form", :avatar, [%{name: "second.jpeg", content: "second"}])
+        assert render_upload(second, "second.jpeg") =~ "consumed:second.jpeg"
+      end
+
+      @tag allow: [
+             max_entries: 1,
+             chunk_size: 20,
+             accept: :any,
              max_file_size: 1,
              auto_upload: true
            ]

--- a/test/phoenix_live_view/upload/channel_test.exs
+++ b/test/phoenix_live_view/upload/channel_test.exs
@@ -620,6 +620,7 @@ defmodule Phoenix.LiveView.UploadChannelTest do
              chunk_size: 20,
              accept: :any,
              auto_upload: true,
+             max_entries_mode: :total,
              progress: :consume
            ]
       test "consumed auto uploads count towards max_entries", %{lv: lv} do
@@ -649,6 +650,29 @@ defmodule Phoenix.LiveView.UploadChannelTest do
              auto_upload: true,
              progress: :consume
            ]
+      test "consumed auto uploads free max_entries capacity by default", %{lv: lv} do
+        first = file_input(lv, "form", :avatar, [%{name: "first.jpeg", content: "first"}])
+        assert render_upload(first, "first.jpeg") =~ "consumed:first.jpeg"
+
+        assert eventually(fn ->
+                 UploadLive.run(lv, fn socket ->
+                   conf = socket.assigns.uploads.avatar
+                   {:reply, conf.consumed_entries == 0 && conf.entries == [], socket}
+                 end)
+               end)
+
+        second = file_input(lv, "form", :avatar, [%{name: "second.jpeg", content: "second"}])
+        assert render_upload(second, "second.jpeg") =~ "consumed:second.jpeg"
+      end
+
+      @tag allow: [
+             max_entries: 1,
+             chunk_size: 20,
+             accept: :any,
+             auto_upload: true,
+             max_entries_mode: :total,
+             progress: :consume
+           ]
       test "allow_upload starts a new max_entries budget after consumption", %{lv: lv} do
         first = file_input(lv, "form", :avatar, [%{name: "first.jpeg", content: "first"}])
         assert render_upload(first, "first.jpeg") =~ "consumed:first.jpeg"
@@ -667,6 +691,7 @@ defmodule Phoenix.LiveView.UploadChannelTest do
               chunk_size: 20,
               accept: :any,
               auto_upload: true,
+              max_entries_mode: :total,
               progress: fn :avatar, entry, socket -> __MODULE__.consume(entry, socket) end
             )
 

--- a/test/phoenix_live_view/upload/channel_test.exs
+++ b/test/phoenix_live_view/upload/channel_test.exs
@@ -1006,6 +1006,7 @@ defmodule Phoenix.LiveView.UploadChannelTest do
 
         assert render_upload(avatar, "foo.jpeg", 50) =~ "#{@context}:foo.jpeg:50%"
         assert %{"foo.jpeg" => channel_pid} = UploadClient.channel_pids(avatar)
+        assert {:ok, %{token: token}} = UploadClient.fetch_allow_acknowledged(avatar, "foo.jpeg")
 
         unlink(channel_pid, lv, avatar)
         Process.monitor(channel_pid)
@@ -1038,6 +1039,14 @@ defmodule Phoenix.LiveView.UploadChannelTest do
                         [writer_failure: :custom_error]}
 
         refute_receive {:writer_failure_progress, _, _, _}
+        assert Process.alive?(lv.pid)
+
+        # the entry is retained, but its still valid token may no longer be joined with
+        {:ok, socket} = Phoenix.ChannelTest.connect(Phoenix.LiveView.Socket, %{})
+
+        assert {:error, %{reason: :disallowed}} =
+                 Phoenix.ChannelTest.subscribe_and_join(socket, "lvu:123", %{"token" => token})
+
         assert Process.alive?(lv.pid)
 
         UploadLive.run(lv, fn socket ->

--- a/test/phoenix_live_view/upload/channel_test.exs
+++ b/test/phoenix_live_view/upload/channel_test.exs
@@ -214,6 +214,23 @@ defmodule Phoenix.LiveView.UploadChannelTest do
     {:noreply, socket}
   end
 
+  def consume_all_when_done(%LiveView.UploadEntry{done?: true}, socket) do
+    case LiveView.uploaded_entries(socket, :avatar) do
+      {[_ | _], []} ->
+        consumed =
+          LiveView.consume_uploaded_entries(socket, :avatar, fn _meta, entry ->
+            {:ok, entry.client_name}
+          end)
+
+        {:noreply, Component.update(socket, :consumed, &(&1 ++ consumed))}
+
+      _ ->
+        {:noreply, socket}
+    end
+  end
+
+  def consume_all_when_done(%LiveView.UploadEntry{}, socket), do: {:noreply, socket}
+
   def record_writer_failure(%LiveView.UploadEntry{} = entry, socket) do
     errors = Component.upload_errors(socket.assigns.uploads.avatar, entry)
 
@@ -350,6 +367,38 @@ defmodule Phoenix.LiveView.UploadChannelTest do
     case Keyword.fetch(opts, :validator_response) do
       {:ok, response} -> Keyword.put(opts, :validator, fn _ -> response end)
       :error -> opts
+    end
+  end
+
+  describe "multiple file uploads" do
+    setup :setup_lv
+
+    @tag allow: [max_entries: 2, chunk_size: 20, accept: :any]
+    test "completed entries can be consumed on submit", %{lv: lv} do
+      avatar = file_input(lv, "form", :avatar, build_entries(2))
+
+      assert render_upload(avatar, "myfile1.jpeg") =~ "lv:myfile1.jpeg:100%"
+      assert render_upload(avatar, "myfile2.jpeg") =~ "lv:myfile2.jpeg:100%"
+
+      html = lv |> form("form") |> render_submit()
+      assert html =~ "consumed:myfile1.jpeg"
+      assert html =~ "consumed:myfile2.jpeg"
+    end
+
+    @tag allow: [
+           max_entries: 2,
+           chunk_size: 20,
+           accept: :any,
+           progress: :consume_all_when_done
+         ]
+    test "completed entries can be consumed from the final progress callback", %{lv: lv} do
+      avatar = file_input(lv, "form", :avatar, build_entries(2))
+
+      assert render_upload(avatar, "myfile1.jpeg") =~ "lv:myfile1.jpeg:100%"
+
+      html = render_upload(avatar, "myfile2.jpeg")
+      assert html =~ "consumed:myfile1.jpeg"
+      assert html =~ "consumed:myfile2.jpeg"
     end
   end
 

--- a/test/phoenix_live_view/upload/channel_test.exs
+++ b/test/phoenix_live_view/upload/channel_test.exs
@@ -126,6 +126,18 @@ defmodule Phoenix.LiveView.UploadChannelTest do
     end)
   end
 
+  defp cancel_last_entry_and_reallow(lv) do
+    UploadLive.run(lv, fn socket ->
+      {completed, in_progress} = LiveView.uploaded_entries(socket, :avatar)
+      [%{ref: ref}] = completed ++ in_progress
+      {:reply, :ok, LiveView.cancel_upload(socket, :avatar, ref)}
+    end)
+
+    UploadLive.run(lv, fn socket ->
+      {:reply, :ok, LiveView.allow_upload(socket, :avatar, accept: :any)}
+    end)
+  end
+
   # TODO: Replace this helper with ExUnit's trace/3 once it is available in our
   # supported Elixir versions.
   defp eventually(fun, attempts \\ 100)
@@ -211,6 +223,20 @@ defmodule Phoenix.LiveView.UploadChannelTest do
       {_completed, in_progress} = LiveView.uploaded_entries(socket, :avatar)
       in_progress? = Enum.any?(in_progress, &(&1.ref == entry.ref))
       send(:test_writer, {:writer_failure_progress, entry, in_progress?, errors})
+      {:noreply, socket}
+    end
+  end
+
+  def cancel_and_disallow_writer_failure(%LiveView.UploadEntry{} = entry, socket) do
+    if Component.upload_errors(socket.assigns.uploads.avatar, entry) == [] do
+      {:noreply, socket}
+    else
+      socket =
+        socket
+        |> LiveView.cancel_upload(:avatar, entry.ref)
+        |> LiveView.disallow_upload(:avatar)
+
+      send(:test_writer, :writer_failure_cancelled_and_disallowed)
       {:noreply, socket}
     end
   end
@@ -533,7 +559,7 @@ defmodule Phoenix.LiveView.UploadChannelTest do
       end
 
       @tag allow: [max_entries: 1, chunk_size: 20, accept: :any, max_file_size: 1]
-      test "render_change error with upload", %{lv: lv} do
+      test "too_large entry is retained without starting an upload channel", %{lv: lv} do
         avatar = file_input(lv, "form", :avatar, [%{name: "foo.jpeg", content: "overmax"}])
 
         assert lv
@@ -541,6 +567,12 @@ defmodule Phoenix.LiveView.UploadChannelTest do
                |> render_change(avatar) =~ "entry_error::too_large"
 
         assert {:error, [[_ref, :too_large]]} = render_upload(avatar, "foo.jpeg")
+        assert UploadClient.channel_pids(avatar) == %{}
+
+        cancel_last_entry_and_reallow(lv)
+
+        retry = file_input(lv, "form", :avatar, [%{name: "retry.jpeg", content: "retry"}])
+        assert render_upload(retry, "retry.jpeg") =~ "#{@context}:retry.jpeg:100%"
       end
 
       @tag allow: [
@@ -590,7 +622,7 @@ defmodule Phoenix.LiveView.UploadChannelTest do
              max_file_size: 1,
              auto_upload: true
            ]
-      test "render_upload invalid with auto_upload", %{lv: lv} do
+      test "auto-upload too_large entry releases its upload name when cancelled", %{lv: lv} do
         avatar = file_input(lv, "form", :avatar, [%{name: "foo.jpeg", content: "overmax"}])
 
         html =
@@ -602,6 +634,14 @@ defmodule Phoenix.LiveView.UploadChannelTest do
         assert html =~ "foo.jpeg:0%"
 
         assert {:error, [[_ref, :too_large]]} = render_upload(avatar, "foo.jpeg")
+
+        assert {:error, [:too_large]} =
+                 UploadClient.fetch_allow_acknowledged(avatar, "foo.jpeg")
+
+        cancel_last_entry_and_reallow(lv)
+
+        retry = file_input(lv, "form", :avatar, [%{name: "retry.jpeg", content: "retry"}])
+        assert render_upload(retry, "retry.jpeg") =~ "#{@context}:retry.jpeg:100%"
       end
 
       @tag allow: [max_entries: 1, chunk_size: 20, accept: :any]
@@ -901,6 +941,13 @@ defmodule Phoenix.LiveView.UploadChannelTest do
         end)
 
         refute render(lv) =~ file_name
+
+        UploadLive.run(lv, fn socket ->
+          {:reply, :ok, LiveView.allow_upload(socket, :avatar, accept: :any)}
+        end)
+
+        retry = file_input(lv, "form", :avatar, [%{name: "retry.jpeg", content: "retry"}])
+        assert render_upload(retry, "retry.jpeg") =~ "#{@context}:retry.jpeg:100%"
       end
 
       @tag allow: [max_entries: 1, chunk_size: 20, accept: :any]
@@ -1060,6 +1107,39 @@ defmodule Phoenix.LiveView.UploadChannelTest do
         assert html =~ ~s(data-phx-active-refs="")
         assert html =~ ~s(data-phx-preflighted-refs="")
         assert html =~ ~s(data-phx-done-refs="")
+
+        UploadLive.run(lv, fn socket ->
+          {:reply, :ok, LiveView.allow_upload(socket, :avatar, accept: :any)}
+        end)
+
+        retry = file_input(lv, "form", :avatar, [%{name: "retry.jpeg", content: "retry"}])
+        assert render_upload(retry, "retry.jpeg") =~ "#{@context}:retry.jpeg:100%"
+      end
+
+      @tag allow: [
+             max_entries: 1,
+             chunk_size: 5,
+             accept: :any,
+             progress: :cancel_and_disallow_writer_failure,
+             writer: &__MODULE__.build_writer/3
+           ]
+      test "writer failure callback may cancel and disallow before channel cleanup", %{lv: lv} do
+        Process.register(self(), :test_writer)
+
+        avatar = file_input(lv, "form", :avatar, [%{name: "foo.jpeg", content: "00000error"}])
+
+        assert render_upload(avatar, "foo.jpeg", 50) =~ "#{@context}:foo.jpeg:50%"
+        assert %{"foo.jpeg" => channel_pid} = UploadClient.channel_pids(avatar)
+
+        unlink(channel_pid, lv, avatar)
+        Process.monitor(channel_pid)
+
+        render_upload(avatar, "foo.jpeg", 50)
+
+        assert_receive :writer_failure_cancelled_and_disallowed
+        assert_receive {:DOWN, _ref, :process, ^channel_pid, {:shutdown, :closed}}, 1000
+        assert render(lv) =~ "save"
+        assert Process.alive?(lv.pid)
       end
 
       @tag allow: [

--- a/test/phoenix_live_view/upload/config_test.exs
+++ b/test/phoenix_live_view/upload/config_test.exs
@@ -333,6 +333,60 @@ defmodule Phoenix.LiveView.UploadConfigTest do
       assert avatar.errors == [{avatar.ref, :too_many_files}]
     end
 
+    test "counts consumed entries towards max_entries until the upload is allowed again" do
+      socket =
+        LiveView.allow_upload(build_socket(), :avatar,
+          accept: :any,
+          auto_upload: true,
+          max_entries: 2
+        )
+
+      assert {:ok, avatar} =
+               UploadConfig.put_entries(socket.assigns.uploads.avatar, [
+                 build_client_entry(:avatar)
+               ])
+
+      [first_entry] = avatar.entries
+      avatar = UploadConfig.consume_entry(avatar, first_entry)
+
+      assert avatar.consumed_entries == 1
+      assert avatar.entries == []
+
+      assert {:ok, avatar} = UploadConfig.put_entries(avatar, [build_client_entry(:avatar)])
+      [second_entry] = avatar.entries
+      avatar = UploadConfig.consume_entry(avatar, second_entry)
+
+      assert avatar.consumed_entries == 2
+      assert avatar.entries == []
+
+      assert {:ok, avatar} = UploadConfig.put_entries(avatar, [build_client_entry(:avatar)])
+      assert avatar.errors == [{avatar.ref, :too_many_files}]
+
+      socket =
+        put_in(socket.assigns.uploads.avatar, UploadConfig.drop_entry(avatar, hd(avatar.entries)))
+
+      socket = LiveView.allow_upload(socket, :avatar, accept: :any, max_entries: 2)
+
+      assert socket.assigns.uploads.avatar.consumed_entries == 0
+    end
+
+    test "cancelling an entry does not consume a max_entries slot" do
+      socket = LiveView.allow_upload(build_socket(), :avatar, accept: :any, max_entries: 1)
+
+      assert {:ok, avatar} =
+               UploadConfig.put_entries(socket.assigns.uploads.avatar, [
+                 build_client_entry(:avatar)
+               ])
+
+      [entry] = avatar.entries
+      avatar = UploadConfig.drop_entry(avatar, entry)
+
+      assert avatar.consumed_entries == 0
+      assert {:ok, avatar} = UploadConfig.put_entries(avatar, [build_client_entry(:avatar)])
+      assert length(avatar.entries) == 1
+      assert avatar.errors == []
+    end
+
     test "returns error when entry with greater than max_file_size provided" do
       socket = LiveView.allow_upload(build_socket(), :avatar, accept: :any)
       entry = build_client_entry(:avatar, %{"size" => 8_000_001})

--- a/test/phoenix_live_view/upload/config_test.exs
+++ b/test/phoenix_live_view/upload/config_test.exs
@@ -208,6 +208,57 @@ defmodule Phoenix.LiveView.UploadConfigTest do
     end
   end
 
+  describe "fail_entry/3" do
+    test "retains the entry with its error and rejects further registration" do
+      socket = LiveView.allow_upload(build_socket(), :avatar, accept: :any)
+      %{"ref" => ref} = entry = build_client_entry(:avatar)
+      assert {:ok, avatar} = UploadConfig.put_entries(socket.assigns.uploads.avatar, [entry])
+
+      avatar = UploadConfig.fail_entry(avatar, ref, {:writer_failure, :custom_error})
+
+      assert [%UploadEntry{ref: ^ref}] = avatar.entries
+      assert avatar.errors == [{ref, {:writer_failure, :custom_error}}]
+
+      assert UploadConfig.entry_pid(avatar, UploadConfig.get_entry_by_ref(avatar, ref)) == nil
+
+      assert UploadConfig.register_entry_upload(avatar, self(), ref) == {:error, :disallowed}
+
+      # the failed entry is kept when its upload channel goes down
+      assert UploadConfig.unregister_completed_entry(avatar, ref) == avatar
+    end
+
+    test "ignores a failure reported for an entry that is already gone" do
+      socket = LiveView.allow_upload(build_socket(), :avatar, accept: :any)
+      %{"ref" => ref} = entry = build_client_entry(:avatar)
+      assert {:ok, avatar} = UploadConfig.put_entries(socket.assigns.uploads.avatar, [entry])
+
+      avatar = drop_entry(avatar, ref)
+
+      assert UploadConfig.fail_entry(avatar, ref, {:writer_failure, :custom_error}) == avatar
+    end
+
+    test "does not accumulate the same error for a retained entry" do
+      socket = LiveView.allow_upload(build_socket(), :avatar, accept: :any)
+      %{"ref" => ref} = entry = build_client_entry(:avatar)
+      assert {:ok, avatar} = UploadConfig.put_entries(socket.assigns.uploads.avatar, [entry])
+
+      avatar =
+        avatar
+        |> UploadConfig.fail_entry(ref, {:writer_failure, :custom_error})
+        |> UploadConfig.fail_entry(ref, {:writer_failure, :custom_error})
+
+      assert avatar.errors == [{ref, {:writer_failure, :custom_error}}]
+
+      # distinct errors for the same entry are still kept
+      avatar = UploadConfig.put_error(avatar, ref, :external_client_failure)
+
+      assert avatar.errors == [
+               {ref, {:writer_failure, :custom_error}},
+               {ref, :external_client_failure}
+             ]
+    end
+  end
+
   describe "put_entries/2" do
     test "does not overwrite existing refs" do
       socket = LiveView.allow_upload(build_socket(), :avatar, accept: :any, max_entries: 1)

--- a/test/phoenix_live_view/upload/config_test.exs
+++ b/test/phoenix_live_view/upload/config_test.exs
@@ -154,6 +154,26 @@ defmodule Phoenix.LiveView.UploadConfigTest do
       assert %UploadConfig{max_file_size: 10_000_000} = socket.assigns.uploads.avatar
     end
 
+    test "supports :max_entries_mode and defaults to :selected" do
+      socket = LiveView.allow_upload(build_socket(), :avatar, accept: :any)
+      assert socket.assigns.uploads.avatar.max_entries_mode == :selected
+
+      socket =
+        LiveView.allow_upload(build_socket(), :avatar,
+          accept: :any,
+          max_entries_mode: :total
+        )
+
+      assert socket.assigns.uploads.avatar.max_entries_mode == :total
+
+      assert_raise ArgumentError, ~r/invalid :max_entries_mode value provided/, fn ->
+        LiveView.allow_upload(build_socket(), :avatar,
+          accept: :any,
+          max_entries_mode: :invalid
+        )
+      end
+    end
+
     test "raises when invalid :validator provided" do
       assert_raise ArgumentError, ~r/invalid :validator value provided to allow_upload/, fn ->
         LiveView.allow_upload(build_socket(), :avatar, accept: :any, validator: 0)
@@ -338,7 +358,8 @@ defmodule Phoenix.LiveView.UploadConfigTest do
         LiveView.allow_upload(build_socket(), :avatar,
           accept: :any,
           auto_upload: true,
-          max_entries: 2
+          max_entries: 2,
+          max_entries_mode: :total
         )
 
       assert {:ok, avatar} =
@@ -365,9 +386,31 @@ defmodule Phoenix.LiveView.UploadConfigTest do
       socket =
         put_in(socket.assigns.uploads.avatar, UploadConfig.drop_entry(avatar, hd(avatar.entries)))
 
-      socket = LiveView.allow_upload(socket, :avatar, accept: :any, max_entries: 2)
+      socket =
+        LiveView.allow_upload(socket, :avatar,
+          accept: :any,
+          max_entries: 2,
+          max_entries_mode: :total
+        )
 
       assert socket.assigns.uploads.avatar.consumed_entries == 0
+    end
+
+    test "consumed entries free capacity in the default max_entries mode" do
+      socket = LiveView.allow_upload(build_socket(), :avatar, accept: :any, max_entries: 1)
+
+      assert {:ok, avatar} =
+               UploadConfig.put_entries(socket.assigns.uploads.avatar, [
+                 build_client_entry(:avatar)
+               ])
+
+      [entry] = avatar.entries
+      avatar = UploadConfig.consume_entry(avatar, entry)
+
+      assert avatar.consumed_entries == 0
+      assert {:ok, avatar} = UploadConfig.put_entries(avatar, [build_client_entry(:avatar)])
+      assert length(avatar.entries) == 1
+      assert avatar.errors == []
     end
 
     test "cancelling an entry does not consume a max_entries slot" do

--- a/test/phoenix_live_view/upload/external_test.exs
+++ b/test/phoenix_live_view/upload/external_test.exs
@@ -280,7 +280,13 @@ defmodule Phoenix.LiveView.UploadExternalTest do
     refute render(lv) =~ upload_complete
   end
 
-  @tag allow: [max_entries: 2, chunk_size: 20, accept: :any, external: :preflight]
+  @tag allow: [
+         max_entries: 2,
+         max_entries_mode: :total,
+         chunk_size: 20,
+         accept: :any,
+         external: :preflight
+       ]
   test "consume_uploaded_entry", %{lv: lv} do
     upload_complete = "foo.jpeg:100%"
     parent = self()
@@ -309,6 +315,7 @@ defmodule Phoenix.LiveView.UploadExternalTest do
       new_socket =
         Phoenix.LiveView.allow_upload(socket, :avatar,
           max_entries: 2,
+          max_entries_mode: :total,
           chunk_size: 20,
           accept: :any,
           external: &__MODULE__.preflight/2

--- a/test/phoenix_live_view/upload/external_test.exs
+++ b/test/phoenix_live_view/upload/external_test.exs
@@ -302,6 +302,24 @@ defmodule Phoenix.LiveView.UploadExternalTest do
 
     assert_receive {:individual_consume, %{uploader: "S3"}, "foo.jpeg"}
     refute render(lv) =~ upload_complete
+
+    run(lv, fn socket ->
+      assert socket.assigns.uploads.avatar.consumed_entries == 1
+
+      new_socket =
+        Phoenix.LiveView.allow_upload(socket, :avatar,
+          max_entries: 2,
+          chunk_size: 20,
+          accept: :any,
+          external: &__MODULE__.preflight/2
+        )
+
+      assert new_socket.assigns.uploads.avatar.consumed_entries == 0
+      {:reply, :ok, new_socket}
+    end)
+
+    retry = file_input(lv, "form", :avatar, [%{name: "retry.jpeg", content: "retry"}])
+    assert render_upload(retry, "retry.jpeg", 100) =~ "retry.jpeg:100%"
   end
 
   @tag allow: [

--- a/test/support/live_views/upload_live.ex
+++ b/test/support/live_views/upload_live.ex
@@ -55,6 +55,15 @@ defmodule Phoenix.LiveViewTest.Support.UploadLive do
     {:noreply, socket}
   end
 
+  def handle_event("save", _params, socket) do
+    consumed =
+      Phoenix.LiveView.consume_uploaded_entries(socket, :avatar, fn _meta, entry ->
+        {:ok, entry.client_name}
+      end)
+
+    {:noreply, update(socket, :consumed, &(&1 ++ consumed))}
+  end
+
   ## test helpers
 
   def inspect_html_safe(term) do


### PR DESCRIPTION
When consuming uploads, the upload channel would bring down the UploadClient, because they were linked. Monitor instead and only stop if there are no other channels remaining.

Closes #3480.