### PR TITLE
Cancel infinite scroll throttle timers on destroy

### DIFF
--- a/assets/js/phoenix_live_view/hooks.ts
+++ b/assets/js/phoenix_live_view/hooks.ts
@@ -138,6 +138,7 @@ const InfiniteScroll: Hook<
         });
       },
     );
+    this.throttles = [onTopOverrun, onFirstChildAtTop, onLastChildAtBottom];
 
     this.onScroll = (_e: Event) => {
       const scrollNow = scrollTop(this.scrollContainer);
@@ -202,6 +203,9 @@ const InfiniteScroll: Hook<
   },
 
   destroyed() {
+    this.throttles?.forEach((throttled) => throttled.cancel());
+    this.throttles = null;
+
     if (this.scrollContainer) {
       this.scrollContainer.removeEventListener("scroll", this.onScroll);
     } else {
@@ -211,20 +215,20 @@ const InfiniteScroll: Hook<
 
   throttle(interval, callback) {
     let lastCallAt = 0;
-    let timer;
+    let timer: ReturnType<typeof setTimeout> | null = null;
 
-    return (...args) => {
+    const throttled = (...args) => {
       const now = Date.now();
       const remainingTime = interval - (now - lastCallAt);
 
       if (remainingTime <= 0 || remainingTime > interval) {
-        if (timer) {
+        if (timer !== null) {
           clearTimeout(timer);
           timer = null;
         }
         lastCallAt = now;
         callback(...args);
-      } else if (!timer) {
+      } else if (timer === null) {
         timer = setTimeout(() => {
           lastCallAt = Date.now();
           timer = null;
@@ -232,6 +236,15 @@ const InfiniteScroll: Hook<
         }, remainingTime);
       }
     };
+
+    throttled.cancel = () => {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+
+    return throttled;
   },
 
   findOverrunTarget() {

--- a/assets/test/hooks_test.ts
+++ b/assets/test/hooks_test.ts
@@ -1,11 +1,12 @@
 import Hooks from "phoenix_live_view/hooks";
 
 describe("InfiniteScroll", () => {
-  describe("updated", () => {
-    afterEach(() => {
-      document.body.innerHTML = "";
-    });
+  afterEach(() => {
+    jest.useRealTimers();
+    document.body.innerHTML = "";
+  });
 
+  describe("updated", () => {
     // https://github.com/phoenixframework/phoenix_live_view/issues/4169
     test("does not throw when scrollContainer is null (window scrolls)", () => {
       const ctx = {
@@ -49,5 +50,43 @@ describe("InfiniteScroll", () => {
       expect(ctx.destroyed).not.toHaveBeenCalled();
       expect(ctx.mounted).not.toHaveBeenCalled();
     });
+  });
+
+  test("cancels pending throttle timers when destroyed", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+
+    const scrollContainer = document.createElement("div");
+    scrollContainer.style.overflowY = "scroll";
+    const hookEl = document.createElement("div");
+    hookEl.setAttribute("phx-viewport-bottom", "load-more");
+    hookEl.appendChild(document.createElement("div"));
+    scrollContainer.appendChild(hookEl);
+    document.body.appendChild(scrollContainer);
+    Object.defineProperty(scrollContainer, "scrollTop", {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    const push = jest.fn();
+    const ctx = {
+      el: hookEl,
+      liveSocket: {
+        binding: (name: string) => `phx-${name}`,
+        js: () => ({ push }),
+      },
+      findOverrunTarget: Hooks.InfiniteScroll.findOverrunTarget,
+      throttle: Hooks.InfiniteScroll.throttle,
+    };
+
+    Hooks.InfiniteScroll.mounted!.call(ctx as any);
+    scrollContainer.scrollTop = 1;
+    (ctx as any).onScroll(new Event("scroll"));
+    Hooks.InfiniteScroll.destroyed!.call(ctx as any);
+
+    jest.runAllTimers();
+
+    expect(push).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Before this PR a pending throttle timeout could fire up to 500ms after the hook is destroyed and push a viewport event for a removed element