### PR TITLE
Fix runtime hook added node tracking

### DIFF
--- a/assets/js/phoenix_live_view/dom_patch.ts
+++ b/assets/js/phoenix_live_view/dom_patch.ts
@@ -305,7 +305,7 @@ export default class DOMPatch {
 
           // data-phx-runtime-hook
           if (el.nodeName === "SCRIPT" && el.hasAttribute(PHX_RUNTIME_HOOK)) {
-            this.handleRuntimeHook(el as HTMLScriptElement, source);
+            el = this.handleRuntimeHook(el as HTMLScriptElement, source);
           }
 
           added.push(el);
@@ -930,5 +930,6 @@ export default class DOMPatch {
       script.nonce = nonce;
     }
     el.replaceWith(script);
+    return script;
   }
 }

--- a/assets/test/integration/runtime_hook_test.ts
+++ b/assets/test/integration/runtime_hook_test.ts
@@ -1,0 +1,42 @@
+import { Socket } from "phoenix";
+import { PHX_RUNTIME_HOOK } from "phoenix_live_view/constants";
+import DOMPatch from "phoenix_live_view/dom_patch";
+import LiveSocket from "phoenix_live_view/live_socket";
+import { simulateJoinedView } from "../test_helpers";
+
+describe("runtime hook patching", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("reports the replacement script as added", () => {
+    document.body.innerHTML = `
+      <div data-phx-session="abc123"
+           data-phx-root-id="root"
+           data-phx-static="456"
+           id="root">
+        <div id="content"></div>
+      </div>
+    `;
+    const root = document.getElementById("root")!;
+    const liveSocket = new LiveSocket("/live", Socket);
+    const view = simulateJoinedView(root, liveSocket);
+    const container = document.getElementById("content")!;
+    const source = document.createElement("div");
+    source.innerHTML = `<script ${PHX_RUNTIME_HOOK}="Example">window.example = true</script>`;
+    const patch = new DOMPatch(view, container, source, new Set(), null);
+    const added: Node[] = [];
+    patch.afterAdded((el) => added.push(el));
+
+    patch.perform(false);
+
+    const script = container.querySelector("script")!;
+    const addedScript = added.find(
+      (el) =>
+        el instanceof HTMLScriptElement &&
+        el.getAttribute(PHX_RUNTIME_HOOK) === "Example",
+    );
+    expect(addedScript).toBe(script);
+    expect(script.isConnected).toBe(true);
+  });
+});


### PR DESCRIPTION
Runtime hook scripts are replaced during DOM patching so that the browser executes them. Before this PR, the patcher still tracked the original script node as added, even though that node had been detached. As a result, `afterAdded` callbacks could receive a detached script node.
This patch returns the replacement script from `handleRuntimeHook` and tracks that connected node instead