### PR TITLE
Avoid runtime list concatenation in static data_attrs

### DIFF
--- a/lib/phoenix_live_view/static.ex
+++ b/lib/phoenix_live_view/static.ex
@@ -159,7 +159,7 @@ defmodule Phoenix.LiveView.Static do
           phx_static: sign_static_token(socket)
         ]
 
-        data_attrs = if(router, do: [phx_main: true], else: []) ++ data_attrs
+        data_attrs = if router, do: [phx_main: true] ++ data_attrs, else: data_attrs
 
         attrs = [
           {:id, socket.id},


### PR DESCRIPTION
Assisted-by: Antigravity CLI:Gemini 3.8 Flash

> Allows the compiler to emit native put_list instructions.
