### PR TITLE
Ensure external metadata failures are reported consistently

### DIFF
--- a/guides/client/external-uploads.md
+++ b/guides/client/external-uploads.md
@@ -49,8 +49,13 @@ Supply the `:external` option to
 `Phoenix.LiveView.allow_upload/3`. It requires a 2-arity
 function that generates a signed URL where the client will
 push the bytes for the upload entry. This function must
-return either `{:ok, meta, socket}` or `{:error, meta, socket}`,
-where `meta` must be a map.
+return either `{:ok, meta, socket}` or `{:error, error_meta, socket}`,
+where `meta` and `error_meta` must be maps. Returning an error marks the
+entry as failed and makes `{:external_metadata_failure, error_meta}` available
+through `Phoenix.Component.upload_errors/2`. With auto uploads, any remaining
+valid entries continue uploading. For example:
+
+    {:error, %{reason: :presign_failed}, socket}
 
 For example, if you were using a context that provided a
 [`start_session`](https://developers.google.com/youtube/v3/guides/using_resumable_upload_protocol##Start_Resumable_Session)

--- a/guides/server/uploads.md
+++ b/guides/server/uploads.md
@@ -104,7 +104,7 @@ Let's look at an annotated example:
     <%!-- a regular click event whose handler will invoke Phoenix.LiveView.cancel_upload/3 --%>
     <button type="button" phx-click="cancel-upload" phx-value-ref={entry.ref} aria-label="cancel">&times;</button>
 
-    <%!-- Phoenix.Component.upload_errors/2 returns a list of error atoms --%>
+    <%!-- Phoenix.Component.upload_errors/2 returns a list of errors --%>
     <p :for={err <- upload_errors(@uploads.avatar, entry)} class="alert alert-danger">{error_to_string(err)}</p>
   </article>
 

--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1223,8 +1223,10 @@ defmodule Phoenix.Component do
 
   * `:too_large` - The entry exceeds the `:max_file_size` constraint
   * `:not_accepted` - The entry does not match the `:accept` MIME types
-  * `:external_client_failure` - When external upload fails
+  * `:external_client_failure` - When an external client uploader reports a failure
   * `{:writer_failure, reason}` - When the custom writer fails with `reason`
+  * `{:external_metadata_failure, error_meta}` - When external upload metadata
+    generation fails with `{:error, error_meta, socket}`
   * `reason` - When the custom validator fails with `reason`
 
   ## Examples
@@ -1233,6 +1235,9 @@ defmodule Phoenix.Component do
   defp upload_error_to_string(:too_large), do: "The file is too large"
   defp upload_error_to_string(:not_accepted), do: "You have selected an unacceptable file type"
   defp upload_error_to_string(:external_client_failure), do: "Something went terribly wrong"
+  defp upload_error_to_string({:external_metadata_failure, %{reason: :presign_failed}}),
+    do: "Could not prepare upload"
+
   defp upload_error_to_string(:custom_validator_error), do: "Custom validation error"
   ```
 

--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -903,8 +903,11 @@ defmodule Phoenix.LiveView do
 
     * `:external` - A 2-arity function for generating metadata for external
       client uploaders. This function must return either `{:ok, meta, socket}`
-      or `{:error, meta, socket}` where meta is a map. See the Uploads section
-      for example usage.
+      or `{:error, error_meta, socket}`, where `meta` and `error_meta` are maps.
+      An error marks the entry as failed and exposes
+      `{:external_metadata_failure, error_meta}` via `Phoenix.Component.upload_errors/2`.
+      With auto uploads, any remaining valid entries continue uploading. See the
+      Uploads section for example usage.
 
     * `:progress` - An optional 3-arity function for receiving progress events.
 

--- a/lib/phoenix_live_view/upload.ex
+++ b/lib/phoenix_live_view/upload.ex
@@ -470,12 +470,20 @@ defmodule Phoenix.LiveView.Upload do
               new_socket = update_upload_entry_meta(new_socket, conf.name, entry, meta)
               {:cont, {:ok, Map.put(metas, entry.ref, meta), errors, new_socket}}
 
-            {:error, %{} = meta, new_socket} ->
+            {:error, %{} = error_meta, new_socket} ->
               if conf.auto_upload? do
-                new_errors = Map.put(errors, entry.ref, [meta])
+                new_socket =
+                  put_upload_error(
+                    new_socket,
+                    conf.name,
+                    entry.ref,
+                    {:external_metadata_failure, error_meta}
+                  )
+
+                new_errors = Map.put(errors, entry.ref, [error_meta])
                 {:cont, {:ok, metas, new_errors, new_socket}}
               else
-                {:halt, {:error, {entry.ref, meta}, new_socket}}
+                {:halt, {:error, {entry.ref, error_meta}, new_socket}}
               end
           end
         end
@@ -486,9 +494,16 @@ defmodule Phoenix.LiveView.Upload do
         reply = %{ref: conf.ref, config: client_config_meta, entries: entry_metas, errors: errors}
         {:ok, reply, new_socket}
 
-      {:error, {entry_ref, meta_reason}, new_socket} ->
-        new_socket = put_upload_error(new_socket, conf.name, entry_ref, meta_reason)
-        {:error, %{ref: conf.ref, error: [[entry_ref, meta_reason]]}, new_socket}
+      {:error, {entry_ref, error_meta}, new_socket} ->
+        new_socket =
+          put_upload_error(
+            new_socket,
+            conf.name,
+            entry_ref,
+            {:external_metadata_failure, error_meta}
+          )
+
+        {:error, %{ref: conf.ref, error: [[entry_ref, error_meta]]}, new_socket}
     end
   end
 

--- a/test/phoenix_live_view/upload/external_test.exs
+++ b/test/phoenix_live_view/upload/external_test.exs
@@ -228,8 +228,12 @@ defmodule Phoenix.LiveView.UploadExternalTest do
       ])
 
     assert {:error, [[ref, %{reason: "bad name"}]]} = render_upload(avatar, "bad.jpeg", 1)
-    assert {:error, [[^ref, %{reason: "bad name"}]]} = render_upload(avatar, "foo.jpeg", 1)
-    assert render(lv) =~ "bad name"
+
+    assert {:error, [[^ref, {:external_metadata_failure, %{reason: "bad name"}}]]} =
+             render_upload(avatar, "foo.jpeg", 1)
+
+    assert render(lv) =~
+             "entry_error:#{inspect_html_safe({:external_metadata_failure, %{reason: "bad name"}})}"
   end
 
   @tag allow: [
@@ -250,6 +254,9 @@ defmodule Phoenix.LiveView.UploadExternalTest do
     html = render_upload(avatar, "foo.jpeg", 1)
     assert html =~ "foo.jpeg:1%"
     assert html =~ "bad.jpeg:0%"
+
+    assert html =~
+             "entry_error:#{inspect_html_safe({:external_metadata_failure, %{reason: "bad name"}})}"
   end
 
   @tag allow: [max_entries: 2, chunk_size: 20, accept: :any, external: :preflight]


### PR DESCRIPTION
Closes #3369.

Previously, the raw metadata was passed as reason in upload_errors/2, but it was not documented as one of the shapes to expect. For auto uploads, the entry was entirely missing from upload_errors/2.

This commit changes the shape to {:external_metadata_failure, meta}, and ensures auto_upload reports the error too. Since the previous behavior was not documented, I don't consider this to be a breaking change.