### PR TITLE
Remove unreachable empty static branch in to_rendered_struct

### DIFF
--- a/lib/phoenix_live_view/engine.ex
+++ b/lib/phoenix_live_view/engine.ex
@@ -384,13 +384,8 @@ defmodule Phoenix.LiveView.Engine do
       static =
         case Keyword.fetch(meta, :template_annotation) do
           {:ok, {before, aft}} ->
-            case static do
-              [] ->
-                ["#{before}#{aft}"]
-
-              [first | rest] ->
-                List.update_at([to_string(before) <> first | rest], -1, &(&1 <> to_string(aft)))
-            end
+            [first | rest] = static
+            List.update_at([to_string(before) <> first | rest], -1, &(&1 <> to_string(aft)))
 
           :error ->
             static


### PR DESCRIPTION
Assisted-by: Antigravity CLI:Gemini 3.8 Flash

> bins_and_vars guarantees that static is always non-empty with length >= 1. The empty list branch in template annotation handling was unreachable.
