### PR TITLE
Preserve onReply exceptions

### DIFF
--- a/assets/js/phoenix_live_view/view_hook.ts
+++ b/assets/js/phoenix_live_view/view_hook.ts
@@ -469,11 +469,11 @@ export class ViewHook<
     if (onReply === undefined) {
       return promise.then(({ reply }: { reply: any }) => reply);
     }
-    promise
-      .then(({ reply, ref }: { reply: any; ref: number }) =>
-        onReply(reply, ref),
-      )
-      .catch(() => {});
+    // Handle push failures separately so exceptions from onReply are not swallowed.
+    promise.then(
+      ({ reply, ref }: { reply: any; ref: number }) => onReply(reply, ref),
+      () => {},
+    );
   }
 
   pushEventTo(
@@ -514,12 +514,11 @@ export class ViewHook<
     this.__view().withinTargets(
       selectorOrTarget,
       (view: View, targetCtx: any) => {
-        view
-          .pushHookEvent(this.el, targetCtx, event, payload || {})
-          .then(({ reply, ref }: { reply: any; ref: number }) =>
-            onReply(reply, ref),
-          )
-          .catch(() => {});
+        // Handle push failures separately so exceptions from onReply are not swallowed.
+        view.pushHookEvent(this.el, targetCtx, event, payload || {}).then(
+          ({ reply, ref }: { reply: any; ref: number }) => onReply(reply, ref),
+          () => {},
+        );
       },
     );
   }

--- a/assets/js/phoenix_live_view/view_hook.ts
+++ b/assets/js/phoenix_live_view/view_hook.ts
@@ -80,7 +80,8 @@ export interface HookInterface<E extends HTMLElement = HTMLElement> {
   /**
    * Pushes an event to the server and invokes a callback with the server's reply.
    *
-   * **Note:** this version silently ignores push errors.
+   * **Note:** this version silently ignores push errors. Exceptions thrown by the
+   * callback are not ignored.
    * Use the {@link pushEvent | promise-returning version} to handle errors.
    *
    * @param event - The event name.
@@ -114,7 +115,8 @@ export interface HookInterface<E extends HTMLElement = HTMLElement> {
    * If the selector matches multiple elements, the event is sent to all of them,
    * even if they belong to the same LiveComponent or LiveView.
    *
-   * **Note:** this version silently ignores push errors.
+   * **Note:** this version silently ignores push errors. Exceptions thrown by the
+   * callback are not ignored.
    * Use the {@link pushEventTo | promise-returning version} to handle errors.
    *
    * @param selectorOrTarget - The selector, element, or CID to target.

--- a/assets/test/event_test.ts
+++ b/assets/test/event_test.ts
@@ -1,9 +1,9 @@
 import { Socket } from "phoenix";
 import LiveSocket from "phoenix_live_view/live_socket";
 import View from "phoenix_live_view/view";
+import ViewHook, { HooksOptions } from "phoenix_live_view/view_hook";
 
 import { version as liveview_version } from "../../package.json";
-import { HooksOptions } from "phoenix_live_view/view_hook";
 
 let containerId = 0;
 
@@ -301,6 +301,43 @@ describe("pushEvent replies", () => {
       },
       [],
     );
+  });
+
+  test("does not swallow onReply exceptions", () => {
+    const error = new Error("onReply failed");
+    const then = jest.fn();
+    const view = {
+      pushHookEvent: () => ({ then }),
+    };
+    const hook = new ViewHook(view as any, document.createElement("div"));
+
+    hook.pushEvent("charge", {}, () => {
+      throw error;
+    });
+
+    const [onReply, onPushError] = then.mock.calls[0];
+    expect(onPushError).toEqual(expect.any(Function));
+    expect(() => onReply({ transactionID: "1001" }, 0)).toThrow(error);
+  });
+
+  test("does not swallow targeted onReply exceptions", () => {
+    const error = new Error("onReply failed");
+    const then = jest.fn();
+    const pushHookEvent = () => ({ then });
+    const targetView = { pushHookEvent };
+    const view = {
+      pushHookEvent,
+      withinTargets: (_selector, callback) => callback(targetView, null),
+    };
+    const hook = new ViewHook(view as any, document.createElement("div"));
+
+    hook.pushEventTo("#target", "charge", {}, () => {
+      throw error;
+    });
+
+    const [onReply, onPushError] = then.mock.calls[0];
+    expect(onPushError).toEqual(expect.any(Function));
+    expect(() => onReply({ transactionID: "1001" }, 0)).toThrow(error);
   });
 
   test("pushEventTo - promise with multiple targets", (done) => {

--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -171,7 +171,7 @@ The above life-cycle callbacks have in-scope access to the following attributes:
   * `liveSocket` - the reference to the underlying `LiveSocket` instance
   * `pushEvent(event, payload, (reply, ref) => ...)` - method to push an event from the client to the LiveView server.
     Omitting the callback returns a promise that resolves to the `reply`.
-    **Note:** the callback version silently ignores errors.
+    **Note:** the callback version silently ignores push errors. Exceptions thrown by the callback are not ignored.
   * `pushEventTo(selectorOrTarget, event, payload, (reply, ref) => ...)` - method to push targeted events from the client
     to LiveViews and LiveComponents. The `selectorOrTarget` can be a DOM element (such as `this.el`) or a query
     selector string. The event is sent to the LiveComponent or LiveView owning the targeted element(s). If a selector
@@ -179,7 +179,7 @@ The above life-cycle callbacks have in-scope access to the following attributes:
     Omitting the callback returns a promise matching
     [`Promise.allSettled()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled#return_value),
     where fulfilled values are of the format `{ reply, ref }`.
-    **Note:** the callback version silently ignores errors.
+    **Note:** the callback version silently ignores push errors. Exceptions thrown by the callback are not ignored.
   * `handleEvent(event, (payload) => ...)` - method to handle an event pushed from the server. Returns a value that can be passed to `removeHandleEvent` to remove the event handler.
   * `removeHandleEvent(ref)` - method to remove an event handler added via `handleEvent`
   * `upload(name, files)` - method to inject a list of file-like objects into an uploader.


### PR DESCRIPTION
The `.catch(() => {})` after `.then(onReply)` also silences exceptions thrown inside the user's `onReply` which hides application bugs.
Note documentation was ambiguous/conflicting:
- JSDoc explicite stated only push errors are ignored: "this version silently ignores push errors"
- phoenix guide was ambiguous: "the callback version silently ignores errors"

This PR changes the behaviour to swallow only transport errors