### PR TITLE
Stop page loading when pushes fail

### DIFF
--- a/assets/js/phoenix_live_view/view.ts
+++ b/assets/js/phoenix_live_view/view.ts
@@ -1491,6 +1491,7 @@ export default class View {
           }
         },
         error: (reason) => {
+          onLoadingDone();
           resolve({
             type: "error",
             error: `failed with reason: ${JSON.stringify(reason)}`,

--- a/assets/js/phoenix_live_view/view.ts
+++ b/assets/js/phoenix_live_view/view.ts
@@ -1501,6 +1501,7 @@ export default class View {
           });
         },
         timeout: () => {
+          onLoadingDone();
           resolve({
             type: "error",
             error: "push timeout",

--- a/assets/test/view_test.ts
+++ b/assets/test/view_test.ts
@@ -194,6 +194,40 @@ describe("View + DOM", function () {
     expect(view.el.querySelector("form")).toBeTruthy();
   });
 
+  test("pushWithReply stops page loading when a push errors", async function () {
+    liveSocket = new LiveSocket("/live", Socket);
+    const el = liveViewDOM();
+    const view = simulateJoinedView(el, liveSocket);
+    const events: string[] = [];
+    const pageLoadingListener = (event: Event) => events.push(event.type);
+    window.addEventListener("phx:page-loading-start", pageLoadingListener);
+    window.addEventListener("phx:page-loading-stop", pageLoadingListener);
+
+    const push = {
+      receives: [] as [string, (reason: { reason: string }) => void][],
+      receive(status: string, callback: (reason: { reason: string }) => void) {
+        this.receives.push([status, callback]);
+        return this;
+      },
+    };
+    (view["channel"] as any).push = () => push;
+
+    const result = view.pushWithReply(
+      () => [null, [el], { page_loading: true }],
+      "event",
+      { event: "save" },
+    );
+    push.receives.find(([status]) => status === "error")![1]({
+      reason: "invalid",
+    });
+
+    await expect(result).resolves.toMatchObject({ type: "error" });
+    expect(events).toEqual(["phx:page-loading-start", "phx:page-loading-stop"]);
+
+    window.removeEventListener("phx:page-loading-start", pageLoadingListener);
+    window.removeEventListener("phx:page-loading-stop", pageLoadingListener);
+  });
+
   test("pushEvent", function () {
     expect.assertions(3);
 

--- a/assets/test/view_test.ts
+++ b/assets/test/view_test.ts
@@ -228,6 +228,42 @@ describe("View + DOM", function () {
     window.removeEventListener("phx:page-loading-stop", pageLoadingListener);
   });
 
+  test("pushWithReply stops page loading when a push times out", async function () {
+    liveSocket = new LiveSocket("/live", Socket);
+    const el = liveViewDOM();
+    const view = simulateJoinedView(el, liveSocket);
+    const events: string[] = [];
+    const pageLoadingListener = (event: Event) => events.push(event.type);
+    window.addEventListener("phx:page-loading-start", pageLoadingListener);
+    window.addEventListener("phx:page-loading-stop", pageLoadingListener);
+    const reloadWithJitter = jest
+      .spyOn(liveSocket, "reloadWithJitter")
+      .mockImplementation(() => {});
+
+    const push = {
+      receives: [] as [string, () => void][],
+      receive(status: string, callback: () => void) {
+        this.receives.push([status, callback]);
+        return this;
+      },
+    };
+    (view["channel"] as any).push = () => push;
+
+    const result = view.pushWithReply(
+      () => [null, [el], { page_loading: true }],
+      "event",
+      { event: "save" },
+    );
+    push.receives.find(([status]) => status === "timeout")![1]();
+
+    await expect(result).resolves.toMatchObject({ type: "error" });
+    expect(events).toEqual(["phx:page-loading-start", "phx:page-loading-stop"]);
+    expect(reloadWithJitter).toHaveBeenCalledWith(view, expect.any(Function));
+
+    window.removeEventListener("phx:page-loading-start", pageLoadingListener);
+    window.removeEventListener("phx:page-loading-stop", pageLoadingListener);
+  });
+
   test("pushEvent", function () {
     expect.assertions(3);
 


### PR DESCRIPTION
## Summary

Ensure `phx:page-loading-stop` is dispatched when a `page_loading` push receives an error or times out.

## Root cause

`pushWithReply` started element-level page loading before sending the push, but only finished it on successful replies.

## Validation

- `npm run js:test`
- `npm run typecheck:tests`
- `npm run js:format.check`