### PR TITLE
Tag pending diffs and discard outdated ones

### DIFF
--- a/assets/js/phoenix_live_view/view.ts
+++ b/assets/js/phoenix_live_view/view.ts
@@ -108,7 +108,7 @@ export default class View {
   private childJoins: number;
   private loaderTimer: ReturnType<typeof setTimeout> | null;
   private disconnectedTimer: ReturnType<typeof setTimeout> | null;
-  private pendingDiffs: any[];
+  private pendingDiffs: { diff: any; events: any; joinCount: number }[];
   private redirect: boolean;
   private href: string | null;
   private joinCount: number;
@@ -962,7 +962,10 @@ export default class View {
     ) {
       // don't mutate if this is already a pending diff
       if (!isPending) {
-        this.pendingDiffs.push({ diff, events });
+        // A diff only applies to the tree it was computed against. Remember
+        // which join produced that tree, so a rejoin in the meantime can tell
+        // this diff apart from one belonging to the tree it replaced.
+        this.pendingDiffs.push({ diff, events, joinCount: this.joinCount });
       }
       return false;
     }
@@ -1149,7 +1152,24 @@ export default class View {
     // navigation or the join is still pending, `this.update` returns false
     // if the diff was not applied.
     this.pendingDiffs = this.pendingDiffs.filter(
-      ({ diff, events }) => !this.update(diff, events, true),
+      ({ diff, events, joinCount }) => {
+        // A rejoin mounts a new LiveView: its full render replaced this.rendered
+        // and its fingerprints start over. A diff buffered against the previous
+        // tree is not merge-compatible with the one that replaced it, so drop it
+        // rather than merge it into a tree it was never computed against.
+        if (joinCount !== this.joinCount) {
+          this.log(
+            "update",
+            () => ["discarded diff from previous join", diff],
+            {
+              code: "view.stale-diff-discarded",
+              metadata: () => ({ joinCount, currentJoinCount: this.joinCount }),
+            },
+          );
+          return false;
+        }
+        return !this.update(diff, events, true);
+      },
     );
     this.eachChild((child) => child.applyPendingUpdates());
   }

--- a/assets/test/view_test.ts
+++ b/assets/test/view_test.ts
@@ -63,6 +63,81 @@ describe("View + DOM", function () {
     expect(view["rendered"]!.get()).toEqual(updateDiff);
   });
 
+  test("applies diffs buffered during a join once the join completes", async () => {
+    liveSocket = new LiveSocket("/live", Socket);
+    const el = liveViewDOM("<div>initial</div>");
+    const view = simulateJoinedView(el, liveSocket);
+
+    view.update(
+      {
+        s: ["<section>", "</section>"],
+        0: { s: ["<span>", "</span>"], k: { 0: { 0: "a" }, kc: 1 } },
+      },
+      [],
+    );
+
+    // a diff arrives while the join is still pending
+    view["joinPending"] = true;
+    view.update({ 0: { k: { 0: { 0: "b" }, kc: 1 } } }, []);
+    expect(view["pendingDiffs"].length).toBe(1);
+    expect(view.el.innerHTML).toContain("<span>a</span>");
+
+    view["joinPending"] = false;
+    view.applyPendingUpdates();
+
+    expect(view["pendingDiffs"]).toEqual([]);
+    expect(view.el.innerHTML).toContain("<span>b</span>");
+  });
+
+  test("discards diffs buffered against the tree a rejoin replaced", async () => {
+    liveSocket = new LiveSocket("/live", Socket);
+    const el = liveViewDOM("<div>initial</div>");
+    const view = simulateJoinedView(el, liveSocket);
+
+    // the tree the server computed the next diff against: a keyed comprehension
+    // nested two levels down
+    view.update(
+      {
+        s: ["<section>", "</section>"],
+        0: {
+          s: ["<div>", "</div>"],
+          0: {
+            s: ["<span>", "</span>"],
+            k: { 0: { 0: "a" }, 1: { 0: "b" }, 2: { 0: "c" }, kc: 3 },
+          },
+        },
+      },
+      [],
+    );
+
+    // a broadcast arrives while the join is pending and is buffered: a new entry
+    // at the top, so every other entry moves down one
+    view["joinPending"] = true;
+    view.update(
+      {
+        0: { 0: { k: { 0: { 0: "new" }, 1: 0, 2: 1, 3: 2, kc: 4, km: true } } },
+      },
+      [],
+    );
+    expect(view["pendingDiffs"].length).toBe(1);
+
+    // the view rejoins before that diff is applied. The new LiveView renders a
+    // plain nested struct where the previous one rendered the comprehension, so
+    // merging the buffered diff into it would walk into a subtree that has no
+    // keyed entries at all.
+    view.onJoin({
+      rendered: {
+        s: ["<section>", "</section>"],
+        0: { s: ["<div>", "</div>"], 0: { s: ["<b>", "</b>"], 0: "hello" } },
+      },
+      liveview_version,
+    });
+
+    expect(view["pendingDiffs"]).toEqual([]);
+    expect(view.el.innerHTML).toContain("<b>hello</b>");
+    expect(view.el.innerHTML).not.toContain("new");
+  });
+
   test("applyDiff with empty title uses default if present", async () => {
     appendTitle({}, "Foo");
 


### PR DESCRIPTION
If a join was pending, diffs were buffered and applied at once when every view was joined. If a view rejoined before pending diffs were applied, it could try to apply a stale diff to a new tree and crash.