### PR TITLE
Avoid redundant lock lookups in ElementRef.onUnlock

### DIFF
--- a/assets/js/phoenix_live_view/element_ref.ts
+++ b/assets/js/phoenix_live_view/element_ref.ts
@@ -13,13 +13,11 @@ import DOM from "./dom";
 
 export default class ElementRef {
   static onUnlock(el, callback) {
-    if (!DOM.isLocked(el) && !el.closest(`[${PHX_REF_LOCK}]`)) {
+    const closestLock = el.closest(`[${PHX_REF_LOCK}]`);
+    if (!closestLock) {
       return callback();
     }
-    const closestLock = el.closest(`[${PHX_REF_LOCK}]`);
-    const ref = closestLock
-      .closest(`[${PHX_REF_LOCK}]`)
-      .getAttribute(PHX_REF_LOCK);
+    const ref = closestLock.getAttribute(PHX_REF_LOCK);
     closestLock.addEventListener(
       `phx:undo-lock:${ref}`,
       () => {


### PR DESCRIPTION
Assisted-by: Antigravity:Gemini 3.8 Flash
Assisted-by: Codex CLI:GPT 6 Astra

>   The crucial detail is that closest() starts with the element itself. Therefore:
> 
>   - If DOM.isLocked(el) is true, el.closest(lockSelector) returns el.
>   - If neither the element nor an ancestor is locked, both versions immediately return callback().
>   - Once closestLock is found, closestLock.closest(lockSelector) returns that same element—not another locked ancestor. Removing that
>     call preserves the listener target and reference. DOM specification