### PR TITLE
Remove dead indexOf helper from DOMPatch

### DIFF
--- a/assets/js/phoenix_live_view/dom_patch.ts
+++ b/assets/js/phoenix_live_view/dom_patch.ts
@@ -856,10 +856,6 @@ export default class DOMPatch {
     DOM.putPrivate(fromEl, PHX_REF_LOCK, DOM.private(toEl, PHX_REF_LOCK));
   }
 
-  private indexOf(parent, child) {
-    return Array.from(parent.children).indexOf(child);
-  }
-
   private teleport(el, morph) {
     const targetSelector = el.getAttribute(PHX_PORTAL);
     const portalContainer = document.querySelector(targetSelector);


### PR DESCRIPTION
Assisted-by: Gemini 3.8 Flash

> The private indexOf method is never called in dom_patch.ts or elsewhere in the codebase. Child index lookups are done directly on children arrays.
