### PR TITLE
Fix max flash age unit in Utils.verify_flash

### DIFF
--- a/lib/phoenix_live_view/utils.ex
+++ b/lib/phoenix_live_view/utils.ex
@@ -8,7 +8,7 @@ defmodule Phoenix.LiveView.Utils do
   # All available mount options
   @mount_opts [:temporary_assigns, :layout]
 
-  @max_flash_age :timer.seconds(60)
+  @max_flash_age 60
 
   @valid_uri_schemes [
     "http:",

--- a/test/phoenix_live_view/utils_test.exs
+++ b/test/phoenix_live_view/utils_test.exs
@@ -18,6 +18,15 @@ defmodule Phoenix.LiveView.UtilsTest do
     assert Utils.verify_flash(Endpoint, nil) == %{}
   end
 
+  test "verify with expired flash token" do
+    token =
+      Phoenix.Token.sign(Endpoint, "flash:" <> Utils.salt!(Endpoint), %{"info" => "hi"},
+        signed_at: System.system_time(:second) - 61
+      )
+
+    assert Utils.verify_flash(Endpoint, token) == %{}
+  end
+
   test "valid_destination!/2" do
     assert Utils.valid_destination!("/foo", "")
     assert Utils.valid_destination!("http://example.com/foo", "")


### PR DESCRIPTION
Assisted-by: Codex CLI:GPT 6 Astra

> Phoenix.Token.verify/4 expects max_age in seconds, but @max_flash_age was set using :timer.seconds(60) which evaluated to 60000 seconds.
