### PR TITLE
Preserve caret for additional input types

### DIFF
--- a/assets/js/phoenix_live_view/dom.ts
+++ b/assets/js/phoenix_live_view/dom.ts
@@ -649,7 +649,10 @@ const DOM = {
 
   hasSelectionRange(el): el is HTMLInputElement | HTMLTextAreaElement {
     return (
-      el.setSelectionRange && (el.type === "text" || el.type === "textarea")
+      el.setSelectionRange &&
+      ["text", "textarea", "search", "url", "tel", "password"].includes(
+        el.type,
+      )
     );
   },
 

--- a/assets/js/phoenix_live_view/dom.ts
+++ b/assets/js/phoenix_live_view/dom.ts
@@ -650,9 +650,7 @@ const DOM = {
   hasSelectionRange(el): el is HTMLInputElement | HTMLTextAreaElement {
     return (
       el.setSelectionRange &&
-      ["text", "textarea", "search", "url", "tel", "password"].includes(
-        el.type,
-      )
+      ["text", "textarea", "search", "url", "tel", "password"].includes(el.type)
     );
   },
 

--- a/assets/test/dom_test.ts
+++ b/assets/test/dom_test.ts
@@ -417,6 +417,23 @@ describe("DOM", () => {
     });
   });
 
+  describe("restoreFocus", () => {
+    test.each(["search", "url", "tel", "password"])(
+      "restores the selection for input type %s",
+      (type) => {
+        const input = tag("input", { type }, "") as HTMLInputElement;
+        input.value = "hello world";
+        document.body.appendChild(input);
+
+        DOM.restoreFocus(input, 2, 5);
+
+        expect(document.activeElement).toBe(input);
+        expect(input.selectionStart).toBe(2);
+        expect(input.selectionEnd).toBe(5);
+      },
+    );
+  });
+
   describe("isFormAssociated", () => {
     test("identifies inputs, selects, textareas", () => {
       expect(DOM.isFormAssociated(tag("input", { type: "text" }, ""))).toBe(


### PR DESCRIPTION
`hasSelectionRange` accepts only type `text`/`textarea`, but `setSelectionRange` is valid for also for search/url/tel/password. See https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange. A patch that re-focuses such an input restores focus but not the caret/selection. This PR makes it work for all valid input types