### PR TITLE
Preserve zero-duration JS transitions

### DIFF
--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -391,7 +391,7 @@ const JS = {
   },
 
   toggle(eventType, view, el, display, ins, outs, time, blocking) {
-    time = time || default_transition_time;
+    time = time == null ? default_transition_time : time;
     const [inClasses, inStartClasses, inEndClasses] = ins || [[], [], []];
     const [outClasses, outStartClasses, outEndClasses] = outs || [[], [], []];
     if (inClasses.length > 0 || outClasses.length > 0) {
@@ -532,7 +532,7 @@ const JS = {
   },
 
   addOrRemoveClasses(el, adds, removes, transition, time, view, blocking) {
-    time = time || default_transition_time;
+    time = time == null ? default_transition_time : time;
     const [transitionRun, transitionStart, transitionEnd] = transition || [
       [],
       [],

--- a/assets/test/js_test.ts
+++ b/assets/test/js_test.ts
@@ -244,6 +244,49 @@ describe("JS", () => {
   });
 
   describe("exec_toggle", () => {
+    test("preserves a zero-duration transition", () => {
+      const view = setupView(`
+      <div id="modal">modal</div>
+      <div id="click"></div>
+      `);
+      const _modal = simulateVisibility(document.querySelector("#modal"));
+      const click = document.querySelector("#click")!;
+
+      JS.exec(
+        event,
+        "click",
+        [
+          [
+            "hide",
+            { to: "#modal", transition: [["fade-out"], [], []], time: 0 },
+          ],
+        ],
+        view,
+        click,
+      );
+      JS.exec(
+        event,
+        "click",
+        [
+          [
+            "add_class",
+            {
+              to: "#modal",
+              names: ["hidden"],
+              transition: [["fade-in"], [], []],
+              time: 0,
+            },
+          ],
+        ],
+        view,
+        click,
+      );
+
+      expect(view.liveSocket["transitions"].size()).toBe(2);
+      jest.advanceTimersByTime(0);
+      expect(view.liveSocket["transitions"].size()).toBe(0);
+    });
+
     test("with defaults", (done) => {
       const view = setupView(`
       <div id="modal">modal</div>

--- a/test/phoenix_live_view/js_test.exs
+++ b/test/phoenix_live_view/js_test.exs
@@ -874,6 +874,10 @@ defmodule Phoenix.LiveView.JSTest do
       assert JS.hide(to: "#modal", time: 123) == %JS{
                ops: [["hide", %{time: 123, to: "#modal"}]]
              }
+
+      assert JS.hide(to: "#modal", time: 0) == %JS{
+               ops: [["hide", %{time: 0, to: "#modal"}]]
+             }
     end
 
     test "raises with unknown options" do


### PR DESCRIPTION
The code was coercing valid 0 value to 200ms. Elixir side only checks `is_integer` so `JS.hide(..., time: 0)` locks the UI for 200ms and stalls pending server DOM updates.