### PR TITLE
Remove orphaned childNodeLength helper from DOM

### DIFF
--- a/assets/js/phoenix_live_view/dom.ts
+++ b/assets/js/phoenix_live_view/dom.ts
@@ -83,12 +83,6 @@ const DOM = {
     return array;
   },
 
-  childNodeLength(html) {
-    const template = document.createElement("template");
-    template.innerHTML = html;
-    return template.content.childElementCount;
-  },
-
   isUploadInput(el): el is HTMLInputElement {
     return el.type === "file" && el.getAttribute(PHX_UPLOAD_REF) !== null;
   },


### PR DESCRIPTION
Assisted-by: Antigravity CLI:Gemini 3.8 Flash

> The childNodeLength helper was orphaned, it is never referenced in the codebase or test suite.
