### PR TITLE
fix (LiveViewTest): Support configurable timeouts on `:async_pids` GenServer calls to reduce test flakiness

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -47,8 +47,11 @@ defmodule Phoenix.LiveView.Channel do
     send(monitor_ref, {@prefix, :async_result, {kind, {ref, cid, keys, result}}})
   end
 
-  def async_pids(lv_pid) do
-    GenServer.call(lv_pid, {@prefix, :async_pids})
+  def async_pids(
+        lv_pid,
+        timeout \\ Application.get_env(:phoenix_live_view, :async_pids_timeout, 5_000)
+      ) do
+    GenServer.call(lv_pid, {@prefix, :async_pids}, timeout)
   end
 
   def graceful_exit(lv_pid, reason) do

--- a/lib/phoenix_live_view/test/client_proxy.ex
+++ b/lib/phoenix_live_view/test/client_proxy.ex
@@ -673,10 +673,19 @@ defmodule Phoenix.LiveViewTest.ClientProxy do
     end)
   end
 
-  def handle_call({:async_pids, topic_or_element}, _from, state) do
+  def handle_call({:async_pids, topic_or_element, timeout}, _from, state) do
     topic = proxy_topic(topic_or_element)
     %{pid: pid} = fetch_view_by_topic!(state, topic)
-    {:reply, Phoenix.LiveView.Channel.async_pids(pid), state}
+
+    # If the GenServer call times out while looking up PIDs, we'd like to
+    # report a nice error to the user.
+    try do
+      {:reply, Phoenix.LiveView.Channel.async_pids(pid, timeout), state}
+    catch
+      :exit, {:timeout, _} ->
+        message = "expected async process lookup to finish within #{timeout}ms"
+        {:reply, {:raise, RuntimeError.exception(message)}, state}
+    end
   end
 
   def handle_call({:render_event, topic_or_element, type, value}, from, state) do

--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1050,7 +1050,8 @@ defmodule Phoenix.LiveViewTest do
   for a given LiveView or element.
 
   It renders the LiveView or Element once complete and returns the result.
-  The default `timeout` is [ExUnit](https://ex-unit.hexdocs.pm/ExUnit.html#configure/1)'s
+  The default `timeout` is the sum of the time allotted to fetch the LiveView's async processes
+  (5 seconds) and [ExUnit](https://ex-unit.hexdocs.pm/ExUnit.html#configure/1)'s
   `assert_receive_timeout` (100 ms).
 
   ## Examples
@@ -1061,16 +1062,17 @@ defmodule Phoenix.LiveViewTest do
   """
   def render_async(
         view_or_element,
-        timeout \\ Application.fetch_env!(:ex_unit, :assert_receive_timeout)
+        timeout \\ Application.get_env(:phoenix_live_view, :async_pids_timeout, 5_000) +
+          Application.fetch_env!(:ex_unit, :assert_receive_timeout)
       ) do
-    pids =
-      case view_or_element do
-        %View{} = view -> call(view, {:async_pids, {proxy_topic(view), nil, nil}})
-        %Element{} = element -> call(element, {:async_pids, element})
-      end
-
     timeout_ref = make_ref()
     Process.send_after(self(), {timeout_ref, :timeout}, timeout)
+
+    pids =
+      case view_or_element do
+        %View{} = view -> call(view, {:async_pids, {proxy_topic(view), nil, nil}, timeout})
+        %Element{} = element -> call(element, {:async_pids, element, timeout})
+      end
 
     pids
     |> Enum.map(&Process.monitor(&1))

--- a/test/phoenix_live_view/integrations/live_view_test.exs
+++ b/test/phoenix_live_view/integrations/live_view_test.exs
@@ -275,6 +275,14 @@ defmodule Phoenix.LiveView.LiveViewTest do
       {:ok, view, _} = live(conn, "/thermo")
       assert render_hook(view, :save, %{temp: 20}) =~ "The temp is: 20"
     end
+
+    test "render_async errors with too short a timeout", %{conn: conn} do
+      {:ok, view, _} = live(conn, "/assign_async?test=ok")
+
+      assert_raise RuntimeError, ~r/expected async process lookup to finish within 0ms/, fn ->
+        render_async(view, 0)
+      end
+    end
   end
 
   describe "container" do


### PR DESCRIPTION
A common source of CI test flakiness for our LiveView app at work (which heavily uses async assigns) looks like this:

```
    1) test the page loads (MyAppWeb.AccountSettingsLiveTest)
       lib/my_app_web/live/account_settings_live_test.exs:123
       ** (EXIT from #PID<0.12267.0>) exited in: GenServer.call(#PID<0.24640.0>, {:phoenix, :async_pids}, 5000)
           ** (EXIT) time out
```

That error is the result of a `render_async/1` call that timed out (though since it doesn't include a stacktrace, it takes a little effort to figure that out). Given that CI machines tend to be under-powered compared to developer machines, my understanding is this occurs when the CPU is overloaded and takes longer than 5 seconds to fetch all the async processes attached to the LiveView.

The changes here are designed to both
a) allow clients to increase that timeout, and
b) present a clear error when a timeout does occur here.

The biggest part I'm not sure of: should the timeout provided to `render_async/2` be _split_ between the `:async_pids` lookup and the actual message receive (as written), or should it only apply to the message receive portion? Prior to this change, it was the latter, which means the whole function call could have taken up to 5 seconds + the indicated timeout. If the timeout is _not_ shared between the two steps, though, it feels quite awkward; either there's no way to configure the `:async_pids` timeout on a per-call basis (you would only be able to do so using the application config variable), or the function would need to accept *two* timeouts.