### PR TITLE
Simplify push events diff

### DIFF
--- a/lib/phoenix_live_view/channel.ex
+++ b/lib/phoenix_live_view/channel.ex
@@ -1036,7 +1036,7 @@ defmodule Phoenix.LiveView.Channel do
   end
 
   defp push_pending_events_on_redirect(state, socket) do
-    if diff = Diff.get_push_events_diff(socket), do: push_diff(state, diff, nil)
+    push_diff(state, Diff.get_push_events_diff(socket), nil)
     state
   end
 

--- a/lib/phoenix_live_view/diff.ex
+++ b/lib/phoenix_live_view/diff.ex
@@ -181,7 +181,7 @@ defmodule Phoenix.LiveView.Diff do
   Returns a diff containing only the events that have been pushed.
   """
   def get_push_events_diff(socket) do
-    if events = Utils.get_push_events(socket), do: %{@events => events}
+    %{@events => Utils.get_push_events(socket)}
   end
 
   defp maybe_put_title(diff, socket) do


### PR DESCRIPTION
Assisted-by: Codex CLI:GPT 6 Astra

> Construct the events map directly in get_push_events_diff/1. The getter returns a list, which is always truthy in Elixir, so the conditional has an unreachable falsy branch.