### PR TITLE
Resolve templates in moved keyed entries in LiveViewTest

### DIFF
--- a/lib/phoenix_live_view/test/diff.ex
+++ b/lib/phoenix_live_view/test/diff.ex
@@ -122,6 +122,12 @@ defmodule Phoenix.LiveViewTest.Diff do
     Map.new(rendered, fn {k, v} -> {k, resolve_templates(v, template)} end)
   end
 
+  # a keyed entry that moved and changed is sent as [old_pos, diff]
+  defp resolve_templates([old_pos, rendered], template)
+       when is_integer(old_pos) and is_map(rendered) do
+    [old_pos, resolve_templates(rendered, template)]
+  end
+
   defp resolve_templates(other, _template), do: other
 
   def extract_streams(%{} = source, streams) when not is_struct(source) do

--- a/test/phoenix_live_view/test/diff_test.exs
+++ b/test/phoenix_live_view/test/diff_test.exs
@@ -44,6 +44,48 @@ defmodule Phoenix.LiveViewTest.DiffTest do
       assert Diff.merge_diff(base, diff) == result
     end
 
+    test "resolves templates in moved comprehensions" do
+      base = %{
+        0 => %{
+          k: %{
+            0 => %{0 => "a", 1 => ""},
+            1 => %{0 => "b", 1 => ""},
+            kc: 2
+          },
+          s: ["<div>", "", "</div>"]
+        },
+        s: ["", ""]
+      }
+
+      # "a" moves to the end and renders a nested template from the root :p
+      diff = %{
+        0 => %{
+          k: %{
+            0 => [1, %{1 => ""}],
+            1 => [0, %{1 => %{0 => "a", :s => 0}}],
+            km: true,
+            kc: 2
+          }
+        },
+        p: %{0 => ["<span>", "</span>"]}
+      }
+
+      result = %{
+        0 => %{
+          k: %{
+            0 => %{0 => "b", 1 => ""},
+            1 => %{0 => "a", 1 => %{0 => "a", :s => ["<span>", "</span>"]}},
+            kc: 2
+          },
+          s: ["<div>", "", "</div>"]
+        },
+        s: ["", ""],
+        streams: []
+      }
+
+      assert Diff.merge_diff(base, diff) == result
+    end
+
     test "no warning when keyed count is 0" do
       base = %{
         k: %{


### PR DESCRIPTION
`Phoenix.LiveViewTest` raises when a keyed comprehension entry moves and changes in the same render, and the change contains a shared template.

## Reproduction

```elixir
def render(assigns) do
  ~H"""
  <div :for={item <- @items} :key={item.id} id={"item-" <> item.id}>
    {item.id}
    <span :if={@badge == item.id} id={"badge-" <> item.id}>✓</span>
  </div>
  """
end

def handle_event("move_and_badge", _params, socket) do
  [a, b, c] = socket.assigns.items
  {:noreply, assign(socket, items: [b, c, a], badge: "a")}
end
```

Starting from `items: [a, b, c]` and `badge: nil`, `render_click(view, "move_and_badge")` raises:

```
** (BadMapError) expected a map, got: nil
    :erlang.map_get(0, nil)
    (phoenix_live_view 1.2.11) lib/phoenix_live_view/diff.ex:115: Phoenix.LiveView.Diff.template_static/2
    ...
    (phoenix_live_view 1.2.11) lib/phoenix_live_view/test/diff.ex:145: Phoenix.LiveViewTest.Diff.render_diff/1
```

Moving without the badge works, and showing the badge without the move works.

## Cause

The server sends the moved entry as `[old_pos, diff]`, with the badge's statics as a reference into the diff's `p`:

```json
"2": [0, {"2": {"0": "a", "s": 0}}]
```

`Phoenix.LiveViewTest.Diff.resolve_templates/2` walks maps and returns everything else unchanged, so the `s: 0` inside the list is never resolved. The later render has no template to look it up in.

The browser client is not affected: replaying the same two diffs through `rendered.js` renders the moved item with its badge, and it stays correct on later diffs.

## Fix

Resolve templates inside `[old_pos, diff]` entries. The new test in `test/phoenix_live_view/test/diff_test.exs` fails without the change and passes with it; the Elixir suite passes (1525 tests, 6 doctests).
