### PR TITLE
Avoid mutating JS push options

### DIFF
--- a/assets/js/phoenix_live_view/js_commands.ts
+++ b/assets/js/phoenix_live_view/js_commands.ts
@@ -349,10 +349,10 @@ export default (
     },
     push(el, type, opts = {}) {
       liveSocket.withinOwners(el, (view) => {
-        const data = opts.value || {};
-        delete opts.value;
+        const { value, ...rest } = opts;
+        const data = value || {};
         let e = new CustomEvent("phx:exec", { detail: { sourceElement: el } });
-        JS.exec(e, eventType, type, view, el, ["push", { data, ...opts }]);
+        JS.exec(e, eventType, type, view, el, ["push", { data, ...rest }]);
       });
     },
     navigate(href, opts = {}) {

--- a/assets/test/live_socket_test.ts
+++ b/assets/test/live_socket_test.ts
@@ -711,6 +711,36 @@ describe("liveSocket.js()", () => {
     JS.exec = originalExec;
   });
 
+  test("push does not mutate reusable options", () => {
+    const el = document.createElement("div");
+    const opts = { value: { key: "value" }, target: "#target" };
+    view.el.appendChild(el);
+
+    const originalWithinOwners = liveSocket.withinOwners;
+    liveSocket.withinOwners = (_el, callback) => {
+      callback(view);
+    };
+
+    const originalExec = JS.exec;
+    JS.exec = jest.fn();
+
+    js.push(el, "custom-event", opts);
+    js.push(el, "custom-event", opts);
+
+    expect(opts).toEqual({ value: { key: "value" }, target: "#target" });
+    expect((JS.exec as jest.Mock).mock.calls[0][5][1]).toEqual({
+      data: { key: "value" },
+      target: "#target",
+    });
+    expect((JS.exec as jest.Mock).mock.calls[1][5][1]).toEqual({
+      data: { key: "value" },
+      target: "#target",
+    });
+
+    liveSocket.withinOwners = originalWithinOwners;
+    JS.exec = originalExec;
+  });
+
   test("navigate", () => {
     const originalHistoryRedirect = liveSocket.historyRedirect;
     liveSocket.historyRedirect = jest.fn();


### PR DESCRIPTION
The current code mutates user supplied options. A hook that reuses one opts object across two `push()` calls will misbehave. This PR uses destructuring and spread to avoid user data mutation