### PR TITLE
Remove legacy Phoenix.View render_layout clause from classify_taint

### DIFF
--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -1508,9 +1508,6 @@ defmodule Phoenix.LiveView.Engine do
   # Constructs from TagEngine
   defp classify_taint(:inner_block, [_, [do: _]]), do: :live
 
-  # Constructs from Phoenix.View
-  defp classify_taint(:render_layout, [_, _, _, [do: _]]), do: :live
-
   # Special forms are forbidden and raise.
   defp classify_taint(:alias, [_]), do: :special_form
   defp classify_taint(:import, [_]), do: :special_form


### PR DESCRIPTION
Assisted-by: Antigravity CLI:Gemini 3.8 Flash

> Phoenix.View references were removed in 2022 in favor of function components. Modern HEEx layouts use :inner_block slots instead of render_layout/4.
