### PR TITLE
Remove inert form disabled assignment

### DIFF
--- a/assets/js/phoenix_live_view/live_socket.ts
+++ b/assets/js/phoenix_live_view/live_socket.ts
@@ -1785,7 +1785,6 @@ export default class LiveSocket {
         return;
       }
       e.preventDefault();
-      e.target.disabled = true;
       this.withinOwners(e.target, (view) => {
         JS.exec(e, "submit", phxEvent, view, e.target, [
           "push",


### PR DESCRIPTION
`e.target` is guaranteed to be `HTMLFormElement` which has no `disabled` property, see https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement

The code is dead/misleading. It sets a not used expando property on form object. Real double submit protection is `disableForm` ref locking.