### PR TITLE
Fix join completion for empty recovery markup

### DIFF
--- a/assets/js/phoenix_live_view/view.ts
+++ b/assets/js/phoenix_live_view/view.ts
@@ -784,7 +784,7 @@ export default class View {
     template.innerHTML = html;
 
     if (!template.content.firstElementChild) {
-      return;
+      return callback();
     }
 
     // we special case <.portal> here and teleport it into our temporary DOM for recovery

--- a/assets/test/view_test.ts
+++ b/assets/test/view_test.ts
@@ -474,6 +474,16 @@ describe("View + DOM", function () {
     );
   });
 
+  test("maybeRecoverForms completes when the join HTML has no element", function () {
+    liveSocket = new LiveSocket("/live", Socket);
+    const view = new View(liveViewDOM(), liveSocket, null, null, null);
+    const callback = jest.fn();
+
+    view.maybeRecoverForms("", callback);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
   describe("submitForm", function () {
     test("submits payload", function () {
       expect.assertions(3);


### PR DESCRIPTION
The empty content shortcut missed callback execution contrary to
```
if (formsToRecover.length === 0) {
      return callback();
    }
```