### PR TITLE
Remove unused deleteSticky helper from DOM

### DIFF
--- a/assets/js/phoenix_live_view/dom.ts
+++ b/assets/js/phoenix_live_view/dom.ts
@@ -818,12 +818,6 @@ const DOM = {
     }
   },
 
-  deleteSticky(el, name) {
-    this.updatePrivate(el, "sticky", [], (ops) => {
-      return ops.filter(([existingName, _]) => existingName !== name);
-    });
-  },
-
   putSticky(el, name, op) {
     const stashedResult = op(el);
     this.updatePrivate(el, "sticky", [], (ops) => {


### PR DESCRIPTION
Assisted-by: Antigravity CLI:Gemini 3.8 Flash

> The deleteSticky helper was added during initial stream implementation but is never called. Sticky attributes are managed via putSticky, getSticky, and applyStickyOperations.
