### PR TITLE
Remove unreachable binary clause from to_iodata/4

### DIFF
--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -78,10 +78,6 @@ defmodule Phoenix.LiveView.Diff do
     {mapper.(cid, iodata), components}
   end
 
-  defp to_iodata(binary, components, _template, _mapper) when is_binary(binary) do
-    {binary, components}
-  end
-
   defp to_iodata_parts(parts, static, components, template, mapper) do
     [head | tail] = template_static(static, template)
     one_to_iodata(tail, parts, 0, [head], components, template, mapper)


### PR DESCRIPTION
Assisted-by: Antigravity CLI:Gemini 3.8 Flash

> Binaries are already intercepted inline by one_to_iodata/7 before delegating to to_iodata/4. Top-level diffs are always maps, making this clause dead.
