### PR TITLE
Handle falsy keys in assign_async validation

### DIFF
--- a/lib/phoenix_live_view/async.ex
+++ b/lib/phoenix_live_view/async.ex
@@ -140,7 +140,7 @@ defmodule Phoenix.LiveView.Async do
     wrapped_func = fn ->
       case func.() do
         {:ok, %{} = assigns} ->
-          if Enum.find(keys, &(not is_map_key(assigns, &1))) do
+          if Enum.any?(keys, &(not is_map_key(assigns, &1))) do
             raise ArgumentError, """
             expected assign_async to return map of assigns for all keys
             in #{inspect(keys)}, but got: #{inspect(assigns)}

--- a/test/phoenix_live_view/integrations/assign_async_test.exs
+++ b/test/phoenix_live_view/integrations/assign_async_test.exs
@@ -32,6 +32,15 @@ defmodule Phoenix.LiveView.AssignAsyncTest do
       assert render(lv)
     end
 
+    test "missing known key that is a falsy atom", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, "/assign_async?test=bad_ok_falsy_key")
+
+      assert render_async(lv) =~
+               "expected assign_async to return map of assigns for all keys\\nin [:data, nil]"
+
+      assert render(lv)
+    end
+
     test "keyword list return", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/assign_async?test=bad_keyword")
 

--- a/test/support/live_views/assign_async.ex
+++ b/test/support/live_views/assign_async.ex
@@ -40,6 +40,10 @@ defmodule Phoenix.LiveViewTest.Support.AssignAsyncLive do
     {:ok, assign_async(socket, :data, fn -> {:ok, %{bad: 123}} end)}
   end
 
+  def mount(%{"test" => "bad_ok_falsy_key"}, _session, socket) do
+    {:ok, assign_async(socket, [:data, nil], fn -> {:ok, %{data: 123}} end)}
+  end
+
   def mount(%{"test" => "bad_keyword"}, _session, socket) do
     {:ok, assign_async(socket, :data, fn -> {:ok, data: 123} end)}
   end


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix_live_view/issues/4428.