### PR TITLE
Cancel async tasks of components removed from the tree

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -1708,6 +1708,8 @@ defmodule Phoenix.LiveView.Channel do
               live_view_socket: acc.socket
             })
 
+            cancel_asyncs(c_socket)
+
             if deleted_cid in upload_cids do
               {_new_c_socket, canceled_confs} = Upload.maybe_cancel_uploads(c_socket)
               canceled_confs
@@ -1816,6 +1818,17 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   defp maybe_subscribe_to_live_reload(response), do: response
+
+  # A removed component can no longer handle its async results, so we cancel any
+  # task that is still in-flight. The tagged :DOWN then finds no component to
+  # write to and is dropped.
+  defp cancel_asyncs(c_socket) do
+    c_socket.private
+    |> Map.get(:live_async, %{})
+    |> Enum.each(fn {key, _ref_pid_kind} ->
+      Async.cancel_async(c_socket, key, {:shutdown, :cancel})
+    end)
+  end
 
   defp component_asyncs(state) do
     %{components: {components, _ids, _}} = state

--- a/test/phoenix_live_view/integrations/start_async_test.exs
+++ b/test/phoenix_live_view/integrations/start_async_test.exs
@@ -131,6 +131,56 @@ defmodule Phoenix.LiveView.StartAsyncTest do
       Agent.update(observer, &Map.put(&1, :live_view_pid, lv.pid))
     end
 
+    test "removing a component cancels its async tasks", %{conn: conn} do
+      telemetry_ref =
+        :telemetry_test.attach_event_handlers(self(), [[:phoenix, :live_component, :destroyed]])
+
+      {:ok, lv, _html} =
+        live_isolated(conn, Phoenix.LiveViewTest.Support.StartAsyncLive.RemovedComponent,
+          session: %{"test_pid" => self()}
+        )
+
+      assert_receive {:async_started, task_pid}, 1000
+      task_ref = Process.monitor(task_pid)
+
+      # the client acks cids_destroyed asynchronously, so wait for the deletion itself
+      render_click(lv, "hide")
+      assert_receive {[:phoenix, :live_component, :destroyed], ^telemetry_ref, _, _}, 1000
+
+      assert_receive {:DOWN, ^task_ref, :process, ^task_pid, {:shutdown, :cancel}}, 500
+      refute_received :async_finished
+
+      assert {:ok, []} = Phoenix.LiveView.Channel.async_pids(lv.pid)
+
+      assert {elapsed, :ok} =
+               :timer.tc(fn -> GenServer.stop(lv.pid, :shutdown) end, :millisecond)
+
+      assert elapsed < 500
+      refute_received :async_finished
+    end
+
+    test "async tasks awaited before the component is removed still deliver", %{conn: conn} do
+      telemetry_ref =
+        :telemetry_test.attach_event_handlers(self(), [[:phoenix, :live_component, :destroyed]])
+
+      {:ok, lv, _html} =
+        live_isolated(conn, Phoenix.LiveViewTest.Support.StartAsyncLive.RemovedComponent,
+          session: %{"test_pid" => self()}
+        )
+
+      assert_receive {:async_started, task_pid}, 1000
+      send(task_pid, :proceed)
+
+      assert render_async(lv) =~ "result: :finished"
+      assert_received :async_finished
+
+      render_click(lv, "hide")
+      assert_receive {[:phoenix, :live_component, :destroyed], ^telemetry_ref, _, _}, 1000
+
+      assert {:ok, []} = Phoenix.LiveView.Channel.async_pids(lv.pid)
+      assert :ok = GenServer.stop(lv.pid, :shutdown)
+    end
+
     test "patch", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/start_async?test=patch")
 

--- a/test/support/live_views/start_async.ex
+++ b/test/support/live_views/start_async.ex
@@ -375,3 +375,57 @@ defmodule Phoenix.LiveViewTest.Support.StartAsyncLive.LC do
     {:noreply, socket |> put_flash(:info, flash) |> push_navigate(to: "/start_async?test=ok")}
   end
 end
