### PR TITLE
Pattern match keyed diff count in iodata rendering

### DIFF
--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -53,17 +53,17 @@ defmodule Phoenix.LiveView.Diff do
   end
 
   defp to_iodata(
-         %{@static => static, @keyed => keyed} = kc,
+         %{@static => static, @keyed => %{@keyed_count => count} = keyed} = kc,
          components,
          template,
          mapper
        ) do
     template = template || kc[@template]
 
-    if !keyed or keyed[@keyed_count] == 0 do
+    if count == 0 do
       {[], components}
     else
-      keyed_to_iodata(keyed[@keyed_count] - 1, keyed, static, components, template, mapper, [])
+      keyed_to_iodata(count - 1, keyed, static, components, template, mapper, [])
     end
   end
 


### PR DESCRIPTION
Assisted-by: Codex CLI:GPT 5.6 Sol

Diff.to_iodata/2 only accepts full render diffs. For comprehensions, a full render always contains a :k map with a :kc count. When an incremental traversal has no keyed changes, maybe_add_keyed/2 omits :k entirely rather than storing nil or false.

Therefore, once this clause matches both :s and :k, the old !keyed check cannot be reached with a valid diff. Match the count in the function head to make that invariant explicit.
