### PR TITLE
Guard hook disconnected lifecycle callback

### DIFF
--- a/assets/js/phoenix_live_view/view_hook.ts
+++ b/assets/js/phoenix_live_view/view_hook.ts
@@ -452,8 +452,10 @@ export class ViewHook<
   }
   /** @internal */
   __disconnected() {
-    this.__isDisconnected = true;
-    this.disconnected();
+    if (!this.__isDisconnected) {
+      this.__isDisconnected = true;
+      this.disconnected();
+    }
   }
 
   js(): HookJSCommands {

--- a/assets/test/view_test.ts
+++ b/assets/test/view_test.ts
@@ -1935,8 +1935,21 @@ describe("View Hooks", function () {
     view.showLoader();
     expect(values).toEqual(["mounted", "disconnected"]);
 
+    view.showLoader();
+    // The hook is already disconnected, so it shouldn't receive another
+    // "disconnected" message
+    expect(values).toEqual(["mounted", "disconnected"]);
+
     view.triggerReconnected();
     expect(values).toEqual(["mounted", "disconnected", "reconnected"]);
+
+    view.showLoader();
+    expect(values).toEqual([
+      "mounted",
+      "disconnected",
+      "reconnected",
+      "disconnected",
+    ]);
   });
 
   test("dispatches uploads", async () => {


### PR DESCRIPTION
When connection problem persists each `channel.onError` causes `hook.disconnected()` callback be called multiple times while corresponding `__reconnected()` is guarded by `__isDisconnected`. This PR makes the behaviour symmetric