+
+defmodule Phoenix.LiveViewTest.Support.StartAsyncLive.RemovedComponent do
+  use Phoenix.LiveView
+
+  alias Phoenix.LiveViewTest.Support.StartAsyncLive.RemovedComponent
+
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.live_component :if={@show} module={RemovedComponent.LC} id="lc" test_pid={@test_pid} />
+      <button phx-click="hide">hide</button>
+    </div>
+    """
+  end
+
+  def mount(_params, %{"test_pid" => test_pid}, socket) do
+    {:ok, assign(socket, show: true, test_pid: test_pid)}
+  end
+
+  def handle_event("hide", _params, socket) do
+    {:noreply, assign(socket, show: false)}
+  end
+end
+
+defmodule Phoenix.LiveViewTest.Support.StartAsyncLive.RemovedComponent.LC do
+  use Phoenix.LiveComponent
+
+  def render(assigns) do
+    ~H"<div id={@id}>result: {inspect(@result)}</div>"
+  end
+
+  def update(%{test_pid: test_pid} = assigns, socket) do
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign_new(:result, fn -> :loading end)
+     |> start_async(:result_task, fn ->
+       send(test_pid, {:async_started, self()})
+
+       receive do
+         :proceed -> :ok
+       after
+         5_000 -> :ok
+       end
+
+       send(test_pid, :async_finished)
+       :finished
+     end)}
+  end
+
+  def handle_async(:result_task, {:ok, result}, socket) do
+    {:noreply, assign(socket, result: result)}
+  end
+end


### PR DESCRIPTION
Fixes #4400.

Per review: removed components' in-flight async tasks are now **cancelled at deletion time**, instead of being tracked so graceful shutdown could await them.

- `delete_components/2` cancels each deleted component's `live_async` entries inside the existing `read_socket/3` block — after the `[:phoenix, :live_component, :destroyed]` telemetry (observers still see a live socket) and before the upload-cancel branch, while the old components map is still readable.
- Reuses `Async.cancel_async/3`'s key clause: unlink, then exit with `{:shutdown, :cancel}` — the same reason as a user-initiated `Phoenix.LiveView.cancel_async/3`. The unlink is load-bearing: the tasks are `Task.start_link`'ed to the LiveView, so exiting one without it would take the LiveView down.
- No new state or message paths: a killed task never reaches `report_async_result/6`, and the tagged monitor `:DOWN` for the now-gone cid is dropped by the existing `write_component` → `:error` → `push_noop` path — so `handle_async/3` is never invoked for a removed component.
- Regression tests (both red on current `main` for the right reason):
  - "removing a component cancels its async tasks" — waits on the `:destroyed` telemetry event (the deletion actually runs on the client's `cids_destroyed` ack, which the test client sends asynchronously), then asserts a prompt `{:shutdown, :cancel}` `:DOWN`, the work never completing, empty `async_pids`, and an immediate clean `GenServer.stop(pid, :shutdown)` afterwards.
  - "async tasks awaited before the component is removed still deliver" — the prescribed `render_async/2`-before-removal pattern works and delivers the result.

Open points, happy to address either way:

- **Docs**: should `start_async/3`/`assign_async/3` mention that in-flight tasks are cancelled when the owning component is removed (and to `render_async/2` first in tests that need the result)? Can add a sentence.
- The cancel triggers on the client's `cids_destroyed` ack — same timing as upload cancellation at this call site — so a client that never acks leaves the task running until the LiveView exits.
- The exit reason is indistinguishable from a user-initiated `cancel_async/3`; a distinct reason (e.g. `{:shutdown, :component_removed}`) would be more debuggable but diverges from the documented cancel reason.

> **Disclosure:** this fix was developed with AI assistance — Claude Fable 5 (analysis/orchestration) with Claude Opus 5 subagents (implementation), directed and reviewed by a human.
