### PR TITLE
Clear focus stack entries on view teardown

### DIFF
--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -198,18 +198,30 @@ const JS = {
   },
 
   exec_push_focus(e, eventType, phxEvent, view, sourceEl, el) {
-    focusStack.push(el || sourceEl);
+    focusStack.push({ el: el || sourceEl, view });
   },
 
   exec_pop_focus(_e, _eventType, _phxEvent, _view, _sourceEl, _el) {
-    const el = focusStack.pop();
-    if (el) {
+    const focusEntry = focusStack.pop();
+    if (focusEntry) {
+      const { el } = focusEntry;
       el.focus();
       // if you wonder about the nested animation frames, see exec_focus
       window.requestAnimationFrame(() => {
         window.requestAnimationFrame(() => el.focus());
       });
     }
+  },
+
+  dropFocus(view) {
+    let dropped = 0;
+    for (let i = focusStack.length - 1; i >= 0; i--) {
+      if (focusStack[i].view === view) {
+        focusStack.splice(i, 1);
+        dropped++;
+      }
+    }
+    return dropped;
   },
 
   exec_add_class(

--- a/assets/js/phoenix_live_view/js.js
+++ b/assets/js/phoenix_live_view/js.js
@@ -198,10 +198,16 @@ const JS = {
   },
 
   exec_push_focus(e, eventType, phxEvent, view, sourceEl, el) {
+    if (view.isDestroyed()) {
+      return;
+    }
     focusStack.push({ el: el || sourceEl, view });
   },
 
-  exec_pop_focus(_e, _eventType, _phxEvent, _view, _sourceEl, _el) {
+  exec_pop_focus(_e, _eventType, _phxEvent, view, _sourceEl, _el) {
+    if (view.isDestroyed()) {
+      return;
+    }
     const focusEntry = focusStack.pop();
     if (focusEntry) {
       const { el } = focusEntry;

--- a/assets/js/phoenix_live_view/view.ts
+++ b/assets/js/phoenix_live_view/view.ts
@@ -259,6 +259,7 @@ export default class View {
   }
 
   destroy(callback = function () {}) {
+    JS.dropFocus(this);
     this.destroyAllChildren();
     this.destroyPortalElements();
     this.destroyed = true;

--- a/assets/test/js_test.ts
+++ b/assets/test/js_test.ts
@@ -1429,9 +1429,10 @@ describe("JS", () => {
 
       expect(dropFocus).toHaveBeenCalledWith(view);
       expect(dropFocus).toHaveReturnedWith(1);
+      dropFocus.mockRestore();
     });
 
-    test("does not pop focus targets from a destroyed view", () => {
+    test("does not pop focus targets owned by a destroyed view", () => {
       const oldView = setupView(`
       <div id="modal" tabindex="0">modal</div>
       <div id="push" phx-click='[["push_focus", {"to": "#modal"}]]'></div>
@@ -1475,6 +1476,85 @@ describe("JS", () => {
       jest.runAllTimers();
       expect(focus).not.toHaveBeenCalled();
       expect(newFocus).not.toHaveBeenCalled();
+    });
+
+    test("does not push focus after the view is destroyed", () => {
+      const oldView = setupView(`
+      <div id="old-modal" tabindex="0">old modal</div>
+      <div id="old-push" phx-remove='[["push_focus", {"to": "#old-modal"}]]'></div>
+      `);
+      const oldModal = document.querySelector<HTMLElement>("#old-modal")!;
+      const oldPush = document.querySelector("#old-push")!;
+      const oldFocus = jest.spyOn(oldModal, "focus");
+
+      oldView.destroy();
+      JS.exec(
+        event,
+        "remove",
+        oldPush.getAttribute("phx-remove"),
+        oldView,
+        oldPush,
+      );
+
+      const newView = setupView(`
+      <div id="new-pop" phx-click='[["pop_focus", {}]]'></div>
+      `);
+      const newPop = document.querySelector("#new-pop")!;
+
+      JS.exec(
+        event,
+        "click",
+        newPop.getAttribute("phx-click"),
+        newView,
+        newPop,
+      );
+      jest.runAllTimers();
+      expect(oldFocus).not.toHaveBeenCalled();
+    });
+
+    test("does not pop focus after the view is destroyed", () => {
+      const oldView = setupView(`
+      <div id="old-pop" phx-remove='[["pop_focus", {}]]'></div>
+      `);
+      const oldPop = document.querySelector("#old-pop")!;
+      oldView.destroy();
+
+      const newView = setupView(`
+      <div id="new-modal" tabindex="0">new modal</div>
+      <div id="new-push" phx-click='[["push_focus", {"to": "#new-modal"}]]'></div>
+      <div id="new-pop" phx-click='[["pop_focus", {}]]'></div>
+      `);
+      const newModal = document.querySelector<HTMLElement>("#new-modal")!;
+      const newPush = document.querySelector("#new-push")!;
+      const newPop = document.querySelector("#new-pop")!;
+      const newFocus = jest.spyOn(newModal, "focus");
+
+      JS.exec(
+        event,
+        "click",
+        newPush.getAttribute("phx-click"),
+        newView,
+        newPush,
+      );
+      JS.exec(
+        event,
+        "remove",
+        oldPop.getAttribute("phx-remove"),
+        oldView,
+        oldPop,
+      );
+      jest.runAllTimers();
+      expect(newFocus).not.toHaveBeenCalled();
+
+      JS.exec(
+        event,
+        "click",
+        newPop.getAttribute("phx-click"),
+        newView,
+        newPop,
+      );
+      jest.runAllTimers();
+      expect(newFocus).toHaveBeenCalled();
     });
   });
 

--- a/assets/test/js_test.ts
+++ b/assets/test/js_test.ts
@@ -1415,6 +1415,67 @@ describe("JS", () => {
       jest.runAllTimers();
       expect(document.activeElement).toBe(modal1);
     });
+
+    test("clears unmatched focus targets when their view is destroyed", () => {
+      const view = setupView(`
+      <div id="modal" tabindex="0">modal</div>
+      <div id="push" phx-click='[["push_focus", {"to": "#modal"}]]'></div>
+      `);
+      const push = document.querySelector("#push")!;
+      const dropFocus = jest.spyOn(JS, "dropFocus");
+
+      JS.exec(event, "click", push.getAttribute("phx-click"), view, push);
+      view.destroy();
+
+      expect(dropFocus).toHaveBeenCalledWith(view);
+      expect(dropFocus).toHaveReturnedWith(1);
+    });
+
+    test("does not pop focus targets from a destroyed view", () => {
+      const oldView = setupView(`
+      <div id="modal" tabindex="0">modal</div>
+      <div id="push" phx-click='[["push_focus", {"to": "#modal"}]]'></div>
+      `);
+      const oldModal = document.querySelector<HTMLElement>("#modal")!;
+      const oldPush = document.querySelector("#push")!;
+      const focus = jest.spyOn(oldModal, "focus");
+
+      JS.exec(
+        event,
+        "click",
+        oldPush.getAttribute("phx-click"),
+        oldView,
+        oldPush,
+      );
+      oldView.destroy();
+
+      const newView = setupView(`
+      <div id="new-modal" tabindex="0">new modal</div>
+      <div id="new-push" phx-click='[["push_focus", {"to": "#new-modal"}]]'></div>
+      <div id="pop" phx-click='[["pop_focus", {}]]'></div>
+      `);
+      const newModal = document.querySelector<HTMLElement>("#new-modal")!;
+      const newPush = document.querySelector("#new-push")!;
+      const pop = document.querySelector("#pop")!;
+      const newFocus = jest.spyOn(newModal, "focus");
+
+      JS.exec(
+        event,
+        "click",
+        newPush.getAttribute("phx-click"),
+        newView,
+        newPush,
+      );
+      JS.exec(event, "click", pop.getAttribute("phx-click"), newView, pop);
+      jest.runAllTimers();
+      expect(newFocus).toHaveBeenCalled();
+
+      newFocus.mockClear();
+      JS.exec(event, "click", pop.getAttribute("phx-click"), newView, pop);
+      jest.runAllTimers();
+      expect(focus).not.toHaveBeenCalled();
+      expect(newFocus).not.toHaveBeenCalled();
+    });
   });
 
   describe("exec_focus_first", () => {


### PR DESCRIPTION
This PR addresses a small memory leak. `focusStack` is a module-level array which were never cleared on view teardown or live navigation. Any `push_focus` without a matching `pop_focus` leaks the detached element
Another issue: `pop_focus` could also pop an element pushed by a navigated-away view.