### PR TITLE
Remove redundant stream-rendering branches

### DIFF
--- a/assets/js/phoenix_live_view/rendered.js
+++ b/assets/js/phoenix_live_view/rendered.js
@@ -460,11 +460,8 @@ export default class Rendered {
     // we don't need to store the rendered tree for streams
     if (rendered[STREAM]) {
       const stream = rendered[STREAM];
-      const [_ref, _inserts, deleteIds, reset] = stream || [null, {}, [], null];
-      if (
-        stream !== undefined &&
-        (rendered[KEYED][KEYED_COUNT] > 0 || deleteIds.length > 0 || reset)
-      ) {
+      const [_ref, _inserts, deleteIds, reset] = stream;
+      if (rendered[KEYED][KEYED_COUNT] > 0 || deleteIds.length > 0 || reset) {
         delete rendered[STREAM];
         rendered[KEYED] = {
           [KEYED_COUNT]: 0,


### PR DESCRIPTION
Assisted-by: Antigravity: Gemini 3.8 Flash

Removes unreachable code and condition.